### PR TITLE
feat: exposure provenance via source_id

### DIFF
--- a/reference/identity-agent/cmd/identity-agent/main.go
+++ b/reference/identity-agent/cmd/identity-agent/main.go
@@ -81,14 +81,9 @@ func main() {
 			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: "request body is not valid JSON"})
 			return
 		}
-		if req.PackageID == "" {
+		if err := tmproto.ValidateExposeRequest(&req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: "package_id is required"})
-			return
-		}
-		if req.UserToken == "" && len(req.Identities) == 0 {
-			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: "user_token or identities required"})
+			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: err.Error()})
 			return
 		}
 		resp, err := engine.RecordExposure(r.Context(), &req)

--- a/schema/tmp/expose_request.json
+++ b/schema/tmp/expose_request.json
@@ -6,6 +6,11 @@
   "x-go-name": "ExposeRequest",
   "required": ["user_token", "package_id"],
   "properties": {
+    "source_id": {
+      "type": "string",
+      "description": "Identifies the agent or system that recorded this exposure. Used for dedup namespacing, rollback, and audit.",
+      "x-go-omitempty": true
+    },
     "user_token": {
       "type": "string"
     },

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -591,8 +591,17 @@ func (e *Engine) SetUserProfile(ctx context.Context, userToken string, segments 
 // Valkey Lua scripting for atomic append.
 // TODO: Add Store.Append method for atomic binary append.
 func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest) (*tmproto.ExposeResponse, error) {
+	if err := tmproto.ValidateExposeRequest(req); err != nil {
+		return nil, fmt.Errorf("invalid expose request: %w", err)
+	}
 	now := e.now()
 	identities := resolveExposeIdentities(req)
+
+	// Resolve source ID: use request field, fall back to engine's provider ID.
+	sourceID := req.SourceID
+	if sourceID == "" {
+		sourceID = e.providerID
+	}
 
 	// Resolve campaign ID.
 	campaignID := req.CampaignID
@@ -613,6 +622,7 @@ func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest)
 		ImpressionID: impressionID,
 		PackageID:    req.PackageID,
 		CampaignID:   campaignID,
+		SourceID:     sourceID,
 		Timestamp:    now.Unix(),
 	}
 
@@ -638,7 +648,7 @@ func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest)
 			continue
 		}
 
-		// Prune expired entries and append new one, preserving versioned header.
+		// Prune expired entries and append new one, upgrading v1→v2 if needed.
 		existing := BinaryExposureLog(val)
 		if len(val) > 0 {
 			if err := ValidateBinaryLog(existing); err != nil {
@@ -649,13 +659,20 @@ func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest)
 		newEntry := EncodeBinaryExposureLog(ExposureLog{entry})
 
 		pruned := newBinaryLog(existing.Len() + 1)
+		es := int(existing.EntrySize())
 		for j := range existing.Len() {
 			if existing.Timestamp(j) >= cutoff {
 				off := existing.entryOffset(j)
-				pruned = append(pruned, existing[off:off+binaryEntrySize]...)
+				if es == binaryEntrySize {
+					pruned = append(pruned, existing[off:off+binaryEntrySize]...)
+				} else {
+					// Upgrade v1 entry: copy 32 bytes + 8 zero bytes for source hash.
+					pruned = append(pruned, existing[off:off+binaryEntrySize1]...)
+					pruned = append(pruned, 0, 0, 0, 0, 0, 0, 0, 0)
+				}
 			}
 		}
-		// Append the new entry's payload (skip its header).
+		// Append the new v2 entry's payload (skip its header).
 		pruned = append(pruned, newEntry[binaryHeaderSize:]...)
 		pruned = TruncateBinaryLog(pruned, maxExposureEntries)
 
@@ -667,8 +684,9 @@ func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest)
 		}
 
 		// Package frequency sorted set.
+		member := sourceID + ":" + impressionID
 		pkgFreqKey := fmt.Sprintf("freq:pkg:%s:%s", req.PackageID, hash)
-		if err := e.store.ZAdd(ctx, pkgFreqKey, nowMs, impressionID); err != nil {
+		if err := e.store.ZAdd(ctx, pkgFreqKey, nowMs, member); err != nil {
 			e.metrics.StoreError("zadd_pkg_freq", err)
 		} else {
 			if err := e.store.ZRemRangeByScore(ctx, pkgFreqKey, 0, pruneBeforeMs); err != nil {
@@ -680,7 +698,7 @@ func (e *Engine) RecordExposure(ctx context.Context, req *tmproto.ExposeRequest)
 		// Campaign frequency sorted set.
 		if campaignID != "" {
 			campFreqKey := fmt.Sprintf("freq:campaign:%s:%s", campaignID, hash)
-			if err := e.store.ZAdd(ctx, campFreqKey, nowMs, impressionID); err != nil {
+			if err := e.store.ZAdd(ctx, campFreqKey, nowMs, member); err != nil {
 				e.metrics.StoreError("zadd_campaign_freq", err)
 			} else {
 				if err := e.store.ZRemRangeByScore(ctx, campFreqKey, 0, pruneBeforeMs); err != nil {

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -800,5 +801,91 @@ func TestIdentityNonResolved_PackageCappedButCampaignNot(t *testing.T) {
 	}
 	if !byPkg["pkg-display-002"].Eligible {
 		t.Error("pkg-display-002 should still be eligible")
+	}
+}
+
+// --- Source Provenance Tests ---
+
+func TestIdentity_SourceIDFallsBackToProviderID(t *testing.T) {
+	engine, _, _ := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	// No source_id → engine uses providerID ("test-provider").
+	resp, err := engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		UserToken:    "user-src",
+		PackageID:    "pkg-display-001",
+		ImpressionID: "imp-src-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.PackageID != "pkg-display-001" {
+		t.Errorf("expected pkg-display-001, got %s", resp.PackageID)
+	}
+
+	// Read back the binary log and verify source hash = hash("test-provider").
+	hash := HashToken("user-src")
+	val, _, _ := engine.store.Get(ctx, "user:exposures:"+hash)
+	blog := BinaryExposureLog(val)
+	if blog.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", blog.Len())
+	}
+	if blog.SourceHash(0) != hashString("test-provider") {
+		t.Error("expected source hash of 'test-provider' when source_id not provided")
+	}
+}
+
+func TestIdentity_SourceIDStampedOnBinaryLog(t *testing.T) {
+	engine, _, _ := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	_, err := engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		SourceID:     "agent-cnn-v2",
+		UserToken:    "user-src2",
+		PackageID:    "pkg-display-001",
+		ImpressionID: "imp-src-2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hash := HashToken("user-src2")
+	val, _, _ := engine.store.Get(ctx, "user:exposures:"+hash)
+	blog := BinaryExposureLog(val)
+	if blog.Len() != 1 {
+		t.Fatalf("expected 1 entry, got %d", blog.Len())
+	}
+	if blog.SourceHash(0) != hashString("agent-cnn-v2") {
+		t.Error("expected source hash of 'agent-cnn-v2'")
+	}
+}
+
+func TestIdentity_SourceNamespacesSortedSetMembers(t *testing.T) {
+	engine, _, _ := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	// Two different sources submit the same impression_id.
+	_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		SourceID:     "agent-a",
+		UserToken:    "user-ns",
+		PackageID:    "pkg-display-001",
+		ImpressionID: "imp-dup",
+	})
+	_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		SourceID:     "agent-b",
+		UserToken:    "user-ns",
+		PackageID:    "pkg-display-001",
+		ImpressionID: "imp-dup",
+	})
+
+	// ZCount should show 2 distinct members (agent-a:imp-dup and agent-b:imp-dup).
+	hash := HashToken("user-ns")
+	key := "freq:pkg:pkg-display-001:" + hash
+	count, err := engine.store.ZCount(ctx, key, 0, math.MaxFloat64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 sorted set members (namespaced by source), got %d", count)
 	}
 }

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -841,7 +841,7 @@ func TestIdentity_SourceIDStampedOnBinaryLog(t *testing.T) {
 
 	_, err := engine.RecordExposure(ctx, &tmproto.ExposeRequest{
 		SourceID:     "agent-cnn-v2",
-		UserToken:    "user-src2",
+		UserToken:    "user-source-stamp",
 		PackageID:    "pkg-display-001",
 		ImpressionID: "imp-src-2",
 	})
@@ -849,7 +849,7 @@ func TestIdentity_SourceIDStampedOnBinaryLog(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hash := HashToken("user-src2")
+	hash := HashToken("user-source-stamp")
 	val, _, _ := engine.store.Get(ctx, "user:exposures:"+hash)
 	blog := BinaryExposureLog(val)
 	if blog.Len() != 1 {

--- a/targeting/exposure.go
+++ b/targeting/exposure.go
@@ -13,6 +13,7 @@ type ExposureEntry struct {
 	ImpressionID string `json:"id"`
 	PackageID    string `json:"pkg"`
 	CampaignID   string `json:"cmp,omitempty"`
+	SourceID     string `json:"src,omitempty"`
 	Timestamp    int64  `json:"ts"`
 }
 

--- a/targeting/exposure_binary.go
+++ b/targeting/exposure_binary.go
@@ -15,16 +15,22 @@ import (
 // Version 1 entry (32 bytes):
 //
 //	timestamp(8) + impressionHash(8) + packageHash(8) + campaignHash(8)
+//
+// Version 2 entry (40 bytes):
+//
+//	timestamp(8) + impressionHash(8) + packageHash(8) + campaignHash(8) + sourceHash(8)
 const (
 	binaryHeaderSize    = 4
 	binaryVersion1      = 1
-	binaryEntrySize     = 32
-	maxExposureEntries  = 10000 // cap per-user log to bound linear scan cost (~320 KB)
+	binaryVersion2      = 2
+	binaryEntrySize1    = 32
+	binaryEntrySize     = 40 // current write format (v2)
+	maxExposureEntries  = 10000 // cap per-user log to bound linear scan cost (~400 KB)
 )
 
 var (
 	ErrBinaryTooShort      = errors.New("binary log too short for header")
-	ErrBinaryUnknownVersion = fmt.Errorf("unknown binary log version (supported: %d)", binaryVersion1)
+	ErrBinaryUnknownVersion = fmt.Errorf("unknown binary log version (supported: %d, %d)", binaryVersion1, binaryVersion2)
 	ErrBinaryCorrupt       = errors.New("binary log size not aligned to entry size")
 )
 
@@ -32,15 +38,15 @@ var (
 // Format: 4-byte header + N fixed-size entries.
 type BinaryExposureLog []byte
 
-// newBinaryLog allocates a versioned binary log buffer with capacity for n entries.
+// newBinaryLog allocates a v2 binary log buffer with capacity for n entries.
 func newBinaryLog(n int) []byte {
 	buf := make([]byte, binaryHeaderSize, binaryHeaderSize+n*binaryEntrySize)
-	binary.LittleEndian.PutUint16(buf[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(buf[0:], binaryVersion2)
 	binary.LittleEndian.PutUint16(buf[2:], binaryEntrySize)
 	return buf
 }
 
-// EncodeBinaryExposureLog converts a JSON exposure log to binary format.
+// EncodeBinaryExposureLog converts a JSON exposure log to v2 binary format.
 func EncodeBinaryExposureLog(log ExposureLog) BinaryExposureLog {
 	buf := newBinaryLog(len(log))
 	buf = buf[:binaryHeaderSize+len(log)*binaryEntrySize]
@@ -50,6 +56,7 @@ func EncodeBinaryExposureLog(log ExposureLog) BinaryExposureLog {
 		binary.LittleEndian.PutUint64(buf[offset+8:], hashString(e.ImpressionID))
 		binary.LittleEndian.PutUint64(buf[offset+16:], hashString(e.PackageID))
 		binary.LittleEndian.PutUint64(buf[offset+24:], hashString(e.CampaignID))
+		binary.LittleEndian.PutUint64(buf[offset+32:], hashString(e.SourceID))
 	}
 	return buf
 }
@@ -60,12 +67,18 @@ func ValidateBinaryLog(b BinaryExposureLog) error {
 		return ErrBinaryTooShort
 	}
 	version := binary.LittleEndian.Uint16(b[0:])
-	if version != binaryVersion1 {
-		return ErrBinaryUnknownVersion
-	}
 	entrySize := int(binary.LittleEndian.Uint16(b[2:]))
-	if entrySize != binaryEntrySize {
-		return ErrBinaryCorrupt
+	switch version {
+	case binaryVersion1:
+		if entrySize != binaryEntrySize1 {
+			return ErrBinaryCorrupt
+		}
+	case binaryVersion2:
+		if entrySize != binaryEntrySize {
+			return ErrBinaryCorrupt
+		}
+	default:
+		return ErrBinaryUnknownVersion
 	}
 	payload := len(b) - binaryHeaderSize
 	if payload%entrySize != 0 {
@@ -95,13 +108,17 @@ func (b BinaryExposureLog) Len() int {
 	if len(b) < binaryHeaderSize {
 		return 0
 	}
-	return (len(b) - binaryHeaderSize) / binaryEntrySize
+	es := int(b.EntrySize())
+	if es == 0 {
+		return 0
+	}
+	return (len(b) - binaryHeaderSize) / es
 }
 
 // entryOffset returns the byte offset for entry i.
 // Caller must ensure 0 <= i < Len().
 func (b BinaryExposureLog) entryOffset(i int) int {
-	return binaryHeaderSize + i*binaryEntrySize
+	return binaryHeaderSize + i*int(b.EntrySize())
 }
 
 // Timestamp returns the timestamp of entry i. Panics if i >= Len().
@@ -124,8 +141,16 @@ func (b BinaryExposureLog) CampaignHash(i int) uint64 {
 	return binary.LittleEndian.Uint64(b[b.entryOffset(i)+24:])
 }
 
+// SourceHash returns the source ID hash of entry i. Returns 0 for v1 entries (no source). Panics if i >= Len().
+func (b BinaryExposureLog) SourceHash(i int) uint64 {
+	if b.Version() < binaryVersion2 {
+		return 0
+	}
+	return binary.LittleEndian.Uint64(b[b.entryOffset(i)+32:])
+}
+
 // MergeBinaryLogs merges multiple binary logs, deduplicating by impression hash.
-// Returns a new versioned binary log.
+// Returns a new v2 binary log. V1 entries are upgraded (source hash = 0).
 func MergeBinaryLogs(logs ...BinaryExposureLog) BinaryExposureLog {
 	total := 0
 	for _, log := range logs {
@@ -135,6 +160,7 @@ func MergeBinaryLogs(logs ...BinaryExposureLog) BinaryExposureLog {
 	result := newBinaryLog(total)
 
 	for _, log := range logs {
+		es := int(log.EntrySize())
 		for i := range log.Len() {
 			impHash := log.ImpressionHash(i)
 			if _, dup := seen[impHash]; dup {
@@ -142,7 +168,14 @@ func MergeBinaryLogs(logs ...BinaryExposureLog) BinaryExposureLog {
 			}
 			seen[impHash] = struct{}{}
 			offset := log.entryOffset(i)
-			result = append(result, log[offset:offset+binaryEntrySize]...)
+			if es == binaryEntrySize {
+				// V2: copy directly.
+				result = append(result, log[offset:offset+binaryEntrySize]...)
+			} else {
+				// V1: upgrade by copying 32 bytes + 8 zero bytes for source hash.
+				result = append(result, log[offset:offset+binaryEntrySize1]...)
+				result = append(result, 0, 0, 0, 0, 0, 0, 0, 0)
+			}
 		}
 	}
 	return result
@@ -238,15 +271,32 @@ func LatestExposureMultiLog(logs []BinaryExposureLog, pkgHash uint64) int64 {
 
 // TruncateBinaryLog keeps only the last maxEntries entries (appended most recently).
 // Returns the input unchanged if it is already within the limit.
+// V1 logs are upgraded to v2 during truncation.
 func TruncateBinaryLog(b BinaryExposureLog, maxEntries int) BinaryExposureLog {
 	n := b.Len()
-	if n <= maxEntries {
+	if n <= maxEntries && b.Version() == binaryVersion2 {
 		return b
 	}
+	if n <= maxEntries {
+		// V1 log under limit: upgrade to v2 via merge.
+		return MergeBinaryLogs(b)
+	}
 	keepFrom := n - maxEntries
+	es := int(b.EntrySize())
+	if es == binaryEntrySize {
+		// V2: direct copy.
+		result := newBinaryLog(maxEntries)
+		result = result[:binaryHeaderSize+maxEntries*binaryEntrySize]
+		copy(result[binaryHeaderSize:], b[b.entryOffset(keepFrom):])
+		return result
+	}
+	// V1: upgrade entries during truncation.
 	result := newBinaryLog(maxEntries)
-	result = result[:binaryHeaderSize+maxEntries*binaryEntrySize]
-	copy(result[binaryHeaderSize:], b[b.entryOffset(keepFrom):])
+	for i := keepFrom; i < n; i++ {
+		off := b.entryOffset(i)
+		result = append(result, b[off:off+binaryEntrySize1]...)
+		result = append(result, 0, 0, 0, 0, 0, 0, 0, 0)
+	}
 	return result
 }
 

--- a/targeting/exposure_binary_test.go
+++ b/targeting/exposure_binary_test.go
@@ -1,6 +1,7 @@
 package targeting
 
 import (
+	"encoding/binary"
 	"fmt"
 	"testing"
 	"time"
@@ -59,15 +60,15 @@ func TestBinary_VersionHeader(t *testing.T) {
 	}
 	bin := EncodeBinaryExposureLog(log)
 
-	if bin.Version() != 1 {
-		t.Errorf("expected version 1, got %d", bin.Version())
+	if bin.Version() != 2 {
+		t.Errorf("expected version 2, got %d", bin.Version())
 	}
-	if bin.EntrySize() != 32 {
-		t.Errorf("expected entry size 32, got %d", bin.EntrySize())
+	if bin.EntrySize() != 40 {
+		t.Errorf("expected entry size 40, got %d", bin.EntrySize())
 	}
-	// 4-byte header + 1*32 = 36 bytes total.
-	if len(bin) != 36 {
-		t.Errorf("expected 36 bytes, got %d", len(bin))
+	// 4-byte header + 1*40 = 44 bytes total.
+	if len(bin) != 44 {
+		t.Errorf("expected 44 bytes, got %d", len(bin))
 	}
 	if err := ValidateBinaryLog(bin); err != nil {
 		t.Errorf("valid log failed validation: %v", err)
@@ -81,11 +82,16 @@ func TestBinary_ValidateRejectsInvalid(t *testing.T) {
 		err  error
 	}{
 		{"too short", BinaryExposureLog{0x01}, ErrBinaryTooShort},
-		{"unknown version", BinaryExposureLog{0x02, 0x00, 0x20, 0x00}, ErrBinaryUnknownVersion},
-		{"zero entry size", BinaryExposureLog{0x01, 0x00, 0x00, 0x00}, ErrBinaryCorrupt},
-		{"wrong entry size", BinaryExposureLog{0x01, 0x00, 0x10, 0x00}, ErrBinaryCorrupt},
-		{"unaligned payload", append(
-			BinaryExposureLog{0x01, 0x00, 0x20, 0x00}, // valid header
+		{"unknown version", BinaryExposureLog{0x03, 0x00, 0x28, 0x00}, ErrBinaryUnknownVersion},
+		{"zero entry size", BinaryExposureLog{0x02, 0x00, 0x00, 0x00}, ErrBinaryCorrupt},
+		{"wrong entry size v2", BinaryExposureLog{0x02, 0x00, 0x10, 0x00}, ErrBinaryCorrupt},
+		{"wrong entry size v1", BinaryExposureLog{0x01, 0x00, 0x10, 0x00}, ErrBinaryCorrupt},
+		{"unaligned payload v2", append(
+			BinaryExposureLog{0x02, 0x00, 0x28, 0x00}, // valid v2 header
+			make([]byte, 15)...,                         // 15 bytes, not multiple of 40
+		), ErrBinaryCorrupt},
+		{"unaligned payload v1", append(
+			BinaryExposureLog{0x01, 0x00, 0x20, 0x00}, // valid v1 header
 			make([]byte, 15)...,                         // 15 bytes, not multiple of 32
 		), ErrBinaryCorrupt},
 	}
@@ -120,8 +126,8 @@ func TestBinary_MergedLogIsVersioned(t *testing.T) {
 	if err := ValidateBinaryLog(merged); err != nil {
 		t.Errorf("merged log failed validation: %v", err)
 	}
-	if merged.Version() != 1 {
-		t.Errorf("expected version 1 on merged log, got %d", merged.Version())
+	if merged.Version() != 2 {
+		t.Errorf("expected version 2 on merged log, got %d", merged.Version())
 	}
 	if merged.Len() != 2 {
 		t.Errorf("expected 2 entries, got %d", merged.Len())
@@ -168,6 +174,204 @@ func TestBinary_MergeEmptyReturnsValidLog(t *testing.T) {
 	}
 	if merged.Len() != 0 {
 		t.Errorf("expected 0 entries, got %d", merged.Len())
+	}
+}
+
+func TestBinary_SourceHash(t *testing.T) {
+	log := ExposureLog{
+		{ImpressionID: "imp-1", PackageID: "pkg-food", CampaignID: "acme", SourceID: "agent-cnn", Timestamp: 1000},
+		{ImpressionID: "imp-2", PackageID: "pkg-tech", CampaignID: "acme", SourceID: "agent-nyt", Timestamp: 2000},
+	}
+	bin := EncodeBinaryExposureLog(log)
+
+	cnnHash := hashString("agent-cnn")
+	nytHash := hashString("agent-nyt")
+
+	if bin.SourceHash(0) != cnnHash {
+		t.Errorf("entry 0: expected source hash %d, got %d", cnnHash, bin.SourceHash(0))
+	}
+	if bin.SourceHash(1) != nytHash {
+		t.Errorf("entry 1: expected source hash %d, got %d", nytHash, bin.SourceHash(1))
+	}
+}
+
+func TestBinary_SourceHashOfEmptyString(t *testing.T) {
+	log := ExposureLog{
+		{ImpressionID: "imp-1", PackageID: "pkg-food", Timestamp: 1000},
+	}
+	bin := EncodeBinaryExposureLog(log)
+	emptyHash := hashString("")
+	if bin.SourceHash(0) != emptyHash {
+		t.Errorf("expected hash of empty string, got %d", bin.SourceHash(0))
+	}
+}
+
+func TestBinary_V1ReadCompatibility(t *testing.T) {
+	// Construct a v1 binary log manually (32-byte entries).
+	v1 := make([]byte, binaryHeaderSize+2*binaryEntrySize1)
+	binary.LittleEndian.PutUint16(v1[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
+
+	// Entry 0: ts=1000, imp=hash("imp-1"), pkg=hash("pkg-a"), camp=hash("c1")
+	off := binaryHeaderSize
+	binary.LittleEndian.PutUint64(v1[off:], 1000)
+	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+
+	// Entry 1: ts=2000
+	off = binaryHeaderSize + binaryEntrySize1
+	binary.LittleEndian.PutUint64(v1[off:], 2000)
+	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-2"))
+	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-b"))
+	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+
+	blog := BinaryExposureLog(v1)
+
+	// Validation passes.
+	if err := ValidateBinaryLog(blog); err != nil {
+		t.Fatalf("v1 log should validate: %v", err)
+	}
+	if blog.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", blog.Len())
+	}
+	if blog.Timestamp(0) != 1000 {
+		t.Errorf("expected ts 1000, got %d", blog.Timestamp(0))
+	}
+	// V1 source hash returns 0.
+	if blog.SourceHash(0) != 0 {
+		t.Errorf("v1 source hash should be 0, got %d", blog.SourceHash(0))
+	}
+
+	// Frequency check works on v1 logs.
+	rules := []FrequencyRule{{MaxCount: 1, Window: 24 * time.Hour}}
+	capped := CheckFrequencyRulesBinary(blog, hashString("pkg-a"), false, rules, 3000)
+	if !capped {
+		t.Error("expected capped for pkg-a (1 exposure, cap 1)")
+	}
+}
+
+func TestBinary_V1UpgradeOnMerge(t *testing.T) {
+	// Build a v1 log.
+	v1 := make([]byte, binaryHeaderSize+1*binaryEntrySize1)
+	binary.LittleEndian.PutUint16(v1[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
+	off := binaryHeaderSize
+	binary.LittleEndian.PutUint64(v1[off:], 1000)
+	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-v1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+
+	// Build a v2 log.
+	v2 := EncodeBinaryExposureLog(ExposureLog{
+		{ImpressionID: "imp-v2", PackageID: "pkg-a", CampaignID: "c1", SourceID: "agent-x", Timestamp: 2000},
+	})
+
+	// Merge upgrades v1 entries to v2 format.
+	merged := MergeBinaryLogs(BinaryExposureLog(v1), v2)
+	if merged.Version() != 2 {
+		t.Errorf("expected v2 after merge, got %d", merged.Version())
+	}
+	if merged.Len() != 2 {
+		t.Fatalf("expected 2 entries, got %d", merged.Len())
+	}
+	if err := ValidateBinaryLog(merged); err != nil {
+		t.Fatalf("merged log should validate: %v", err)
+	}
+
+	// V1 entry gets source hash 0, v2 entry keeps its source hash.
+	if merged.SourceHash(0) != 0 {
+		t.Errorf("upgraded v1 entry should have source hash 0, got %d", merged.SourceHash(0))
+	}
+	if merged.SourceHash(1) != hashString("agent-x") {
+		t.Errorf("v2 entry should keep source hash")
+	}
+}
+
+func TestBinary_V1TruncateUpgrades(t *testing.T) {
+	// Build a v1 log with 20 entries, truncate to 5 — should upgrade to v2.
+	v1 := make([]byte, binaryHeaderSize+20*binaryEntrySize1)
+	binary.LittleEndian.PutUint16(v1[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
+	for i := range 20 {
+		off := binaryHeaderSize + i*binaryEntrySize1
+		binary.LittleEndian.PutUint64(v1[off:], uint64(1000+i))
+		binary.LittleEndian.PutUint64(v1[off+8:], hashString(fmt.Sprintf("imp-%d", i)))
+		binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
+		binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	}
+
+	truncated := TruncateBinaryLog(BinaryExposureLog(v1), 5)
+	if err := ValidateBinaryLog(truncated); err != nil {
+		t.Fatalf("truncated log failed validation: %v", err)
+	}
+	if truncated.Version() != 2 {
+		t.Errorf("expected v2 after truncation, got %d", truncated.Version())
+	}
+	if truncated.Len() != 5 {
+		t.Fatalf("expected 5 entries, got %d", truncated.Len())
+	}
+	// Should keep last 5 entries (timestamps 1015-1019).
+	if truncated.Timestamp(0) != 1015 {
+		t.Errorf("expected first kept timestamp 1015, got %d", truncated.Timestamp(0))
+	}
+	// Upgraded entries should have source hash 0.
+	if truncated.SourceHash(0) != 0 {
+		t.Errorf("upgraded v1 entry should have source hash 0, got %d", truncated.SourceHash(0))
+	}
+}
+
+func TestBinary_V1UnderLimitUpgrades(t *testing.T) {
+	// Build a v1 log with 2 entries, under limit — should upgrade to v2 without truncation.
+	v1 := make([]byte, binaryHeaderSize+2*binaryEntrySize1)
+	binary.LittleEndian.PutUint16(v1[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
+	for i := range 2 {
+		off := binaryHeaderSize + i*binaryEntrySize1
+		binary.LittleEndian.PutUint64(v1[off:], uint64(1000+i))
+		binary.LittleEndian.PutUint64(v1[off+8:], hashString(fmt.Sprintf("imp-%d", i)))
+		binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
+		binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	}
+
+	upgraded := TruncateBinaryLog(BinaryExposureLog(v1), 100)
+	if upgraded.Version() != 2 {
+		t.Errorf("expected v2 after upgrade, got %d", upgraded.Version())
+	}
+	if upgraded.Len() != 2 {
+		t.Errorf("expected 2 entries preserved, got %d", upgraded.Len())
+	}
+}
+
+func TestBinary_MultiLogWorksWithMixedVersions(t *testing.T) {
+	// V1 log with 1 entry for pkg-a.
+	v1 := make([]byte, binaryHeaderSize+1*binaryEntrySize1)
+	binary.LittleEndian.PutUint16(v1[0:], binaryVersion1)
+	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
+	off := binaryHeaderSize
+	binary.LittleEndian.PutUint64(v1[off:], 1000)
+	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-v1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+
+	// V2 log with 1 entry for pkg-a (different impression).
+	v2 := EncodeBinaryExposureLog(ExposureLog{
+		{ImpressionID: "imp-v2", PackageID: "pkg-a", CampaignID: "c1", SourceID: "agent-x", Timestamp: 2000},
+	})
+
+	logs := []BinaryExposureLog{BinaryExposureLog(v1), v2}
+	rules := []FrequencyRule{{MaxCount: 2, Window: 24 * time.Hour}}
+
+	// 2 entries for pkg-a, cap=2 → capped.
+	capped := CheckFrequencyRulesMultiLog(logs, hashString("pkg-a"), false, rules, 3000)
+	if !capped {
+		t.Error("expected capped with mixed v1+v2 logs")
+	}
+
+	// latest across mixed versions.
+	latest := LatestExposureMultiLog(logs, hashString("pkg-a"))
+	if latest != 2000 {
+		t.Errorf("expected latest 2000, got %d", latest)
 	}
 }
 

--- a/tmproto/types_gen.go
+++ b/tmproto/types_gen.go
@@ -174,6 +174,7 @@ type ErrorResponse struct {
 
 // ExposeRequest notifies the identity provider that a user was exposed to a package. Sent by the publisher AFTER rendering the ad. This closes the frequency cap loop. campaign_id enables cross-publisher, cross-media-buy frequency management.
 type ExposeRequest struct {
+	SourceID     string         `json:"source_id,omitempty"` // Identifies the agent or system that recorded this exposure. Used for dedup namespacing, rollback, and audit.
 	UserToken    string         `json:"user_token"`
 	UIDType      UIDType        `json:"uid_type,omitempty"`
 	Identities   []UserIdentity `json:"identities,omitempty"`

--- a/tmproto/types_test.go
+++ b/tmproto/types_test.go
@@ -239,3 +239,113 @@ func TestMarshalJSON_RoundTrip(t *testing.T) {
 		t.Errorf("property_type: got %q, want ai_assistant", got.PropertyType)
 	}
 }
+
+func TestValidateExposeRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     ExposeRequest
+		wantErr bool
+	}{
+		{
+			name:    "valid with source_id",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", SourceID: "agent-cnn"},
+			wantErr: false,
+		},
+		{
+			name:    "valid without source_id",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1"},
+			wantErr: false,
+		},
+		{
+			name:    "missing user_token and identities",
+			req:     ExposeRequest{PackageID: "pkg-1"},
+			wantErr: true,
+		},
+		{
+			name:    "missing package_id",
+			req:     ExposeRequest{UserToken: "u1"},
+			wantErr: true,
+		},
+		{
+			name:    "source_id with colon",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", SourceID: "bad:id"},
+			wantErr: true,
+		},
+		{
+			name:    "source_id with slash",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", SourceID: "bad/id"},
+			wantErr: true,
+		},
+		{
+			name:    "campaign_id with colon",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", CampaignID: "bad:camp"},
+			wantErr: true,
+		},
+		{
+			name:    "package_id with newline",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg\n1"},
+			wantErr: true,
+		},
+		{
+			name: "valid with identities instead of user_token",
+			req: ExposeRequest{
+				PackageID:  "pkg-1",
+				Identities: []UserIdentity{{UserToken: "u1", UIDType: UIDTypeUID2}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "impression_id with colon",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", ImpressionID: "bad:imp"},
+			wantErr: true,
+		},
+		{
+			name:    "impression_id with newline",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", ImpressionID: "bad\nimp"},
+			wantErr: true,
+		},
+		{
+			name:    "source_id exceeds max length",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", SourceID: strings.Repeat("a", MaxIDLength+1)},
+			wantErr: true,
+		},
+		{
+			name:    "source_id at max length is ok",
+			req:     ExposeRequest{UserToken: "u1", PackageID: "pkg-1", SourceID: strings.Repeat("a", MaxIDLength)},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExposeRequest(&tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateExposeRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestExposeRequest_SourceID_RoundTrip(t *testing.T) {
+	req := ExposeRequest{
+		SourceID:     "aao-agent-cnn-identity-v2",
+		UserToken:    "uid2-abc123",
+		PackageID:    "pkg-display-001",
+		ImpressionID: "imp-12345",
+		CampaignID:   "campaign-acme",
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"source_id":"aao-agent-cnn-identity-v2"`) {
+		t.Error("source_id missing from JSON output")
+	}
+
+	var got ExposeRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.SourceID != "aao-agent-cnn-identity-v2" {
+		t.Errorf("source_id: got %q, want aao-agent-cnn-identity-v2", got.SourceID)
+	}
+}

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -13,9 +13,15 @@ const (
 	MaxIdentitiesPerRequest = 10
 )
 
+// MaxIDLength caps identifier fields to prevent oversized store keys.
+const MaxIDLength = 256
+
 // validateSafeID checks that an ID does not contain characters that could
-// cause Store key injection (colons, slashes, newlines).
+// cause Store key injection (colons, slashes, newlines) and is within length limits.
 func validateSafeID(field, value string) error {
+	if len(value) > MaxIDLength {
+		return fmt.Errorf("%s exceeds maximum length of %d", field, MaxIDLength)
+	}
 	if strings.ContainsAny(value, ":\n\r\t/\\") {
 		return fmt.Errorf("%s contains invalid characters", field)
 	}
@@ -85,6 +91,35 @@ func ValidateIdentityRequest(req *IdentityMatchRequest) error {
 	}
 	for _, id := range req.PackageIDs {
 		if err := validateSafeID("package_id", id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateExposeRequest checks that required fields are present on an expose request.
+func ValidateExposeRequest(req *ExposeRequest) error {
+	if req.UserToken == "" && len(req.Identities) == 0 {
+		return errors.New("user_token or identities is required")
+	}
+	if req.PackageID == "" {
+		return errors.New("package_id is required")
+	}
+	if err := validateSafeID("package_id", req.PackageID); err != nil {
+		return err
+	}
+	if req.SourceID != "" {
+		if err := validateSafeID("source_id", req.SourceID); err != nil {
+			return err
+		}
+	}
+	if req.ImpressionID != "" {
+		if err := validateSafeID("impression_id", req.ImpressionID); err != nil {
+			return err
+		}
+	}
+	if req.CampaignID != "" {
+		if err := validateSafeID("campaign_id", req.CampaignID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `source_id` field to `ExposeRequest` for tracking which agent/system recorded each exposure
- Namespaces sorted set members as `{sourceID}:{impressionID}` to guarantee global uniqueness across sources
- Bumps binary exposure log from v1 (32-byte entries) to v2 (40-byte entries) with FNV-1a source hash
- Transparent v1→v2 migration during read, merge, and truncate — no manual migration needed
- Validates all ID fields (`source_id`, `impression_id`, `campaign_id`, `package_id`) with safe-ID rules and 256-char length limit
- Defense-in-depth: validation at both HTTP handler and engine library layer

Closes #20

## Test plan

- [x] `TestBinary_SourceHash` — v2 entries store correct source hashes
- [x] `TestBinary_V1ReadCompatibility` — v1 logs validate, read, and frequency-check correctly
- [x] `TestBinary_V1UpgradeOnMerge` — merging v1+v2 produces valid v2 with source hash 0 for upgraded entries
- [x] `TestBinary_V1TruncateUpgrades` — v1 truncation upgrades to v2
- [x] `TestBinary_MultiLogWorksWithMixedVersions` — CheckFrequencyRulesMultiLog works across v1/v2
- [x] `TestIdentity_SourceIDFallsBackToProviderID` — engine providerID used when source_id omitted
- [x] `TestIdentity_SourceIDStampedOnBinaryLog` — explicit source_id stamped on binary entries
- [x] `TestIdentity_SourceNamespacesSortedSetMembers` — same impression_id from two sources creates distinct members
- [x] `TestValidateExposeRequest` — rejects colons/slashes/newlines in all IDs, enforces length limit
- [x] `TestExposeRequest_SourceID_RoundTrip` — JSON serialization round-trip
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)