### PR TITLE
feat: gate PRs on benchmark regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,9 @@ jobs:
         with:
           go-version: "1.26"
 
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260312031701-16a31bc5fbd0
+
       - name: Benchmark PR
         working-directory: bench
         run: go test -bench=. -benchmem -count=5 ./... | tee /tmp/bench-pr.txt
@@ -108,32 +111,95 @@ jobs:
         working-directory: _base/bench
         run: go test -bench=. -benchmem -count=5 ./... | tee /tmp/bench-main.txt
 
-      - name: Install benchstat
-        run: go install golang.org/x/perf/cmd/benchstat@latest
-
       - name: Compare benchmarks
         run: |
           benchstat /tmp/bench-main.txt /tmp/bench-pr.txt | tee /tmp/benchstat.txt
 
-      - name: Post benchmark comparison
+      - name: Check for regressions
+        id: check_regressions
+        run: |
+          # Parse benchstat output for statistically significant regressions > 5%.
+          # benchstat lines look like:  BenchmarkName  1.234µ ± ∞ ¹   1.345µ ± ∞ ¹  +9.00% (p=0.008 n=5)
+          # We match lines with a positive % change and p < 0.05.
+          regressions=""
+          while IFS= read -r line; do
+            # Extract percentage and p-value from lines showing a change
+            if echo "$line" | grep -qE '\+[0-9]+\.[0-9]+% \(p='; then
+              pct=$(echo "$line" | sed -n 's/.*+\([0-9]*\.[0-9]*\)%.*/\1/p')
+              pval=$(echo "$line" | sed -n 's/.*p=\([0-9]*\.[0-9]*\).*/\1/p')
+              name=$(echo "$line" | awk '{print $1}')
+              # Validate extracted values are numeric before using in awk
+              if ! [[ "$pct" =~ ^[0-9]+\.[0-9]+$ ]] || ! [[ "$pval" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                continue
+              fi
+              # Check: regression > 5% AND statistically significant (p < 0.05)
+              if awk "BEGIN{exit !($pct > 5.0 && $pval < 0.05)}"; then
+                regressions="${regressions}${name}: +${pct}% (p=${pval})\n"
+              fi
+            fi
+          done < /tmp/benchstat.txt
+
+          if [ -n "$regressions" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            printf '%b' "$regressions" | tee /tmp/regressions.txt
+            echo ""
+            echo "::error::Benchmark regressions detected (>5%, p<0.05):"
+            printf '%b' "$regressions"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No significant regressions found."
+          fi
+
+      - name: Remove stale regression comment
+        if: steps.check_regressions.outputs.found == 'false'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const fs = require('fs');
-            const path = '/tmp/benchstat.txt';
-            if (!fs.existsSync(path)) {
-              core.warning('benchstat.txt not found, skipping comment');
-              return;
-            }
-            const raw = fs.readFileSync(path, 'utf8');
-            const result = raw.replace(/`/g, '\\`');
-            const body = `## Benchmark Comparison (vs main)\n\n\`\`\`\n${result}\n\`\`\``;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
+              per_page: 100,
             });
-            const existing = comments.find(c => c.body.startsWith('## Benchmark Comparison'));
+            const existing = comments.find(c => c.body.startsWith('## Benchmark Regression'));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }
+
+      - name: Comment on regression
+        if: steps.check_regressions.outputs.found == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const regressions = fs.readFileSync('/tmp/regressions.txt', 'utf8').trim();
+            const full = fs.readFileSync('/tmp/benchstat.txt', 'utf8').replace(/`/g, '\\`');
+            const body = [
+              '## Benchmark Regression Detected',
+              '',
+              '```',
+              regressions,
+              '```',
+              '',
+              '<details><summary>Full benchstat output</summary>',
+              '',
+              '```',
+              full,
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existing = comments.find(c => c.body.startsWith('## Benchmark Regression'));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -149,3 +215,9 @@ jobs:
                 body,
               });
             }
+
+      - name: Fail on regression
+        if: steps.check_regressions.outputs.found == 'true'
+        run: |
+          echo "Benchmark regressions exceed 5% threshold. See PR comment for details."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,26 +125,26 @@ jobs:
           while IFS= read -r line; do
             # Extract percentage and p-value from lines showing a change
             if echo "$line" | grep -qE '\+[0-9]+\.[0-9]+% \(p='; then
-              pct=$(echo "$line" | sed -n 's/.*+\([0-9]*\.[0-9]*\)%.*/\1/p')
-              pval=$(echo "$line" | sed -n 's/.*p=\([0-9]*\.[0-9]*\).*/\1/p')
+              pct=$(echo "$line" | sed -n 's/.*+\([0-9][0-9]*\.[0-9][0-9]*\)%.*/\1/p')
+              pval=$(echo "$line" | sed -n 's/.*p=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p')
               name=$(echo "$line" | awk '{print $1}')
               # Validate extracted values are numeric before using in awk
               if ! [[ "$pct" =~ ^[0-9]+\.[0-9]+$ ]] || ! [[ "$pval" =~ ^[0-9]+\.[0-9]+$ ]]; then
                 continue
               fi
               # Check: regression > 5% AND statistically significant (p < 0.05)
-              if awk "BEGIN{exit !($pct > 5.0 && $pval < 0.05)}"; then
-                regressions="${regressions}${name}: +${pct}% (p=${pval})\n"
+              if awk -v p="$pct" -v pv="$pval" 'BEGIN{exit !(p > 5.0 && pv < 0.05)}'; then
+                regressions="${regressions}${name}: +${pct}% (p=${pval})"$'\n'
               fi
             fi
           done < /tmp/benchstat.txt
 
           if [ -n "$regressions" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
-            printf '%b' "$regressions" | tee /tmp/regressions.txt
+            printf '%s' "$regressions" | tee /tmp/regressions.txt
             echo ""
             echo "::error::Benchmark regressions detected (>5%, p<0.05):"
-            printf '%b' "$regressions"
+            printf '%s' "$regressions"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "No significant regressions found."
@@ -161,7 +161,8 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find(c => c.body.startsWith('## Benchmark Regression'));
+            const isBotComment = c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Benchmark Regression');
+            const existing = comments.find(isBotComment);
             if (existing) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
@@ -176,7 +177,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const regressions = fs.readFileSync('/tmp/regressions.txt', 'utf8').trim();
+            const regressions = fs.readFileSync('/tmp/regressions.txt', 'utf8').trim().replace(/`/g, '\\`');
             const full = fs.readFileSync('/tmp/benchstat.txt', 'utf8').replace(/`/g, '\\`');
             const body = [
               '## Benchmark Regression Detected',
@@ -199,7 +200,8 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            const existing = comments.find(c => c.body.startsWith('## Benchmark Regression'));
+            const isBotComment = c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Benchmark Regression');
+            const existing = comments.find(isBotComment);
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
## Summary
- Replace always-post benchmark comment with a regression gate that fails CI on >5% regressions (p<0.05)
- Only post a PR comment when regressions are found; clean up stale comments when fixed
- Pin benchstat to a specific version (supply chain hardening)
- Move benchstat install before benchmark runs (fail fast)
- Add numeric validation on parsed values before shell interpolation

## Test plan
- [ ] Open a PR with no benchmark regressions — verify job passes with no comment posted
- [ ] Introduce a deliberate regression (e.g., add `time.Sleep` in a benchmark) — verify job fails and posts a comment listing the regression
- [ ] Fix the regression and push again — verify stale comment is deleted and job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)