### PR TITLE
refactor: extract ExposureRecorder from Engine for standalone library use

### DIFF
--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -51,38 +51,68 @@ r := router.NewRouter(providers, registry, nil, health,
 )
 ```
 
-## Implementing targeting.Metrics
+## Implementing targeting.Metrics and exposure.Metrics
 
-The `targeting.Metrics` interface is the observability hook for the evaluation engine. If your host application already has Prometheus (or any metrics system), implement the interface directly:
+Observability is split across two interfaces. The evaluation engine emits
+`targeting.Metrics` callbacks (context/identity evaluation outcomes, stage
+latency, store errors). The impression recorder in the `exposure` package
+emits `exposure.Metrics` callbacks (exposure recorded, store errors during
+write). A single type can satisfy both — that is what `targeting/prommetrics`
+does.
 
 ```go
 type MyMetrics struct {
-    contextEval *prometheus.CounterVec
-    latency     *prometheus.HistogramVec
-    // ...
+    contextEval     *prometheus.CounterVec
+    identityEval    *prometheus.CounterVec
+    exposureRecord  *prometheus.CounterVec
+    storeErrors     *prometheus.CounterVec
+    latency         *prometheus.HistogramVec
 }
 
+// targeting.Metrics — read path (evaluation).
 func (m *MyMetrics) ContextEvaluated(packageID, stage string, passed bool) {
     m.contextEval.WithLabelValues(stage, strconv.FormatBool(passed)).Inc()
 }
+func (m *MyMetrics) IdentityEvaluated(packageID, stage string, passed bool) { /* ... */ }
+func (m *MyMetrics) Latency(stage string, d time.Duration)                  { /* ... */ }
 
-func (m *MyMetrics) Latency(stage string, d time.Duration) {
-    m.latency.WithLabelValues(stage).Observe(d.Seconds())
+// Shared with exposure.Metrics — both interfaces include StoreError.
+func (m *MyMetrics) StoreError(operation string, err error) { /* ... */ }
+
+// exposure.Metrics — write path (impression recording).
+func (m *MyMetrics) ExposureRecorded(packageID string) {
+    m.exposureRecord.WithLabelValues().Inc()
 }
-
-// ... implement remaining methods
 ```
 
-Then pass it to the engine:
+Wire each interface where it's consumed:
 
 ```go
 engine := targeting.NewEngine(targeting.EngineConfig{
-    Metrics: &MyMetrics{...},
+    Metrics: &MyMetrics{...}, // satisfies targeting.Metrics
+    // ...
+})
+
+recorder := exposure.NewRecorder(exposure.RecorderConfig{
+    Metrics: &MyMetrics{...}, // satisfies exposure.Metrics
     // ...
 })
 ```
 
-The `targeting/prommetrics` sub-module is a reference implementation with zero external dependencies. Use it directly or as a template for your own.
+The `targeting/prommetrics` sub-module is a reference implementation with
+zero external dependencies that satisfies both interfaces on a single struct.
+Use it directly or as a template.
+
+### Breaking change in this split
+
+Prior versions exposed `ExposureRecorded` on `targeting.Metrics` because the
+engine owned impression recording. Recording is now owned by
+`exposure.Recorder`, and the callback lives on `exposure.Metrics`. External
+implementations that defined `ExposureRecorded` on their `targeting.Metrics`
+type still compile (extra methods don't break satisfaction), but the engine
+no longer invokes that method. To continue receiving the callback, pass the
+same implementation as `exposure.RecorderConfig.Metrics` when constructing
+the recorder.
 
 ## Security considerations for embedders
 

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/router"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/tmpclient"
@@ -20,10 +21,11 @@ import (
 
 // testStack holds all components for an integration test.
 type testStack struct {
-	client         *tmpclient.Client
-	store          *targeting.MockStore
-	contextEngine  *targeting.Engine
-	identityEngine *targeting.Engine
+	client           *tmpclient.Client
+	store            *targeting.MockStore
+	contextEngine    *targeting.Engine
+	identityEngine   *targeting.Engine
+	exposureRecorder *exposure.Recorder
 }
 
 func setupStack(t *testing.T) *testStack {
@@ -41,8 +43,8 @@ func setupStack(t *testing.T) *testStack {
 	store.SetAdd("url:blocklist:pkg-family", targeting.HashURL("article:adult-content"))
 
 	// Seed audience segments.
-	aliceHash := targeting.HashToken("tok-alice")
-	bobHash := targeting.HashToken("tok-bob")
+	aliceHash := exposure.HashToken("tok-alice")
+	bobHash := exposure.HashToken("tok-bob")
 	store.SetAdd("audience:cooking_fans", aliceHash)
 	store.SetAdd("audience:sports_fans", bobHash)
 
@@ -61,17 +63,17 @@ func setupStack(t *testing.T) *testStack {
 	})
 
 	// Seed identity config in Store (data-driven, not static config).
-	store.SetPackageIdentityConfig("pkg-food", targeting.PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-food", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
 		TargetSegments: []string{"cooking_fans"},
 	})
 	// pkg-tech: no identity config = always eligible
-	store.SetPackageIdentityConfig("pkg-family", targeting.PackageIdentityConfig{
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
+	store.SetPackageIdentityConfig("pkg-family", exposure.PackageIdentityConfig{
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
 	})
-	store.SetCampaignFreqConfig("campaign-acme", targeting.CampaignFreqConfig{
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
+	store.SetCampaignFreqConfig("campaign-acme", exposure.CampaignFreqConfig{
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
 	})
 
 	// User profiles for identity evaluation.
@@ -94,13 +96,13 @@ func setupStack(t *testing.T) *testStack {
 		SegmentIndex: map[string][]string{
 			"cooking_fans": {"pkg-food"},
 		},
-		IdentityConfigs: map[string]*targeting.PackageIdentityConfig{
-			"pkg-food":   {CampaignID: "campaign-acme", FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking_fans"}},
+		IdentityConfigs: map[string]*exposure.PackageIdentityConfig{
+			"pkg-food":   {CampaignID: "campaign-acme", FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking_fans"}},
 			"pkg-tech":   {},
-			"pkg-family": {FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
+			"pkg-family": {FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
 		},
-		CampaignConfigs: map[string]*targeting.CampaignFreqConfig{
-			"campaign-acme": {FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
+		CampaignConfigs: map[string]*exposure.CampaignFreqConfig{
+			"campaign-acme": {FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
 		},
 	}
 
@@ -139,6 +141,10 @@ func setupStack(t *testing.T) *testStack {
 		store:          store,
 		contextEngine:  contextEngine,
 		identityEngine: identityEngine,
+		exposureRecorder: exposure.NewRecorder(exposure.RecorderConfig{
+			ProviderID: "integration-identity",
+			Store:      store,
+		}),
 	}
 }
 
@@ -290,7 +296,7 @@ func TestIntegration_FrequencyCapping(t *testing.T) {
 		result, err := s.client.Activate(ctx, params)
 		require.NoError(t, err, "activate %d", i)
 		require.NotEmpty(t, result.Activations, "activate %d: expected activation before cap", i)
-		_, err = s.identityEngine.RecordExposure(ctx, &targeting.ExposeRequest{
+		_, err = s.exposureRecorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken:    "tok-alice",
 			PackageID:    "pkg-food",
 			ImpressionID: fmt.Sprintf("imp-fcap-%d", i),
@@ -367,7 +373,7 @@ func TestIntegration_ExposeUpdatesState(t *testing.T) {
 	require.NotEmpty(t, result1.Activations, "expected activation")
 
 	// Record exposure directly via the engine (TMPX replaces router-based expose).
-	expResp, err := s.identityEngine.RecordExposure(ctx, &targeting.ExposeRequest{
+	expResp, err := s.exposureRecorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken:    "tok-alice",
 		PackageID:    "pkg-food",
 		ImpressionID: "imp-state-1",
@@ -413,7 +419,7 @@ func TestIntegration_Mediation(t *testing.T) {
 	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
 
 	// Audience: alice is a cooking fan.
-	store.SetAdd("audience:cooking_fans", targeting.HashToken("tok-alice"))
+	store.SetAdd("audience:cooking_fans", exposure.HashToken("tok-alice"))
 
 	creativeManifest, _ := json.Marshal(map[string]any{
 		"format_id": "sponsored_card",
@@ -463,9 +469,9 @@ func TestIntegration_Mediation(t *testing.T) {
 	})
 
 	// Seed identity config for mediation packages.
-	store.SetPackageIdentityConfig("pkg-olive-oil", targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
-	store.SetPackageIdentityConfig("pkg-cookware", targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
-	store.SetPackageIdentityConfig("pkg-wine", targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
+	store.SetPackageIdentityConfig("pkg-olive-oil", exposure.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
+	store.SetPackageIdentityConfig("pkg-cookware", exposure.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
+	store.SetPackageIdentityConfig("pkg-wine", exposure.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}})
 
 	identityEngine := targeting.NewEngine(targeting.EngineConfig{
 		ProviderID: "mediation-identity",
@@ -478,7 +484,7 @@ func TestIntegration_Mediation(t *testing.T) {
 	})
 
 	// Seed intent scores directly in store to simulate prior exposure history.
-	oliveHash := targeting.HashToken("tok-alice")
+	oliveHash := exposure.HashToken("tok-alice")
 	_ = store.Set(context.Background(), "intent:pkg-olive-oil:"+oliveHash, fmt.Sprintf("%d", time.Now().Add(-6*time.Hour).Unix()), 7*24*time.Hour)
 	_ = store.Set(context.Background(), "intent:pkg-wine:"+oliveHash, fmt.Sprintf("%d", time.Now().Add(-4*24*time.Hour).Unix()), 7*24*time.Hour)
 

--- a/exposure/binary.go
+++ b/exposure/binary.go
@@ -1,10 +1,9 @@
-package targeting
+package exposure
 
 import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"hash/fnv"
 )
 
 // Binary exposure log format:
@@ -20,18 +19,18 @@ import (
 //
 //	timestamp(8) + impressionHash(8) + packageHash(8) + campaignHash(8) + sourceHash(8)
 const (
-	binaryHeaderSize    = 4
-	binaryVersion1      = 1
-	binaryVersion2      = 2
-	binaryEntrySize1    = 32
-	binaryEntrySize     = 40 // current write format (v2)
-	maxExposureEntries  = 10000 // cap per-user log to bound linear scan cost (~400 KB)
+	binaryHeaderSize   = 4
+	binaryVersion1     = 1
+	binaryVersion2     = 2
+	binaryEntrySize1   = 32
+	binaryEntrySize    = 40    // current write format (v2)
+	maxExposureEntries = 10000 // cap per-user log to bound linear scan cost (~400 KB)
 )
 
 var (
-	ErrBinaryTooShort      = errors.New("binary log too short for header")
+	ErrBinaryTooShort       = errors.New("binary log too short for header")
 	ErrBinaryUnknownVersion = fmt.Errorf("unknown binary log version (supported: %d, %d)", binaryVersion1, binaryVersion2)
-	ErrBinaryCorrupt       = errors.New("binary log size not aligned to entry size")
+	ErrBinaryCorrupt        = errors.New("binary log size not aligned to entry size")
 )
 
 // BinaryExposureLog is a compact byte-slice exposure log.
@@ -53,10 +52,10 @@ func EncodeBinaryExposureLog(log ExposureLog) BinaryExposureLog {
 	for i, e := range log {
 		offset := binaryHeaderSize + i*binaryEntrySize
 		binary.LittleEndian.PutUint64(buf[offset:], uint64(e.Timestamp)) //nolint:gosec // timestamp is always positive
-		binary.LittleEndian.PutUint64(buf[offset+8:], hashString(e.ImpressionID))
-		binary.LittleEndian.PutUint64(buf[offset+16:], hashString(e.PackageID))
-		binary.LittleEndian.PutUint64(buf[offset+24:], hashString(e.CampaignID))
-		binary.LittleEndian.PutUint64(buf[offset+32:], hashString(e.SourceID))
+		binary.LittleEndian.PutUint64(buf[offset+8:], HashString(e.ImpressionID))
+		binary.LittleEndian.PutUint64(buf[offset+16:], HashString(e.PackageID))
+		binary.LittleEndian.PutUint64(buf[offset+24:], HashString(e.CampaignID))
+		binary.LittleEndian.PutUint64(buf[offset+32:], HashString(e.SourceID))
 	}
 	return buf
 }
@@ -298,14 +297,4 @@ func TruncateBinaryLog(b BinaryExposureLog, maxEntries int) BinaryExposureLog {
 		result = append(result, 0, 0, 0, 0, 0, 0, 0, 0)
 	}
 	return result
-}
-
-// hashString returns an FNV-1a 64-bit hash. Used for compact binary storage
-// of package/campaign/impression IDs. Collision probability is ~0.0003% at
-// 10M unique strings (birthday bound). Acceptable for frequency cap counting
-// where an occasional collision causes slight over/under-counting.
-func hashString(s string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(s)) // fnv.Write never returns an error
-	return h.Sum64()
 }

--- a/exposure/binary_test.go
+++ b/exposure/binary_test.go
@@ -1,4 +1,4 @@
-package targeting
+package exposure
 
 import (
 	"encoding/binary"
@@ -21,7 +21,7 @@ func TestBinary_EncodeAndQuery(t *testing.T) {
 	require.Equal(t, 3, bin.Len())
 	assert.Equal(t, int64(1000), bin.Timestamp(0))
 
-	foodHash := hashString("pkg-food")
+	foodHash := HashString("pkg-food")
 	latest := LatestExposureBinary(bin, foodHash)
 	assert.Equal(t, int64(3000), latest)
 
@@ -73,11 +73,11 @@ func TestBinary_ValidateRejectsInvalid(t *testing.T) {
 		{"wrong entry size v1", BinaryExposureLog{0x01, 0x00, 0x10, 0x00}, ErrBinaryCorrupt},
 		{"unaligned payload v2", append(
 			BinaryExposureLog{0x02, 0x00, 0x28, 0x00}, // valid v2 header
-			make([]byte, 15)...,                         // 15 bytes, not multiple of 40
+			make([]byte, 15)..., // 15 bytes, not multiple of 40
 		), ErrBinaryCorrupt},
 		{"unaligned payload v1", append(
 			BinaryExposureLog{0x01, 0x00, 0x20, 0x00}, // valid v1 header
-			make([]byte, 15)...,                         // 15 bytes, not multiple of 32
+			make([]byte, 15)..., // 15 bytes, not multiple of 32
 		), ErrBinaryCorrupt},
 	}
 	for _, tt := range tests {
@@ -143,8 +143,8 @@ func TestBinary_SourceHash(t *testing.T) {
 	}
 	bin := EncodeBinaryExposureLog(log)
 
-	cnnHash := hashString("agent-cnn")
-	nytHash := hashString("agent-nyt")
+	cnnHash := HashString("agent-cnn")
+	nytHash := HashString("agent-nyt")
 
 	assert.Equal(t, cnnHash, bin.SourceHash(0))
 	assert.Equal(t, nytHash, bin.SourceHash(1))
@@ -155,7 +155,7 @@ func TestBinary_SourceHashOfEmptyString(t *testing.T) {
 		{ImpressionID: "imp-1", PackageID: "pkg-food", Timestamp: 1000},
 	}
 	bin := EncodeBinaryExposureLog(log)
-	emptyHash := hashString("")
+	emptyHash := HashString("")
 	assert.Equal(t, emptyHash, bin.SourceHash(0))
 }
 
@@ -168,16 +168,16 @@ func TestBinary_V1ReadCompatibility(t *testing.T) {
 	// Entry 0: ts=1000, imp=hash("imp-1"), pkg=hash("pkg-a"), camp=hash("c1")
 	off := binaryHeaderSize
 	binary.LittleEndian.PutUint64(v1[off:], 1000)
-	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-1"))
-	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
-	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	binary.LittleEndian.PutUint64(v1[off+8:], HashString("imp-1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 
 	// Entry 1: ts=2000
 	off = binaryHeaderSize + binaryEntrySize1
 	binary.LittleEndian.PutUint64(v1[off:], 2000)
-	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-2"))
-	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-b"))
-	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	binary.LittleEndian.PutUint64(v1[off+8:], HashString("imp-2"))
+	binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-b"))
+	binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 
 	blog := BinaryExposureLog(v1)
 
@@ -190,7 +190,7 @@ func TestBinary_V1ReadCompatibility(t *testing.T) {
 
 	// Frequency check works on v1 logs.
 	rules := []FrequencyRule{{MaxCount: 1, Window: 24 * time.Hour}}
-	capped := CheckFrequencyRulesBinary(blog, hashString("pkg-a"), false, rules, 3000)
+	capped := CheckFrequencyRulesBinary(blog, HashString("pkg-a"), false, rules, 3000)
 	assert.True(t, capped, "expected capped for pkg-a (1 exposure, cap 1)")
 }
 
@@ -201,9 +201,9 @@ func TestBinary_V1UpgradeOnMerge(t *testing.T) {
 	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
 	off := binaryHeaderSize
 	binary.LittleEndian.PutUint64(v1[off:], 1000)
-	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-v1"))
-	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
-	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	binary.LittleEndian.PutUint64(v1[off+8:], HashString("imp-v1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 
 	// Build a v2 log.
 	v2 := EncodeBinaryExposureLog(ExposureLog{
@@ -218,7 +218,7 @@ func TestBinary_V1UpgradeOnMerge(t *testing.T) {
 
 	// V1 entry gets source hash 0, v2 entry keeps its source hash.
 	assert.Equal(t, uint64(0), merged.SourceHash(0))
-	assert.Equal(t, hashString("agent-x"), merged.SourceHash(1))
+	assert.Equal(t, HashString("agent-x"), merged.SourceHash(1))
 }
 
 func TestBinary_V1TruncateUpgrades(t *testing.T) {
@@ -229,9 +229,9 @@ func TestBinary_V1TruncateUpgrades(t *testing.T) {
 	for i := range 20 {
 		off := binaryHeaderSize + i*binaryEntrySize1
 		binary.LittleEndian.PutUint64(v1[off:], uint64(1000+i))
-		binary.LittleEndian.PutUint64(v1[off+8:], hashString(fmt.Sprintf("imp-%d", i)))
-		binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
-		binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+		binary.LittleEndian.PutUint64(v1[off+8:], HashString(fmt.Sprintf("imp-%d", i)))
+		binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-a"))
+		binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 	}
 
 	truncated := TruncateBinaryLog(BinaryExposureLog(v1), 5)
@@ -252,9 +252,9 @@ func TestBinary_V1UnderLimitUpgrades(t *testing.T) {
 	for i := range 2 {
 		off := binaryHeaderSize + i*binaryEntrySize1
 		binary.LittleEndian.PutUint64(v1[off:], uint64(1000+i))
-		binary.LittleEndian.PutUint64(v1[off+8:], hashString(fmt.Sprintf("imp-%d", i)))
-		binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
-		binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+		binary.LittleEndian.PutUint64(v1[off+8:], HashString(fmt.Sprintf("imp-%d", i)))
+		binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-a"))
+		binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 	}
 
 	upgraded := TruncateBinaryLog(BinaryExposureLog(v1), 100)
@@ -269,9 +269,9 @@ func TestBinary_MultiLogWorksWithMixedVersions(t *testing.T) {
 	binary.LittleEndian.PutUint16(v1[2:], binaryEntrySize1)
 	off := binaryHeaderSize
 	binary.LittleEndian.PutUint64(v1[off:], 1000)
-	binary.LittleEndian.PutUint64(v1[off+8:], hashString("imp-v1"))
-	binary.LittleEndian.PutUint64(v1[off+16:], hashString("pkg-a"))
-	binary.LittleEndian.PutUint64(v1[off+24:], hashString("c1"))
+	binary.LittleEndian.PutUint64(v1[off+8:], HashString("imp-v1"))
+	binary.LittleEndian.PutUint64(v1[off+16:], HashString("pkg-a"))
+	binary.LittleEndian.PutUint64(v1[off+24:], HashString("c1"))
 
 	// V2 log with 1 entry for pkg-a (different impression).
 	v2 := EncodeBinaryExposureLog(ExposureLog{
@@ -282,11 +282,11 @@ func TestBinary_MultiLogWorksWithMixedVersions(t *testing.T) {
 	rules := []FrequencyRule{{MaxCount: 2, Window: 24 * time.Hour}}
 
 	// 2 entries for pkg-a, cap=2 → capped.
-	capped := CheckFrequencyRulesMultiLog(logs, hashString("pkg-a"), false, rules, 3000)
+	capped := CheckFrequencyRulesMultiLog(logs, HashString("pkg-a"), false, rules, 3000)
 	assert.True(t, capped, "expected capped with mixed v1+v2 logs")
 
 	// latest across mixed versions.
-	latest := LatestExposureMultiLog(logs, hashString("pkg-a"))
+	latest := LatestExposureMultiLog(logs, HashString("pkg-a"))
 	assert.Equal(t, int64(2000), latest)
 }
 
@@ -315,8 +315,8 @@ func TestScale_JSONvsBinary(t *testing.T) {
 	t.Logf("")
 
 	const iterations = 1000
-	pkgHash := hashString("pkg-0")
-	campHash := hashString("campaign-0")
+	pkgHash := HashString("pkg-0")
+	campHash := HashString("campaign-0")
 	rules := []FrequencyRule{{MaxCount: 50, Window: 24 * time.Hour}}
 	nowUnix := now.Unix()
 

--- a/exposure/config.go
+++ b/exposure/config.go
@@ -1,4 +1,4 @@
-package targeting
+package exposure
 
 import (
 	"context"
@@ -10,9 +10,9 @@ import (
 // PackageIdentityConfig is the identity-side configuration for a package,
 // stored in the Store as JSON at key "config:pkg:{packageID}".
 type PackageIdentityConfig struct {
-	CampaignID     string             `json:"campaign_id,omitempty"`
+	CampaignID     string              `json:"campaign_id,omitempty"`
 	FrequencyRules []FrequencyRuleJSON `json:"frequency_rules,omitempty"`
-	TargetSegments []string           `json:"target_segments,omitempty"`
+	TargetSegments []string            `json:"target_segments,omitempty"`
 }
 
 // CampaignFreqConfig is the frequency cap configuration for a campaign,
@@ -27,8 +27,8 @@ type FrequencyRuleJSON struct {
 	WindowSeconds int `json:"window_seconds"`
 }
 
-// toFrequencyRules converts JSON rules to engine rules.
-func toFrequencyRules(rules []FrequencyRuleJSON) []FrequencyRule {
+// ToFrequencyRules converts JSON rules to engine rules.
+func ToFrequencyRules(rules []FrequencyRuleJSON) []FrequencyRule {
 	out := make([]FrequencyRule, len(rules))
 	for i, r := range rules {
 		out[i] = FrequencyRule{
@@ -39,9 +39,9 @@ func toFrequencyRules(rules []FrequencyRuleJSON) []FrequencyRule {
 	return out
 }
 
-// loadPackageIdentityConfig reads identity config for a package from the Store.
+// LoadPackageIdentityConfig reads identity config for a package from the Store.
 // Returns nil if no config is found (package has no identity dimensions).
-func loadPackageIdentityConfig(ctx context.Context, store Store, pkgID string) (*PackageIdentityConfig, error) {
+func LoadPackageIdentityConfig(ctx context.Context, store ConfigStore, pkgID string) (*PackageIdentityConfig, error) {
 	key := fmt.Sprintf("config:pkg:%s", pkgID)
 	val, ok, err := store.Get(ctx, key)
 	if err != nil {
@@ -57,35 +57,26 @@ func loadPackageIdentityConfig(ctx context.Context, store Store, pkgID string) (
 	return &cfg, nil
 }
 
-// batchLoadPackageContextConfigs loads context configs for multiple packages in one MGet.
-func batchLoadPackageContextConfigs(ctx context.Context, store Store, pkgIDs []string) (map[string]*PackageContextConfig, error) {
-	if len(pkgIDs) == 0 {
-		return nil, nil
-	}
-	keys := make([]string, len(pkgIDs))
-	for i, id := range pkgIDs {
-		keys[i] = fmt.Sprintf("config:pkg:%s:context", id)
-	}
-	values, err := store.MGet(ctx, keys...)
+// LoadCampaignFreqConfig reads frequency cap config for a campaign from the Store.
+// Returns nil if no config is found.
+func LoadCampaignFreqConfig(ctx context.Context, store ConfigStore, campaignID string) (*CampaignFreqConfig, error) {
+	key := fmt.Sprintf("config:campaign:%s", campaignID)
+	val, ok, err := store.Get(ctx, key)
 	if err != nil {
 		return nil, err
 	}
-	result := make(map[string]*PackageContextConfig, len(pkgIDs))
-	for i, val := range values {
-		if val == "" {
-			continue
-		}
-		var cfg PackageContextConfig
-		if err := json.Unmarshal([]byte(val), &cfg); err != nil {
-			continue // skip unparseable
-		}
-		result[pkgIDs[i]] = &cfg
+	if !ok {
+		return nil, nil
 	}
-	return result, nil
+	var cfg CampaignFreqConfig
+	if err := json.Unmarshal([]byte(val), &cfg); err != nil {
+		return nil, fmt.Errorf("parse campaign config for %s: %w", campaignID, err)
+	}
+	return &cfg, nil
 }
 
-// batchLoadPackageIdentityConfigs loads identity configs for multiple packages in one MGet.
-func batchLoadPackageIdentityConfigs(ctx context.Context, store Store, pkgIDs []string) (map[string]*PackageIdentityConfig, error) {
+// BatchLoadPackageIdentityConfigs loads identity configs for multiple packages in one MGet.
+func BatchLoadPackageIdentityConfigs(ctx context.Context, store BatchStore, pkgIDs []string) (map[string]*PackageIdentityConfig, error) {
 	if len(pkgIDs) == 0 {
 		return nil, nil
 	}
@@ -111,8 +102,8 @@ func batchLoadPackageIdentityConfigs(ctx context.Context, store Store, pkgIDs []
 	return result, nil
 }
 
-// batchLoadCampaignFreqConfigs loads campaign configs for multiple campaigns in one MGet.
-func batchLoadCampaignFreqConfigs(ctx context.Context, store Store, campaignIDs []string) (map[string]*CampaignFreqConfig, error) {
+// BatchLoadCampaignFreqConfigs loads campaign configs for multiple campaigns in one MGet.
+func BatchLoadCampaignFreqConfigs(ctx context.Context, store BatchStore, campaignIDs []string) (map[string]*CampaignFreqConfig, error) {
 	if len(campaignIDs) == 0 {
 		return nil, nil
 	}
@@ -139,7 +130,7 @@ func batchLoadCampaignFreqConfigs(ctx context.Context, store Store, campaignIDs 
 }
 
 // SeedPackageIdentityConfig writes identity config for a package to any Store.
-func SeedPackageIdentityConfig(ctx context.Context, store Store, pkgID string, cfg PackageIdentityConfig) error {
+func SeedPackageIdentityConfig(ctx context.Context, store ConfigStore, pkgID string, cfg PackageIdentityConfig) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
@@ -148,28 +139,10 @@ func SeedPackageIdentityConfig(ctx context.Context, store Store, pkgID string, c
 }
 
 // SeedCampaignFreqConfig writes frequency config for a campaign to any Store.
-func SeedCampaignFreqConfig(ctx context.Context, store Store, campaignID string, cfg CampaignFreqConfig) error {
+func SeedCampaignFreqConfig(ctx context.Context, store ConfigStore, campaignID string, cfg CampaignFreqConfig) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
 	return store.Set(ctx, fmt.Sprintf("config:campaign:%s", campaignID), string(data), 0)
-}
-
-// loadCampaignFreqConfig reads frequency cap config for a campaign from the Store.
-// Returns nil if no config is found.
-func loadCampaignFreqConfig(ctx context.Context, store Store, campaignID string) (*CampaignFreqConfig, error) {
-	key := fmt.Sprintf("config:campaign:%s", campaignID)
-	val, ok, err := store.Get(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, nil
-	}
-	var cfg CampaignFreqConfig
-	if err := json.Unmarshal([]byte(val), &cfg); err != nil {
-		return nil, fmt.Errorf("parse campaign config for %s: %w", campaignID, err)
-	}
-	return &cfg, nil
 }

--- a/exposure/exposure.go
+++ b/exposure/exposure.go
@@ -1,12 +1,24 @@
-package targeting
+// Package exposure provides frequency-capping and ad exposure recording.
+//
+// It exposes:
+//   - Wire types (ExposeRequest, ExposeResponse, UserIdentity, UserProfile)
+//     shared between recorders and identity-match agents.
+//   - Binary exposure log format used for compact per-user history storage.
+//   - Package/campaign frequency configuration and JSON serialization.
+//   - ExposureRecorder — a standalone writer that persists impressions and
+//     frequency-cap state to a Store.
+//
+// The package is consumed by the targeting engine (which reads exposure
+// state during identity evaluation) and can also be embedded directly in
+// systems that own impression recording without pulling in the rest of the
+// targeting engine.
+package exposure
 
 import (
 	"encoding/json"
 	"errors"
 	"sort"
 	"time"
-
-	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
 // UserIdentity represents a user identity token with its type.
@@ -59,6 +71,12 @@ type ExposureLog []ExposureEntry
 // UserProfile holds a user's segment memberships with optional intent scores.
 type UserProfile struct {
 	Segments map[string]float64 `json:"segments"` // segment name → intent score (0 = member, no score)
+}
+
+// FrequencyRule defines a sliding-window impression cap.
+type FrequencyRule struct {
+	MaxCount int
+	Window   time.Duration
 }
 
 // ParseExposureLog parses a JSON-serialized exposure log.
@@ -196,16 +214,9 @@ func ComputeIntentScore(exposureTime int64, now time.Time) float64 {
 	return score
 }
 
-// resolveIdentities extracts UserIdentity entries from an identity match request.
-func resolveIdentities(req *tmproto.IdentityMatchRequest) []UserIdentity {
-	if req.UserToken != "" {
-		return []UserIdentity{{UserToken: req.UserToken, UIDType: string(req.UIDType)}}
-	}
-	return nil
-}
-
-// resolveExposeIdentities extracts UserIdentity entries from an expose request.
-func resolveExposeIdentities(req *ExposeRequest) []UserIdentity {
+// ResolveExposeIdentities extracts UserIdentity entries from an expose request.
+// Prefers an explicit Identities slice, falls back to the top-level UserToken.
+func ResolveExposeIdentities(req *ExposeRequest) []UserIdentity {
 	if len(req.Identities) > 0 {
 		return req.Identities
 	}

--- a/exposure/exposure_test.go
+++ b/exposure/exposure_test.go
@@ -1,4 +1,4 @@
-package targeting
+package exposure
 
 import (
 	"testing"

--- a/exposure/hash.go
+++ b/exposure/hash.go
@@ -1,0 +1,27 @@
+package exposure
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash/fnv"
+)
+
+// HashToken returns a truncated SHA-256 hex digest of a user token.
+// Uses the first 16 bytes (32 hex characters) for compactness.
+// The digest is used to key per-user Store entries (exposure logs,
+// frequency-cap sorted sets, intent timestamps, profiles).
+func HashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:16])
+}
+
+// HashString returns an FNV-1a 64-bit hash of s. It is used to encode
+// package, campaign, impression and source IDs into fixed-width slots
+// inside the binary exposure log. Collision probability is ~0.0003% at
+// 10M unique strings (birthday bound). Acceptable for frequency cap
+// counting where an occasional collision causes slight over/under-counting.
+func HashString(s string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(s)) // fnv.Write never returns an error
+	return h.Sum64()
+}

--- a/exposure/recorder.go
+++ b/exposure/recorder.go
@@ -25,14 +25,6 @@ type ClockFunc func() time.Time
 
 func (f ClockFunc) Now() time.Time { return f() }
 
-// Store is the Store surface required by RecordExposure. It combines the
-// exposure-log reader/writer operations with the sorted-set append used
-// for the frequency-cap bookkeeping and the config reader needed to resolve
-// campaign IDs.
-type Store interface {
-	RecorderStore
-}
-
 // RecorderConfig holds configuration for Recorder.
 type RecorderConfig struct {
 	// ProviderID is the source identifier to record on impressions that do
@@ -41,7 +33,7 @@ type RecorderConfig struct {
 
 	// Store persists exposure logs, frequency-cap sorted sets, intent
 	// timestamps, and reads package/campaign configs.
-	Store Store
+	Store RecorderStore
 
 	// Metrics receives per-exposure instrumentation callbacks. nil = noop.
 	Metrics Metrics
@@ -59,7 +51,7 @@ type RecorderConfig struct {
 // engine's EvaluateIdentity path).
 type Recorder struct {
 	providerID string
-	store      Store
+	store      RecorderStore
 	metrics    Metrics
 	clock      Clock
 }

--- a/exposure/recorder.go
+++ b/exposure/recorder.go
@@ -1,0 +1,253 @@
+package exposure
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Metrics receives instrumentation callbacks from ExposureRecorder.
+// The noop default adds zero overhead.
+type Metrics interface {
+	ExposureRecorded(packageID string)
+	StoreError(operation string, err error)
+}
+
+// Clock returns the current wall-clock time. A Clock can be shared between
+// a recorder, a targeting engine, and a store in tests so a single time
+// source drives all time-dependent code.
+type Clock interface {
+	Now() time.Time
+}
+
+// ClockFunc adapts a plain func() time.Time to the Clock interface.
+type ClockFunc func() time.Time
+
+func (f ClockFunc) Now() time.Time { return f() }
+
+// Store is the Store surface required by RecordExposure. It combines the
+// exposure-log reader/writer operations with the sorted-set append used
+// for the frequency-cap bookkeeping and the config reader needed to resolve
+// campaign IDs.
+type Store interface {
+	RecorderStore
+}
+
+// RecorderConfig holds configuration for Recorder.
+type RecorderConfig struct {
+	// ProviderID is the source identifier to record on impressions that do
+	// not set SourceID explicitly.
+	ProviderID string
+
+	// Store persists exposure logs, frequency-cap sorted sets, intent
+	// timestamps, and reads package/campaign configs.
+	Store Store
+
+	// Metrics receives per-exposure instrumentation callbacks. nil = noop.
+	Metrics Metrics
+
+	// Clock is the time source. nil = wall clock.
+	Clock Clock
+}
+
+// Recorder writes exposure events and frequency-cap data to the store.
+//
+// The recorder reads package-identity and campaign configuration from the
+// same Store that the targeting engine reads. The store schema — keys such
+// as user:exposures:<hash>, freq:pkg:*, freq:campaign:*, intent:* — is the
+// integration contract shared with any reader (including the targeting
+// engine's EvaluateIdentity path).
+type Recorder struct {
+	providerID string
+	store      Store
+	metrics    Metrics
+	clock      Clock
+}
+
+type noopMetrics struct{}
+
+func (noopMetrics) ExposureRecorded(string)  {}
+func (noopMetrics) StoreError(string, error) {}
+
+// NewRecorder creates a Recorder.
+func NewRecorder(cfg RecorderConfig) *Recorder {
+	metrics := cfg.Metrics
+	if metrics == nil {
+		metrics = noopMetrics{}
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = ClockFunc(time.Now)
+	}
+	return &Recorder{
+		providerID: cfg.ProviderID,
+		store:      cfg.Store,
+		metrics:    metrics,
+		clock:      clock,
+	}
+}
+
+// RecordExposure records an impression to the exposure log for all UIDs.
+// Each UID's exposure log is read, the new entry is appended,
+// old entries are pruned, and the log is written back.
+//
+// NOTE: The read-modify-write is not atomic. Concurrent RecordExposure calls
+// for the same user may lose an exposure. This is acceptable for frequency
+// capping (slightly under-counting is benign). For strict counting, use
+// Valkey Lua scripting for atomic append.
+// TODO: Add Store.Append method for atomic binary append.
+func (r *Recorder) RecordExposure(ctx context.Context, req *ExposeRequest) (*ExposeResponse, error) {
+	if err := ValidateExposeRequest(req); err != nil {
+		return nil, fmt.Errorf("invalid expose request: %w", err)
+	}
+	now := r.clock.Now()
+	identities := ResolveExposeIdentities(req)
+
+	// Resolve source ID: use request field, fall back to recorder's provider ID.
+	sourceID := req.SourceID
+	if sourceID == "" {
+		sourceID = r.providerID
+	}
+
+	// Resolve campaign ID.
+	campaignID := req.CampaignID
+	if campaignID == "" {
+		idCfg, _ := LoadPackageIdentityConfig(ctx, r.store, req.PackageID)
+		if idCfg != nil {
+			campaignID = idCfg.CampaignID
+		}
+	}
+
+	// Generate impression ID if not provided.
+	impressionID := req.ImpressionID
+	if impressionID == "" {
+		impressionID = fmt.Sprintf("%d:%s", now.UnixNano(), req.PackageID)
+	}
+
+	entry := ExposureEntry{
+		ImpressionID: impressionID,
+		PackageID:    req.PackageID,
+		CampaignID:   campaignID,
+		SourceID:     sourceID,
+		Timestamp:    now.Unix(),
+	}
+
+	cutoff := now.Add(-30 * 24 * time.Hour).Unix()
+	nowMs := float64(now.UnixMilli())
+	pruneBeforeMs := float64(now.Add(-30 * 24 * time.Hour).UnixMilli())
+	nowStr := fmt.Sprintf("%d", now.Unix())
+
+	hashes := make([]string, len(identities))
+	for i, uid := range identities {
+		hashes[i] = HashToken(uid.UserToken)
+	}
+
+	// Write to each UID's exposure log. Capture the first UID's log for the response.
+	var firstLog BinaryExposureLog
+	for i, hash := range hashes {
+		key := "user:exposures:" + hash
+
+		val, _, err := r.store.Get(ctx, key)
+		if err != nil {
+			r.metrics.StoreError("read_exposure_log", err)
+			continue
+		}
+
+		// Prune expired entries and append new one, upgrading v1→v2 if needed.
+		existing := BinaryExposureLog(val)
+		if len(val) > 0 {
+			if err := ValidateBinaryLog(existing); err != nil {
+				r.metrics.StoreError("corrupt_exposure_log", err)
+				existing = nil
+			}
+		}
+		newEntry := EncodeBinaryExposureLog(ExposureLog{entry})
+
+		pruned := newBinaryLog(existing.Len() + 1)
+		es := int(existing.EntrySize())
+		for j := range existing.Len() {
+			if existing.Timestamp(j) >= cutoff {
+				off := existing.entryOffset(j)
+				if es == binaryEntrySize {
+					pruned = append(pruned, existing[off:off+binaryEntrySize]...)
+				} else {
+					// Upgrade v1 entry: copy 32 bytes + 8 zero bytes for source hash.
+					pruned = append(pruned, existing[off:off+binaryEntrySize1]...)
+					pruned = append(pruned, 0, 0, 0, 0, 0, 0, 0, 0)
+				}
+			}
+		}
+		// Append the new v2 entry's payload (skip its header).
+		pruned = append(pruned, newEntry[binaryHeaderSize:]...)
+		pruned = TruncateBinaryLog(pruned, maxExposureEntries)
+
+		if err := r.store.Set(ctx, key, string(pruned), 30*24*time.Hour); err != nil {
+			r.metrics.StoreError("write_exposure_log", err)
+		}
+		if i == 0 {
+			firstLog = BinaryExposureLog(pruned)
+		}
+
+		// Package frequency sorted set.
+		member := sourceID + ":" + impressionID
+		pkgFreqKey := fmt.Sprintf("freq:pkg:%s:%s", req.PackageID, hash)
+		if err := r.store.ZAdd(ctx, pkgFreqKey, nowMs, member); err != nil {
+			r.metrics.StoreError("zadd_pkg_freq", err)
+		} else {
+			if err := r.store.ZRemRangeByScore(ctx, pkgFreqKey, 0, pruneBeforeMs); err != nil {
+				r.metrics.StoreError("zremrangebyscore_pkg_freq", err)
+			}
+			_ = r.store.ZExpire(ctx, pkgFreqKey, 30*24*time.Hour)
+		}
+
+		// Campaign frequency sorted set.
+		if campaignID != "" {
+			campFreqKey := fmt.Sprintf("freq:campaign:%s:%s", campaignID, hash)
+			if err := r.store.ZAdd(ctx, campFreqKey, nowMs, member); err != nil {
+				r.metrics.StoreError("zadd_campaign_freq", err)
+			} else {
+				if err := r.store.ZRemRangeByScore(ctx, campFreqKey, 0, pruneBeforeMs); err != nil {
+					r.metrics.StoreError("zremrangebyscore_campaign_freq", err)
+				}
+				_ = r.store.ZExpire(ctx, campFreqKey, 30*24*time.Hour)
+			}
+		}
+
+		// Intent timestamp.
+		intentKey := fmt.Sprintf("intent:%s:%s", req.PackageID, hash)
+		if err := r.store.Set(ctx, intentKey, nowStr, 7*24*time.Hour); err != nil {
+			r.metrics.StoreError("set_intent", err)
+		}
+	}
+
+	r.metrics.ExposureRecorded(req.PackageID)
+
+	// Compute campaign count from the first UID's log (already in memory, no re-read).
+	resp := &ExposeResponse{PackageID: req.PackageID}
+	if campaignID != "" && firstLog.Len() > 0 {
+		campHash := HashString(campaignID)
+
+		campCfg, _ := LoadCampaignFreqConfig(ctx, r.store, campaignID)
+		if campCfg != nil && len(campCfg.FrequencyRules) > 0 {
+			rules := ToFrequencyRules(campCfg.FrequencyRules)
+			shortestRule := rules[0]
+			for _, rule := range rules[1:] {
+				if rule.Window < shortestRule.Window {
+					shortestRule = rule
+				}
+			}
+			windowStart := now.Add(-shortestRule.Window).Unix()
+			count := 0
+			for i := range firstLog.Len() {
+				if firstLog.CampaignHash(i) == campHash && firstLog.Timestamp(i) >= windowStart {
+					count++
+				}
+			}
+			resp.CampaignCount = count
+			remaining := max(shortestRule.MaxCount-count, 0)
+			resp.CampaignRemaining = remaining
+		}
+	}
+
+	return resp, nil
+}

--- a/exposure/recorder_test.go
+++ b/exposure/recorder_test.go
@@ -1,0 +1,144 @@
+package exposure
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStore is a minimal in-memory Store implementation used by Recorder
+// tests. It satisfies the Store interface without importing any targeting
+// machinery — the whole point of this test is to demonstrate that a caller
+// can wire Recorder against a bare Store with zero targeting coupling.
+type fakeStore struct {
+	mu      sync.Mutex
+	strings map[string]string
+	zsets   map[string][]zmember
+}
+
+type zmember struct {
+	score  float64
+	member string
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		strings: make(map[string]string),
+		zsets:   make(map[string][]zmember),
+	}
+}
+
+func (s *fakeStore) Get(_ context.Context, key string) (string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.strings[key]
+	return v, ok, nil
+}
+
+func (s *fakeStore) Set(_ context.Context, key, value string, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.strings[key] = value
+	return nil
+}
+
+func (s *fakeStore) ZAdd(_ context.Context, key string, score float64, member string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.zsets[key] = append(s.zsets[key], zmember{score, member})
+	return nil
+}
+
+func (s *fakeStore) ZRemRangeByScore(_ context.Context, _ string, _, _ float64) error {
+	return nil
+}
+
+func (s *fakeStore) ZExpire(_ context.Context, _ string, _ time.Duration) error {
+	return nil
+}
+
+// TestStandaloneRecorder_MinimalWiring verifies the motivating use case for
+// splitting Recorder into its own package: a caller can construct a Recorder
+// from just (Store, ProviderID), call RecordExposure, and observe the full
+// store-schema writes — with no Engine, property registry, signature
+// verification, or package configuration anywhere in sight.
+func TestStandaloneRecorder_MinimalWiring(t *testing.T) {
+	store := newFakeStore()
+	recorder := NewRecorder(RecorderConfig{
+		ProviderID: "standalone-provider",
+		Store:      store,
+	})
+
+	ctx := context.Background()
+	resp, err := recorder.RecordExposure(ctx, &ExposeRequest{
+		UserToken:    "user-standalone",
+		PackageID:    "pkg-standalone",
+		ImpressionID: "imp-standalone-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "pkg-standalone", resp.PackageID)
+
+	// Binary exposure log written under user:exposures:<hash>.
+	userHash := HashToken("user-standalone")
+	val, ok, err := store.Get(ctx, "user:exposures:"+userHash)
+	require.NoError(t, err)
+	require.True(t, ok, "expected user:exposures:* entry")
+
+	blog := BinaryExposureLog(val)
+	require.NoError(t, ValidateBinaryLog(blog))
+	require.Equal(t, 1, blog.Len(), "expected one entry in the binary log")
+	assert.Equal(t, HashString("pkg-standalone"), blog.PackageHash(0))
+	assert.Equal(t, HashString("imp-standalone-1"), blog.ImpressionHash(0))
+
+	// Source hash falls back to ProviderID when SourceID is not set on the request.
+	assert.Equal(t, HashString("standalone-provider"), blog.SourceHash(0),
+		"expected source hash to fall back to ProviderID")
+
+	// Package-level frequency sorted-set received the impression.
+	pkgFreqKey := "freq:pkg:pkg-standalone:" + userHash
+	_, hasFreq := store.zsets[pkgFreqKey]
+	assert.True(t, hasFreq, "expected freq:pkg:* sorted-set entry")
+
+	// Intent timestamp under intent:pkg-standalone:<hash>.
+	_, ok, err = store.Get(ctx, "intent:pkg-standalone:"+userHash)
+	require.NoError(t, err)
+	assert.True(t, ok, "expected intent:* entry")
+
+	// No campaign frequency set — the request had no CampaignID and the
+	// standalone store was not pre-seeded with a PackageIdentityConfig.
+	// CampaignCount/CampaignRemaining should both be zero on the response.
+	assert.Zero(t, resp.CampaignCount)
+	assert.Zero(t, resp.CampaignRemaining)
+}
+
+// TestStandaloneRecorder_SharedClock verifies that a single Clock shared
+// between the recorder and its caller drives time consistently. This is the
+// follow-up to the PR review note on the dual-Now papercut.
+func TestStandaloneRecorder_SharedClock(t *testing.T) {
+	store := newFakeStore()
+
+	fixedTime := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	clock := ClockFunc(func() time.Time { return fixedTime })
+
+	recorder := NewRecorder(RecorderConfig{
+		ProviderID: "clock-provider",
+		Store:      store,
+		Clock:      clock,
+	})
+
+	_, err := recorder.RecordExposure(context.Background(), &ExposeRequest{
+		UserToken: "user-clock",
+		PackageID: "pkg-clock",
+	})
+	require.NoError(t, err)
+
+	// The entry timestamp must reflect the injected clock, not wall time.
+	val, _, _ := store.Get(context.Background(), "user:exposures:"+HashToken("user-clock"))
+	blog := BinaryExposureLog(val)
+	require.Equal(t, 1, blog.Len())
+	assert.Equal(t, fixedTime.Unix(), blog.Timestamp(0))
+}

--- a/exposure/store.go
+++ b/exposure/store.go
@@ -1,0 +1,31 @@
+package exposure
+
+import (
+	"context"
+	"time"
+)
+
+// ConfigStore is the narrow Store surface required for reading and seeding
+// package/campaign configuration.
+type ConfigStore interface {
+	Get(ctx context.Context, key string) (string, bool, error)
+	Set(ctx context.Context, key, value string, ttl time.Duration) error
+}
+
+// BatchStore is the narrow Store surface required for batch-loading configs.
+type BatchStore interface {
+	MGet(ctx context.Context, keys ...string) ([]string, error)
+}
+
+// RecorderStore is the Store surface required by ExposureRecorder.
+//
+// Any backing store that supports string reads/writes, sorted-set append
+// with TTL, and config reads satisfies this interface. targeting.Store and
+// concrete Valkey/in-memory implementations satisfy it structurally — no
+// explicit conformance is required.
+type RecorderStore interface {
+	ConfigStore
+	ZAdd(ctx context.Context, key string, score float64, member string) error
+	ZRemRangeByScore(ctx context.Context, key string, min, max float64) error
+	ZExpire(ctx context.Context, key string, ttl time.Duration) error
+}

--- a/reference/identity-agent/cmd/identity-agent/main.go
+++ b/reference/identity-agent/cmd/identity-agent/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/prommetrics"
 	"github.com/adcontextprotocol/adcp-go/targeting/valkeystore"
@@ -164,20 +165,20 @@ func seedConfigs(store targeting.Store) {
 
 	configs := []struct {
 		pkgID string
-		cfg   targeting.PackageIdentityConfig
+		cfg   exposure.PackageIdentityConfig
 	}{
-		{"pkg-display-0041", targeting.PackageIdentityConfig{
+		{"pkg-display-0041", exposure.PackageIdentityConfig{
 			CampaignID:     "campaign-acme-q1",
-			FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 			TargetSegments: []string{"cooking_enthusiast", "home_improvement"},
 		}},
-		{"pkg-display-0042", targeting.PackageIdentityConfig{
+		{"pkg-display-0042", exposure.PackageIdentityConfig{
 			CampaignID:     "campaign-acme-q1",
-			FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 43200}},
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 43200}},
 		}},
-		{"pkg-native-0078", targeting.PackageIdentityConfig{
+		{"pkg-native-0078", exposure.PackageIdentityConfig{
 			CampaignID: "campaign-nova-spring",
-			FrequencyRules: []targeting.FrequencyRuleJSON{
+			FrequencyRules: []exposure.FrequencyRuleJSON{
 				{MaxCount: 2, WindowSeconds: 43200},
 				{MaxCount: 5, WindowSeconds: 604800},
 			},
@@ -185,7 +186,7 @@ func seedConfigs(store targeting.Store) {
 		}},
 	}
 	for _, c := range configs {
-		if err := targeting.SeedPackageIdentityConfig(ctx, store, c.pkgID, c.cfg); err != nil {
+		if err := exposure.SeedPackageIdentityConfig(ctx, store, c.pkgID, c.cfg); err != nil {
 			slog.Error("seed package config failed", "package_id", c.pkgID, "error", err)
 			os.Exit(1)
 		}
@@ -193,17 +194,17 @@ func seedConfigs(store targeting.Store) {
 
 	campaigns := []struct {
 		campaignID string
-		cfg        targeting.CampaignFreqConfig
+		cfg        exposure.CampaignFreqConfig
 	}{
-		{"campaign-acme-q1", targeting.CampaignFreqConfig{
-			FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 604800}},
+		{"campaign-acme-q1", exposure.CampaignFreqConfig{
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 604800}},
 		}},
-		{"campaign-nova-spring", targeting.CampaignFreqConfig{
-			FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 15, WindowSeconds: 2592000}},
+		{"campaign-nova-spring", exposure.CampaignFreqConfig{
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 15, WindowSeconds: 2592000}},
 		}},
 	}
 	for _, c := range campaigns {
-		if err := targeting.SeedCampaignFreqConfig(ctx, store, c.campaignID, c.cfg); err != nil {
+		if err := exposure.SeedCampaignFreqConfig(ctx, store, c.campaignID, c.cfg); err != nil {
 			slog.Error("seed campaign config failed", "campaign_id", c.campaignID, "error", err)
 			os.Exit(1)
 		}

--- a/router/providerset_test.go
+++ b/router/providerset_test.go
@@ -83,24 +83,20 @@ func TestProviderSet_ConcurrentReadWrite(t *testing.T) {
 
 	// Concurrent readers
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 100 {
 				_ = ps.Active()
 				_ = ps.All()
 			}
-		}()
+		})
 	}
 
 	// Concurrent writer
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 100 {
 			ps.Swap([]ProviderConfig{{ID: "a"}, {ID: "b"}})
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/router/router.go
+++ b/router/router.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"sort"
+	"maps"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -369,9 +370,7 @@ func mergeContextResponses(requestID string, responses []*tmproto.ContextMatchRe
 
 	for _, resp := range responses {
 		merged.Offers = append(merged.Offers, resp.Offers...)
-		for k, v := range resp.Signals {
-			mergedSignals[k] = v
-		}
+		maps.Copy(mergedSignals, resp.Signals)
 	}
 
 	if len(mergedSignals) > 0 {

--- a/targeting/context_config.go
+++ b/targeting/context_config.go
@@ -1,0 +1,34 @@
+package targeting
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// batchLoadPackageContextConfigs loads context configs for multiple packages in one MGet.
+func batchLoadPackageContextConfigs(ctx context.Context, store Store, pkgIDs []string) (map[string]*PackageContextConfig, error) {
+	if len(pkgIDs) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, len(pkgIDs))
+	for i, id := range pkgIDs {
+		keys[i] = fmt.Sprintf("config:pkg:%s:context", id)
+	}
+	values, err := store.MGet(ctx, keys...)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]*PackageContextConfig, len(pkgIDs))
+	for i, val := range values {
+		if val == "" {
+			continue
+		}
+		var cfg PackageContextConfig
+		if err := json.Unmarshal([]byte(val), &cfg); err != nil {
+			continue // skip unparseable
+		}
+		result[pkgIDs[i]] = &cfg
+	}
+	return result, nil
+}

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -6,6 +6,11 @@
 //
 // The engine evaluates both context match and identity match requests,
 // replacing the need for separate agent implementations.
+//
+// Impression recording and frequency-cap bookkeeping live in the exposure
+// package. The engine consumes the same store schema that exposure.Recorder
+// writes to — so any reader/writer pair sharing the Store contract will
+// interoperate.
 package targeting
 
 import (
@@ -16,6 +21,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -225,14 +231,14 @@ type IdentityResult struct {
 //  4. Intent score
 func (e *Engine) EvaluateIdentity(ctx context.Context, req *tmproto.IdentityMatchRequest) (*IdentityResult, error) {
 	evalStart := time.Now()
-	tokenHash := HashToken(req.UserToken)
+	tokenHash := exposure.HashToken(req.UserToken)
 	now := e.now()
 
 	// Batch-load all identity configs (1 MGet) and campaign configs (1 MGet).
-	idConfigs, err := batchLoadPackageIdentityConfigs(ctx, e.store, req.PackageIDs)
+	idConfigs, err := exposure.BatchLoadPackageIdentityConfigs(ctx, e.store, req.PackageIDs)
 	if err != nil {
 		e.metrics.StoreError("load_identity_configs", err)
-		idConfigs = make(map[string]*PackageIdentityConfig)
+		idConfigs = make(map[string]*exposure.PackageIdentityConfig)
 	}
 
 	// Collect unique campaign IDs for batch campaign config load.
@@ -246,10 +252,10 @@ func (e *Engine) EvaluateIdentity(ctx context.Context, req *tmproto.IdentityMatc
 	for id := range campaignIDSet {
 		campaignIDs = append(campaignIDs, id)
 	}
-	campConfigs, err := batchLoadCampaignFreqConfigs(ctx, e.store, campaignIDs)
+	campConfigs, err := exposure.BatchLoadCampaignFreqConfigs(ctx, e.store, campaignIDs)
 	if err != nil {
 		e.metrics.StoreError("load_campaign_configs", err)
-		campConfigs = make(map[string]*CampaignFreqConfig)
+		campConfigs = make(map[string]*exposure.CampaignFreqConfig)
 	}
 
 	var eligibility []tmproto.PackageEligibility
@@ -274,7 +280,7 @@ func (e *Engine) EvaluateIdentity(ctx context.Context, req *tmproto.IdentityMatc
 			campCfg := campConfigs[idCfg.CampaignID]
 			if campCfg != nil && len(campCfg.FrequencyRules) > 0 {
 				key := fmt.Sprintf("freq:campaign:%s:%s", idCfg.CampaignID, tokenHash)
-				rules := toFrequencyRules(campCfg.FrequencyRules)
+				rules := exposure.ToFrequencyRules(campCfg.FrequencyRules)
 				capped, err := e.checkFrequencyRules(ctx, key, rules, now)
 				if err != nil {
 					e.metrics.StoreError(StageCampaignFreq, err)
@@ -288,7 +294,7 @@ func (e *Engine) EvaluateIdentity(ctx context.Context, req *tmproto.IdentityMatc
 		// Package frequency cap (graceful: skip on Store error).
 		if eligible && idCfg != nil && len(idCfg.FrequencyRules) > 0 {
 			key := fmt.Sprintf("freq:pkg:%s:%s", pkgID, tokenHash)
-			rules := toFrequencyRules(idCfg.FrequencyRules)
+			rules := exposure.ToFrequencyRules(idCfg.FrequencyRules)
 			capped, err := e.checkFrequencyRules(ctx, key, rules, now)
 			if err != nil {
 				e.metrics.StoreError(StagePackageFreq, err)
@@ -464,7 +470,7 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	// 1. Build MGet keys: profile + exposures for each UID.
 	keys := make([]string, 0, len(identities)*2)
 	for _, uid := range identities {
-		hash := HashToken(uid.UserToken)
+		hash := exposure.HashToken(uid.UserToken)
 		keys = append(keys, "user:profile:"+hash)
 		keys = append(keys, "user:exposures:"+hash)
 	}
@@ -477,22 +483,22 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	}
 
 	// 3. Parse profiles (JSON, small) and exposure logs (binary, zero-copy).
-	profiles := make([]*UserProfile, 0, len(identities))
-	firstLogs := make([]BinaryExposureLog, 0, len(identities))
+	profiles := make([]*exposure.UserProfile, 0, len(identities))
+	firstLogs := make([]exposure.BinaryExposureLog, 0, len(identities))
 	for i := range identities {
 		profileData := values[i*2]
 		exposureData := values[i*2+1]
-		profiles = append(profiles, ParseUserProfile(profileData))
-		binLog := BinaryExposureLog(exposureData)
+		profiles = append(profiles, exposure.ParseUserProfile(profileData))
+		binLog := exposure.BinaryExposureLog(exposureData)
 		if len(exposureData) > 0 {
-			if err := ValidateBinaryLog(binLog); err != nil {
+			if err := exposure.ValidateBinaryLog(binLog); err != nil {
 				e.metrics.StoreError("corrupt_exposure_log", err)
 				binLog = nil
 			}
 		}
 		firstLogs = append(firstLogs, binLog)
 	}
-	mergedProfile := MergeUserProfiles(profiles...)
+	mergedProfile := exposure.MergeUserProfiles(profiles...)
 
 	// 4. Extract segment names from merged profile.
 	var userSegments []string
@@ -521,9 +527,9 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		if eligible && idCfg != nil && idCfg.CampaignID != "" {
 			campCfg := resolved.CampaignConfigs[idCfg.CampaignID]
 			if campCfg != nil && len(campCfg.FrequencyRules) > 0 {
-				rules := toFrequencyRules(campCfg.FrequencyRules)
-				campHash := hashString(idCfg.CampaignID)
-				if CheckFrequencyRulesMultiLog(firstLogs, campHash, true, rules, nowUnix) {
+				rules := exposure.ToFrequencyRules(campCfg.FrequencyRules)
+				campHash := exposure.HashString(idCfg.CampaignID)
+				if exposure.CheckFrequencyRulesMultiLog(firstLogs, campHash, true, rules, nowUnix) {
 					eligible = false
 					e.metrics.IdentityEvaluated(pkgID, StageCampaignFreq, false)
 				}
@@ -531,10 +537,10 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		}
 
 		// Package frequency cap (binary lazy dedup across all UID logs).
-		pkgHash := hashString(pkgID)
+		pkgHash := exposure.HashString(pkgID)
 		if eligible && idCfg != nil && len(idCfg.FrequencyRules) > 0 {
-			rules := toFrequencyRules(idCfg.FrequencyRules)
-			if CheckFrequencyRulesMultiLog(firstLogs, pkgHash, false, rules, nowUnix) {
+			rules := exposure.ToFrequencyRules(idCfg.FrequencyRules)
+			if exposure.CheckFrequencyRulesMultiLog(firstLogs, pkgHash, false, rules, nowUnix) {
 				eligible = false
 				e.metrics.IdentityEvaluated(pkgID, StagePackageFreq, false)
 			}
@@ -542,9 +548,9 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 
 		// Intent score (binary, scan across all UID logs).
 		var intent float64
-		latestTS := LatestExposureMultiLog(firstLogs, pkgHash)
+		latestTS := exposure.LatestExposureMultiLog(firstLogs, pkgHash)
 		if latestTS > 0 {
-			intent = ComputeIntentScore(latestTS, now)
+			intent = exposure.ComputeIntentScore(latestTS, now)
 		}
 
 		pe := tmproto.PackageEligibility{PackageID: pkgID, Eligible: eligible}
@@ -564,179 +570,13 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 
 // SetUserProfile writes a user's segment memberships to the profile key.
 func (e *Engine) SetUserProfile(ctx context.Context, userToken string, segments map[string]float64) error {
-	hash := HashToken(userToken)
-	profile := UserProfile{Segments: segments}
+	hash := exposure.HashToken(userToken)
+	profile := exposure.UserProfile{Segments: segments}
 	data, err := json.Marshal(profile)
 	if err != nil {
 		return err
 	}
 	return e.store.Set(ctx, "user:profile:"+hash, string(data), 0)
-}
-
-// RecordExposure records an impression to the exposure log for all UIDs.
-// Each UID's exposure log is read, the new entry is appended,
-// old entries are pruned, and the log is written back.
-//
-// NOTE: The read-modify-write is not atomic. Concurrent RecordExposure calls
-// for the same user may lose an exposure. This is acceptable for frequency
-// capping (slightly under-counting is benign). For strict counting, use
-// Valkey Lua scripting for atomic append.
-// TODO: Add Store.Append method for atomic binary append.
-func (e *Engine) RecordExposure(ctx context.Context, req *ExposeRequest) (*ExposeResponse, error) {
-	if err := ValidateExposeRequest(req); err != nil {
-		return nil, fmt.Errorf("invalid expose request: %w", err)
-	}
-	now := e.now()
-	identities := resolveExposeIdentities(req)
-
-	// Resolve source ID: use request field, fall back to engine's provider ID.
-	sourceID := req.SourceID
-	if sourceID == "" {
-		sourceID = e.providerID
-	}
-
-	// Resolve campaign ID.
-	campaignID := req.CampaignID
-	if campaignID == "" {
-		idCfg, _ := loadPackageIdentityConfig(ctx, e.store, req.PackageID)
-		if idCfg != nil {
-			campaignID = idCfg.CampaignID
-		}
-	}
-
-	// Generate impression ID if not provided.
-	impressionID := req.ImpressionID
-	if impressionID == "" {
-		impressionID = fmt.Sprintf("%d:%s", now.UnixNano(), req.PackageID)
-	}
-
-	entry := ExposureEntry{
-		ImpressionID: impressionID,
-		PackageID:    req.PackageID,
-		CampaignID:   campaignID,
-		SourceID:     sourceID,
-		Timestamp:    now.Unix(),
-	}
-
-	cutoff := now.Add(-30 * 24 * time.Hour).Unix()
-	nowMs := float64(now.UnixMilli())
-	pruneBeforeMs := float64(now.Add(-30 * 24 * time.Hour).UnixMilli())
-	nowStr := fmt.Sprintf("%d", now.Unix())
-
-	// Pre-compute token hashes (SHA-256, avoid re-hashing per loop).
-	hashes := make([]string, len(identities))
-	for i, uid := range identities {
-		hashes[i] = HashToken(uid.UserToken)
-	}
-
-	// Write to each UID's exposure log. Capture the first UID's log for the response.
-	var firstLog BinaryExposureLog
-	for i, hash := range hashes {
-		key := "user:exposures:" + hash
-
-		val, _, err := e.store.Get(ctx, key)
-		if err != nil {
-			e.metrics.StoreError("read_exposure_log", err)
-			continue
-		}
-
-		// Prune expired entries and append new one, upgrading v1→v2 if needed.
-		existing := BinaryExposureLog(val)
-		if len(val) > 0 {
-			if err := ValidateBinaryLog(existing); err != nil {
-				e.metrics.StoreError("corrupt_exposure_log", err)
-				existing = nil
-			}
-		}
-		newEntry := EncodeBinaryExposureLog(ExposureLog{entry})
-
-		pruned := newBinaryLog(existing.Len() + 1)
-		es := int(existing.EntrySize())
-		for j := range existing.Len() {
-			if existing.Timestamp(j) >= cutoff {
-				off := existing.entryOffset(j)
-				if es == binaryEntrySize {
-					pruned = append(pruned, existing[off:off+binaryEntrySize]...)
-				} else {
-					// Upgrade v1 entry: copy 32 bytes + 8 zero bytes for source hash.
-					pruned = append(pruned, existing[off:off+binaryEntrySize1]...)
-					pruned = append(pruned, 0, 0, 0, 0, 0, 0, 0, 0)
-				}
-			}
-		}
-		// Append the new v2 entry's payload (skip its header).
-		pruned = append(pruned, newEntry[binaryHeaderSize:]...)
-		pruned = TruncateBinaryLog(pruned, maxExposureEntries)
-
-		if err := e.store.Set(ctx, key, string(pruned), 30*24*time.Hour); err != nil {
-			e.metrics.StoreError("write_exposure_log", err)
-		}
-		if i == 0 {
-			firstLog = BinaryExposureLog(pruned)
-		}
-
-		// Package frequency sorted set.
-		member := sourceID + ":" + impressionID
-		pkgFreqKey := fmt.Sprintf("freq:pkg:%s:%s", req.PackageID, hash)
-		if err := e.store.ZAdd(ctx, pkgFreqKey, nowMs, member); err != nil {
-			e.metrics.StoreError("zadd_pkg_freq", err)
-		} else {
-			if err := e.store.ZRemRangeByScore(ctx, pkgFreqKey, 0, pruneBeforeMs); err != nil {
-				e.metrics.StoreError("zremrangebyscore_pkg_freq", err)
-			}
-			_ = e.store.ZExpire(ctx, pkgFreqKey, 30*24*time.Hour)
-		}
-
-		// Campaign frequency sorted set.
-		if campaignID != "" {
-			campFreqKey := fmt.Sprintf("freq:campaign:%s:%s", campaignID, hash)
-			if err := e.store.ZAdd(ctx, campFreqKey, nowMs, member); err != nil {
-				e.metrics.StoreError("zadd_campaign_freq", err)
-			} else {
-				if err := e.store.ZRemRangeByScore(ctx, campFreqKey, 0, pruneBeforeMs); err != nil {
-					e.metrics.StoreError("zremrangebyscore_campaign_freq", err)
-				}
-				_ = e.store.ZExpire(ctx, campFreqKey, 30*24*time.Hour)
-			}
-		}
-
-		// Intent timestamp.
-		intentKey := fmt.Sprintf("intent:%s:%s", req.PackageID, hash)
-		if err := e.store.Set(ctx, intentKey, nowStr, 7*24*time.Hour); err != nil {
-			e.metrics.StoreError("set_intent", err)
-		}
-	}
-
-	e.metrics.ExposureRecorded(req.PackageID)
-
-	// Compute campaign count from the first UID's log (already in memory, no re-read).
-	resp := &ExposeResponse{PackageID: req.PackageID}
-	if campaignID != "" && firstLog.Len() > 0 {
-		campHash := hashString(campaignID)
-
-		campCfg, _ := loadCampaignFreqConfig(ctx, e.store, campaignID)
-		if campCfg != nil && len(campCfg.FrequencyRules) > 0 {
-			rules := toFrequencyRules(campCfg.FrequencyRules)
-			shortestRule := rules[0]
-			for _, r := range rules[1:] {
-				if r.Window < shortestRule.Window {
-					shortestRule = r
-				}
-			}
-			windowStart := now.Add(-shortestRule.Window).Unix()
-			count := 0
-			for i := range firstLog.Len() {
-				if firstLog.CampaignHash(i) == campHash && firstLog.Timestamp(i) >= windowStart {
-					count++
-				}
-			}
-			resp.CampaignCount = count
-			remaining := max(shortestRule.MaxCount-count, 0)
-			resp.CampaignRemaining = remaining
-		}
-	}
-
-	return resp, nil
 }
 
 // checkURLFilter checks artifacts against URL blocklists and allowlists.
@@ -794,7 +634,7 @@ func (e *Engine) checkTopicMatch(ctx context.Context, artifacts []string, pkgID 
 
 // checkFrequencyRules checks all rules against a sorted set.
 // Returns true (capped) if ANY rule is exceeded.
-func (e *Engine) checkFrequencyRules(ctx context.Context, key string, rules []FrequencyRule, now time.Time) (bool, error) {
+func (e *Engine) checkFrequencyRules(ctx context.Context, key string, rules []exposure.FrequencyRule, now time.Time) (bool, error) {
 	for _, rule := range rules {
 		cutoff := float64(now.Add(-rule.Window).UnixMilli())
 		count, err := e.store.ZCount(ctx, key, cutoff, math.MaxFloat64)
@@ -848,6 +688,14 @@ func (e *Engine) now() time.Time {
 		return e.Now()
 	}
 	return time.Now()
+}
+
+// resolveIdentities extracts identity entries from an identity match request.
+func resolveIdentities(req *tmproto.IdentityMatchRequest) []exposure.UserIdentity {
+	if req.UserToken != "" {
+		return []exposure.UserIdentity{{UserToken: req.UserToken, UIDType: string(req.UIDType)}}
+	}
+	return nil
 }
 
 // buildOffers returns one or more Offers for an activated package.

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -38,9 +38,10 @@ type Engine struct {
 
 	metrics Metrics
 
-	// Now returns the current time. Defaults to time.Now.
-	// Override in tests to control time.
-	Now func() time.Time
+	// Clock is the time source used by identity-freq cutoffs. Share the same
+	// Clock with the Store and with any exposure.Recorder driving the store
+	// so read and write sides agree on "now." Override in tests to control time.
+	Clock exposure.Clock
 }
 
 // EngineConfig holds all configuration for creating an Engine.
@@ -49,8 +50,9 @@ type EngineConfig struct {
 	Store           Store
 	Properties      PropertyList
 	Packages        []PackageConfig
-	DynamicPackages bool    // When true, load package configs from Store at eval time.
-	Metrics         Metrics // nil = noop
+	DynamicPackages bool           // When true, load package configs from Store at eval time.
+	Metrics         Metrics        // nil = noop
+	Clock           exposure.Clock // nil = wall clock
 }
 
 // NewEngine creates a targeting engine.
@@ -63,6 +65,10 @@ func NewEngine(cfg EngineConfig) *Engine {
 	if metrics == nil {
 		metrics = noopMetrics{}
 	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = exposure.ClockFunc(time.Now)
+	}
 	return &Engine{
 		providerID:      cfg.ProviderID,
 		store:           cfg.Store,
@@ -70,7 +76,7 @@ func NewEngine(cfg EngineConfig) *Engine {
 		packages:        pkgMap,
 		dynamicPackages: cfg.DynamicPackages,
 		metrics:         metrics,
-		Now:             time.Now,
+		Clock:           clock,
 	}
 }
 
@@ -684,8 +690,8 @@ func (e *Engine) computeIntentScore(ctx context.Context, tokenHash, packageID st
 }
 
 func (e *Engine) now() time.Time {
-	if e.Now != nil {
-		return e.Now()
+	if e.Clock != nil {
+		return e.Clock.Now()
 	}
 	return time.Now()
 }

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -75,9 +75,12 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages, 
 		},
 	}
 
+	clock := exposure.ClockFunc(func() time.Time { return now })
+	store.Clock = clock
 	engine := NewEngine(EngineConfig{
 		ProviderID: "test-provider",
 		Store:      store,
+		Clock:      clock,
 		Packages: []PackageConfig{
 			{PackageID: "pkg-display-001"},
 			{PackageID: "pkg-display-002"},
@@ -85,9 +88,6 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages, 
 			{PackageID: "pkg-no-cap"},
 		},
 	})
-	clock := exposure.ClockFunc(func() time.Time { return now })
-	engine.Now = clock.Now
-	store.Now = clock.Now
 	recorder := exposure.NewRecorder(exposure.RecorderConfig{
 		ProviderID: "test-provider",
 		Store:      store,
@@ -447,8 +447,8 @@ func TestIdentity_SlidingWindowExpiry(t *testing.T) {
 
 	// Advance past 24h window.
 	future := now.Add(25 * time.Hour)
-	engine.Now = func() time.Time { return future }
-	store.Now = func() time.Time { return future }
+	engine.Clock = exposure.ClockFunc(func() time.Time { return future })
+	store.Clock = exposure.ClockFunc(func() time.Time { return future })
 
 	resp, _ = engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "id-after", UserToken: "user-abc", PackageIDs: []string{"pkg-display-001"},
@@ -584,8 +584,8 @@ func TestIdentityNonResolved_SlidingWindowExpiry(t *testing.T) {
 
 	// Advance past 24h window.
 	future := now.Add(25 * time.Hour)
-	engine.Now = func() time.Time { return future }
-	store.Now = func() time.Time { return future }
+	engine.Clock = exposure.ClockFunc(func() time.Time { return future })
+	store.Clock = exposure.ClockFunc(func() time.Time { return future })
 
 	resp, _ = engine.EvaluateIdentity(ctx, &tmproto.IdentityMatchRequest{
 		RequestID: "nr-after", UserToken: "user-abc",

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,31 +31,31 @@ func setupContextEngine(t *testing.T) (*Engine, *MockStore) {
 	return engine, store
 }
 
-func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages) {
+func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages, *exposure.Recorder) {
 	t.Helper()
 	store := NewMockStore()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	// Seed identity config in Store (data-driven).
-	store.SetPackageIdentityConfig("pkg-display-001", PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-display-001", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
-		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
 		TargetSegments: []string{"cooking", "home"},
 	})
-	store.SetPackageIdentityConfig("pkg-display-002", PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-display-002", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
-		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 43200}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 43200}},
 	})
-	store.SetPackageIdentityConfig("pkg-multi-rule", PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-multi-rule", exposure.PackageIdentityConfig{
 		CampaignID: "campaign-acme",
-		FrequencyRules: []FrequencyRuleJSON{
+		FrequencyRules: []exposure.FrequencyRuleJSON{
 			{MaxCount: 2, WindowSeconds: 43200},
 			{MaxCount: 5, WindowSeconds: 604800},
 		},
 	})
 	// pkg-no-cap: no identity config = always eligible
-	store.SetCampaignFreqConfig("campaign-acme", CampaignFreqConfig{
-		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
+	store.SetCampaignFreqConfig("campaign-acme", exposure.CampaignFreqConfig{
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
 	})
 
 	// Build resolved packages for the resolved eval path.
@@ -63,14 +64,14 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages) 
 			"cooking": {"pkg-display-001"},
 			"home":    {"pkg-display-001"},
 		},
-		IdentityConfigs: map[string]*PackageIdentityConfig{
-			"pkg-display-001": {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking", "home"}},
-			"pkg-display-002": {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 43200}}},
-			"pkg-multi-rule":  {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 2, WindowSeconds: 43200}, {MaxCount: 5, WindowSeconds: 604800}}},
+		IdentityConfigs: map[string]*exposure.PackageIdentityConfig{
+			"pkg-display-001": {CampaignID: "campaign-acme", FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking", "home"}},
+			"pkg-display-002": {CampaignID: "campaign-acme", FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 43200}}},
+			"pkg-multi-rule":  {CampaignID: "campaign-acme", FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 2, WindowSeconds: 43200}, {MaxCount: 5, WindowSeconds: 604800}}},
 			"pkg-no-cap":      {},
 		},
-		CampaignConfigs: map[string]*CampaignFreqConfig{
-			"campaign-acme": {FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
+		CampaignConfigs: map[string]*exposure.CampaignFreqConfig{
+			"campaign-acme": {FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
 		},
 	}
 
@@ -84,9 +85,15 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages) 
 			{PackageID: "pkg-no-cap"},
 		},
 	})
-	engine.Now = func() time.Time { return now }
-	store.Now = func() time.Time { return now }
-	return engine, store, resolved
+	clock := exposure.ClockFunc(func() time.Time { return now })
+	engine.Now = clock.Now
+	store.Now = clock.Now
+	recorder := exposure.NewRecorder(exposure.RecorderConfig{
+		ProviderID: "test-provider",
+		Store:      store,
+		Clock:      clock,
+	})
+	return engine, store, resolved, recorder
 }
 
 // --- Context Tests ---
@@ -341,10 +348,10 @@ func TestContext_UnknownPackageSkipped(t *testing.T) {
 // --- Identity Tests (using resolved path with exposure logs) ---
 
 func TestIdentity_ExposureIncrements(t *testing.T) {
-	engine, _, _ := setupIdentityEngine(t)
+	_, _, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	resp, err := engine.RecordExposure(ctx, &ExposeRequest{
+	resp, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken: "user-abc",
 		PackageID: "pkg-display-001",
 	})
@@ -354,17 +361,17 @@ func TestIdentity_ExposureIncrements(t *testing.T) {
 }
 
 func TestIdentity_CampaignFrequencyCap(t *testing.T) {
-	engine, store, resolved := setupIdentityEngine(t)
+	engine, store, resolved, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
 
 	// 5 exposures across two packages in campaign-acme (cap is 5/7d).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-001-%d", i)})
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-001-%d", i)})
 	}
 	for i := range 2 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-002", ImpressionID: fmt.Sprintf("imp-002-%d", i)})
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-002", ImpressionID: fmt.Sprintf("imp-002-%d", i)})
 	}
 
 	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
@@ -379,14 +386,14 @@ func TestIdentity_CampaignFrequencyCap(t *testing.T) {
 }
 
 func TestIdentity_PackageCappedButCampaignNot(t *testing.T) {
-	engine, store, resolved := setupIdentityEngine(t)
+	engine, store, resolved, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
 
 	// 3 exposures on pkg-display-001 (package cap=3, campaign cap=5).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-cap-%d", i)})
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-cap-%d", i)})
 	}
 
 	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
@@ -405,12 +412,12 @@ func TestIdentity_PackageCappedButCampaignNot(t *testing.T) {
 }
 
 func TestIdentity_MultipleFrequencyRules(t *testing.T) {
-	engine, _, resolved := setupIdentityEngine(t)
+	engine, _, resolved, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	// pkg-multi-rule: 2 per 12h AND 5 per 7d.
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-multi-rule", ImpressionID: "imp-multi-1"})
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-multi-rule", ImpressionID: "imp-multi-2"})
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-multi-rule", ImpressionID: "imp-multi-1"})
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-multi-rule", ImpressionID: "imp-multi-2"})
 
 	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
 		RequestID:  "id-multi",
@@ -422,7 +429,7 @@ func TestIdentity_MultipleFrequencyRules(t *testing.T) {
 }
 
 func TestIdentity_SlidingWindowExpiry(t *testing.T) {
-	engine, store, resolved := setupIdentityEngine(t)
+	engine, store, resolved, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
@@ -430,7 +437,7 @@ func TestIdentity_SlidingWindowExpiry(t *testing.T) {
 
 	// 3 exposures (hits cap).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-window-%d", i)})
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001", ImpressionID: fmt.Sprintf("imp-window-%d", i)})
 	}
 
 	resp, _ := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
@@ -450,12 +457,12 @@ func TestIdentity_SlidingWindowExpiry(t *testing.T) {
 }
 
 func TestIdentity_IntentScore(t *testing.T) {
-	engine, store, resolved := setupIdentityEngine(t)
+	engine, store, resolved, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
 
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001"})
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001"})
 
 	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "id-intent", UserToken: "user-abc", PackageIDs: []string{"pkg-display-001"},
@@ -466,7 +473,7 @@ func TestIdentity_IntentScore(t *testing.T) {
 }
 
 func TestIdentity_AudienceNotInSegment(t *testing.T) {
-	engine, _, resolved := setupIdentityEngine(t)
+	engine, _, resolved, _ := setupIdentityEngine(t)
 	// No user profile set -> user has no segments -> should fail audience gate.
 	resp, _ := engine.EvaluateIdentityResolved(context.Background(), resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "id-audience", UserToken: "user-abc", PackageIDs: []string{"pkg-display-001"},
@@ -475,7 +482,7 @@ func TestIdentity_AudienceNotInSegment(t *testing.T) {
 }
 
 func TestIdentity_NoCapPackage(t *testing.T) {
-	engine, _, resolved := setupIdentityEngine(t)
+	engine, _, resolved, _ := setupIdentityEngine(t)
 	resp, _ := engine.EvaluateIdentityResolved(context.Background(), resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "id-nocap", UserToken: "user-abc", PackageIDs: []string{"pkg-no-cap"},
 	})
@@ -483,7 +490,7 @@ func TestIdentity_NoCapPackage(t *testing.T) {
 }
 
 func TestIdentity_UnknownPackage(t *testing.T) {
-	engine, _, resolved := setupIdentityEngine(t)
+	engine, _, resolved, _ := setupIdentityEngine(t)
 	resp, _ := engine.EvaluateIdentityResolved(context.Background(), resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "id-unknown", UserToken: "user-abc", PackageIDs: []string{"pkg-unknown"},
 	})
@@ -492,7 +499,7 @@ func TestIdentity_UnknownPackage(t *testing.T) {
 }
 
 func TestIdentity_RequestIDPreserved(t *testing.T) {
-	engine, _, resolved := setupIdentityEngine(t)
+	engine, _, resolved, _ := setupIdentityEngine(t)
 	resp, _ := engine.EvaluateIdentityResolved(context.Background(), resolved, &tmproto.IdentityMatchRequest{
 		RequestID: "keep-this", UserToken: "user-abc", PackageIDs: []string{"pkg-no-cap"},
 	})
@@ -502,14 +509,14 @@ func TestIdentity_RequestIDPreserved(t *testing.T) {
 // --- Non-Resolved Identity Tests (sorted-set frequency capping) ---
 
 func TestIdentityNonResolved_PackageFrequencyCap(t *testing.T) {
-	engine, store, _ := setupIdentityEngine(t)
+	engine, store, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetAdd("audience:cooking", HashToken("user-abc"))
+	store.SetAdd("audience:cooking", exposure.HashToken("user-abc"))
 
 	// Record 3 exposures (package cap = 3/24h).
 	for i := range 3 {
-		_, err := engine.RecordExposure(ctx, &ExposeRequest{
+		_, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-abc", PackageID: "pkg-display-001",
 			ImpressionID: fmt.Sprintf("imp-nr-%d", i),
 		})
@@ -525,20 +532,20 @@ func TestIdentityNonResolved_PackageFrequencyCap(t *testing.T) {
 }
 
 func TestIdentityNonResolved_CampaignFrequencyCap(t *testing.T) {
-	engine, store, _ := setupIdentityEngine(t)
+	engine, store, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetAdd("audience:cooking", HashToken("user-abc"))
+	store.SetAdd("audience:cooking", exposure.HashToken("user-abc"))
 
 	// 5 exposures across two packages in campaign-acme (cap = 5/7d).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-abc", PackageID: "pkg-display-001",
 			ImpressionID: fmt.Sprintf("imp-nr-camp-1-%d", i),
 		})
 	}
 	for i := range 2 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-abc", PackageID: "pkg-display-002",
 			ImpressionID: fmt.Sprintf("imp-nr-camp-2-%d", i),
 		})
@@ -555,15 +562,15 @@ func TestIdentityNonResolved_CampaignFrequencyCap(t *testing.T) {
 }
 
 func TestIdentityNonResolved_SlidingWindowExpiry(t *testing.T) {
-	engine, store, _ := setupIdentityEngine(t)
+	engine, store, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	store.SetAdd("audience:cooking", HashToken("user-abc"))
+	store.SetAdd("audience:cooking", exposure.HashToken("user-abc"))
 
 	// 3 exposures (hits package cap of 3/24h).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-abc", PackageID: "pkg-display-001",
 			ImpressionID: fmt.Sprintf("imp-nr-window-%d", i),
 		})
@@ -588,12 +595,12 @@ func TestIdentityNonResolved_SlidingWindowExpiry(t *testing.T) {
 }
 
 func TestIdentityNonResolved_IntentScore(t *testing.T) {
-	engine, store, _ := setupIdentityEngine(t)
+	engine, store, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetAdd("audience:cooking", HashToken("user-abc"))
+	store.SetAdd("audience:cooking", exposure.HashToken("user-abc"))
 
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken: "user-abc", PackageID: "pkg-display-001",
 	})
 
@@ -607,14 +614,14 @@ func TestIdentityNonResolved_IntentScore(t *testing.T) {
 }
 
 func TestIdentityNonResolved_PackageCappedButCampaignNot(t *testing.T) {
-	engine, store, _ := setupIdentityEngine(t)
+	engine, store, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetAdd("audience:cooking", HashToken("user-abc"))
+	store.SetAdd("audience:cooking", exposure.HashToken("user-abc"))
 
 	// 3 exposures on pkg-display-001 (package cap=3, campaign cap=5).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-abc", PackageID: "pkg-display-001",
 			ImpressionID: fmt.Sprintf("imp-nr-mixed-%d", i),
 		})
@@ -637,11 +644,11 @@ func TestIdentityNonResolved_PackageCappedButCampaignNot(t *testing.T) {
 // --- Source Provenance Tests ---
 
 func TestIdentity_SourceIDFallsBackToProviderID(t *testing.T) {
-	engine, _, _ := setupIdentityEngine(t)
+	engine, _, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	// No source_id -> engine uses providerID ("test-provider").
-	resp, err := engine.RecordExposure(ctx, &ExposeRequest{
+	resp, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken:    "user-src",
 		PackageID:    "pkg-display-001",
 		ImpressionID: "imp-src-1",
@@ -650,18 +657,18 @@ func TestIdentity_SourceIDFallsBackToProviderID(t *testing.T) {
 	assert.Equal(t, "pkg-display-001", resp.PackageID)
 
 	// Read back the binary log and verify source hash = hash("test-provider").
-	hash := HashToken("user-src")
+	hash := exposure.HashToken("user-src")
 	val, _, _ := engine.store.Get(ctx, "user:exposures:"+hash)
-	blog := BinaryExposureLog(val)
+	blog := exposure.BinaryExposureLog(val)
 	require.Equal(t, 1, blog.Len())
-	assert.Equal(t, hashString("test-provider"), blog.SourceHash(0), "expected source hash of 'test-provider' when source_id not provided")
+	assert.Equal(t, exposure.HashString("test-provider"), blog.SourceHash(0), "expected source hash of 'test-provider' when source_id not provided")
 }
 
 func TestIdentity_SourceIDStampedOnBinaryLog(t *testing.T) {
-	engine, _, _ := setupIdentityEngine(t)
+	engine, _, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	_, err := engine.RecordExposure(ctx, &ExposeRequest{
+	_, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		SourceID:     "agent-cnn-v2",
 		UserToken:    "user-source-stamp",
 		PackageID:    "pkg-display-001",
@@ -669,25 +676,25 @@ func TestIdentity_SourceIDStampedOnBinaryLog(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	hash := HashToken("user-source-stamp")
+	hash := exposure.HashToken("user-source-stamp")
 	val, _, _ := engine.store.Get(ctx, "user:exposures:"+hash)
-	blog := BinaryExposureLog(val)
+	blog := exposure.BinaryExposureLog(val)
 	require.Equal(t, 1, blog.Len())
-	assert.Equal(t, hashString("agent-cnn-v2"), blog.SourceHash(0), "expected source hash of 'agent-cnn-v2'")
+	assert.Equal(t, exposure.HashString("agent-cnn-v2"), blog.SourceHash(0), "expected source hash of 'agent-cnn-v2'")
 }
 
 func TestIdentity_SourceNamespacesSortedSetMembers(t *testing.T) {
-	engine, _, _ := setupIdentityEngine(t)
+	engine, _, _, recorder := setupIdentityEngine(t)
 	ctx := context.Background()
 
 	// Two different sources submit the same impression_id.
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		SourceID:     "agent-a",
 		UserToken:    "user-ns",
 		PackageID:    "pkg-display-001",
 		ImpressionID: "imp-dup",
 	})
-	_, _ = engine.RecordExposure(ctx, &ExposeRequest{
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		SourceID:     "agent-b",
 		UserToken:    "user-ns",
 		PackageID:    "pkg-display-001",
@@ -695,7 +702,7 @@ func TestIdentity_SourceNamespacesSortedSetMembers(t *testing.T) {
 	})
 
 	// ZCount should show 2 distinct members (agent-a:imp-dup and agent-b:imp-dup).
-	hash := HashToken("user-ns")
+	hash := exposure.HashToken("user-ns")
 	key := "freq:pkg:pkg-display-001:" + hash
 	count, err := engine.store.ZCount(ctx, key, 0, math.MaxFloat64)
 	require.NoError(t, err)

--- a/targeting/entity.go
+++ b/targeting/entity.go
@@ -51,29 +51,29 @@ type PackageConfig struct {
 // stored in the Store as JSON at key "config:pkg:{packageID}:context".
 // Used when DynamicPackages is true on the Engine.
 type PackageContextConfig struct {
-	PackageID    string              `json:"package_id"`
-	MediaBuyID   string              `json:"media_buy_id,omitempty"`
-	URLBlocklist bool                `json:"url_blocklist,omitempty"`
-	URLAllowlist bool                `json:"url_allowlist,omitempty"`
-	TopicTargets bool                `json:"topic_targets,omitempty"`
-	PropertyRIDs []string             `json:"property_rids,omitempty"` // per-package property targeting
-	EmitSegments []string            `json:"emit_segments,omitempty"`
-	Offers       []OfferConfigJSON   `json:"offers,omitempty"`
-	Brand        json.RawMessage   `json:"brand,omitempty"`
-	Price        tmproto.OfferPrice `json:"price,omitempty"`
-	Summary      string              `json:"summary,omitempty"`
-	ManifestType string              `json:"manifest_type,omitempty"`
-	Macros       map[string]string   `json:"macros,omitempty"`
+	PackageID    string             `json:"package_id"`
+	MediaBuyID   string             `json:"media_buy_id,omitempty"`
+	URLBlocklist bool               `json:"url_blocklist,omitempty"`
+	URLAllowlist bool               `json:"url_allowlist,omitempty"`
+	TopicTargets bool               `json:"topic_targets,omitempty"`
+	PropertyRIDs []string           `json:"property_rids,omitempty"` // per-package property targeting
+	EmitSegments []string           `json:"emit_segments,omitempty"`
+	Offers       []OfferConfigJSON  `json:"offers,omitempty"`
+	Brand        json.RawMessage    `json:"brand,omitempty"`
+	Price        tmproto.OfferPrice `json:"price"`
+	Summary      string             `json:"summary,omitempty"`
+	ManifestType string             `json:"manifest_type,omitempty"`
+	Macros       map[string]string  `json:"macros,omitempty"`
 }
 
 // OfferConfigJSON is the JSON-serializable form of OfferConfig.
 type OfferConfigJSON struct {
-	DealID       string              `json:"deal_id,omitempty"`
-	Brand        json.RawMessage   `json:"brand,omitempty"`
-	Price        tmproto.OfferPrice `json:"price,omitempty"`
-	Summary      string              `json:"summary,omitempty"`
-	ManifestType string              `json:"manifest_type,omitempty"`
-	Macros       map[string]string   `json:"macros,omitempty"`
+	DealID       string             `json:"deal_id,omitempty"`
+	Brand        json.RawMessage    `json:"brand,omitempty"`
+	Price        tmproto.OfferPrice `json:"price"`
+	Summary      string             `json:"summary,omitempty"`
+	ManifestType string             `json:"manifest_type,omitempty"`
+	Macros       map[string]string  `json:"macros,omitempty"`
 }
 
 // OfferConfig represents a single brand's offer competing for a package.
@@ -86,4 +86,3 @@ type OfferConfig struct {
 	CreativeManifest json.RawMessage
 	Macros           map[string]string
 }
-

--- a/targeting/hash.go
+++ b/targeting/hash.go
@@ -6,13 +6,6 @@ import (
 	"strings"
 )
 
-// HashToken returns a truncated SHA-256 hex digest of a user token.
-// Uses the first 16 bytes (32 hex characters) for compactness.
-func HashToken(token string) string {
-	h := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(h[:16])
-}
-
 // HashURL returns a full SHA-256 hex digest of a lowercased URL.
 func HashURL(url string) string {
 	h := sha256.Sum256([]byte(strings.ToLower(url)))

--- a/targeting/identity_system_test.go
+++ b/targeting/identity_system_test.go
@@ -16,9 +16,11 @@ import (
 // (50/day across 10 packages) and verifies fcap evaluation works correctly
 // with the single-pull exposure log model.
 func TestSystem_HeavyUser(t *testing.T) {
-	store := NewMockStore()
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	store.Now = func() time.Time { return now }
+	clock := exposure.ClockFunc(func() time.Time { return now })
+
+	store := NewMockStore()
+	store.Clock = clock
 
 	// Build 1,500 exposures: 50/day × 30 days across 10 packages.
 	var entries []exposure.ExposureEntry
@@ -61,8 +63,7 @@ func TestSystem_HeavyUser(t *testing.T) {
 		CampaignConfigs: campConfigs,
 	}
 
-	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
-	engine.Now = func() time.Time { return now }
+	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store, Clock: clock})
 
 	pkgIDs := make([]string, 10)
 	for i := range 10 {
@@ -108,9 +109,11 @@ func TestSystem_HeavyUser(t *testing.T) {
 // TestSystem_IdentityGraph tests 3 UIDs for the same user with inconsistent
 // pairs per request. Verifies segment union and exposure dedup.
 func TestSystem_IdentityGraph(t *testing.T) {
-	store := NewMockStore()
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	store.Now = func() time.Time { return now }
+	clock := exposure.ClockFunc(func() time.Time { return now })
+
+	store := NewMockStore()
+	store.Clock = clock
 
 	// 3 UIDs: cookie, UID2, hashed email.
 	cookie := "tok-cookie-abc"
@@ -122,12 +125,11 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	store.SetUserProfile(uid2, map[string]float64{"sports_fans": 0.5})
 	store.SetUserProfile(email, map[string]float64{"cooking_fans": 0.6, "tech_enthusiasts": 0.9})
 
-	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
-	engine.Now = func() time.Time { return now }
+	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store, Clock: clock})
 	recorder := exposure.NewRecorder(exposure.RecorderConfig{
 		ProviderID: "test",
 		Store:      store,
-		Clock:      exposure.ClockFunc(func() time.Time { return now }),
+		Clock:      clock,
 	})
 
 	// Record exposures under different UIDs at different times.
@@ -259,14 +261,13 @@ func TestSystem_IdentityGraph(t *testing.T) {
 // TestSystem_RollingWindowExpiry simulates 35 days and verifies old exposures
 // are pruned and fcap rules correctly ignore expired entries.
 func TestSystem_RollingWindowExpiry(t *testing.T) {
-	store := NewMockStore()
 	baseTime := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	currentTime := baseTime
-	store.Now = func() time.Time { return currentTime }
-
 	clock := exposure.ClockFunc(func() time.Time { return currentTime })
-	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
-	engine.Now = clock.Now
+
+	store := NewMockStore()
+	store.Clock = clock
+	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store, Clock: clock})
 	recorder := exposure.NewRecorder(exposure.RecorderConfig{
 		ProviderID: "test",
 		Store:      store,
@@ -290,10 +291,11 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 	t.Log("=== Rolling Window Expiry: 35 days simulated ===")
 	t.Log("")
 
-	// Simulate 35 days, recording 2 exposures per day.
+	// Simulate 35 days, recording 2 exposures per day. All three clock
+	// consumers (store, engine, recorder) read through the same clock
+	// closure, so mutating currentTime is enough to advance them.
 	for day := range 35 {
 		currentTime = baseTime.Add(time.Duration(day) * 24 * time.Hour)
-		store.Now = clock.Now
 
 		for i := range 2 {
 			_, err := recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{

--- a/targeting/identity_system_test.go
+++ b/targeting/identity_system_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,12 +21,12 @@ func TestSystem_HeavyUser(t *testing.T) {
 	store.Now = func() time.Time { return now }
 
 	// Build 1,500 exposures: 50/day × 30 days across 10 packages.
-	var entries []ExposureEntry
+	var entries []exposure.ExposureEntry
 	for day := range 30 {
 		for imp := range 50 {
 			pkgIdx := imp % 10
 			ts := now.Add(-time.Duration(30-day) * 24 * time.Hour).Add(time.Duration(imp) * time.Minute)
-			entries = append(entries, ExposureEntry{
+			entries = append(entries, exposure.ExposureEntry{
 				ImpressionID: fmt.Sprintf("imp-d%d-i%d", day, imp),
 				PackageID:    fmt.Sprintf("pkg-%d", pkgIdx),
 				CampaignID:   fmt.Sprintf("campaign-%d", pkgIdx/3),
@@ -39,18 +40,18 @@ func TestSystem_HeavyUser(t *testing.T) {
 	t.Logf("Loaded %d exposures for heavy user", len(entries))
 
 	// Build identity configs.
-	idConfigs := make(map[string]*PackageIdentityConfig)
-	campConfigs := make(map[string]*CampaignFreqConfig)
+	idConfigs := make(map[string]*exposure.PackageIdentityConfig)
+	campConfigs := make(map[string]*exposure.CampaignFreqConfig)
 	for i := range 10 {
 		pkgID := fmt.Sprintf("pkg-%d", i)
 		campID := fmt.Sprintf("campaign-%d", i/3)
-		idConfigs[pkgID] = &PackageIdentityConfig{
+		idConfigs[pkgID] = &exposure.PackageIdentityConfig{
 			CampaignID:     campID,
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},  // 5/day
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}}, // 5/day
 			TargetSegments: []string{"premium_audience"},
 		}
-		campConfigs[campID] = &CampaignFreqConfig{
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 20, WindowSeconds: 604800}}, // 20/week
+		campConfigs[campID] = &exposure.CampaignFreqConfig{
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 20, WindowSeconds: 604800}}, // 20/week
 		}
 	}
 
@@ -85,7 +86,7 @@ func TestSystem_HeavyUser(t *testing.T) {
 	}
 
 	t.Logf("Heavy user: %d/%d eligible, evaluated in %v", eligible, len(pkgIDs), elapsed)
-	t.Logf("Exposure log size: %d bytes", len(SerializeExposureLog(entries)))
+	t.Logf("Exposure log size: %d bytes", len(exposure.SerializeExposureLog(entries)))
 
 	// All packages should be daily-capped (5 exposures/day, user has 5/day per pkg).
 	for _, e := range resp.Eligibility {
@@ -123,13 +124,18 @@ func TestSystem_IdentityGraph(t *testing.T) {
 
 	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
 	engine.Now = func() time.Time { return now }
+	recorder := exposure.NewRecorder(exposure.RecorderConfig{
+		ProviderID: "test",
+		Store:      store,
+		Clock:      exposure.ClockFunc(func() time.Time { return now }),
+	})
 
 	// Record exposures under different UIDs at different times.
 	// Day 1-10: cookie only.
 	for day := range 10 {
 		for i := range 3 {
 			ts := now.Add(-time.Duration(30-day) * 24 * time.Hour)
-			_, _ = engine.RecordExposure(context.Background(), &ExposeRequest{
+			_, _ = recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 				UserToken: cookie, PackageID: "pkg-food", ImpressionID: fmt.Sprintf("imp-cookie-d%d-i%d", day, i),
 				CampaignID: "campaign-food",
 			})
@@ -139,7 +145,7 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	// Day 11-20: UID2 only.
 	for day := 10; day < 20; day++ {
 		for i := range 2 {
-			_, _ = engine.RecordExposure(context.Background(), &ExposeRequest{
+			_, _ = recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 				UserToken: uid2, PackageID: "pkg-food", ImpressionID: fmt.Sprintf("imp-uid2-d%d-i%d", day, i),
 				CampaignID: "campaign-food",
 			})
@@ -148,17 +154,17 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	// Day 21-30: hashed email. Some impressions shared with cookie (same impression ID).
 	for day := 20; day < 30; day++ {
 		// Unique impressions under email.
-		_, _ = engine.RecordExposure(context.Background(), &ExposeRequest{
+		_, _ = recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 			UserToken: email, PackageID: "pkg-food", ImpressionID: fmt.Sprintf("imp-email-d%d", day),
 			CampaignID: "campaign-food",
 		})
 		// Shared impression: also record under cookie with same impression ID.
 		sharedImpID := fmt.Sprintf("imp-shared-d%d", day)
-		_, _ = engine.RecordExposure(context.Background(), &ExposeRequest{
+		_, _ = recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 			UserToken: email, PackageID: "pkg-food", ImpressionID: sharedImpID,
 			CampaignID: "campaign-food",
 		})
-		_, _ = engine.RecordExposure(context.Background(), &ExposeRequest{
+		_, _ = recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 			UserToken: cookie, PackageID: "pkg-food", ImpressionID: sharedImpID,
 			CampaignID: "campaign-food",
 		})
@@ -170,13 +176,13 @@ func TestSystem_IdentityGraph(t *testing.T) {
 			"sports_fans":      {"pkg-sports"},
 			"tech_enthusiasts": {"pkg-tech"},
 		},
-		IdentityConfigs: map[string]*PackageIdentityConfig{
-			"pkg-food":   {CampaignID: "campaign-food", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}, TargetSegments: []string{"cooking_fans"}},
+		IdentityConfigs: map[string]*exposure.PackageIdentityConfig{
+			"pkg-food":   {CampaignID: "campaign-food", FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}, TargetSegments: []string{"cooking_fans"}},
 			"pkg-sports": {TargetSegments: []string{"sports_fans"}},
 			"pkg-tech":   {TargetSegments: []string{"tech_enthusiasts"}},
 		},
-		CampaignConfigs: map[string]*CampaignFreqConfig{
-			"campaign-food": {FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}},
+		CampaignConfigs: map[string]*exposure.CampaignFreqConfig{
+			"campaign-food": {FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}},
 		},
 	}
 
@@ -237,13 +243,13 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	// Verify: exposure dedup. Cookie has ~40 exposures (30 unique + 10 shared).
 	// Email has ~20 exposures (10 unique + 10 shared). Union should dedup the shared ones.
 	// Total unique impressions across cookie+email should be less than sum of both.
-	cookieHash := HashToken(cookie)
-	emailHash := HashToken(email)
+	cookieHash := exposure.HashToken(cookie)
+	emailHash := exposure.HashToken(email)
 	cookieVal, _, _ := store.Get(context.Background(), "user:exposures:"+cookieHash)
 	emailVal, _, _ := store.Get(context.Background(), "user:exposures:"+emailHash)
-	cookieBin := BinaryExposureLog(cookieVal)
-	emailBin := BinaryExposureLog(emailVal)
-	mergedBin := MergeBinaryLogs(cookieBin, emailBin)
+	cookieBin := exposure.BinaryExposureLog(cookieVal)
+	emailBin := exposure.BinaryExposureLog(emailVal)
+	mergedBin := exposure.MergeBinaryLogs(cookieBin, emailBin)
 	t.Logf("  Cookie exposures: %d, Email exposures: %d, Merged (deduped): %d",
 		cookieBin.Len(), emailBin.Len(), mergedBin.Len())
 
@@ -258,20 +264,26 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 	currentTime := baseTime
 	store.Now = func() time.Time { return currentTime }
 
+	clock := exposure.ClockFunc(func() time.Time { return currentTime })
 	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
-	engine.Now = func() time.Time { return currentTime }
+	engine.Now = clock.Now
+	recorder := exposure.NewRecorder(exposure.RecorderConfig{
+		ProviderID: "test",
+		Store:      store,
+		Clock:      clock,
+	})
 
 	store.SetUserProfile("user-rolling", map[string]float64{"all": 0})
 
 	resolved := &ResolvedPackages{
 		SegmentIndex: map[string][]string{"all": {"pkg-test"}},
-		IdentityConfigs: map[string]*PackageIdentityConfig{
+		IdentityConfigs: map[string]*exposure.PackageIdentityConfig{
 			"pkg-test": {
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}}, // 5/day
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}}, // 5/day
 				TargetSegments: []string{"all"},
 			},
 		},
-		CampaignConfigs: map[string]*CampaignFreqConfig{},
+		CampaignConfigs: map[string]*exposure.CampaignFreqConfig{},
 	}
 
 	t.Log("")
@@ -281,11 +293,10 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 	// Simulate 35 days, recording 2 exposures per day.
 	for day := range 35 {
 		currentTime = baseTime.Add(time.Duration(day) * 24 * time.Hour)
-		engine.Now = func() time.Time { return currentTime }
-		store.Now = func() time.Time { return currentTime }
+		store.Now = clock.Now
 
 		for i := range 2 {
-			_, err := engine.RecordExposure(context.Background(), &ExposeRequest{
+			_, err := recorder.RecordExposure(context.Background(), &exposure.ExposeRequest{
 				UserToken:    "user-rolling",
 				PackageID:    "pkg-test",
 				ImpressionID: fmt.Sprintf("imp-d%d-i%d", day, i),
@@ -303,10 +314,10 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 	}
 
 	// Check the exposure log: should be pruned to ~30 days.
-	hash := HashToken("user-rolling")
+	hash := exposure.HashToken("user-rolling")
 	val, _, _ := store.Get(context.Background(), "user:exposures:"+hash)
-	binLog := BinaryExposureLog(val)
-	require.NoError(t, ValidateBinaryLog(binLog))
+	binLog := exposure.BinaryExposureLog(val)
+	require.NoError(t, exposure.ValidateBinaryLog(binLog))
 
 	// Pruning happens on each write. Entries older than 30 days should be gone.
 	thirtyDaysAgo := currentTime.Add(-30 * 24 * time.Hour).Unix()

--- a/targeting/metrics.go
+++ b/targeting/metrics.go
@@ -17,18 +17,18 @@ const (
 // Metrics receives instrumentation callbacks from the targeting engine.
 // Implementations can map these to Prometheus counters or structured logging.
 // The noop default adds zero overhead.
+//
+// Exposure recording emits its own metric set via exposure.Metrics.
 type Metrics interface {
 	ContextEvaluated(packageID, stage string, passed bool)
 	IdentityEvaluated(packageID, stage string, passed bool)
-	ExposureRecorded(packageID string)
 	StoreError(operation string, err error)
 	Latency(stage string, d time.Duration)
 }
 
 type noopMetrics struct{}
 
-func (noopMetrics) ContextEvaluated(string, string, bool) {}
+func (noopMetrics) ContextEvaluated(string, string, bool)  {}
 func (noopMetrics) IdentityEvaluated(string, string, bool) {}
-func (noopMetrics) ExposureRecorded(string) {}
-func (noopMetrics) StoreError(string, error) {}
-func (noopMetrics) Latency(string, time.Duration) {}
+func (noopMetrics) StoreError(string, error)               {}
+func (noopMetrics) Latency(string, time.Duration)          {}

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -20,9 +20,10 @@ type MockStore struct {
 	zsets   map[string][]zsetMember
 	expiry  map[string]time.Time // key -> expiry time
 
-	// Now returns the current time. Defaults to time.Now.
+	// Clock drives TTL expiry checks. Share it with the Engine and any
+	// exposure.Recorder using the same store so all three agree on "now."
 	// Override in tests to control time.
-	Now func() time.Time
+	Clock exposure.Clock
 }
 
 type stringEntry struct {
@@ -35,15 +36,24 @@ type zsetMember struct {
 	member string
 }
 
-// NewMockStore creates an empty MockStore.
+// NewMockStore creates an empty MockStore with a wall-clock source.
 func NewMockStore() *MockStore {
 	return &MockStore{
 		sets:    make(map[string]map[string]struct{}),
 		strings: make(map[string]stringEntry),
 		zsets:   make(map[string][]zsetMember),
 		expiry:  make(map[string]time.Time),
-		Now:     time.Now,
+		Clock:   exposure.ClockFunc(time.Now),
 	}
+}
+
+// now returns the current time from the configured Clock, falling back to
+// wall time when Clock is nil.
+func (m *MockStore) now() time.Time {
+	if m.Clock != nil {
+		return m.Clock.Now()
+	}
+	return time.Now()
 }
 
 // SetAdd adds members to a set. Test helper, not part of Store interface.
@@ -194,7 +204,7 @@ func (m *MockStore) Get(_ context.Context, key string) (string, bool, error) {
 	if !ok {
 		return "", false, nil
 	}
-	if !entry.expiry.IsZero() && m.Now().After(entry.expiry) {
+	if !entry.expiry.IsZero() && m.now().After(entry.expiry) {
 		return "", false, nil
 	}
 	return entry.value, true, nil
@@ -205,7 +215,7 @@ func (m *MockStore) Set(_ context.Context, key, value string, ttl time.Duration)
 	defer m.mu.Unlock()
 	entry := stringEntry{value: value}
 	if ttl > 0 {
-		entry.expiry = m.Now().Add(ttl)
+		entry.expiry = m.now().Add(ttl)
 	}
 	m.strings[key] = entry
 	return nil
@@ -215,7 +225,7 @@ func (m *MockStore) Exists(_ context.Context, key string) (bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if entry, ok := m.strings[key]; ok {
-		if !entry.expiry.IsZero() && m.Now().After(entry.expiry) {
+		if !entry.expiry.IsZero() && m.now().After(entry.expiry) {
 			return false, nil
 		}
 		return true, nil
@@ -267,7 +277,7 @@ func (m *MockStore) ZExpire(_ context.Context, key string, ttl time.Duration) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if ttl > 0 {
-		m.expiry[key] = m.Now().Add(ttl)
+		m.expiry[key] = m.now().Add(ttl)
 	} else {
 		delete(m.expiry, key)
 	}
@@ -315,7 +325,7 @@ func (m *MockStore) MGet(_ context.Context, keys ...string) ([]string, error) {
 		if !ok {
 			continue
 		}
-		if !entry.expiry.IsZero() && m.Now().After(entry.expiry) {
+		if !entry.expiry.IsZero() && m.now().After(entry.expiry) {
 			continue
 		}
 		results[i] = entry.value
@@ -329,5 +339,5 @@ func (m *MockStore) isExpired(key string) bool {
 	if !ok {
 		return false
 	}
-	return m.Now().After(exp)
+	return m.now().After(exp)
 }

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/adcontextprotocol/adcp-go/exposure"
 )
 
 // MockStore is an in-memory Store for testing. It supports sets, strings,
@@ -59,7 +61,7 @@ func (m *MockStore) SetAdd(key string, members ...string) {
 }
 
 // SetPackageIdentityConfig stores identity config for a package. Test helper.
-func (m *MockStore) SetPackageIdentityConfig(pkgID string, cfg PackageIdentityConfig) {
+func (m *MockStore) SetPackageIdentityConfig(pkgID string, cfg exposure.PackageIdentityConfig) {
 	data, _ := json.Marshal(cfg)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -67,7 +69,7 @@ func (m *MockStore) SetPackageIdentityConfig(pkgID string, cfg PackageIdentityCo
 }
 
 // SetCampaignFreqConfig stores frequency config for a campaign. Test helper.
-func (m *MockStore) SetCampaignFreqConfig(campaignID string, cfg CampaignFreqConfig) {
+func (m *MockStore) SetCampaignFreqConfig(campaignID string, cfg exposure.CampaignFreqConfig) {
 	data, _ := json.Marshal(cfg)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -93,8 +95,8 @@ func (m *MockStore) SetMediaBuy(mb MediaBuy) {
 
 // SetUserProfile stores a user's segment memberships. Test helper.
 func (m *MockStore) SetUserProfile(token string, segments map[string]float64) {
-	hash := HashToken(token)
-	profile := UserProfile{Segments: segments}
+	hash := exposure.HashToken(token)
+	profile := exposure.UserProfile{Segments: segments}
 	data, _ := json.Marshal(profile)
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -102,23 +104,23 @@ func (m *MockStore) SetUserProfile(token string, segments map[string]float64) {
 }
 
 // SetUserExposures stores a user's exposure log in binary format. Test helper.
-func (m *MockStore) SetUserExposures(token string, entries []ExposureEntry) {
-	hash := HashToken(token)
-	bin := EncodeBinaryExposureLog(entries)
+func (m *MockStore) SetUserExposures(token string, entries []exposure.ExposureEntry) {
+	hash := exposure.HashToken(token)
+	bin := exposure.EncodeBinaryExposureLog(entries)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.strings["user:exposures:"+hash] = stringEntry{value: string(bin)}
 }
 
 // AddExposure appends an exposure entry to a user's log. Test helper.
-func (m *MockStore) AddExposure(token string, entry ExposureEntry) {
-	hash := HashToken(token)
+func (m *MockStore) AddExposure(token string, entry exposure.ExposureEntry) {
+	hash := exposure.HashToken(token)
 	key := "user:exposures:" + hash
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	existing := BinaryExposureLog(m.strings[key].value)
-	newEntry := EncodeBinaryExposureLog(ExposureLog{entry})
-	merged := MergeBinaryLogs(existing, newEntry)
+	existing := exposure.BinaryExposureLog(m.strings[key].value)
+	newEntry := exposure.EncodeBinaryExposureLog(exposure.ExposureLog{entry})
+	merged := exposure.MergeBinaryLogs(existing, newEntry)
 	m.strings[key] = stringEntry{value: string(merged)}
 }
 

--- a/targeting/mock_store_test.go
+++ b/targeting/mock_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +74,7 @@ func TestMockStore_StringOperations(t *testing.T) {
 
 	t.Run("TTLExpiry", func(t *testing.T) {
 		now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		s.Now = func() time.Time { return now }
+		s.Clock = exposure.ClockFunc(func() time.Time { return now })
 
 		err := s.Set(ctx, "temp", "value", 10*time.Second)
 		require.NoError(t, err)
@@ -84,7 +85,7 @@ func TestMockStore_StringOperations(t *testing.T) {
 		assert.Equal(t, "value", val)
 
 		// Advance past TTL.
-		s.Now = func() time.Time { return now.Add(11 * time.Second) }
+		s.Clock = exposure.ClockFunc(func() time.Time { return now.Add(11 * time.Second) })
 
 		_, ok, err = s.Get(ctx, "temp")
 		require.NoError(t, err)
@@ -130,7 +131,7 @@ func TestMockStore_SortedSetOperations(t *testing.T) {
 
 	t.Run("ZExpire", func(t *testing.T) {
 		now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-		s.Now = func() time.Time { return now }
+		s.Clock = exposure.ClockFunc(func() time.Time { return now })
 
 		require.NoError(t, s.ZAdd(ctx, "expiring", 1, "x"))
 		require.NoError(t, s.ZExpire(ctx, "expiring", 5*time.Second))
@@ -139,7 +140,7 @@ func TestMockStore_SortedSetOperations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), count)
 
-		s.Now = func() time.Time { return now.Add(6 * time.Second) }
+		s.Clock = exposure.ClockFunc(func() time.Time { return now.Add(6 * time.Second) })
 
 		count, err = s.ZCount(ctx, "expiring", 0, 10)
 		require.NoError(t, err)

--- a/targeting/primitives.go
+++ b/targeting/primitives.go
@@ -1,7 +1,5 @@
 package targeting
 
-import "time"
-
 // Bitmap is a set of string values with O(1) membership test.
 // For small sets (<10K), MapBitmap is a stdlib-only alternative.
 type Bitmap interface {
@@ -58,10 +56,4 @@ func (p *PropertyList) ContainsPackage(packageID string, rid string) bool {
 		return true
 	}
 	return bm.Contains(rid)
-}
-
-// FrequencyRule defines a sliding-window impression cap.
-type FrequencyRule struct {
-	MaxCount int
-	Window   time.Duration
 }

--- a/targeting/prommetrics/metrics.go
+++ b/targeting/prommetrics/metrics.go
@@ -8,16 +8,20 @@ package prommetrics
 import (
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 )
 
-// Metrics implements targeting.Metrics backed by a Registry.
+// Metrics implements targeting.Metrics and exposure.Metrics backed by a Registry.
 type Metrics struct {
 	Registry *Registry
 }
 
-// Ensure Metrics satisfies the targeting.Metrics interface.
-var _ targeting.Metrics = (*Metrics)(nil)
+// Ensure Metrics satisfies both Metrics interfaces.
+var (
+	_ targeting.Metrics = (*Metrics)(nil)
+	_ exposure.Metrics  = (*Metrics)(nil)
+)
 
 // New creates a Metrics instance with pre-registered targeting metrics.
 func New() *Metrics {

--- a/targeting/resolved.go
+++ b/targeting/resolved.go
@@ -3,6 +3,7 @@ package targeting
 import (
 	"slices"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -13,7 +14,7 @@ type ResolvedPackages struct {
 	Packages []tmproto.AvailablePackage
 
 	// Context indexes (zero Store calls at eval time).
-	PropertyIndex     map[string][]string             // propertyRID → packageIDs
+	PropertyIndex     map[string][]string            // propertyRID → packageIDs
 	TopicIndex        map[string][]string            // topic → packageIDs
 	URLBlocklistIndex map[string][]string            // urlHash → packageIDs that block it
 	URLAllowlists     map[string]map[string]struct{} // pkgID → set of allowed urlHashes
@@ -22,9 +23,9 @@ type ResolvedPackages struct {
 	SegmentIndex map[string][]string // segment → packageIDs
 
 	// Pre-loaded configs.
-	ContextConfigs  map[string]*PackageContextConfig  // pkgID → config
-	IdentityConfigs map[string]*PackageIdentityConfig // pkgID → config
-	CampaignConfigs map[string]*CampaignFreqConfig    // campaignID → config
+	ContextConfigs  map[string]*PackageContextConfig           // pkgID → config
+	IdentityConfigs map[string]*exposure.PackageIdentityConfig // pkgID → config
+	CampaignConfigs map[string]*exposure.CampaignFreqConfig    // campaignID → config
 }
 
 // ContextCandidates returns package IDs that could match the given property.

--- a/targeting/resolver.go
+++ b/targeting/resolver.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -120,9 +121,9 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 	}
 
 	// Step 3: Batch-load identity configs (1 MGet).
-	idConfigs, err := batchLoadPackageIdentityConfigs(ctx, store, pkgIDs)
+	idConfigs, err := exposure.BatchLoadPackageIdentityConfigs(ctx, store, pkgIDs)
 	if err != nil {
-		idConfigs = make(map[string]*PackageIdentityConfig)
+		idConfigs = make(map[string]*exposure.PackageIdentityConfig)
 	}
 
 	// Step 4: Collect unique campaign IDs, batch-load (1 MGet).
@@ -136,9 +137,9 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 	for id := range campIDSet {
 		campIDs = append(campIDs, id)
 	}
-	campConfigs, err := batchLoadCampaignFreqConfigs(ctx, store, campIDs)
+	campConfigs, err := exposure.BatchLoadCampaignFreqConfigs(ctx, store, campIDs)
 	if err != nil {
-		campConfigs = make(map[string]*CampaignFreqConfig)
+		campConfigs = make(map[string]*exposure.CampaignFreqConfig)
 	}
 
 	// Step 5: Build indexes.

--- a/targeting/resolver_test.go
+++ b/targeting/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -178,16 +179,16 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	store.SetAdd("url:blocklist:pkg-food", HashURL("article:bad"))
 
 	// Identity configs.
-	store.SetPackageIdentityConfig("pkg-food", PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-food", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-1",
 		TargetSegments: []string{"cooking_fans"},
-		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 	})
-	store.SetPackageIdentityConfig("pkg-tech", PackageIdentityConfig{
+	store.SetPackageIdentityConfig("pkg-tech", exposure.PackageIdentityConfig{
 		TargetSegments: []string{"tech_enthusiasts", "cooking_fans"},
 	})
-	store.SetCampaignFreqConfig("campaign-1", CampaignFreqConfig{
-		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 604800}},
+	store.SetCampaignFreqConfig("campaign-1", exposure.CampaignFreqConfig{
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 604800}},
 	})
 
 	resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)

--- a/targeting/scale_test.go
+++ b/targeting/scale_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -30,7 +31,7 @@ func TestScale_PropertyBitmap(t *testing.T) {
 		})
 
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:   "bench",
 			PropertyRID: fmt.Sprintf("%d", n/2),
 			PackageIDs:  []string{"pkg-1"},
 		}
@@ -58,8 +59,8 @@ func TestScale_Campaigns(t *testing.T) {
 
 		// Create N campaigns in the Store.
 		for i := range numCampaigns {
-			store.SetCampaignFreqConfig(fmt.Sprintf("campaign-%d", i), CampaignFreqConfig{
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
+			store.SetCampaignFreqConfig(fmt.Sprintf("campaign-%d", i), exposure.CampaignFreqConfig{
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
 			})
 		}
 
@@ -68,9 +69,9 @@ func TestScale_Campaigns(t *testing.T) {
 		for i := range 5 {
 			pkgID := fmt.Sprintf("pkg-%d", i)
 			pkgs = append(pkgs, PackageConfig{PackageID: pkgID})
-			store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
+			store.SetPackageIdentityConfig(pkgID, exposure.PackageIdentityConfig{
 				CampaignID:     fmt.Sprintf("campaign-%d", numCampaigns-1),
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 			})
 		}
 
@@ -111,12 +112,12 @@ func TestScale_AudienceSegmentSize(t *testing.T) {
 			store.SetAdd("audience:big-segment", fmt.Sprintf("hash-%d", i))
 		}
 
-		store.SetPackageIdentityConfig("pkg-1", PackageIdentityConfig{
+		store.SetPackageIdentityConfig("pkg-1", exposure.PackageIdentityConfig{
 			TargetSegments: []string{"big-segment"},
 		})
 
 		// The lookup user IS in the segment (worst case for "check then pass").
-		targetHash := HashToken("tok-bench")
+		targetHash := exposure.HashToken("tok-bench")
 		store.SetAdd("audience:big-segment", targetHash)
 
 		engine := NewEngine(EngineConfig{
@@ -153,12 +154,12 @@ func TestScale_FrequencyCapExposures(t *testing.T) {
 		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 		store.Now = func() time.Time { return now }
 
-		store.SetPackageIdentityConfig("pkg-1", PackageIdentityConfig{
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100_000, WindowSeconds: 86400}},
+		store.SetPackageIdentityConfig("pkg-1", exposure.PackageIdentityConfig{
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 100_000, WindowSeconds: 86400}},
 		})
 
 		// Pre-populate exposure history.
-		tokenHash := HashToken("tok-bench")
+		tokenHash := exposure.HashToken("tok-bench")
 		key := fmt.Sprintf("freq:pkg:pkg-1:%s", tokenHash)
 		for i := range numExposures {
 			ts := float64(now.Add(-time.Duration(i) * time.Minute).UnixMilli())
@@ -213,7 +214,7 @@ func TestScale_TopicSetSize(t *testing.T) {
 		})
 
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []map[string]any{{"url": "article:test"}},
 			PackageIDs:   []string{"pkg-1"},
@@ -252,7 +253,7 @@ func TestScale_URLBlocklistSize(t *testing.T) {
 
 		// Check a URL that is NOT blocked (worst case: full lookup, no short-circuit).
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []map[string]any{{"url": "article:safe-content"}},
 			PackageIDs:   []string{"pkg-1"},
@@ -286,8 +287,8 @@ func TestScale_DynamicVsStatic(t *testing.T) {
 			staticPkgs = append(staticPkgs, PackageConfig{PackageID: pkgID, TopicTargets: true})
 			pkgIDs = append(pkgIDs, pkgID)
 			store.SetAdd(fmt.Sprintf("topics:package:%s", pkgID), "food.cooking")
-			store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
+			store.SetPackageIdentityConfig(pkgID, exposure.PackageIdentityConfig{
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
 			})
 			store.SetPackageContextConfig(pkgID, PackageContextConfig{
 				PackageID:    pkgID,
@@ -313,7 +314,7 @@ func TestScale_DynamicVsStatic(t *testing.T) {
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []map[string]any{{"url": "article:food"}},
 			PackageIDs:   pkgIDs,
@@ -411,9 +412,9 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 				TopicTargets: true,
 				PropertyRIDs: []string{"1"},
 			})
-			store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
+			store.SetPackageIdentityConfig(pkgID, exposure.PackageIdentityConfig{
 				TargetSegments: []string{"cooking_fans"},
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
 			})
 		}
 		store.SetMediaBuy(MediaBuy{
@@ -423,7 +424,7 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 			Packages: mbPkgs,
 		})
 		store.SetAdd("topics:artifact:article:food", "food.cooking")
-		store.SetAdd("audience:cooking_fans", HashToken("tok-bench"))
+		store.SetAdd("audience:cooking_fans", exposure.HashToken("tok-bench"))
 
 		// Build resolved once.
 		resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)
@@ -439,7 +440,7 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []map[string]any{{"url": "article:food"}},
 			PackageIDs:   pkgIDs,
@@ -491,8 +492,8 @@ func TestScale_PackagesPerRequest(t *testing.T) {
 			pkgs = append(pkgs, PackageConfig{PackageID: pkgID, TopicTargets: true})
 			pkgIDs = append(pkgIDs, pkgID)
 			store.SetAdd(fmt.Sprintf("topics:package:%s", pkgID), "food.cooking")
-			store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
-				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
+			store.SetPackageIdentityConfig(pkgID, exposure.PackageIdentityConfig{
+				FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
 			})
 		}
 		store.SetAdd("topics:artifact:article:food", "food.cooking")
@@ -505,7 +506,7 @@ func TestScale_PackagesPerRequest(t *testing.T) {
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []map[string]any{{"url": "article:food"}},
 			PackageIDs:   pkgIDs,

--- a/targeting/scale_test.go
+++ b/targeting/scale_test.go
@@ -150,9 +150,11 @@ func TestScale_FrequencyCapExposures(t *testing.T) {
 	t.Log("")
 
 	for _, numExposures := range []int{0, 10, 100, 1_000, 10_000} {
-		store := NewMockStore()
 		now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
-		store.Now = func() time.Time { return now }
+		clock := exposure.ClockFunc(func() time.Time { return now })
+
+		store := NewMockStore()
+		store.Clock = clock
 
 		store.SetPackageIdentityConfig("pkg-1", exposure.PackageIdentityConfig{
 			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 100_000, WindowSeconds: 86400}},
@@ -169,9 +171,9 @@ func TestScale_FrequencyCapExposures(t *testing.T) {
 		engine := NewEngine(EngineConfig{
 			ProviderID: "bench",
 			Store:      store,
+			Clock:      clock,
 			Packages:   []PackageConfig{{PackageID: "pkg-1"}},
 		})
-		engine.Now = func() time.Time { return now }
 
 		req := &tmproto.IdentityMatchRequest{
 			RequestID:  "bench",

--- a/targeting/system_test.go
+++ b/targeting/system_test.go
@@ -30,9 +30,11 @@ func TestSystem_EndToEnd(t *testing.T) {
 		pagesPerUser    = 5
 	)
 
-	store := NewMockStore()
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
-	store.Now = func() time.Time { return now }
+	clock := exposure.ClockFunc(func() time.Time { return now })
+
+	store := NewMockStore()
+	store.Clock = clock
 
 	t.Logf("")
 	t.Logf("=== System Test: %d packages, %d segments × %d members, %d campaigns ===", totalPackages, numSegments, membersPerSeg, numCampaigns)
@@ -153,25 +155,25 @@ func TestSystem_EndToEnd(t *testing.T) {
 	staticEngine := NewEngine(EngineConfig{
 		ProviderID: "bench",
 		Store:      store,
+		Clock:      clock,
 		Properties: PropertyList{Global: NewMapBitmap("1")},
 		Packages:   staticPkgs,
 	})
-	staticEngine.Now = func() time.Time { return now }
 
 	dynamicEngine := NewEngine(EngineConfig{
 		ProviderID:      "bench",
 		Store:           store,
+		Clock:           clock,
 		Properties:      PropertyList{Global: NewMapBitmap("1")},
 		DynamicPackages: true,
 	})
-	dynamicEngine.Now = func() time.Time { return now }
 
 	resolvedEngine := NewEngine(EngineConfig{
 		ProviderID: "bench",
 		Store:      store,
+		Clock:      clock,
 		Properties: PropertyList{Global: NewMapBitmap("1")},
 	})
-	resolvedEngine.Now = func() time.Time { return now }
 
 	// --- Benchmark: simulate user sessions ---
 

--- a/targeting/system_test.go
+++ b/targeting/system_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -17,16 +18,16 @@ func TestSystem_EndToEnd(t *testing.T) {
 	// --- Setup: realistic seller with many media buys ---
 
 	const (
-		numMediaBuys     = 50
-		packagesPerBuy   = 10
-		totalPackages    = numMediaBuys * packagesPerBuy // 500
-		numSegments      = 20
-		membersPerSeg    = 10_000
-		topicsPerPkg     = 5
-		blocklistPerPkg  = 100
-		numCampaigns     = 10
-		numUsers         = 100
-		pagesPerUser     = 5
+		numMediaBuys    = 50
+		packagesPerBuy  = 10
+		totalPackages   = numMediaBuys * packagesPerBuy // 500
+		numSegments     = 20
+		membersPerSeg   = 10_000
+		topicsPerPkg    = 5
+		blocklistPerPkg = 100
+		numCampaigns    = 10
+		numUsers        = 100
+		pagesPerUser    = 5
 	)
 
 	store := NewMockStore()
@@ -88,17 +89,17 @@ func TestSystem_EndToEnd(t *testing.T) {
 
 		// Identity config.
 		targetSegs := []string{segments[i%numSegments], segments[(i+1)%numSegments]}
-		store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
+		store.SetPackageIdentityConfig(pkgID, exposure.PackageIdentityConfig{
 			CampaignID:     campID,
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 			TargetSegments: targetSegs,
 		})
 	}
 
 	// Campaign configs.
 	for i := range numCampaigns {
-		store.SetCampaignFreqConfig(fmt.Sprintf("campaign-%d", i), CampaignFreqConfig{
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 20, WindowSeconds: 604800}},
+		store.SetCampaignFreqConfig(fmt.Sprintf("campaign-%d", i), exposure.CampaignFreqConfig{
+			FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 20, WindowSeconds: 604800}},
 		})
 	}
 
@@ -106,7 +107,7 @@ func TestSystem_EndToEnd(t *testing.T) {
 	userTokens := make([]string, numUsers)
 	for u := range numUsers {
 		userTokens[u] = fmt.Sprintf("tok-user-%d", u)
-		hash := HashToken(userTokens[u])
+		hash := exposure.HashToken(userTokens[u])
 		// Each user is in 2-3 segments.
 		store.SetAdd("audience:"+segments[u%numSegments], hash)
 		store.SetAdd("audience:"+segments[(u+3)%numSegments], hash)
@@ -182,13 +183,13 @@ func TestSystem_EndToEnd(t *testing.T) {
 	}
 
 	type result struct {
-		name            string
-		totalTime       time.Duration
-		contextTime     time.Duration
-		identityTime    time.Duration
-		contextOffers   int
+		name             string
+		totalTime        time.Duration
+		contextTime      time.Duration
+		identityTime     time.Duration
+		contextOffers    int
 		identityEligible int
-		requests        int
+		requests         int
 	}
 
 	runBench := func(name string, evalCtx func(context.Context, *tmproto.ContextMatchRequest) (*ContextResult, error), evalId func(context.Context, *tmproto.IdentityMatchRequest) (*IdentityResult, error)) result {

--- a/targeting/valkeystore/integration_test.go
+++ b/targeting/valkeystore/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/exposure"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 	"github.com/alicebob/miniredis/v2"
@@ -15,8 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setupIntegration creates an Engine backed by a real Redis (miniredis) Store.
-func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Miniredis) {
+// setupIntegration creates an Engine and Recorder backed by a real Redis
+// (miniredis) Store. The recorder writes exposure state; the engine reads it.
+func setupIntegration(t *testing.T) (*targeting.Engine, *exposure.Recorder, *Store, *miniredis.Miniredis) {
 	t.Helper()
 	mr, err := miniredis.Run()
 	require.NoError(t, err)
@@ -32,21 +34,21 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 		require.NoError(t, store.Set(ctx, key, string(data), 0))
 	}
 
-	seedJSON("config:pkg:pkg-alpha", targeting.PackageIdentityConfig{
+	seedJSON("config:pkg:pkg-alpha", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-x",
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
 		TargetSegments: []string{"sports"},
 	})
-	seedJSON("config:pkg:pkg-beta", targeting.PackageIdentityConfig{
+	seedJSON("config:pkg:pkg-beta", exposure.PackageIdentityConfig{
 		CampaignID:     "campaign-x",
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 	})
-	seedJSON("config:campaign:campaign-x", targeting.CampaignFreqConfig{
-		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
+	seedJSON("config:campaign:campaign-x", exposure.CampaignFreqConfig{
+		FrequencyRules: []exposure.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
 	})
 
 	// Add user to audience segment.
-	tokenHash := targeting.HashToken("user-valkey")
+	tokenHash := exposure.HashToken("user-valkey")
 	mr.SAdd("audience:sports", tokenHash)
 
 	engine := targeting.NewEngine(targeting.EngineConfig{
@@ -57,18 +59,22 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 			{PackageID: "pkg-beta"},
 		},
 	})
+	recorder := exposure.NewRecorder(exposure.RecorderConfig{
+		ProviderID: "test-valkey",
+		Store:      store,
+	})
 
-	return engine, store, mr
+	return engine, recorder, store, mr
 }
 
 func TestValkeyIntegration_PackageFrequencyCap(t *testing.T) {
-	engine, _, mr := setupIntegration(t)
+	engine, recorder, _, mr := setupIntegration(t)
 	defer mr.Close()
 	ctx := context.Background()
 
 	// Record 3 exposures (package cap = 3/24h).
 	for i := range 3 {
-		_, err := engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		_, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-valkey", PackageID: "pkg-alpha",
 			ImpressionID: fmt.Sprintf("imp-valkey-%d", i),
 		})
@@ -84,19 +90,19 @@ func TestValkeyIntegration_PackageFrequencyCap(t *testing.T) {
 }
 
 func TestValkeyIntegration_CampaignFrequencyCap(t *testing.T) {
-	engine, _, mr := setupIntegration(t)
+	engine, recorder, _, mr := setupIntegration(t)
 	defer mr.Close()
 	ctx := context.Background()
 
 	// 3 on pkg-alpha + 2 on pkg-beta = 5 total (campaign cap = 5/7d).
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-valkey", PackageID: "pkg-alpha",
 			ImpressionID: fmt.Sprintf("imp-v-camp-a-%d", i),
 		})
 	}
 	for i := range 2 {
-		_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-valkey", PackageID: "pkg-beta",
 			ImpressionID: fmt.Sprintf("imp-v-camp-b-%d", i),
 		})
@@ -113,13 +119,13 @@ func TestValkeyIntegration_CampaignFrequencyCap(t *testing.T) {
 }
 
 func TestValkeyIntegration_SlidingWindowExpiry(t *testing.T) {
-	engine, _, mr := setupIntegration(t)
+	engine, recorder, _, mr := setupIntegration(t)
 	defer mr.Close()
 	ctx := context.Background()
 
 	// 3 exposures hits package cap.
 	for i := range 3 {
-		_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+		_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 			UserToken: "user-valkey", PackageID: "pkg-alpha",
 			ImpressionID: fmt.Sprintf("imp-v-window-%d", i),
 		})
@@ -144,11 +150,11 @@ func TestValkeyIntegration_SlidingWindowExpiry(t *testing.T) {
 }
 
 func TestValkeyIntegration_IntentScore(t *testing.T) {
-	engine, _, mr := setupIntegration(t)
+	engine, recorder, _, mr := setupIntegration(t)
 	defer mr.Close()
 	ctx := context.Background()
 
-	_, _ = engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+	_, _ = recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken: "user-valkey", PackageID: "pkg-alpha",
 	})
 
@@ -162,11 +168,11 @@ func TestValkeyIntegration_IntentScore(t *testing.T) {
 }
 
 func TestValkeyIntegration_ExposureResponse(t *testing.T) {
-	engine, _, mr := setupIntegration(t)
+	_, recorder, _, mr := setupIntegration(t)
 	defer mr.Close()
 	ctx := context.Background()
 
-	resp, err := engine.RecordExposure(ctx, &tmproto.ExposeRequest{
+	resp, err := recorder.RecordExposure(ctx, &exposure.ExposeRequest{
 		UserToken: "user-valkey", PackageID: "pkg-alpha",
 	})
 	require.NoError(t, err)

--- a/targeting/valkeystore/integration_test.go
+++ b/targeting/valkeystore/integration_test.go
@@ -140,7 +140,7 @@ func TestValkeyIntegration_SlidingWindowExpiry(t *testing.T) {
 	// Fast-forward miniredis past the 24h window.
 	mr.FastForward(25 * time.Hour)
 	// Also advance engine time so ZCount cutoff is correct.
-	engine.Now = func() time.Time { return time.Now().Add(25 * time.Hour) }
+	engine.Clock = exposure.ClockFunc(func() time.Time { return time.Now().Add(25 * time.Hour) })
 
 	resp, _ = engine.EvaluateIdentity(ctx, &tmproto.IdentityMatchRequest{
 		RequestID: "v-after", UserToken: "user-valkey",

--- a/tmproto/types_test.go
+++ b/tmproto/types_test.go
@@ -236,4 +236,4 @@ func TestMarshalJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, PropertyTypeAIAssistant, got.PropertyType, "property_type")
 }
 
-// ExposeRequest tests moved to targeting package where the type now lives.
+// ExposeRequest tests live in the exposure package where the type now lives.


### PR DESCRIPTION
## Summary

Extract the frequency-capping and ad-exposure write path out of the `targeting` package into a new top-level `exposure` package. The targeting engine consumes `exposure` for read-side evaluation; systems that own impression recording can now embed `exposure.Recorder` against a bare Store without pulling in the engine, property registry, or signature machinery.

This replaces the earlier attempt (#?), which only split `RecordExposure` into a struct inside `targeting/`. Reviewers wanted a real package boundary so the dependency direction is visible — and so this seam becomes the natural place to later move exposure recording out of the identity-match library entirely (follow-up).

## Package layout

```
exposure/                   (new — no targeting import, no tmproto import)
├── exposure.go             ExposeRequest, ExposeResponse, UserIdentity, ExposureEntry/Log,
│                           UserProfile, FrequencyRule, validators, merge/prune/intent helpers
├── binary.go               BinaryExposureLog format + readers/writers
├── config.go               PackageIdentityConfig, CampaignFreqConfig, Load/BatchLoad/Seed
├── hash.go                 HashToken (SHA-256, user keys), HashString (FNV, compact IDs)
├── recorder.go             Recorder, RecorderConfig, Metrics, Clock, ClockFunc, RecordExposure
├── store.go                ConfigStore, BatchStore, RecorderStore interfaces
└── recorder_test.go        standalone-recorder test using a 30-line fakeStore — no targeting

targeting/                  (engine now imports exposure)
├── engine.go               uses exposure.HashToken, BatchLoadPackageIdentityConfigs,
│                           BinaryExposureLog, CheckFrequencyRulesMultiLog, etc.
├── context_config.go       PackageContextConfig loader (stays here — targeting-local)
├── metrics.go              ExposureRecorded removed; exposure.Metrics owns that callback
├── resolved.go             IdentityConfigs / CampaignConfigs now *exposure.* pointers
└── ...
```

**Dependency direction:** `targeting` → `exposure`. Never the reverse. `exposure` defines its own narrow Store interfaces; any `targeting.Store` satisfies them structurally, but `exposure` can also be wired against a minimal store with zero targeting coupling (demonstrated in `exposure/recorder_test.go`).

## What moved

| From `targeting` | To `exposure` |
|---|---|
| `ExposeRequest`, `ExposeResponse`, `UserIdentity`, `ValidateExposeRequest` | `exposure.*` (same names) |
| `ExposureEntry`, `ExposureLog`, JSON helpers, `Merge`/`Prune`/`Check`/`Latest`/`ComputeIntentScore` | `exposure.*` |
| `UserProfile`, `ParseUserProfile`, `MergeUserProfiles` | `exposure.*` |
| `FrequencyRule`, `FrequencyRuleJSON`, `ToFrequencyRules` | `exposure.*` |
| `PackageIdentityConfig`, `CampaignFreqConfig`, `Load*`, `BatchLoad*`, `Seed*` | `exposure.*` |
| `BinaryExposureLog` + all helpers | `exposure.*` |
| `HashToken` | `exposure.HashToken` |
| `hashString` (private) | `exposure.HashString` (now exported for cross-package access) |
| `Engine.RecordExposure` | `exposure.Recorder.RecordExposure` |

## Breaking changes

**`targeting.Metrics` no longer declares `ExposureRecorded`.** That callback moved to the new `exposure.Metrics` interface, which `exposure.Recorder` invokes.

External implementers who defined `ExposureRecorded` on their `targeting.Metrics` type will compile fine (Go interfaces ignore extra methods) but will silently stop receiving the callback once they upgrade. To continue receiving it, pass the same implementation as `exposure.RecorderConfig.Metrics`. See `docs/embedding.md` for the updated pattern — a single struct can satisfy both interfaces, as `targeting/prommetrics/Metrics` now does (compile-time asserted).

**Import-path renames for users of targeting-side types:**

| Old | New |
|---|---|
| `targeting.PackageIdentityConfig` | `exposure.PackageIdentityConfig` |
| `targeting.CampaignFreqConfig` | `exposure.CampaignFreqConfig` |
| `targeting.FrequencyRuleJSON` | `exposure.FrequencyRuleJSON` |
| `targeting.HashToken` | `exposure.HashToken` |
| `targeting.Seed{Package,Campaign}...Config` | `exposure.Seed{Package,Campaign}...Config` |
| `engine.RecordExposure(...)` | `exposure.NewRecorder(...).RecordExposure(...)` |
| `engine.Now = func() time.Time {...}` | `engine.Clock = exposure.ClockFunc(func() time.Time {...})` or pass `Clock` to `EngineConfig` |
| `mockStore.Now = ...` | `mockStore.Clock = ...` |

The reference identity-agent (`reference/identity-agent/cmd/...`), `targeting/valkeystore`, and `targeting/prommetrics` are all updated in this PR.

## Review-feedback addressed

From the previous reviews on the struct-only extraction:

- **Shadowing bug.** The `for _, r := range rules[1:]` loop inside the old `RecordExposure` shadowed the method receiver once the method moved onto a struct with receiver `r`. Renamed the loop variable to `rule`.
- **Shared clock.** `exposure.Clock` / `ClockFunc` replace the triple `Now func() time.Time` fields that previously lived on `Engine`, `MockStore`, and the `ExposureRecorder` draft. Tests now construct one `ClockFunc`, hand it to all three, and advance time by mutating the closed-over variable — no per-iteration reassignment. `TestSystem_RollingWindowExpiry` is the canonical example.
- **Standalone-recorder test.** `exposure/recorder_test.go::TestStandaloneRecorder_MinimalWiring` builds a `Recorder` from `(ProviderID, Store)` against a 30-line `fakeStore` that imports nothing from `targeting`. `TestStandaloneRecorder_SharedClock` verifies the shared-clock path.
- **Store-schema coupling called out.** Package doc on `exposure.Recorder` names the store keys (`user:exposures:<hash>`, `freq:pkg:*`, `freq:campaign:*`, `intent:*`) explicitly as the integration contract — any reader or writer honoring the schema interoperates.
- **Metrics breaking change documented.** `docs/embedding.md` now has an "Implementing targeting.Metrics and exposure.Metrics" section with the migration note.
- **Stale comment.** `tmproto/types_test.go:239` no longer claims ExposeRequest tests moved to `targeting`; they're in `exposure` now.

## Test plan

- [x] `go test ./...` (main module) — exposure / targeting / router / tmpclient / tmproto all green
- [x] `go test ./targeting/valkeystore/...` (miniredis integration) — green
- [x] `go test ./targeting/prommetrics/...` — green; both `targeting.Metrics` and `exposure.Metrics` conformance asserted
- [x] `go build ./reference/identity-agent/...` — green
- [x] `go test -run TestIntegration_ ./e2e/...` — green (integration round-trips context + identity + record over real router/registry/tmpclient)
- [x] `go vet ./...` — clean
- [x] Behavior of `RecordExposure` byte-identical to main (same store schema, same TTLs, same pruning math, same response shape — only change is the receiver rename and shadowing fix)

## Non-goals / follow-ups

- The reviewer flagged that if exposure recording is truly standalone, it probably shouldn't live in this repo at all — the natural owner is the impression pipeline (SSP / ad server / exchange callback), and the identity-match library should be read-only. This PR creates the package boundary that makes that relocation cheap; the actual move is a follow-up.
