### PR TITLE
feat: provider discovery, health tracking, lifecycle states

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -32,7 +32,10 @@ func main() {
 	// Initialize components
 	registry := router.NewRegistry("", "")
 	health := router.NewProviderHealth(cfg.Health.FailureThreshold, time.Duration(cfg.Health.CooldownSeconds)*time.Second)
-	r, err := router.NewRouter(cfg.Providers, registry, nil, health)
+	fanOutMetrics := &fanOutMetricsAdapter{} // set after metrics registry is created
+	r, err := router.NewRouter(cfg.Providers, registry, nil, health,
+		router.WithLatencyBudget(cfg.LatencyBudget()),
+		router.WithFanOutMetrics(fanOutMetrics))
 	if err != nil {
 		slog.Error("invalid router configuration", "error", err)
 		os.Exit(1)
@@ -43,6 +46,28 @@ func main() {
 	reg.DefineCounter("router_requests_total", "Total requests by type.", []string{"type"})
 	reg.DefineHistogram("router_request_duration_seconds", "Request latency by type.", []string{"type"},
 		[]float64{.001, .005, .01, .025, .05, .1, .25, .5, 1})
+	reg.DefineGauge("tmp_provider_health_status", "Provider health status (1=healthy, 0=unhealthy).", []string{"provider"})
+	reg.DefineHistogram("tmp_provider_health_check_duration_ms", "Health check latency.", []string{"provider"},
+		[]float64{1, 5, 10, 25, 50, 100, 500})
+	reg.DefineCounter("tmp_provider_excluded_total", "Times a provider was excluded from fan-out.", []string{"provider"})
+	reg.DefineCounter("tmp_provider_recovered_total", "Times a provider recovered from exclusion.", []string{"provider"})
+
+	// Wire fan-out metrics now that registry exists.
+	fanOutMetrics.reg = reg
+
+	// Health checker
+	hcMetrics := &healthCheckMetricsAdapter{reg: reg}
+	hc := router.NewHealthChecker(r.Providers(), health, cfg.HealthCheck,
+		router.WithHealthCheckMetrics(hcMetrics))
+	hc.Preflight(context.Background())
+	hc.Start()
+
+	// Optional dynamic discovery
+	var disc *router.Discovery
+	if cfg.Discovery.Endpoint != "" {
+		disc = router.NewDiscovery(r.Providers(), health, cfg.Discovery, cfg.LatencyBudget())
+		disc.Start()
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /tmp/context", func(w http.ResponseWriter, req *http.Request) {
@@ -68,6 +93,20 @@ func main() {
 			"version": version,
 		})
 	})
+	mux.HandleFunc("GET /providers", func(w http.ResponseWriter, _ *http.Request) {
+		type providerInfo struct {
+			router.ProviderConfig
+			Health router.ProviderStatsSnapshot `json:"health"`
+		}
+		snap := health.Snapshot()
+		providers := r.Providers().All()
+		out := make([]providerInfo, len(providers))
+		for i, p := range providers {
+			out[i] = providerInfo{ProviderConfig: p, Health: snap[p.ID]}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	})
 
 	srv := &http.Server{
 		Addr:         cfg.Addr,
@@ -89,6 +128,10 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), drainTimeout)
 		defer cancel()
 
+		if disc != nil {
+			disc.Stop()
+		}
+		hc.Stop()
 		if err := srv.Shutdown(ctx); err != nil {
 			slog.Error("shutdown error", "error", err)
 		}
@@ -135,4 +178,40 @@ func loadConfig(configFile, addr string) *router.ServerConfig {
 	}
 
 	return cfg
+}
+
+// healthCheckMetricsAdapter bridges router.HealthCheckMetrics to prommetrics.
+type healthCheckMetricsAdapter struct {
+	reg *prommetrics.Registry
+}
+
+func (a *healthCheckMetricsAdapter) SetHealthStatus(providerID string, healthy bool) {
+	v := float64(0)
+	if healthy {
+		v = 1
+	}
+	a.reg.GaugeSet("tmp_provider_health_status", v, providerID)
+}
+
+func (a *healthCheckMetricsAdapter) ObserveCheckDuration(providerID string, ms float64) {
+	a.reg.HistogramObserve("tmp_provider_health_check_duration_ms", ms, providerID)
+}
+
+func (a *healthCheckMetricsAdapter) IncExcluded(providerID string) {
+	a.reg.CounterInc("tmp_provider_excluded_total", providerID)
+}
+
+func (a *healthCheckMetricsAdapter) IncRecovered(providerID string) {
+	a.reg.CounterInc("tmp_provider_recovered_total", providerID)
+}
+
+// fanOutMetricsAdapter bridges router.FanOutMetrics to prommetrics.
+type fanOutMetricsAdapter struct {
+	reg *prommetrics.Registry
+}
+
+func (a *fanOutMetricsAdapter) IncExcluded(providerID string) {
+	if a.reg != nil {
+		a.reg.CounterInc("tmp_provider_excluded_total", providerID)
+	}
 }

--- a/router/config.go
+++ b/router/config.go
@@ -8,13 +8,23 @@ import (
 	"time"
 )
 
+// ProviderStatus represents the lifecycle state of a provider.
+type ProviderStatus string
+
+const (
+	ProviderStatusActive   ProviderStatus = "active"
+	ProviderStatusInactive ProviderStatus = "inactive"
+	ProviderStatusDraining ProviderStatus = "draining"
+)
+
 // ProviderConfig defines a registered TMP provider.
 type ProviderConfig struct {
-	ID            string   `json:"id"`
-	Endpoint      string   `json:"endpoint"`
-	ContextMatch  bool     `json:"context_match"`
-	IdentityMatch bool     `json:"identity_match"`
-	WireFormats   []string `json:"wire_formats"`
+	ID            string         `json:"id"`
+	Endpoint      string         `json:"endpoint"`
+	Status        ProviderStatus `json:"status,omitempty"` // default: active
+	ContextMatch  bool           `json:"context_match"`
+	IdentityMatch bool           `json:"identity_match"`
+	WireFormats   []string       `json:"wire_formats"`
 
 	// Provider-side filters — router skips this provider for non-matching requests.
 	PropertyIDs        []string `json:"property_ids,omitempty"`         // Only send these (empty = all)
@@ -27,6 +37,45 @@ type ProviderConfig struct {
 	UIDTypes  []string `json:"uid_types,omitempty"` // Identity types this provider can resolve
 
 	Timeout time.Duration `json:"timeout"`
+}
+
+// EffectiveStatus returns the provider's status, defaulting to active when empty.
+func (p *ProviderConfig) EffectiveStatus() ProviderStatus {
+	if p.Status == "" {
+		return ProviderStatusActive
+	}
+	return p.Status
+}
+
+// ValidateProviderConfig checks that a provider registration is valid.
+// latencyBudget of 0 disables the timeout check.
+func ValidateProviderConfig(p *ProviderConfig, latencyBudget time.Duration) error {
+	if p.ID == "" {
+		return fmt.Errorf("provider ID must not be empty")
+	}
+	if len(p.ID) > 128 {
+		return fmt.Errorf("provider %q: ID exceeds maximum length of 128", p.ID[:64]+"...")
+	}
+	for _, c := range p.ID {
+		if c < 0x20 || c == 0x7f || c == 0x00 {
+			return fmt.Errorf("provider ID contains invalid characters")
+		}
+	}
+	if !p.ContextMatch && !p.IdentityMatch {
+		return fmt.Errorf("provider %q: at least one of context_match or identity_match must be true", p.ID)
+	}
+	if p.IdentityMatch {
+		if len(p.Countries) == 0 {
+			return fmt.Errorf("provider %q: countries must be non-empty when identity_match is true", p.ID)
+		}
+		if len(p.UIDTypes) == 0 {
+			return fmt.Errorf("provider %q: uid_types must be non-empty when identity_match is true", p.ID)
+		}
+	}
+	if latencyBudget > 0 && p.Timeout > 0 && p.Timeout > latencyBudget {
+		return fmt.Errorf("provider %q: timeout %v exceeds latency budget %v", p.ID, p.Timeout, latencyBudget)
+	}
+	return nil
 }
 
 // RouterConfig defines the router's runtime configuration.

--- a/router/config_test.go
+++ b/router/config_test.go
@@ -1,6 +1,9 @@
 package router
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestValidateProviderEndpoint(t *testing.T) {
 	valid := []struct {
@@ -45,5 +48,164 @@ func TestValidateProviderEndpoint(t *testing.T) {
 				t.Errorf("expected error for %q, got nil", tt.endpoint)
 			}
 		})
+	}
+}
+
+func TestValidateProviderConfig(t *testing.T) {
+	budget := 50 * time.Millisecond
+
+	t.Run("valid context-only provider", func(t *testing.T) {
+		p := &ProviderConfig{ID: "p1", ContextMatch: true}
+		if err := ValidateProviderConfig(p, budget); err != nil {
+			t.Errorf("expected valid, got: %v", err)
+		}
+	})
+
+	t.Run("valid identity provider", func(t *testing.T) {
+		p := &ProviderConfig{ID: "p2", IdentityMatch: true, Countries: []string{"US"}, UIDTypes: []string{"uid2"}}
+		if err := ValidateProviderConfig(p, budget); err != nil {
+			t.Errorf("expected valid, got: %v", err)
+		}
+	})
+
+	t.Run("valid both match types", func(t *testing.T) {
+		p := &ProviderConfig{ID: "p3", ContextMatch: true, IdentityMatch: true, Countries: []string{"US"}, UIDTypes: []string{"uid2"}}
+		if err := ValidateProviderConfig(p, budget); err != nil {
+			t.Errorf("expected valid, got: %v", err)
+		}
+	})
+
+	t.Run("neither context nor identity", func(t *testing.T) {
+		p := &ProviderConfig{ID: "bad"}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error when neither match type is set")
+		}
+	})
+
+	t.Run("identity without countries", func(t *testing.T) {
+		p := &ProviderConfig{ID: "bad", IdentityMatch: true, UIDTypes: []string{"uid2"}}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error when identity_match without countries")
+		}
+	})
+
+	t.Run("identity without uid_types", func(t *testing.T) {
+		p := &ProviderConfig{ID: "bad", IdentityMatch: true, Countries: []string{"US"}}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error when identity_match without uid_types")
+		}
+	})
+
+	t.Run("timeout exceeds budget", func(t *testing.T) {
+		p := &ProviderConfig{ID: "slow", ContextMatch: true, Timeout: 100 * time.Millisecond}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error when timeout exceeds latency budget")
+		}
+	})
+
+	t.Run("timeout within budget", func(t *testing.T) {
+		p := &ProviderConfig{ID: "fast", ContextMatch: true, Timeout: 30 * time.Millisecond}
+		if err := ValidateProviderConfig(p, budget); err != nil {
+			t.Errorf("expected valid, got: %v", err)
+		}
+	})
+
+	t.Run("zero budget disables check", func(t *testing.T) {
+		p := &ProviderConfig{ID: "any", ContextMatch: true, Timeout: 500 * time.Millisecond}
+		if err := ValidateProviderConfig(p, 0); err != nil {
+			t.Errorf("expected valid with zero budget, got: %v", err)
+		}
+	})
+
+	t.Run("empty ID", func(t *testing.T) {
+		p := &ProviderConfig{ID: "", ContextMatch: true}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error for empty ID")
+		}
+	})
+
+	t.Run("ID too long", func(t *testing.T) {
+		long := string(make([]byte, 200))
+		p := &ProviderConfig{ID: long, ContextMatch: true}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error for overly long ID")
+		}
+	})
+
+	t.Run("ID with control characters", func(t *testing.T) {
+		p := &ProviderConfig{ID: "bad\x00id", ContextMatch: true}
+		if err := ValidateProviderConfig(p, budget); err == nil {
+			t.Error("expected error for ID with null byte")
+		}
+	})
+}
+
+func TestEffectiveStatus(t *testing.T) {
+	tests := []struct {
+		status ProviderStatus
+		want   ProviderStatus
+	}{
+		{"", ProviderStatusActive},
+		{ProviderStatusActive, ProviderStatusActive},
+		{ProviderStatusInactive, ProviderStatusInactive},
+		{ProviderStatusDraining, ProviderStatusDraining},
+	}
+	for _, tt := range tests {
+		p := &ProviderConfig{Status: tt.status}
+		if got := p.EffectiveStatus(); got != tt.want {
+			t.Errorf("EffectiveStatus(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestEffectiveTimeout(t *testing.T) {
+	r := &Router{latencyBudget: 50 * time.Millisecond}
+
+	tests := []struct {
+		name            string
+		providerTimeout time.Duration
+		want            time.Duration
+	}{
+		{"zero defaults to 30ms", 0, 30 * time.Millisecond},
+		{"within budget", 40 * time.Millisecond, 40 * time.Millisecond},
+		{"exceeds budget clamped", 100 * time.Millisecond, 50 * time.Millisecond},
+		{"equal to budget", 50 * time.Millisecond, 50 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.effectiveTimeout(tt.providerTimeout)
+			if got != tt.want {
+				t.Errorf("effectiveTimeout(%v) = %v, want %v", tt.providerTimeout, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("zero budget does not clamp", func(t *testing.T) {
+		r2 := &Router{}
+		got := r2.effectiveTimeout(100 * time.Millisecond)
+		if got != 100*time.Millisecond {
+			t.Errorf("expected 100ms with zero budget, got %v", got)
+		}
+	})
+}
+
+func TestProviderSet_ActiveFiltersByStatus(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "active", Status: ProviderStatusActive, ContextMatch: true},
+		{ID: "empty-status", ContextMatch: true},         // defaults to active
+		{ID: "inactive", Status: ProviderStatusInactive, ContextMatch: true},
+		{ID: "draining", Status: ProviderStatusDraining, ContextMatch: true},
+	})
+
+	active := ps.Active()
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active, got %d", len(active))
+	}
+	ids := map[string]bool{}
+	for _, p := range active {
+		ids[p.ID] = true
+	}
+	if !ids["active"] || !ids["empty-status"] {
+		t.Errorf("expected active and empty-status, got %v", ids)
 	}
 }

--- a/router/discovery.go
+++ b/router/discovery.go
@@ -1,0 +1,232 @@
+package router
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// DiscoveryConfig controls dynamic provider discovery.
+// When Endpoint is empty, discovery is disabled.
+type DiscoveryConfig struct {
+	Endpoint        string `json:"endpoint"`
+	IntervalSeconds int    `json:"interval_seconds"` // default 30
+	TimeoutSeconds  int    `json:"timeout_seconds"`  // default 10
+}
+
+// Discovery polls an HTTP endpoint for provider registrations and reconciles
+// the router's provider set.
+type Discovery struct {
+	providers     *ProviderSet
+	health        *ProviderHealth
+	client        *http.Client
+	logger        *slog.Logger
+	endpoint      string
+	interval      time.Duration
+	timeout       time.Duration
+	latencyBudget time.Duration
+	stop          chan struct{}
+	done          chan struct{}
+}
+
+// DiscoveryOption configures a Discovery instance.
+type DiscoveryOption func(*Discovery)
+
+// WithDiscoveryLogger sets the logger for discovery.
+func WithDiscoveryLogger(l *slog.Logger) DiscoveryOption {
+	return func(d *Discovery) { d.logger = l }
+}
+
+// WithDiscoveryClient sets a custom HTTP client. For tests only —
+// production should use the default client with safeDialContext.
+func WithDiscoveryClient(c *http.Client) DiscoveryOption {
+	return func(d *Discovery) { d.client = c }
+}
+
+// NewDiscovery creates a provider discovery poller.
+func NewDiscovery(providers *ProviderSet, health *ProviderHealth, cfg DiscoveryConfig, latencyBudget time.Duration, opts ...DiscoveryOption) *Discovery {
+	interval := time.Duration(cfg.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	d := &Discovery{
+		providers:     providers,
+		health:        health,
+		client: &http.Client{
+			Timeout:   timeout,
+			Transport: &http.Transport{DialContext: safeDialContext},
+		},
+		logger:        slog.Default(),
+		endpoint:      cfg.Endpoint,
+		interval:      interval,
+		timeout:       timeout,
+		latencyBudget: latencyBudget,
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(d)
+	}
+	return d
+}
+
+// Start begins background discovery polling. Call Stop to shut down.
+func (d *Discovery) Start() {
+	go d.run()
+}
+
+// Stop gracefully shuts down discovery.
+func (d *Discovery) Stop() {
+	close(d.stop)
+	<-d.done
+}
+
+func (d *Discovery) run() {
+	defer close(d.done)
+
+	// Poll immediately on start, then on interval.
+	d.pollAndLog()
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-d.stop:
+			return
+		case <-ticker.C:
+			d.pollAndLog()
+		}
+	}
+}
+
+func (d *Discovery) pollAndLog() {
+	ctx, cancel := context.WithTimeout(context.Background(), d.timeout)
+	defer cancel()
+	if err := d.poll(ctx); err != nil {
+		d.logger.Error("discovery poll failed", "endpoint", d.endpoint, "error", err)
+	}
+}
+
+func (d *Discovery) poll(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", d.endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return &healthCheckError{statusCode: resp.StatusCode}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024)) // 1MB max
+	if err != nil {
+		return err
+	}
+
+	var incoming []ProviderConfig
+	if err := json.Unmarshal(body, &incoming); err != nil {
+		return err
+	}
+
+	const maxDiscoveredProviders = 500
+
+	// Validate and filter incoming providers.
+	valid := make([]ProviderConfig, 0, len(incoming))
+	for _, p := range incoming {
+		if err := ValidateProviderEndpoint(p.Endpoint); err != nil {
+			d.logger.Warn("discovery: skipping provider with invalid endpoint",
+				"provider", p.ID, "error", err)
+			continue
+		}
+		if err := ValidateProviderConfig(&p, d.latencyBudget); err != nil {
+			d.logger.Warn("discovery: skipping invalid provider",
+				"provider", p.ID, "error", err)
+			continue
+		}
+		valid = append(valid, p)
+	}
+
+	if len(valid) > maxDiscoveredProviders {
+		d.logger.Error("discovery: too many providers, truncating",
+			"count", len(valid), "max", maxDiscoveredProviders)
+		valid = valid[:maxDiscoveredProviders]
+	}
+
+	current := d.providers.All()
+
+	// Protect against empty responses removing all providers.
+	if len(valid) == 0 && len(current) > 0 {
+		d.logger.Warn("discovery: incoming provider list is empty, preserving current providers")
+		return nil
+	}
+
+	reconciled := d.reconcile(current, valid)
+	d.providers.Swap(reconciled)
+	return nil
+}
+
+// reconcile merges current and incoming provider sets by ID.
+// New providers are added as active. Removed providers are set to draining
+// (if in-flight > 0) or dropped. Changed providers get their config updated
+// while preserving status and health state.
+func (d *Discovery) reconcile(current, incoming []ProviderConfig) []ProviderConfig {
+	currentByID := make(map[string]ProviderConfig, len(current))
+	for _, p := range current {
+		currentByID[p.ID] = p
+	}
+
+	incomingByID := make(map[string]ProviderConfig, len(incoming))
+	for _, p := range incoming {
+		incomingByID[p.ID] = p
+	}
+
+	var result []ProviderConfig
+
+	// Process incoming: add new or update existing.
+	for _, inc := range incoming {
+		if cur, exists := currentByID[inc.ID]; exists {
+			// Preserve status from current if incoming doesn't specify one.
+			if inc.Status == "" {
+				inc.Status = cur.Status
+			}
+			result = append(result, inc)
+		} else {
+			// New provider.
+			if inc.Status == "" {
+				inc.Status = ProviderStatusActive
+			}
+			d.logger.Info("discovery: adding provider", "provider", inc.ID)
+			result = append(result, inc)
+		}
+	}
+
+	// Process removed: keep draining providers with in-flight requests.
+	for _, cur := range current {
+		if _, stillPresent := incomingByID[cur.ID]; stillPresent {
+			continue
+		}
+		if d.health != nil && d.health.Inflight(cur.ID) > 0 {
+			cur.Status = ProviderStatusDraining
+			d.logger.Info("discovery: draining removed provider", "provider", cur.ID,
+				"inflight", d.health.Inflight(cur.ID))
+			result = append(result, cur)
+		} else {
+			d.logger.Info("discovery: removing provider", "provider", cur.ID)
+		}
+	}
+
+	return result
+}

--- a/router/discovery_test.go
+++ b/router/discovery_test.go
@@ -1,0 +1,231 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testDiscovery creates a Discovery that bypasses safeDialContext for httptest.Server.
+func testDiscovery(ps *ProviderSet, health *ProviderHealth, endpoint string, budget time.Duration) *Discovery {
+	d := NewDiscovery(ps, health, DiscoveryConfig{Endpoint: endpoint}, budget,
+		WithDiscoveryClient(&http.Client{Timeout: 5 * time.Second}))
+	d.interval = 50 * time.Millisecond
+	return d
+}
+
+func TestDiscovery_AddsNewProviders(t *testing.T) {
+	providers := []ProviderConfig{
+		{ID: "new-1", Endpoint: "https://example.com", ContextMatch: true},
+		{ID: "new-2", Endpoint: "https://example.com", IdentityMatch: true, Countries: []string{"US"}, UIDTypes: []string{"uid2"}},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(providers)
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet(nil)
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	all := ps.All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(all))
+	}
+	if all[0].EffectiveStatus() != ProviderStatusActive {
+		t.Errorf("new provider should be active, got %v", all[0].Status)
+	}
+}
+
+func TestDiscovery_RemovesProviders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]ProviderConfig{
+			{ID: "kept", Endpoint: "https://example.com", ContextMatch: true},
+		})
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "kept", Endpoint: "https://example.com", ContextMatch: true},
+		{ID: "removed", Endpoint: "https://example.com", ContextMatch: true},
+	})
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	all := ps.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 provider, got %d", len(all))
+	}
+	if all[0].ID != "kept" {
+		t.Errorf("expected kept, got %s", all[0].ID)
+	}
+}
+
+func TestDiscovery_DrainsRemovedWithInflight(t *testing.T) {
+	// Discovery returns a single provider; the "draining" provider from current set
+	// is not in the response but has inflight > 0.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]ProviderConfig{
+			{ID: "kept", Endpoint: "https://example.com", ContextMatch: true},
+		})
+	}))
+	defer srv.Close()
+
+	health := NewProviderHealth(3, 10*time.Second)
+	health.IncrInflight("draining")
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "kept", Endpoint: "https://example.com", ContextMatch: true},
+		{ID: "draining", Endpoint: "https://example.com", ContextMatch: true},
+	})
+	d := testDiscovery(ps, health, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	all := ps.All()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 providers (kept + draining), got %d", len(all))
+	}
+	byID := map[string]ProviderConfig{}
+	for _, p := range all {
+		byID[p.ID] = p
+	}
+	if byID["draining"].Status != ProviderStatusDraining {
+		t.Errorf("expected draining, got %v", byID["draining"].Status)
+	}
+}
+
+func TestDiscovery_UpdatesChangedProviders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]ProviderConfig{
+			{ID: "p1", Endpoint: "https://new-endpoint.com", ContextMatch: true, Timeout: 25 * time.Millisecond},
+		})
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "p1", Endpoint: "https://old-endpoint.com", ContextMatch: true, Status: ProviderStatusActive},
+	})
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	p, ok := ps.Get("p1")
+	if !ok {
+		t.Fatal("p1 should still exist")
+	}
+	if p.Endpoint != "https://new-endpoint.com" {
+		t.Errorf("endpoint should be updated, got %s", p.Endpoint)
+	}
+	if p.Status != ProviderStatusActive {
+		t.Errorf("status should be preserved as active, got %v", p.Status)
+	}
+}
+
+func TestDiscovery_SkipsInvalidProviders(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]ProviderConfig{
+			{ID: "valid", Endpoint: "https://example.com", ContextMatch: true},
+			{ID: "no-match", Endpoint: "https://example.com"}, // neither context nor identity
+			{ID: "bad-endpoint", Endpoint: "http://localhost:8080", ContextMatch: true},
+		})
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet(nil)
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	all := ps.All()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 valid provider, got %d", len(all))
+	}
+	if all[0].ID != "valid" {
+		t.Errorf("expected valid, got %s", all[0].ID)
+	}
+}
+
+func TestDiscovery_EndpointFailure(t *testing.T) {
+	var callCount atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "existing", Endpoint: "https://example.com", ContextMatch: true},
+	})
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(200 * time.Millisecond)
+	d.Stop()
+
+	// Existing providers should be preserved on failure.
+	all := ps.All()
+	if len(all) != 1 || all[0].ID != "existing" {
+		t.Errorf("existing providers should be preserved on discovery failure, got %v", all)
+	}
+
+	if callCount.Load() < 2 {
+		t.Errorf("expected at least 2 poll attempts, got %d", callCount.Load())
+	}
+}
+
+func TestDiscovery_EmptyResponsePreservesCurrent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]ProviderConfig{})
+	}))
+	defer srv.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "existing", Endpoint: "https://example.com", ContextMatch: true},
+	})
+	d := testDiscovery(ps, nil, srv.URL, 50*time.Millisecond)
+
+	d.Start()
+	time.Sleep(100 * time.Millisecond)
+	d.Stop()
+
+	all := ps.All()
+	if len(all) != 1 || all[0].ID != "existing" {
+		t.Errorf("empty discovery should preserve current providers, got %v", all)
+	}
+}
+
+func TestReconcile_PreservesStatus(t *testing.T) {
+	d := &Discovery{latencyBudget: 50 * time.Millisecond}
+
+	current := []ProviderConfig{
+		{ID: "p1", Endpoint: "https://example.com", ContextMatch: true, Status: ProviderStatusDraining},
+	}
+	incoming := []ProviderConfig{
+		{ID: "p1", Endpoint: "https://example.com", ContextMatch: true}, // no status in incoming
+	}
+
+	result := d.reconcile(current, incoming)
+	if len(result) != 1 {
+		t.Fatalf("expected 1, got %d", len(result))
+	}
+	if result[0].Status != ProviderStatusDraining {
+		t.Errorf("status should be preserved, got %v", result[0].Status)
+	}
+}

--- a/router/drain.go
+++ b/router/drain.go
@@ -1,0 +1,38 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// DrainProvider sets a provider to draining status and waits for in-flight
+// requests to complete. Once drained, the provider is set to inactive.
+// Respects context cancellation — if the context expires, the provider is
+// forcibly set to inactive.
+func (r *Router) DrainProvider(ctx context.Context, providerID string) error {
+	if !r.providers.SetStatus(providerID, ProviderStatusDraining) {
+		return fmt.Errorf("provider %q not found", providerID)
+	}
+
+	if r.health == nil {
+		r.providers.SetStatus(providerID, ProviderStatusInactive)
+		return nil
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if r.health.Inflight(providerID) == 0 {
+			r.providers.SetStatus(providerID, ProviderStatusInactive)
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			r.providers.SetStatus(providerID, ProviderStatusInactive)
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}

--- a/router/filter.go
+++ b/router/filter.go
@@ -7,6 +7,7 @@ import (
 )
 
 // MatchesContextProvider checks if a context match request should be sent to this provider.
+// Assumes the caller has already filtered by status (e.g., via ProviderSet.Active()).
 func MatchesContextProvider(req *tmproto.ContextMatchRequest, p *ProviderConfig) bool {
 	if !p.ContextMatch {
 		return false
@@ -19,6 +20,7 @@ func MatchesContextProvider(req *tmproto.ContextMatchRequest, p *ProviderConfig)
 
 // MatchesIdentityProvider checks if an identity match request should be sent to this provider.
 // Filters by country and uid_type when configured on the provider.
+// Assumes the caller has already filtered by status (e.g., via ProviderSet.Active()).
 func MatchesIdentityProvider(req *tmproto.IdentityMatchRequest, p *ProviderConfig) bool {
 	if !p.IdentityMatch {
 		return false

--- a/router/health.go
+++ b/router/health.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,11 +16,12 @@ type ProviderHealth struct {
 }
 
 type providerStats struct {
-	successes          atomic.Int64
-	failures           atomic.Int64
-	timeouts           atomic.Int64
+	successes           atomic.Int64
+	failures            atomic.Int64
+	timeouts            atomic.Int64
 	consecutiveFailures atomic.Int64
-	circuitOpenUntil   atomic.Int64 // unix nano; 0 = closed
+	circuitOpenUntil    atomic.Int64 // unix nano; 0 = closed
+	inflight            atomic.Int64
 }
 
 // NewProviderHealth creates a health tracker.
@@ -99,13 +101,31 @@ func (h *ProviderHealth) IsCircuitOpen(providerID string) bool {
 	return true // circuit still open for all other racers
 }
 
-// ProviderStats returns stats for a single provider.
+// IncrInflight increments the in-flight request count for a provider.
+func (h *ProviderHealth) IncrInflight(providerID string) {
+	h.getOrCreate(providerID).inflight.Add(1)
+}
+
+// DecrInflight decrements the in-flight request count for a provider.
+func (h *ProviderHealth) DecrInflight(providerID string) {
+	if n := h.getOrCreate(providerID).inflight.Add(-1); n < 0 {
+		slog.Warn("inflight counter went negative", "provider", providerID, "value", n)
+	}
+}
+
+// Inflight returns the current in-flight request count for a provider.
+func (h *ProviderHealth) Inflight(providerID string) int64 {
+	return h.getOrCreate(providerID).inflight.Load()
+}
+
+// ProviderStatsSnapshot is a point-in-time snapshot of provider health stats.
 type ProviderStatsSnapshot struct {
-	Successes          int64 `json:"successes"`
-	Failures           int64 `json:"failures"`
-	Timeouts           int64 `json:"timeouts"`
+	Successes           int64 `json:"successes"`
+	Failures            int64 `json:"failures"`
+	Timeouts            int64 `json:"timeouts"`
 	ConsecutiveFailures int64 `json:"consecutive_failures"`
-	CircuitOpen        bool  `json:"circuit_open"`
+	CircuitOpen         bool  `json:"circuit_open"`
+	Inflight            int64 `json:"inflight"`
 }
 
 // Snapshot returns a snapshot of all provider stats.
@@ -124,6 +144,7 @@ func (h *ProviderHealth) Snapshot() map[string]ProviderStatsSnapshot {
 			Timeouts:            s.timeouts.Load(),
 			ConsecutiveFailures: s.consecutiveFailures.Load(),
 			CircuitOpen:         circuitOpen,
+			Inflight:            s.inflight.Load(),
 		}
 	}
 	return out

--- a/router/healthcheck.go
+++ b/router/healthcheck.go
@@ -1,0 +1,187 @@
+package router
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// HealthCheckMetrics is the metrics interface used by the health checker.
+// Implemented by the cmd layer to bridge to prommetrics without a direct dependency.
+type HealthCheckMetrics interface {
+	SetHealthStatus(providerID string, healthy bool)
+	ObserveCheckDuration(providerID string, ms float64)
+	IncExcluded(providerID string)
+	IncRecovered(providerID string)
+}
+
+// HealthChecker polls provider health endpoints in the background.
+type HealthChecker struct {
+	providers *ProviderSet
+	health    *ProviderHealth
+	client    *http.Client
+	logger    *slog.Logger
+	interval  time.Duration
+	timeout   time.Duration
+	metrics   HealthCheckMetrics
+	stop      chan struct{}
+	done      chan struct{}
+}
+
+// HealthCheckerOption configures a HealthChecker.
+type HealthCheckerOption func(*HealthChecker)
+
+// WithHealthCheckMetrics sets the metrics callback for the health checker.
+func WithHealthCheckMetrics(m HealthCheckMetrics) HealthCheckerOption {
+	return func(hc *HealthChecker) { hc.metrics = m }
+}
+
+// WithHealthCheckLogger sets the logger for the health checker.
+func WithHealthCheckLogger(l *slog.Logger) HealthCheckerOption {
+	return func(hc *HealthChecker) { hc.logger = l }
+}
+
+// WithHealthCheckClient sets a custom HTTP client. For tests only —
+// production should use the default client with safeDialContext.
+func WithHealthCheckClient(c *http.Client) HealthCheckerOption {
+	return func(hc *HealthChecker) { hc.client = c }
+}
+
+// NewHealthChecker creates a health checker that polls provider /health endpoints.
+func NewHealthChecker(providers *ProviderSet, health *ProviderHealth, cfg HealthCheckConfig, opts ...HealthCheckerOption) *HealthChecker {
+	interval := time.Duration(cfg.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	hc := &HealthChecker{
+		providers: providers,
+		health:    health,
+		client: &http.Client{
+			Timeout:   timeout,
+			Transport: &http.Transport{DialContext: safeDialContext},
+		},
+		logger:    slog.Default(),
+		interval:  interval,
+		timeout:   timeout,
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	for _, o := range opts {
+		o(hc)
+	}
+	return hc
+}
+
+// Preflight checks all providers once. Logs warnings for unreachable providers
+// but does not block startup. Does not record failures against the circuit breaker.
+func (hc *HealthChecker) Preflight(ctx context.Context) {
+	for _, p := range hc.providers.All() {
+		if p.EffectiveStatus() == ProviderStatusInactive {
+			continue
+		}
+		if err := hc.checkProvider(ctx, p); err != nil {
+			hc.logger.Warn("provider health check failed during preflight",
+				"provider", p.ID, "endpoint", p.Endpoint, "error", err)
+		}
+	}
+}
+
+// Start begins background health polling. Call Stop to shut down.
+func (hc *HealthChecker) Start() {
+	go hc.run()
+}
+
+// Stop gracefully shuts down the health checker.
+func (hc *HealthChecker) Stop() {
+	close(hc.stop)
+	<-hc.done
+}
+
+func (hc *HealthChecker) run() {
+	defer close(hc.done)
+	ticker := time.NewTicker(hc.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-hc.stop:
+			return
+		case <-ticker.C:
+			hc.checkAll()
+		}
+	}
+}
+
+func (hc *HealthChecker) checkAll() {
+	for _, p := range hc.providers.All() {
+		if p.EffectiveStatus() == ProviderStatusInactive {
+			continue
+		}
+
+		wasOpen := hc.health.IsCircuitOpen(p.ID)
+
+		ctx, cancel := context.WithTimeout(context.Background(), hc.timeout)
+		start := time.Now()
+		err := hc.checkProvider(ctx, p)
+		duration := time.Since(start)
+		cancel()
+
+		if hc.metrics != nil {
+			hc.metrics.ObserveCheckDuration(p.ID, float64(duration.Milliseconds()))
+		}
+
+		if err != nil {
+			hc.logger.Debug("provider health check failed", "provider", p.ID, "error", err)
+			hc.health.RecordFailure(p.ID)
+			if hc.metrics != nil {
+				hc.metrics.SetHealthStatus(p.ID, false)
+			}
+		} else {
+			hc.health.RecordSuccess(p.ID)
+			if hc.metrics != nil {
+				hc.metrics.SetHealthStatus(p.ID, true)
+			}
+			if wasOpen {
+				hc.logger.Info("provider recovered", "provider", p.ID)
+				if hc.metrics != nil {
+					hc.metrics.IncRecovered(p.ID)
+				}
+			}
+		}
+	}
+}
+
+func (hc *HealthChecker) checkProvider(ctx context.Context, p ProviderConfig) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", p.Endpoint+"/health", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := hc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return &healthCheckError{statusCode: resp.StatusCode}
+	}
+	return nil
+}
+
+type healthCheckError struct {
+	statusCode int
+}
+
+func (e *healthCheckError) Error() string {
+	return "health check returned " + http.StatusText(e.statusCode)
+}

--- a/router/healthcheck_test.go
+++ b/router/healthcheck_test.go
@@ -1,0 +1,164 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testMetrics struct {
+	recovered atomic.Int64
+	excluded  atomic.Int64
+}
+
+func (m *testMetrics) SetHealthStatus(string, bool)         {}
+func (m *testMetrics) ObserveCheckDuration(string, float64) {}
+func (m *testMetrics) IncExcluded(string)                   { m.excluded.Add(1) }
+func (m *testMetrics) IncRecovered(string)                  { m.recovered.Add(1) }
+
+// testHealthChecker creates a HealthChecker that bypasses safeDialContext for httptest.Server.
+func testHealthChecker(ps *ProviderSet, health *ProviderHealth, opts ...HealthCheckerOption) *HealthChecker {
+	allOpts := []HealthCheckerOption{
+		WithHealthCheckClient(&http.Client{Timeout: 5 * time.Second}),
+	}
+	allOpts = append(allOpts, opts...)
+	hc := NewHealthChecker(ps, health, HealthCheckConfig{IntervalSeconds: 0, TimeoutSeconds: 5}, allOpts...)
+	hc.interval = 50 * time.Millisecond
+	return hc
+}
+
+func TestHealthChecker_Preflight(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer healthy.Close()
+
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer unhealthy.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "ok", Endpoint: healthy.URL, ContextMatch: true},
+		{ID: "bad", Endpoint: unhealthy.URL, ContextMatch: true},
+	})
+	health := NewProviderHealth(3, 10*time.Second)
+	hc := testHealthChecker(ps, health)
+
+	hc.Preflight(context.Background())
+
+	// Preflight logs warnings but doesn't call RecordFailure — it's diagnostic only.
+}
+
+func TestHealthChecker_BackgroundPolling(t *testing.T) {
+	var callCount atomic.Int64
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer provider.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "p1", Endpoint: provider.URL, ContextMatch: true},
+	})
+	health := NewProviderHealth(3, 10*time.Second)
+	hc := testHealthChecker(ps, health)
+
+	hc.Start()
+	time.Sleep(200 * time.Millisecond)
+	hc.Stop()
+
+	if callCount.Load() < 2 {
+		t.Errorf("expected at least 2 health checks, got %d", callCount.Load())
+	}
+}
+
+func TestHealthChecker_CircuitOpensAfterFailures(t *testing.T) {
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer provider.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "p1", Endpoint: provider.URL, ContextMatch: true},
+	})
+	health := NewProviderHealth(2, 10*time.Second) // threshold=2
+	hc := testHealthChecker(ps, health)
+
+	hc.Start()
+	time.Sleep(200 * time.Millisecond)
+	hc.Stop()
+
+	snap := health.Snapshot()
+	if !snap["p1"].CircuitOpen {
+		t.Error("circuit should be open after multiple health check failures")
+	}
+}
+
+func TestHealthChecker_Recovery(t *testing.T) {
+	var healthy atomic.Bool
+	healthy.Store(false)
+
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if healthy.Load() {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer provider.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "p1", Endpoint: provider.URL, ContextMatch: true},
+	})
+	health := NewProviderHealth(2, 100*time.Millisecond)
+	m := &testMetrics{}
+	hc := testHealthChecker(ps, health, WithHealthCheckMetrics(m))
+
+	hc.Start()
+	time.Sleep(200 * time.Millisecond) // let circuit open
+
+	snap := health.Snapshot()
+	if !snap["p1"].CircuitOpen {
+		t.Fatal("circuit should be open")
+	}
+
+	healthy.Store(true)
+	time.Sleep(300 * time.Millisecond)
+	hc.Stop()
+
+	snap = health.Snapshot()
+	if snap["p1"].CircuitOpen {
+		t.Error("circuit should be closed after recovery")
+	}
+
+	if m.recovered.Load() < 1 {
+		t.Errorf("expected at least 1 recovery, got %d", m.recovered.Load())
+	}
+}
+
+func TestHealthChecker_SkipsInactiveProviders(t *testing.T) {
+	var callCount atomic.Int64
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer provider.Close()
+
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "p1", Endpoint: provider.URL, ContextMatch: true, Status: ProviderStatusInactive},
+	})
+	health := NewProviderHealth(3, 10*time.Second)
+	hc := testHealthChecker(ps, health)
+
+	hc.Start()
+	time.Sleep(200 * time.Millisecond)
+	hc.Stop()
+
+	if callCount.Load() != 0 {
+		t.Errorf("inactive provider should not be health checked, got %d calls", callCount.Load())
+	}
+}

--- a/router/providerset.go
+++ b/router/providerset.go
@@ -5,11 +5,17 @@ import (
 	"sync/atomic"
 )
 
+// providerSnapshot holds both the full provider list and the pre-filtered active subset.
+type providerSnapshot struct {
+	all    []ProviderConfig
+	active []ProviderConfig
+}
+
 // ProviderSet holds the current set of providers with atomic read access.
 // Reads (Active, All) are lock-free via atomic.Value.
 // Writes (Swap, SetStatus) are serialized by a mutex.
 type ProviderSet struct {
-	v  atomic.Value // holds []ProviderConfig
+	v  atomic.Value // holds providerSnapshot
 	mu sync.Mutex   // serializes writes
 }
 
@@ -19,25 +25,33 @@ func NewProviderSet(initial []ProviderConfig) *ProviderSet {
 	if initial == nil {
 		initial = []ProviderConfig{}
 	}
-	ps.v.Store(initial)
+	ps.v.Store(buildSnapshot(initial))
 	return ps
+}
+
+func buildSnapshot(all []ProviderConfig) providerSnapshot {
+	active := make([]ProviderConfig, 0, len(all))
+	for _, p := range all {
+		if p.EffectiveStatus() == ProviderStatusActive {
+			active = append(active, p)
+		}
+	}
+	return providerSnapshot{all: all, active: active}
+}
+
+func (ps *ProviderSet) snapshot() providerSnapshot {
+	return ps.v.Load().(providerSnapshot)
 }
 
 // All returns a snapshot of all providers.
 func (ps *ProviderSet) All() []ProviderConfig {
-	return ps.v.Load().([]ProviderConfig)
+	return ps.snapshot().all
 }
 
 // Active returns providers with effective status "active".
+// This is a cached snapshot — no allocation on the read path.
 func (ps *ProviderSet) Active() []ProviderConfig {
-	all := ps.All()
-	out := make([]ProviderConfig, 0, len(all))
-	for _, p := range all {
-		if p.EffectiveStatus() == ProviderStatusActive {
-			out = append(out, p)
-		}
-	}
-	return out
+	return ps.snapshot().active
 }
 
 // Swap atomically replaces the entire provider set.
@@ -47,7 +61,7 @@ func (ps *ProviderSet) Swap(next []ProviderConfig) {
 	}
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
-	ps.v.Store(next)
+	ps.v.Store(buildSnapshot(next))
 }
 
 // SetStatus updates a single provider's status via copy-on-write.
@@ -55,13 +69,13 @@ func (ps *ProviderSet) Swap(next []ProviderConfig) {
 func (ps *ProviderSet) SetStatus(id string, status ProviderStatus) bool {
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
-	current := ps.v.Load().([]ProviderConfig)
+	current := ps.snapshot().all
 	for i, p := range current {
 		if p.ID == id {
 			next := make([]ProviderConfig, len(current))
 			copy(next, current)
 			next[i].Status = status
-			ps.v.Store(next)
+			ps.v.Store(buildSnapshot(next))
 			return true
 		}
 	}

--- a/router/providerset.go
+++ b/router/providerset.go
@@ -1,0 +1,79 @@
+package router
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// ProviderSet holds the current set of providers with atomic read access.
+// Reads (Active, All) are lock-free via atomic.Value.
+// Writes (Swap, SetStatus) are serialized by a mutex.
+type ProviderSet struct {
+	v  atomic.Value // holds []ProviderConfig
+	mu sync.Mutex   // serializes writes
+}
+
+// NewProviderSet creates a ProviderSet with the given initial providers.
+func NewProviderSet(initial []ProviderConfig) *ProviderSet {
+	ps := &ProviderSet{}
+	if initial == nil {
+		initial = []ProviderConfig{}
+	}
+	ps.v.Store(initial)
+	return ps
+}
+
+// All returns a snapshot of all providers.
+func (ps *ProviderSet) All() []ProviderConfig {
+	return ps.v.Load().([]ProviderConfig)
+}
+
+// Active returns providers with effective status "active".
+func (ps *ProviderSet) Active() []ProviderConfig {
+	all := ps.All()
+	out := make([]ProviderConfig, 0, len(all))
+	for _, p := range all {
+		if p.EffectiveStatus() == ProviderStatusActive {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// Swap atomically replaces the entire provider set.
+func (ps *ProviderSet) Swap(next []ProviderConfig) {
+	if next == nil {
+		next = []ProviderConfig{}
+	}
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	ps.v.Store(next)
+}
+
+// SetStatus updates a single provider's status via copy-on-write.
+// Returns true if the provider was found.
+func (ps *ProviderSet) SetStatus(id string, status ProviderStatus) bool {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+	current := ps.v.Load().([]ProviderConfig)
+	for i, p := range current {
+		if p.ID == id {
+			next := make([]ProviderConfig, len(current))
+			copy(next, current)
+			next[i].Status = status
+			ps.v.Store(next)
+			return true
+		}
+	}
+	return false
+}
+
+// Get returns the config for a single provider by ID.
+func (ps *ProviderSet) Get(id string) (ProviderConfig, bool) {
+	for _, p := range ps.All() {
+		if p.ID == id {
+			return p, true
+		}
+	}
+	return ProviderConfig{}, false
+}

--- a/router/providerset_test.go
+++ b/router/providerset_test.go
@@ -1,0 +1,207 @@
+package router
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestProviderSet_ActiveFilters(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "a", Status: ProviderStatusActive},
+		{ID: "b", Status: ProviderStatusInactive},
+		{ID: "c", Status: ProviderStatusDraining},
+		{ID: "d"}, // empty = active
+	})
+
+	active := ps.Active()
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active providers, got %d", len(active))
+	}
+	ids := map[string]bool{}
+	for _, p := range active {
+		ids[p.ID] = true
+	}
+	if !ids["a"] || !ids["d"] {
+		t.Errorf("expected a and d, got %v", ids)
+	}
+}
+
+func TestProviderSet_All(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "a"},
+		{ID: "b", Status: ProviderStatusInactive},
+	})
+	if len(ps.All()) != 2 {
+		t.Errorf("expected 2, got %d", len(ps.All()))
+	}
+}
+
+func TestProviderSet_Swap(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{{ID: "old"}})
+	ps.Swap([]ProviderConfig{{ID: "new1"}, {ID: "new2"}})
+	if len(ps.All()) != 2 {
+		t.Fatalf("expected 2 after swap, got %d", len(ps.All()))
+	}
+	if ps.All()[0].ID != "new1" {
+		t.Errorf("expected new1, got %s", ps.All()[0].ID)
+	}
+}
+
+func TestProviderSet_SwapNil(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{{ID: "a"}})
+	ps.Swap(nil)
+	if len(ps.All()) != 0 {
+		t.Errorf("expected 0 after nil swap, got %d", len(ps.All()))
+	}
+}
+
+func TestProviderSet_SetStatus(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{
+		{ID: "a", Status: ProviderStatusActive},
+		{ID: "b", Status: ProviderStatusActive},
+	})
+
+	if !ps.SetStatus("a", ProviderStatusDraining) {
+		t.Error("expected SetStatus to return true for existing provider")
+	}
+	p, ok := ps.Get("a")
+	if !ok || p.Status != ProviderStatusDraining {
+		t.Errorf("expected draining, got %v", p.Status)
+	}
+
+	// b should be unchanged
+	p, _ = ps.Get("b")
+	if p.Status != ProviderStatusActive {
+		t.Errorf("b should still be active, got %v", p.Status)
+	}
+
+	if ps.SetStatus("nonexistent", ProviderStatusInactive) {
+		t.Error("expected SetStatus to return false for nonexistent provider")
+	}
+}
+
+func TestProviderSet_Get(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{{ID: "a", Endpoint: "http://a.com"}})
+	p, ok := ps.Get("a")
+	if !ok || p.Endpoint != "http://a.com" {
+		t.Errorf("expected to find provider a")
+	}
+	_, ok = ps.Get("missing")
+	if ok {
+		t.Error("expected not found")
+	}
+}
+
+func TestProviderSet_ConcurrentReadWrite(t *testing.T) {
+	ps := NewProviderSet([]ProviderConfig{{ID: "a"}})
+	var wg sync.WaitGroup
+
+	// Concurrent readers
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				_ = ps.Active()
+				_ = ps.All()
+			}
+		}()
+	}
+
+	// Concurrent writer
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			ps.Swap([]ProviderConfig{{ID: "a"}, {ID: "b"}})
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestInflightTracking(t *testing.T) {
+	h := NewProviderHealth(3, 10*time.Second)
+
+	h.IncrInflight("p1")
+	h.IncrInflight("p1")
+	if got := h.Inflight("p1"); got != 2 {
+		t.Errorf("expected 2 inflight, got %d", got)
+	}
+
+	h.DecrInflight("p1")
+	if got := h.Inflight("p1"); got != 1 {
+		t.Errorf("expected 1 inflight, got %d", got)
+	}
+
+	snap := h.Snapshot()
+	if snap["p1"].Inflight != 1 {
+		t.Errorf("snapshot inflight: expected 1, got %d", snap["p1"].Inflight)
+	}
+}
+
+func TestDrainProvider(t *testing.T) {
+	health := NewProviderHealth(3, 10*time.Second)
+	r, _ := NewRouter(
+		[]ProviderConfig{{ID: "p1", ContextMatch: true, Endpoint: "https://example.com"}},
+		nil, nil, health,
+	)
+
+	// Simulate an in-flight request that completes after 200ms
+	health.IncrInflight("p1")
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		health.DecrInflight("p1")
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := r.DrainProvider(ctx, "p1")
+	if err != nil {
+		t.Fatalf("drain failed: %v", err)
+	}
+
+	p, ok := r.Providers().Get("p1")
+	if !ok {
+		t.Fatal("provider not found after drain")
+	}
+	if p.Status != ProviderStatusInactive {
+		t.Errorf("expected inactive after drain, got %v", p.Status)
+	}
+}
+
+func TestDrainProvider_Timeout(t *testing.T) {
+	health := NewProviderHealth(3, 10*time.Second)
+	r, _ := NewRouter(
+		[]ProviderConfig{{ID: "p1", ContextMatch: true, Endpoint: "https://example.com"}},
+		nil, nil, health,
+	)
+
+	// In-flight that never completes
+	health.IncrInflight("p1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := r.DrainProvider(ctx, "p1")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	// Should still be set to inactive on timeout
+	p, _ := r.Providers().Get("p1")
+	if p.Status != ProviderStatusInactive {
+		t.Errorf("expected inactive after drain timeout, got %v", p.Status)
+	}
+}
+
+func TestDrainProvider_NotFound(t *testing.T) {
+	r, _ := NewRouter(nil, nil, nil, nil)
+	err := r.DrainProvider(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent provider")
+	}
+}

--- a/router/router.go
+++ b/router/router.go
@@ -78,18 +78,23 @@ func NewRouter(providers []ProviderConfig, registry *Registry, sigCache *Signatu
 		registry:  registry,
 		sigCache:  sigCache,
 		health:    health,
-		client: &http.Client{
-			Transport: &http.Transport{
-				DialContext:         safeDialContext,
-				MaxIdleConns:        100,
-				MaxIdleConnsPerHost: maxPerHost,
-				IdleConnTimeout:     90 * time.Second,
-			},
-		},
-		logger: slog.Default(),
+		logger:    slog.Default(),
 	}
 	for _, o := range opts {
 		o(r)
+	}
+	// Set default client if not overridden by options.
+	// Use safeDialContext in production to prevent DNS rebinding attacks.
+	if r.client == nil {
+		transport := &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: maxPerHost,
+			IdleConnTimeout:     90 * time.Second,
+		}
+		if !r.skipEndpointValidation {
+			transport.DialContext = safeDialContext
+		}
+		r.client = &http.Client{Transport: transport}
 	}
 	if !r.skipEndpointValidation {
 		for _, p := range r.providers.All() {

--- a/router/router.go
+++ b/router/router.go
@@ -15,14 +15,21 @@ import (
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
+// FanOutMetrics is called during fan-out to record provider exclusions.
+type FanOutMetrics interface {
+	IncExcluded(providerID string)
+}
+
 // Router fans out TMP requests to registered providers and merges responses.
 type Router struct {
-	providers              []ProviderConfig
+	providers              *ProviderSet
 	registry               *Registry
 	sigCache               *SignatureCache // nil = no signing
 	health                 *ProviderHealth // nil = no health tracking
+	latencyBudget          time.Duration
 	client                 *http.Client
 	logger                 *slog.Logger
+	metrics                FanOutMetrics
 	skipEndpointValidation bool
 }
 
@@ -47,18 +54,33 @@ func WithoutEndpointValidation() RouterOption {
 	return func(r *Router) { r.skipEndpointValidation = true }
 }
 
+// WithLatencyBudget sets the overall fan-out latency budget.
+// Per-provider timeouts are clamped to this value.
+func WithLatencyBudget(d time.Duration) RouterOption {
+	return func(r *Router) { r.latencyBudget = d }
+}
+
+// WithFanOutMetrics sets the metrics callback for fan-out exclusion tracking.
+func WithFanOutMetrics(m FanOutMetrics) RouterOption {
+	return func(r *Router) { r.metrics = m }
+}
+
+// Providers returns the router's provider set for use by health checkers and discovery.
+func (r *Router) Providers() *ProviderSet { return r.providers }
+
 // NewRouter creates a router with the given provider configuration and registry.
 // sigCache is optional — pass nil to disable request signing.
 // Returns an error if any provider endpoint fails SSRF validation.
 func NewRouter(providers []ProviderConfig, registry *Registry, sigCache *SignatureCache, health *ProviderHealth, opts ...RouterOption) (*Router, error) {
 	maxPerHost := max(len(providers), 10)
 	r := &Router{
-		providers: providers,
+		providers: NewProviderSet(providers),
 		registry:  registry,
 		sigCache:  sigCache,
 		health:    health,
 		client: &http.Client{
 			Transport: &http.Transport{
+				DialContext:         safeDialContext,
 				MaxIdleConns:        100,
 				MaxIdleConnsPerHost: maxPerHost,
 				IdleConnTimeout:     90 * time.Second,
@@ -70,7 +92,7 @@ func NewRouter(providers []ProviderConfig, registry *Registry, sigCache *Signatu
 		o(r)
 	}
 	if !r.skipEndpointValidation {
-		for _, p := range providers {
+		for _, p := range r.providers.All() {
 			if err := ValidateProviderEndpoint(p.Endpoint); err != nil {
 				return nil, fmt.Errorf("provider %q: %w", p.ID, err)
 			}
@@ -125,7 +147,7 @@ func (r *Router) HandleContextMatch(w http.ResponseWriter, req *http.Request) {
 
 	// Find matching providers
 	var matching []ProviderConfig
-	for _, p := range r.providers {
+	for _, p := range r.providers.Active() {
 		if MatchesContextProvider(&cmReq, &p) {
 			matching = append(matching, p)
 		}
@@ -165,7 +187,7 @@ func (r *Router) HandleIdentityMatch(w http.ResponseWriter, req *http.Request) {
 
 	// Find matching providers (filtered by country + uid_type).
 	var matching []ProviderConfig
-	for _, p := range r.providers {
+	for _, p := range r.providers.Active() {
 		if MatchesIdentityProvider(&imReq, &p) {
 			matching = append(matching, p)
 		}
@@ -193,6 +215,18 @@ func (r *Router) HandleIdentityMatch(w http.ResponseWriter, req *http.Request) {
 	}
 }
 
+// effectiveTimeout returns the per-call timeout, clamped to the latency budget.
+func (r *Router) effectiveTimeout(providerTimeout time.Duration) time.Duration {
+	t := providerTimeout
+	if t == 0 {
+		t = 30 * time.Millisecond
+	}
+	if r.latencyBudget > 0 && t > r.latencyBudget {
+		t = r.latencyBudget
+	}
+	return t
+}
+
 func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, cmReq *tmproto.ContextMatchRequest, body []byte) []*tmproto.ContextMatchResponse {
 	var mu sync.Mutex
 	results := make([]*tmproto.ContextMatchResponse, 0, len(providers))
@@ -201,14 +235,17 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 	for _, p := range providers {
 		wg.Go(func() {
 			if r.health != nil && r.health.IsCircuitOpen(p.ID) {
+				if r.metrics != nil {
+					r.metrics.IncExcluded(p.ID)
+				}
 				return
 			}
-
-			timeout := p.Timeout
-			if timeout == 0 {
-				timeout = 30 * time.Millisecond
+			if r.health != nil {
+				r.health.IncrInflight(p.ID)
+				defer r.health.DecrInflight(p.ID)
 			}
-			callCtx, cancel := context.WithTimeout(ctx, timeout)
+
+			callCtx, cancel := context.WithTimeout(ctx, r.effectiveTimeout(p.Timeout))
 			defer cancel()
 
 			// Filter packages if provider has PackageIDs configured.
@@ -262,14 +299,17 @@ func (r *Router) fanOutIdentity(ctx context.Context, providers []ProviderConfig,
 	for _, p := range providers {
 		wg.Go(func() {
 			if r.health != nil && r.health.IsCircuitOpen(p.ID) {
+				if r.metrics != nil {
+					r.metrics.IncExcluded(p.ID)
+				}
 				return
 			}
-
-			timeout := p.Timeout
-			if timeout == 0 {
-				timeout = 30 * time.Millisecond
+			if r.health != nil {
+				r.health.IncrInflight(p.ID)
+				defer r.health.DecrInflight(p.ID)
 			}
-			callCtx, cancel := context.WithTimeout(ctx, timeout)
+
+			callCtx, cancel := context.WithTimeout(ctx, r.effectiveTimeout(p.Timeout))
 			defer cancel()
 
 			var imResp tmproto.IdentityMatchResponse

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -17,7 +17,7 @@ import (
 // httptest.Server (which binds to localhost).
 func testRouter(providers []ProviderConfig) *Router {
 	return &Router{
-		providers: providers,
+		providers: NewProviderSet(providers),
 		client:    &http.Client{Timeout: 10 * time.Second},
 		logger:    slog.Default(),
 	}

--- a/router/safedial.go
+++ b/router/safedial.go
@@ -1,0 +1,34 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+// safeDialContext resolves DNS and validates the resolved IP against private/loopback
+// ranges before connecting. This prevents DNS rebinding attacks where a hostname
+// passes initial SSRF validation but later resolves to an internal address.
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no addresses found for %s", host)
+	}
+	for _, ip := range ips {
+		resolved := ip.IP
+		if v4 := resolved.To4(); v4 != nil {
+			resolved = v4
+		}
+		if resolved.IsLoopback() || resolved.IsPrivate() || resolved.IsLinkLocalUnicast() || resolved.IsLinkLocalMulticast() {
+			return nil, fmt.Errorf("resolved address %s is not allowed for %s", resolved, host)
+		}
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+}

--- a/router/serverconfig.go
+++ b/router/serverconfig.go
@@ -2,16 +2,28 @@ package router
 
 import (
 	"encoding/json"
-	"fmt"
+	"log/slog"
 	"os"
+	"time"
 )
 
 // ServerConfig is the JSON config file format for the router.
 type ServerConfig struct {
-	Addr      string           `json:"addr"`
-	Providers []ProviderConfig `json:"providers"`
-	Health    HealthConfig     `json:"health"`
-	Shutdown  ShutdownConfig   `json:"shutdown"`
+	Addr            string            `json:"addr"`
+	LatencyBudgetMs int               `json:"latency_budget_ms"`
+	Providers       []ProviderConfig  `json:"providers"`
+	Health          HealthConfig      `json:"health"`
+	HealthCheck     HealthCheckConfig `json:"health_check"`
+	Discovery       DiscoveryConfig   `json:"discovery"`
+	Shutdown        ShutdownConfig    `json:"shutdown"`
+}
+
+// LatencyBudget returns the latency budget as a time.Duration.
+func (c *ServerConfig) LatencyBudget() time.Duration {
+	if c.LatencyBudgetMs <= 0 {
+		return 50 * time.Millisecond
+	}
+	return time.Duration(c.LatencyBudgetMs) * time.Millisecond
 }
 
 // HealthConfig controls circuit breaker behavior.
@@ -20,12 +32,19 @@ type HealthConfig struct {
 	CooldownSeconds  int    `json:"cooldown_seconds"`
 }
 
+// HealthCheckConfig controls active provider health polling.
+type HealthCheckConfig struct {
+	IntervalSeconds int `json:"interval_seconds"` // default 30
+	TimeoutSeconds  int `json:"timeout_seconds"`  // per-check timeout, default 5
+}
+
 // ShutdownConfig controls graceful shutdown.
 type ShutdownConfig struct {
 	DrainSeconds int `json:"drain_seconds"`
 }
 
 // LoadServerConfig reads a JSON config file and returns the config.
+// Invalid providers are logged and skipped rather than causing a hard error.
 func LoadServerConfig(path string) (*ServerConfig, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // path is from CLI flag, not user input
 	if err != nil {
@@ -35,11 +54,20 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	budget := cfg.LatencyBudget()
+	valid := cfg.Providers[:0]
 	for _, p := range cfg.Providers {
 		if err := ValidateProviderEndpoint(p.Endpoint); err != nil {
-			return nil, fmt.Errorf("provider %q: %w", p.ID, err)
+			slog.Warn("skipping provider with invalid endpoint", "provider", p.ID, "error", err)
+			continue
 		}
+		if err := ValidateProviderConfig(&p, budget); err != nil {
+			slog.Warn("skipping invalid provider", "provider", p.ID, "error", err)
+			continue
+		}
+		valid = append(valid, p)
 	}
+	cfg.Providers = valid
 	return &cfg, nil
 }
 
@@ -47,8 +75,10 @@ func LoadServerConfig(path string) (*ServerConfig, error) {
 // Providers must be supplied via a config file or programmatically.
 func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
-		Addr:     ":8080",
-		Health:   HealthConfig{FailureThreshold: 3, CooldownSeconds: 10},
-		Shutdown: ShutdownConfig{DrainSeconds: 5},
+		Addr:            ":8080",
+		LatencyBudgetMs: 50,
+		Health:          HealthConfig{FailureThreshold: 3, CooldownSeconds: 10},
+		HealthCheck:     HealthCheckConfig{IntervalSeconds: 30, TimeoutSeconds: 5},
+		Shutdown:        ShutdownConfig{DrainSeconds: 5},
 	}
 }

--- a/targeting/prommetrics/metrics_test.go
+++ b/targeting/prommetrics/metrics_test.go
@@ -51,6 +51,48 @@ func TestMetricsInterface(t *testing.T) {
 	}
 }
 
+func TestGaugeOutput(t *testing.T) {
+	reg := NewRegistry()
+	reg.DefineGauge("provider_health", "Health status.", []string{"provider"})
+	reg.GaugeSet("provider_health", 1, "acme")
+	reg.GaugeSet("provider_health", 0, "broken")
+
+	rec := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body, _ := io.ReadAll(rec.Body)
+	text := string(body)
+
+	for _, want := range []string{
+		"# HELP provider_health Health status.",
+		"# TYPE provider_health gauge",
+		`provider_health{provider="acme"} 1`,
+		`provider_health{provider="broken"} 0`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("gauge output missing %q\n\ngot:\n%s", want, text)
+		}
+	}
+}
+
+func TestGaugeSet_Overwrite(t *testing.T) {
+	reg := NewRegistry()
+	reg.DefineGauge("my_gauge", "Test.", []string{"id"})
+	reg.GaugeSet("my_gauge", 5, "a")
+	reg.GaugeSet("my_gauge", 10, "a") // overwrite
+
+	rec := httptest.NewRecorder()
+	reg.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body, _ := io.ReadAll(rec.Body)
+	text := string(body)
+
+	if !strings.Contains(text, `my_gauge{id="a"} 10`) {
+		t.Errorf("gauge should be overwritten to 10, got:\n%s", text)
+	}
+	if strings.Contains(text, `my_gauge{id="a"} 5`) {
+		t.Errorf("old gauge value should not appear")
+	}
+}
+
 func TestConcurrentAccess(t *testing.T) {
 	m := New()
 	done := make(chan struct{})

--- a/targeting/prommetrics/registry.go
+++ b/targeting/prommetrics/registry.go
@@ -11,19 +11,26 @@ import (
 	"sync/atomic"
 )
 
-// Registry collects counters and histograms, and serves them in
+// Registry collects counters, gauges, and histograms, and serves them in
 // Prometheus text exposition format (v0.0.4).
 type Registry struct {
-	mu         sync.RWMutex
+	mu            sync.RWMutex
 	counterDefs   map[string]*counterDef
+	gaugeDefs     map[string]*gaugeDef
 	histogramDefs map[string]*histogramDef
 	order         []string // insertion order for stable output
 
 	counters   sync.Map // "name\x00label1\x00label2..." -> *atomic.Int64
+	gauges     sync.Map // "name\x00label1\x00label2..." -> *atomic.Int64 (value * 1e9)
 	histograms sync.Map // "name\x00label1\x00label2..." -> *histogram
 }
 
 type counterDef struct {
+	help   string
+	labels []string
+}
+
+type gaugeDef struct {
 	help   string
 	labels []string
 }
@@ -45,8 +52,30 @@ type histogram struct {
 func NewRegistry() *Registry {
 	return &Registry{
 		counterDefs:   make(map[string]*counterDef),
+		gaugeDefs:     make(map[string]*gaugeDef),
 		histogramDefs: make(map[string]*histogramDef),
 	}
+}
+
+// DefineGauge registers a gauge metric. Call once at init time.
+func (r *Registry) DefineGauge(name, help string, labels []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.gaugeDefs[name] = &gaugeDef{help: help, labels: labels}
+	r.order = append(r.order, name)
+}
+
+// GaugeSet sets a gauge to a specific value. Label values must match
+// the order of labels passed to DefineGauge.
+func (r *Registry) GaugeSet(name string, value float64, labelValues ...string) {
+	key := buildKey(name, labelValues)
+	encoded := int64(value * 1e9)
+	if v, ok := r.gauges.Load(key); ok {
+		v.(*atomic.Int64).Store(encoded)
+		return
+	}
+	v, _ := r.gauges.LoadOrStore(key, &atomic.Int64{})
+	v.(*atomic.Int64).Store(encoded)
 }
 
 // DefineCounter registers a counter metric. Call once at init time.
@@ -126,11 +155,14 @@ func (r *Registry) writeTo(b *strings.Builder) {
 
 		r.mu.RLock()
 		cDef := r.counterDefs[name]
+		gDef := r.gaugeDefs[name]
 		hDef := r.histogramDefs[name]
 		r.mu.RUnlock()
 
 		if cDef != nil {
 			r.writeCounter(b, name, cDef)
+		} else if gDef != nil {
+			r.writeGauge(b, name, gDef)
 		} else if hDef != nil {
 			r.writeHistogram(b, name, hDef)
 		}
@@ -167,6 +199,39 @@ func (r *Registry) writeCounter(b *strings.Builder, name string, def *counterDef
 	fmt.Fprintf(b, "# TYPE %s counter\n", name)
 	for _, e := range entries {
 		fmt.Fprintf(b, "%s%s %d\n", name, formatLabelPairs(def.labels, e.labels), e.value)
+	}
+}
+
+func (r *Registry) writeGauge(b *strings.Builder, name string, def *gaugeDef) {
+	type entry struct {
+		labels []string
+		value  float64
+	}
+	var entries []entry
+
+	prefix := name + "\x00"
+	r.gauges.Range(func(k, v any) bool {
+		key := k.(string)
+		if key == name || strings.HasPrefix(key, prefix) {
+			labels := parseLabels(key)
+			val := float64(v.(*atomic.Int64).Load()) / 1e9
+			entries = append(entries, entry{labels, val})
+		}
+		return true
+	})
+
+	if len(entries) == 0 {
+		return
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.Join(entries[i].labels, ",") < strings.Join(entries[j].labels, ",")
+	})
+
+	fmt.Fprintf(b, "# HELP %s %s\n", name, def.help)
+	fmt.Fprintf(b, "# TYPE %s gauge\n", name)
+	for _, e := range entries {
+		fmt.Fprintf(b, "%s%s %s\n", name, formatLabelPairs(def.labels, e.labels), formatFloat(e.value))
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements issue #34 — provider discovery, health tracking, and lifecycle states for the TMP router.

- **Provider lifecycle states**: `active`, `inactive`, `draining` with graceful drain support (waits for in-flight requests to complete)
- **Registration validation**: ID format, match type requirements (countries/uid_types for identity), timeout vs latency budget
- **Latency budget**: Router-level `latency_budget_ms` (default 50ms) clamps per-provider timeouts
- **ProviderSet**: Atomic.Value-based mutable provider list — lock-free reads in the hot path, mutex-serialized writes
- **Active health checks**: Background polling of `GET /health` on each provider, integrated with existing circuit breaker
- **Provider discovery**: Optional HTTP polling of a discovery endpoint with reconciliation (add/remove/update/drain)
- **DNS rebinding protection**: `safeDialContext` validates resolved IPs before connecting
- **Prometheus metrics**: Gauge support in prommetrics, 4 new metrics (`tmp_provider_health_status`, `tmp_provider_health_check_duration_ms`, `tmp_provider_excluded_total`, `tmp_provider_recovered_total`)
- **Observability**: `GET /providers` endpoint with combined provider config + health status

### New files
| File | Purpose |
|------|---------|
| `router/providerset.go` | Atomic provider set with Active/All/Swap/SetStatus |
| `router/drain.go` | Graceful provider drain with in-flight tracking |
| `router/healthcheck.go` | Background health polling with HealthCheckMetrics interface |
| `router/discovery.go` | HTTP-based provider discovery with reconciliation |
| `router/safedial.go` | DNS rebinding protection for all outbound HTTP clients |

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] New unit tests for ProviderSet, drain, health checker, discovery, gauge metrics
- [x] Smoke tested router binary locally (`/health`, `/providers`, `/tmp/context`, `/tmp/identity`)
- [x] Code review addressed (double filtering, godoc, gauge test, unused Priority removed)
- [x] Security review addressed (DNS rebinding, provider count limit, ID validation, response body drain, empty discovery protection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)