### PR TITLE
feat: adcp/idempotency package for AdCP idempotency_key

### DIFF
--- a/adcp/idempotency/backend.go
+++ b/adcp/idempotency/backend.go
@@ -1,0 +1,33 @@
+package idempotency
+
+import (
+	"context"
+	"time"
+)
+
+// Entry is the persisted record for one idempotency key.
+// Response holds the encoded inner handler response. The envelope
+// `replayed` flag is injected at response time, not stored.
+type Entry struct {
+	Hash      string
+	Response  []byte
+	CreatedAt time.Time
+	ExpiresAt time.Time
+}
+
+// Backend is the pluggable storage surface for the idempotency middleware.
+// Implementations MUST be safe for concurrent use.
+//
+// Scope is a namespace under which keys are unique. The middleware passes a
+// per-principal (or principal+session) scope so keys from different
+// principals cannot collide.
+type Backend interface {
+	// Get returns the entry for (scope, key), or (nil, nil) on miss.
+	// Expired entries MAY be returned; the middleware checks TTL.
+	Get(ctx context.Context, scope, key string) (*Entry, error)
+
+	// PutIfAbsent stores entry only if (scope, key) has no existing record.
+	// On race, it returns the winning entry and stored=false so the caller can
+	// hash-compare without an extra round trip.
+	PutIfAbsent(ctx context.Context, scope, key string, entry *Entry) (existing *Entry, stored bool, err error)
+}

--- a/adcp/idempotency/canonical.go
+++ b/adcp/idempotency/canonical.go
@@ -1,0 +1,311 @@
+// Package idempotency provides canonicalization, hashing, typed errors,
+// storage backends, and handler middleware for AdCP idempotency_key support.
+package idempotency
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// HashFn canonicalizes a JSON payload and returns a stable digest.
+// Implementations MUST produce byte-identical output for semantically equal
+// inputs so hash comparison correctly detects payload drift.
+type HashFn func(payload []byte) (string, error)
+
+// DefaultExcludePaths are top-level JSON fields removed before canonicalization.
+// These are either the idempotency key itself (tautological) or transport-layer
+// fields that legitimately vary between retries without altering request intent.
+var DefaultExcludePaths = []string{
+	"idempotency_key",
+	"context",
+	"governance_context",
+	"push_notification_config.authentication.credentials",
+}
+
+// CanonicalJSONSHA256 is the default HashFn: RFC 8785 JCS canonicalization
+// followed by SHA-256. The top-level exclude list is applied before hashing.
+var CanonicalJSONSHA256 = NewCanonicalJSONSHA256(DefaultExcludePaths)
+
+// NewCanonicalJSONSHA256 returns a HashFn that strips the given dotted JSON
+// paths, canonicalizes the remainder with JCS (RFC 8785), and SHA-256 hashes
+// the result. Dotted paths apply from the document root (e.g.,
+// "push_notification_config.authentication.credentials").
+func NewCanonicalJSONSHA256(excludePaths []string) HashFn {
+	paths := compileExcludePaths(excludePaths)
+	return func(payload []byte) (string, error) {
+		var v any
+		dec := json.NewDecoder(bytes.NewReader(payload))
+		dec.UseNumber()
+		if err := dec.Decode(&v); err != nil {
+			return "", fmt.Errorf("idempotency: decode payload: %w", err)
+		}
+		v = stripPaths(v, paths, nil)
+		canon, err := canonicalize(v)
+		if err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256(canon)
+		return hex.EncodeToString(sum[:]), nil
+	}
+}
+
+type excludeNode struct {
+	children map[string]*excludeNode
+	leaf     bool
+}
+
+func compileExcludePaths(paths []string) *excludeNode {
+	root := &excludeNode{children: map[string]*excludeNode{}}
+	for _, p := range paths {
+		parts := strings.Split(p, ".")
+		cur := root
+		for _, part := range parts {
+			child, ok := cur.children[part]
+			if !ok {
+				child = &excludeNode{children: map[string]*excludeNode{}}
+				cur.children[part] = child
+			}
+			cur = child
+		}
+		cur.leaf = true
+	}
+	return root
+}
+
+func stripPaths(v any, node *excludeNode, path []string) any {
+	if node == nil {
+		return v
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+	out := make(map[string]any, len(m))
+	for k, child := range m {
+		cn := node.children[k]
+		if cn != nil && cn.leaf {
+			continue
+		}
+		if cn != nil && len(cn.children) > 0 {
+			out[k] = stripPaths(child, cn, append(path, k))
+			continue
+		}
+		out[k] = child
+	}
+	return out
+}
+
+// canonicalize emits RFC 8785 JCS form for a value decoded with UseNumber.
+func canonicalize(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeCanonical(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeCanonical(buf *bytes.Buffer, v any) error {
+	switch x := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if x {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case string:
+		return writeJSONString(buf, x)
+	case json.Number:
+		return writeCanonicalNumber(buf, string(x))
+	case []any:
+		buf.WriteByte('[')
+		for i, item := range x {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeCanonical(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			if !utf8.ValidString(k) {
+				return fmt.Errorf("idempotency: object key is not valid UTF-8")
+			}
+			keys = append(keys, k)
+		}
+		sortUTF16(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := writeJSONString(buf, k); err != nil {
+				return err
+			}
+			buf.WriteByte(':')
+			if err := writeCanonical(buf, x[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		return fmt.Errorf("idempotency: unsupported canonicalization type %T", v)
+	}
+	return nil
+}
+
+// sortUTF16 sorts strings by their UTF-16 code-unit sequences, as required by RFC 8785.
+func sortUTF16(s []string) {
+	sort.Slice(s, func(i, j int) bool {
+		a := utf16.Encode([]rune(s[i]))
+		b := utf16.Encode([]rune(s[j]))
+		for k := 0; k < len(a) && k < len(b); k++ {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+		return len(a) < len(b)
+	})
+}
+
+// writeJSONString applies the RFC 8785 string serialization rules. Invalid
+// UTF-8 is rejected so two payloads with distinct byte sequences cannot
+// canonicalize to the same form via silent U+FFFD substitution.
+func writeJSONString(buf *bytes.Buffer, s string) error {
+	if !utf8.ValidString(s) {
+		return fmt.Errorf("idempotency: string value is not valid UTF-8")
+	}
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				fmt.Fprintf(buf, `\u%04x`, r)
+			} else {
+				buf.WriteRune(r)
+			}
+		}
+	}
+	buf.WriteByte('"')
+	return nil
+}
+
+// writeCanonicalNumber formats a number in ECMAScript Number.prototype.toString
+// form, matching RFC 8785 §3.2.2.3.
+func writeCanonicalNumber(buf *bytes.Buffer, numStr string) error {
+	f, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return fmt.Errorf("idempotency: invalid number %q: %w", numStr, err)
+	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return errors.New("idempotency: NaN/Inf not allowed in JCS")
+	}
+	if f == 0 {
+		buf.WriteByte('0')
+		return nil
+	}
+	buf.WriteString(formatES6(f))
+	return nil
+}
+
+// formatES6 reproduces ECMAScript Number.prototype.toString for finite nonzero doubles.
+func formatES6(f float64) string {
+	// Shortest-round-trip decimal.
+	s := strconv.FormatFloat(f, 'e', -1, 64)
+	// s is of the form "dddd.ddde±dd" or "de±dd".
+	mantissa, expPart, ok := strings.Cut(s, "e")
+	if !ok {
+		return s
+	}
+	exp, err := strconv.Atoi(expPart)
+	if err != nil {
+		return s
+	}
+
+	sign := ""
+	if strings.HasPrefix(mantissa, "-") {
+		sign = "-"
+		mantissa = mantissa[1:]
+	}
+
+	intPart, fracPart, _ := strings.Cut(mantissa, ".")
+	digits := intPart + fracPart
+	digits = strings.TrimRight(digits, "0")
+	if digits == "" {
+		digits = "0"
+	}
+	// decExp = exponent of the most significant digit relative to the decimal point.
+	decExp := exp - len(fracPart) + len(digits) - 1
+
+	// ES6 chooses fixed notation when exponent is in [-6, 20].
+	if decExp >= -6 && decExp < 21 {
+		return sign + fixedDecimal(digits, decExp)
+	}
+	// Exponential form: leading digit, optional .rest, 'e', sign, exponent (no leading zero).
+	var out strings.Builder
+	out.WriteString(sign)
+	out.WriteByte(digits[0])
+	if len(digits) > 1 {
+		out.WriteByte('.')
+		out.WriteString(digits[1:])
+	}
+	out.WriteByte('e')
+	if decExp >= 0 {
+		out.WriteByte('+')
+	}
+	out.WriteString(strconv.Itoa(decExp))
+	return out.String()
+}
+
+func fixedDecimal(digits string, decExp int) string {
+	if decExp < 0 {
+		// 0.000...digits
+		var b strings.Builder
+		b.WriteString("0.")
+		for i := 0; i < -decExp-1; i++ {
+			b.WriteByte('0')
+		}
+		b.WriteString(digits)
+		return b.String()
+	}
+	// decExp >= 0: move the implicit point right of position decExp.
+	if decExp+1 >= len(digits) {
+		// Pad with zeros; no decimal point.
+		var b strings.Builder
+		b.WriteString(digits)
+		for i := 0; i < decExp+1-len(digits); i++ {
+			b.WriteByte('0')
+		}
+		return b.String()
+	}
+	// Insert a decimal point after decExp+1 digits.
+	return digits[:decExp+1] + "." + digits[decExp+1:]
+}

--- a/adcp/idempotency/canonical_test.go
+++ b/adcp/idempotency/canonical_test.go
@@ -1,0 +1,125 @@
+package idempotency
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalOrderingIsStable(t *testing.T) {
+	a := []byte(`{"b":1,"a":2,"c":{"z":1,"y":2}}`)
+	b := []byte(`{"a":2,"c":{"y":2,"z":1},"b":1}`)
+	ha, err := CanonicalJSONSHA256(a)
+	require.NoError(t, err)
+	hb, err := CanonicalJSONSHA256(b)
+	require.NoError(t, err)
+	assert.Equal(t, ha, hb, "key-order permutations must hash identically")
+}
+
+func TestCanonicalExcludesIdempotencyKeyAndContext(t *testing.T) {
+	a := []byte(`{"idempotency_key":"abc","context":{"trace":"1"},"account":"x"}`)
+	b := []byte(`{"idempotency_key":"zzz","context":{"trace":"2"},"account":"x"}`)
+	ha, err := CanonicalJSONSHA256(a)
+	require.NoError(t, err)
+	hb, err := CanonicalJSONSHA256(b)
+	require.NoError(t, err)
+	assert.Equal(t, ha, hb, "excluded top-level fields must not affect hash")
+}
+
+func TestCanonicalExcludesNestedCredentials(t *testing.T) {
+	a := []byte(`{"account":"x","push_notification_config":{"url":"u","authentication":{"scheme":"bearer","credentials":"AAA"}}}`)
+	b := []byte(`{"account":"x","push_notification_config":{"url":"u","authentication":{"scheme":"bearer","credentials":"BBB"}}}`)
+	ha, err := CanonicalJSONSHA256(a)
+	require.NoError(t, err)
+	hb, err := CanonicalJSONSHA256(b)
+	require.NoError(t, err)
+	assert.Equal(t, ha, hb, "nested credentials must be excluded")
+}
+
+func TestCanonicalDetectsPayloadDrift(t *testing.T) {
+	a := []byte(`{"account":"x","budget":1000}`)
+	b := []byte(`{"account":"x","budget":1001}`)
+	ha, err := CanonicalJSONSHA256(a)
+	require.NoError(t, err)
+	hb, err := CanonicalJSONSHA256(b)
+	require.NoError(t, err)
+	assert.NotEqual(t, ha, hb, "different values MUST yield different hashes")
+}
+
+func TestCanonicalNumbers(t *testing.T) {
+	cases := []struct {
+		in       string
+		expected string
+	}{
+		{`0`, `0`},
+		{`1`, `1`},
+		{`-1`, `-1`},
+		{`100`, `100`},
+		{`1.5`, `1.5`},
+		{`1e2`, `100`},
+		{`1e21`, `1e+21`},
+		{`1e-7`, `1e-7`},
+		{`1.0`, `1`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			var v any
+			dec := json.NewDecoder(strings.NewReader(tc.in))
+			dec.UseNumber()
+			require.NoError(t, dec.Decode(&v))
+			out, err := canonicalize(v)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, string(out))
+		})
+	}
+}
+
+func TestCanonicalStringEscaping(t *testing.T) {
+	v := map[string]any{"x": "line1\nline2\t\"q\"\\"}
+	out, err := canonicalize(v)
+	require.NoError(t, err)
+	assert.Equal(t, `{"x":"line1\nline2\t\"q\"\\"}`, string(out))
+}
+
+func TestCanonicalRejectsInvalidJSON(t *testing.T) {
+	_, err := CanonicalJSONSHA256([]byte(`{`))
+	assert.Error(t, err)
+}
+
+func TestCanonicalRejectsInvalidUTF8InStringValue(t *testing.T) {
+	v := map[string]any{"x": "abc\xffdef"}
+	_, err := canonicalize(v)
+	require.Error(t, err)
+}
+
+func TestCanonicalRejectsInvalidUTF8InKey(t *testing.T) {
+	v := map[string]any{"bad\xffkey": "v"}
+	_, err := canonicalize(v)
+	require.Error(t, err)
+}
+
+func TestCanonicalUTF16SortDifferentiatesPrecomposedAndDecomposed(t *testing.T) {
+	// "é" (U+00E9) vs "e" + combining acute (U+0065 U+0301) — JCS sorts by
+	// UTF-16 code units, not NFC equivalence, so these must hash differently.
+	a := []byte(`{"\u00e9":1}`)
+	b := []byte(`{"\u0065\u0301":1}`)
+	ha, err := CanonicalJSONSHA256(a)
+	require.NoError(t, err)
+	hb, err := CanonicalJSONSHA256(b)
+	require.NoError(t, err)
+	assert.NotEqual(t, ha, hb)
+}
+
+func TestCanonicalCustomExcludes(t *testing.T) {
+	hash := NewCanonicalJSONSHA256([]string{"trace_id"})
+	a := []byte(`{"trace_id":"t1","v":1}`)
+	b := []byte(`{"trace_id":"t2","v":1}`)
+	ha, err := hash(a)
+	require.NoError(t, err)
+	hb, err := hash(b)
+	require.NoError(t, err)
+	assert.Equal(t, ha, hb)
+}

--- a/adcp/idempotency/client.go
+++ b/adcp/idempotency/client.go
@@ -1,0 +1,228 @@
+package idempotency
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// keyPattern matches the schema requirement: ASCII letters, digits, and the
+// set [_.:-], length 16..255.
+var keyPattern = regexp.MustCompile(`^[A-Za-z0-9_.:\-]{16,255}$`)
+
+// Generate returns a new UUID v4 formatted idempotency key (36 chars with
+// dashes). The caller SHOULD cache this on the request struct so internal
+// retries resend the same key.
+func Generate() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(fmt.Errorf("idempotency: crypto/rand failed: %w", err))
+	}
+	// RFC 4122 v4 variant bits.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	h := hex.EncodeToString(b[:])
+	return h[0:8] + "-" + h[8:12] + "-" + h[12:16] + "-" + h[16:20] + "-" + h[20:32]
+}
+
+// Validate checks a key against the AdCP schema pattern. Returns nil on OK,
+// or *InvalidKeyError.
+func Validate(key string) error {
+	if key == "" {
+		return &InvalidKeyError{Reason: "empty"}
+	}
+	if !keyPattern.MatchString(key) {
+		return &InvalidKeyError{Reason: "must match ^[A-Za-z0-9_.:-]{16,255}$"}
+	}
+	return nil
+}
+
+// LogKey returns a prefix-truncated form of key safe for default logging.
+// Full keys are retry-pattern oracles; callers that want full keys in logs
+// must opt in explicitly.
+func LogKey(key string) string {
+	const n = 8
+	if len(key) <= n {
+		return "****"
+	}
+	return key[:n] + "…"
+}
+
+// RequestEnvelope is the frozen form of a request, bound to a specific key.
+// Callers that implement their own transport use *RequestEnvelope to satisfy
+// the freeze-bytes-on-first-send rule: marshal once, resend byte-identical
+// on every retry. Re-marshaling the struct is incorrect because Go's
+// json.Marshal stability is not guaranteed across dependency changes.
+type RequestEnvelope struct {
+	Key   string
+	Bytes []byte
+}
+
+// Freeze marshals req through map[string]any, injects an idempotency_key
+// (generating one if neither req nor keyOverride has one), and returns the
+// bound bytes. Use this for untyped / map requests. For strongly-typed
+// request structs where byte-for-byte preservation matters, marshal yourself
+// and call FreezeBytes.
+func Freeze(req any, keyOverride string) (*RequestEnvelope, error) {
+	obj, err := asMap(req)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, _ := obj["idempotency_key"].(string)
+	key, err := resolveKey(existing, keyOverride)
+	if err != nil {
+		return nil, err
+	}
+	obj["idempotency_key"] = key
+
+	frozen, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("idempotency: freeze request bytes: %w", err)
+	}
+	return &RequestEnvelope{Key: key, Bytes: frozen}, nil
+}
+
+// FreezeBytes takes already-marshaled JSON and returns it unchanged, bound to
+// its existing idempotency_key. Use this when byte-exact retry semantics
+// matter: the caller marshals their request struct once (preserving field
+// order, number precision, custom encoders), and the SDK resends those same
+// bytes on every retry.
+//
+// The input MUST contain a top-level idempotency_key. Generating one here
+// would require re-marshaling, which is what this function exists to avoid —
+// callers without a key should use Freeze instead, then treat the returned
+// bytes as the canonical form.
+//
+// If keyOverride is non-empty it must match the key in the payload;
+// mismatches return an error so a caller cannot silently overwrite a key
+// already committed to bytes.
+func FreezeBytes(jsonReq []byte, keyOverride string) (*RequestEnvelope, error) {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(jsonReq, &probe); err != nil {
+		return nil, fmt.Errorf("idempotency: decode request: %w", err)
+	}
+	raw, ok := probe["idempotency_key"]
+	if !ok {
+		return nil, fmt.Errorf("idempotency: FreezeBytes requires idempotency_key in the payload; use Freeze to generate one")
+	}
+	var existing string
+	if err := json.Unmarshal(raw, &existing); err != nil {
+		return nil, &InvalidKeyError{Reason: "not a string"}
+	}
+	if err := Validate(existing); err != nil {
+		return nil, err
+	}
+	if keyOverride != "" && keyOverride != existing {
+		return nil, fmt.Errorf("idempotency: WithIdempotencyKey(%s) conflicts with idempotency_key already set on request (%s)", LogKey(keyOverride), LogKey(existing))
+	}
+	out := make([]byte, len(jsonReq))
+	copy(out, jsonReq)
+	return &RequestEnvelope{Key: existing, Bytes: out}, nil
+}
+
+func resolveKey(existing, override string) (string, error) {
+	switch {
+	case override != "" && existing != "" && override != existing:
+		return "", fmt.Errorf("idempotency: WithIdempotencyKey(%s) conflicts with idempotency_key already set on request (%s)", LogKey(override), LogKey(existing))
+	case override != "":
+		if err := Validate(override); err != nil {
+			return "", err
+		}
+		return override, nil
+	case existing != "":
+		if err := Validate(existing); err != nil {
+			return "", err
+		}
+		return existing, nil
+	default:
+		return Generate(), nil
+	}
+}
+
+func asMap(v any) (map[string]any, error) {
+	if m, ok := v.(map[string]any); ok {
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			out[k] = val
+		}
+		return out, nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("idempotency: marshal request: %w", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("idempotency: decode request: %w", err)
+	}
+	return out, nil
+}
+
+// ParseCapability extracts adcp.idempotency.replay_ttl_seconds from a
+// get_adcp_capabilities response body. Returns MissingCapabilityError if the
+// field is absent — per spec, clients MUST NOT fall back to an assumed TTL.
+func ParseCapability(caps map[string]any, agentID string) (time.Duration, error) {
+	adcp, ok := caps["adcp"].(map[string]any)
+	if !ok {
+		return 0, &MissingCapabilityError{AgentID: agentID}
+	}
+	ide, ok := adcp["idempotency"].(map[string]any)
+	if !ok {
+		return 0, &MissingCapabilityError{AgentID: agentID}
+	}
+	raw, ok := ide["replay_ttl_seconds"]
+	if !ok {
+		return 0, &MissingCapabilityError{AgentID: agentID}
+	}
+	secs, err := toFloat(raw)
+	if err != nil || secs <= 0 {
+		return 0, &MissingCapabilityError{AgentID: agentID}
+	}
+	// Cap at ~292 years to avoid Duration overflow on nonsense values.
+	const maxSecs = float64(1 << 40)
+	if secs > maxSecs {
+		secs = maxSecs
+	}
+	return time.Duration(secs * float64(time.Second)), nil
+}
+
+func toFloat(v any) (float64, error) {
+	switch x := v.(type) {
+	case float64:
+		return x, nil
+	case float32:
+		return float64(x), nil
+	case int:
+		return float64(x), nil
+	case int64:
+		return float64(x), nil
+	case json.Number:
+		return x.Float64()
+	}
+	return 0, fmt.Errorf("idempotency: replay_ttl_seconds is not numeric")
+}
+
+// ReadReplayed returns the envelope's `replayed` flag. Clients use this to
+// suppress side effects on replays (billing, analytics, webhooks). When the
+// field is absent or non-boolean, ok=false.
+func ReadReplayed(envelope []byte) (replayed bool, ok bool) {
+	dec := json.NewDecoder(bytes.NewReader(envelope))
+	var m map[string]any
+	if err := dec.Decode(&m); err != nil {
+		return false, false
+	}
+	v, present := m["replayed"]
+	if !present {
+		return false, false
+	}
+	b, isBool := v.(bool)
+	if !isBool {
+		return false, false
+	}
+	return b, true
+}

--- a/adcp/idempotency/client_test.go
+++ b/adcp/idempotency/client_test.go
@@ -1,0 +1,167 @@
+package idempotency
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateIsUUIDv4(t *testing.T) {
+	k := Generate()
+	assert.Len(t, k, 36)
+	assert.Equal(t, byte('-'), k[8])
+	assert.Equal(t, byte('-'), k[13])
+	assert.Equal(t, byte('-'), k[18])
+	assert.Equal(t, byte('-'), k[23])
+	// v4 indicator
+	assert.Equal(t, byte('4'), k[14])
+	require.NoError(t, Validate(k))
+}
+
+func TestValidate(t *testing.T) {
+	bad := []string{"", "short", "has space in it really", "has!chars!!!!!!!!"}
+	for _, b := range bad {
+		var ike *InvalidKeyError
+		assert.Truef(t, errors.As(Validate(b), &ike), "%q should be invalid", b)
+	}
+	good := []string{
+		"aaaaaaaaaaaaaaaa",
+		"idem-" + Generate(),
+		"A1.b2_c3:d4-e5f6",
+	}
+	for _, g := range good {
+		assert.NoErrorf(t, Validate(g), "%q should be valid", g)
+	}
+}
+
+func TestLogKeyRedacts(t *testing.T) {
+	k := Generate()
+	redacted := LogKey(k)
+	assert.NotEqual(t, k, redacted)
+	assert.Contains(t, redacted, k[:8])
+	assert.NotContains(t, redacted, k[30:])
+}
+
+func TestFreezeGeneratesKey(t *testing.T) {
+	req := map[string]any{"account": "acct-1"}
+	env, err := Freeze(req, "")
+	require.NoError(t, err)
+	require.NoError(t, Validate(env.Key))
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(env.Bytes, &got))
+	assert.Equal(t, env.Key, got["idempotency_key"])
+}
+
+func TestFreezePreservesExistingKey(t *testing.T) {
+	existing := Generate()
+	req := map[string]any{"idempotency_key": existing, "account": "a"}
+	env, err := Freeze(req, "")
+	require.NoError(t, err)
+	assert.Equal(t, existing, env.Key)
+}
+
+func TestFreezeOverrideMatchesExistingOK(t *testing.T) {
+	k := Generate()
+	req := map[string]any{"idempotency_key": k, "account": "a"}
+	env, err := Freeze(req, k)
+	require.NoError(t, err)
+	assert.Equal(t, k, env.Key)
+}
+
+func TestFreezeOverrideConflictsErrors(t *testing.T) {
+	req := map[string]any{"idempotency_key": Generate(), "account": "a"}
+	_, err := Freeze(req, Generate())
+	assert.Error(t, err)
+}
+
+func TestFreezeInvalidOverride(t *testing.T) {
+	req := map[string]any{"account": "a"}
+	_, err := Freeze(req, "bad")
+	var ike *InvalidKeyError
+	assert.True(t, errors.As(err, &ike))
+}
+
+func TestFreezeBytesPreservesExistingEncoding(t *testing.T) {
+	// A non-alphabetical key ordering the caller chose — must be preserved
+	// when idempotency_key is already present.
+	key := Generate()
+	raw := []byte(`{"z":1,"a":2,"idempotency_key":"` + key + `"}`)
+	env, err := FreezeBytes(raw, "")
+	require.NoError(t, err)
+	assert.Equal(t, key, env.Key)
+	assert.Equal(t, raw, env.Bytes, "bytes must be returned verbatim when key is already present")
+}
+
+func TestFreezeBytesRejectsAbsentKey(t *testing.T) {
+	raw := []byte(`{"account":"a","budget":100}`)
+	_, err := FreezeBytes(raw, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "use Freeze")
+}
+
+func TestFreezeBytesRejectsInvalidExistingKey(t *testing.T) {
+	raw := []byte(`{"idempotency_key":"bad","account":"a"}`)
+	_, err := FreezeBytes(raw, "")
+	var ike *InvalidKeyError
+	assert.True(t, errors.As(err, &ike))
+}
+
+func TestFreezeBytesOverrideMatches(t *testing.T) {
+	key := Generate()
+	raw := []byte(`{"idempotency_key":"` + key + `","account":"a"}`)
+	env, err := FreezeBytes(raw, key)
+	require.NoError(t, err)
+	assert.Equal(t, raw, env.Bytes)
+}
+
+func TestFreezeBytesOverrideConflicts(t *testing.T) {
+	raw := []byte(`{"idempotency_key":"` + Generate() + `","account":"a"}`)
+	_, err := FreezeBytes(raw, Generate())
+	assert.Error(t, err)
+}
+
+func TestParseCapability(t *testing.T) {
+	caps := map[string]any{
+		"adcp": map[string]any{
+			"idempotency": map[string]any{
+				"replay_ttl_seconds": 86400,
+			},
+		},
+	}
+	ttl, err := ParseCapability(caps, "seller")
+	require.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, ttl)
+}
+
+func TestParseCapabilityFromJSONNumber(t *testing.T) {
+	raw := []byte(`{"adcp":{"idempotency":{"replay_ttl_seconds":3600}}}`)
+	var caps map[string]any
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	require.NoError(t, dec.Decode(&caps))
+	ttl, err := ParseCapability(caps, "seller")
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, ttl)
+}
+
+func TestParseCapabilityMissing(t *testing.T) {
+	cases := []map[string]any{
+		{},
+		{"adcp": map[string]any{}},
+		{"adcp": map[string]any{"idempotency": map[string]any{}}},
+		{"adcp": map[string]any{"idempotency": map[string]any{"replay_ttl_seconds": 0}}},
+		{"adcp": map[string]any{"idempotency": map[string]any{"replay_ttl_seconds": "nope"}}},
+	}
+	for _, c := range cases {
+		_, err := ParseCapability(c, "s")
+		var mc *MissingCapabilityError
+		assert.True(t, errors.As(err, &mc), "expected MissingCapabilityError for %+v", c)
+	}
+}
+

--- a/adcp/idempotency/envelope.go
+++ b/adcp/idempotency/envelope.go
@@ -1,0 +1,28 @@
+package idempotency
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// InjectReplayed sets {"replayed": replayed} on an AdCP response envelope.
+//
+// Store.Wrap caches and returns the inner handler response; envelope
+// construction (adcp_version, message, status, replayed) happens one layer
+// above, in the transport adapter. Adapters MUST set `replayed` on the
+// envelope — the compliance storyboard validates this field for cached
+// responses — and this helper is the spec-compliant way to do it.
+//
+// If the envelope is not a JSON object, an error is returned.
+func InjectReplayed(envelope []byte, replayed bool) ([]byte, error) {
+	var m map[string]any
+	if err := json.Unmarshal(envelope, &m); err != nil {
+		return nil, fmt.Errorf("idempotency: decode envelope: %w", err)
+	}
+	m["replayed"] = replayed
+	out, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("idempotency: encode envelope: %w", err)
+	}
+	return out, nil
+}

--- a/adcp/idempotency/envelope_test.go
+++ b/adcp/idempotency/envelope_test.go
@@ -1,0 +1,43 @@
+package idempotency
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectReplayedPreservesSiblings(t *testing.T) {
+	env := []byte(`{"adcp_version":"1.0.0","message":"ok","media_buy_id":"mb-1"}`)
+	out, err := InjectReplayed(env, true)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(out, &m))
+	assert.Equal(t, true, m["replayed"])
+	assert.Equal(t, "mb-1", m["media_buy_id"])
+	assert.Equal(t, "1.0.0", m["adcp_version"])
+}
+
+func TestInjectReplayedFalse(t *testing.T) {
+	out, err := InjectReplayed([]byte(`{"x":1}`), false)
+	require.NoError(t, err)
+	rep, ok := ReadReplayed(out)
+	require.True(t, ok)
+	assert.False(t, rep)
+}
+
+func TestInjectReplayedRejectsNonObject(t *testing.T) {
+	_, err := InjectReplayed([]byte(`"not an object"`), true)
+	assert.Error(t, err)
+}
+
+func TestInjectReplayedOverwritesExisting(t *testing.T) {
+	env := []byte(`{"replayed":false,"x":1}`)
+	out, err := InjectReplayed(env, true)
+	require.NoError(t, err)
+	rep, ok := ReadReplayed(out)
+	require.True(t, ok)
+	assert.True(t, rep)
+}

--- a/adcp/idempotency/errors.go
+++ b/adcp/idempotency/errors.go
@@ -1,0 +1,91 @@
+package idempotency
+
+import "fmt"
+
+// Protocol error codes this package maps onto. Only IDEMPOTENCY_CONFLICT and
+// IDEMPOTENCY_EXPIRED are idempotency-specific in the AdCP enum; missing or
+// malformed keys are surfaced as the generic INVALID_REQUEST code and carry
+// a Field value of "idempotency_key" so callers can handle them specifically
+// without inventing codes that won't round-trip across SDKs.
+const (
+	CodeIdempotencyConflict = "IDEMPOTENCY_CONFLICT"
+	CodeIdempotencyExpired  = "IDEMPOTENCY_EXPIRED"
+	CodeInvalidRequest      = "INVALID_REQUEST"
+)
+
+// ConflictError is returned when an idempotency key is reused with a different
+// canonicalized payload. Recovery is caller-driven: either resend the original
+// payload or mint a fresh key.
+type ConflictError struct {
+	Key string
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("idempotency: key %s reused with a different payload", LogKey(e.Key))
+}
+
+// Code returns the protocol error code.
+func (*ConflictError) Code() string { return CodeIdempotencyConflict }
+
+// ExpiredError is returned when an idempotency key was accepted previously but
+// is now past the seller's replay window. Callers should natural-key-check
+// before minting a fresh key to avoid double-create.
+type ExpiredError struct {
+	Key string
+}
+
+func (e *ExpiredError) Error() string {
+	return fmt.Sprintf("idempotency: key %s is past its replay window", LogKey(e.Key))
+}
+
+// Code returns the protocol error code.
+func (*ExpiredError) Code() string { return CodeIdempotencyExpired }
+
+// MissingKeyError is returned when a required idempotency_key is absent from
+// a mutating request. It maps to INVALID_REQUEST with Field="idempotency_key".
+type MissingKeyError struct{}
+
+func (*MissingKeyError) Error() string {
+	return "idempotency: mutating request requires idempotency_key"
+}
+
+// Code returns the protocol error code.
+func (*MissingKeyError) Code() string { return CodeInvalidRequest }
+
+// Field names the request field at fault, for envelope error.field.
+func (*MissingKeyError) Field() string { return "idempotency_key" }
+
+// InvalidKeyError is returned when a provided idempotency_key fails format
+// validation. The malformed key is not embedded to avoid log exposure. Maps
+// to INVALID_REQUEST with Field="idempotency_key".
+type InvalidKeyError struct {
+	Reason string
+}
+
+func (e *InvalidKeyError) Error() string {
+	if e.Reason == "" {
+		return "idempotency: invalid idempotency_key format"
+	}
+	return "idempotency: invalid idempotency_key format: " + e.Reason
+}
+
+// Code returns the protocol error code.
+func (*InvalidKeyError) Code() string { return CodeInvalidRequest }
+
+// Field names the request field at fault, for envelope error.field.
+func (*InvalidKeyError) Field() string { return "idempotency_key" }
+
+// MissingCapabilityError is a client-side condition: the seller's
+// get_adcp_capabilities response did not declare
+// adcp.idempotency.replay_ttl_seconds. Per spec, clients MUST NOT assume a
+// default. This error is not transmitted over the wire, so it has no Code().
+type MissingCapabilityError struct {
+	AgentID string
+}
+
+func (e *MissingCapabilityError) Error() string {
+	if e.AgentID == "" {
+		return "idempotency: seller capabilities missing adcp.idempotency.replay_ttl_seconds"
+	}
+	return "idempotency: seller " + e.AgentID + " capabilities missing adcp.idempotency.replay_ttl_seconds"
+}

--- a/adcp/idempotency/memory.go
+++ b/adcp/idempotency/memory.go
@@ -1,0 +1,106 @@
+package idempotency
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MemoryBackend is an in-process Backend suitable for tests and reference
+// servers. A background sweeper removes expired entries; callers should invoke
+// Close to stop it.
+type MemoryBackend struct {
+	mu      sync.Mutex
+	entries map[string]*Entry
+	clock   func() time.Time
+	stop    chan struct{}
+	stopped chan struct{}
+}
+
+// NewMemoryBackend returns a MemoryBackend with a TTL sweeper running at
+// sweepInterval. A zero interval disables the sweeper (entries still become
+// unobservable past TTL because the middleware checks ExpiresAt).
+func NewMemoryBackend(sweepInterval time.Duration) *MemoryBackend {
+	return newMemoryBackend(sweepInterval, time.Now)
+}
+
+func newMemoryBackend(sweepInterval time.Duration, clock func() time.Time) *MemoryBackend {
+	b := &MemoryBackend{
+		entries: map[string]*Entry{},
+		clock:   clock,
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	if sweepInterval > 0 {
+		go b.sweepLoop(sweepInterval)
+	} else {
+		close(b.stopped)
+	}
+	return b
+}
+
+// Close stops the TTL sweeper.
+func (b *MemoryBackend) Close() {
+	select {
+	case <-b.stop:
+		return
+	default:
+		close(b.stop)
+	}
+	<-b.stopped
+}
+
+func (b *MemoryBackend) sweepLoop(interval time.Duration) {
+	defer close(b.stopped)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-b.stop:
+			return
+		case <-t.C:
+			b.sweep()
+		}
+	}
+}
+
+func (b *MemoryBackend) sweep() {
+	now := b.clock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for k, e := range b.entries {
+		if !e.ExpiresAt.IsZero() && now.After(e.ExpiresAt) {
+			delete(b.entries, k)
+		}
+	}
+}
+
+func scopeKey(scope, key string) string {
+	return scope + "\x00" + key
+}
+
+// Get implements Backend.
+func (b *MemoryBackend) Get(_ context.Context, scope, key string) (*Entry, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if e, ok := b.entries[scopeKey(scope, key)]; ok {
+		cp := *e
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+// PutIfAbsent implements Backend.
+func (b *MemoryBackend) PutIfAbsent(_ context.Context, scope, key string, entry *Entry) (*Entry, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	k := scopeKey(scope, key)
+	if e, ok := b.entries[k]; ok {
+		cp := *e
+		return &cp, false, nil
+	}
+	cp := *entry
+	b.entries[k] = &cp
+	return nil, true, nil
+}
+

--- a/adcp/idempotency/memory_test.go
+++ b/adcp/idempotency/memory_test.go
@@ -1,0 +1,57 @@
+package idempotency
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryPutIfAbsent(t *testing.T) {
+	b := NewMemoryBackend(0)
+	defer b.Close()
+
+	entry := &Entry{Hash: "h1", Response: []byte(`{}`), ExpiresAt: time.Now().Add(time.Hour)}
+	existing, stored, err := b.PutIfAbsent(context.Background(), "s", "k", entry)
+	require.NoError(t, err)
+	assert.True(t, stored)
+	assert.Nil(t, existing)
+
+	entry2 := &Entry{Hash: "h2", Response: []byte(`{"x":1}`), ExpiresAt: time.Now().Add(time.Hour)}
+	existing, stored, err = b.PutIfAbsent(context.Background(), "s", "k", entry2)
+	require.NoError(t, err)
+	assert.False(t, stored)
+	require.NotNil(t, existing)
+	assert.Equal(t, "h1", existing.Hash)
+}
+
+func TestMemoryGetMiss(t *testing.T) {
+	b := NewMemoryBackend(0)
+	defer b.Close()
+	e, err := b.Get(context.Background(), "s", "missing")
+	require.NoError(t, err)
+	assert.Nil(t, e)
+}
+
+func TestMemorySweeperRemovesExpired(t *testing.T) {
+	var clk atomic.Pointer[time.Time]
+	initial := time.Now()
+	clk.Store(&initial)
+	b := newMemoryBackend(5*time.Millisecond, func() time.Time { return *clk.Load() })
+	defer b.Close()
+
+	entry := &Entry{Hash: "h", Response: []byte(`{}`), ExpiresAt: initial.Add(-time.Minute)}
+	_, _, err := b.PutIfAbsent(context.Background(), "s", "k", entry)
+	require.NoError(t, err)
+
+	advanced := initial.Add(time.Hour)
+	clk.Store(&advanced)
+	assert.Eventually(t, func() bool {
+		e, _ := b.Get(context.Background(), "s", "k")
+		return e == nil
+	}, time.Second, 5*time.Millisecond)
+}
+

--- a/adcp/idempotency/postgres.go
+++ b/adcp/idempotency/postgres.go
@@ -1,0 +1,86 @@
+package idempotency
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// PostgresSchema is the table definition PgBackend expects. Create it once in
+// your migration tooling before enabling the backend.
+const PostgresSchema = `
+CREATE TABLE IF NOT EXISTS adcp_idempotency (
+    scope       TEXT        NOT NULL,
+    key         TEXT        NOT NULL,
+    hash        TEXT        NOT NULL,
+    response    BYTEA       NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (scope, key)
+);
+CREATE INDEX IF NOT EXISTS adcp_idempotency_expires_at_idx
+    ON adcp_idempotency (expires_at);
+`
+
+// PgBackend is a Postgres-backed Backend. The PRIMARY KEY on (scope, key)
+// provides the atomicity PutIfAbsent relies on. Uses database/sql so callers
+// can wire any Postgres driver (pgx stdlib adapter, lib/pq, etc.).
+type PgBackend struct {
+	db *sql.DB
+}
+
+// NewPgBackend returns a PgBackend bound to db.
+func NewPgBackend(db *sql.DB) *PgBackend {
+	return &PgBackend{db: db}
+}
+
+// Get implements Backend.
+func (b *PgBackend) Get(ctx context.Context, scope, key string) (*Entry, error) {
+	const q = `SELECT hash, response, created_at, expires_at
+	           FROM adcp_idempotency
+	           WHERE scope = $1 AND key = $2`
+	var e Entry
+	err := b.db.QueryRowContext(ctx, q, scope, key).Scan(&e.Hash, &e.Response, &e.CreatedAt, &e.ExpiresAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("idempotency: pg get: %w", err)
+	}
+	return &e, nil
+}
+
+// PutIfAbsent implements Backend via ON CONFLICT DO NOTHING RETURNING: a
+// RETURNING row indicates we inserted; no row means an existing entry won
+// the race and we re-read it.
+func (b *PgBackend) PutIfAbsent(ctx context.Context, scope, key string, entry *Entry) (*Entry, bool, error) {
+	const insert = `INSERT INTO adcp_idempotency
+	                  (scope, key, hash, response, created_at, expires_at)
+	                VALUES ($1, $2, $3, $4, $5, $6)
+	                ON CONFLICT (scope, key) DO NOTHING
+	                RETURNING hash`
+	createdAt := entry.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	var gotHash string
+	err := b.db.QueryRowContext(ctx, insert, scope, key, entry.Hash, entry.Response, createdAt, entry.ExpiresAt).Scan(&gotHash)
+	if err == nil {
+		return nil, true, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, false, fmt.Errorf("idempotency: pg insert: %w", err)
+	}
+	existing, err := b.Get(ctx, scope, key)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing == nil {
+		// Existing row was deleted between the conflict and our re-read. Treat
+		// the slot as open; caller can retry.
+		return nil, false, nil
+	}
+	return existing, false, nil
+}

--- a/adcp/idempotency/store.go
+++ b/adcp/idempotency/store.go
@@ -1,0 +1,302 @@
+package idempotency
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Spec-mandated bounds on replay_ttl_seconds: 1 hour minimum, 7 days maximum.
+const (
+	MinTTL = 1 * time.Hour
+	MaxTTL = 7 * 24 * time.Hour
+	// DefaultClockSkew is the spec's ±60s tolerance around the TTL boundary.
+	DefaultClockSkew = 60 * time.Second
+)
+
+// Options configures a Store.
+type Options struct {
+	// Backend stores idempotency records. Required.
+	Backend Backend
+
+	// TTL is the replay window surfaced via Capability() and enforced on
+	// lookup. Required. Must be in [MinTTL, MaxTTL].
+	TTL time.Duration
+
+	// ClockSkew is the tolerance applied at the TTL boundary to absorb small
+	// clock differences between client and server. A request that arrives
+	// ClockSkew past TTL is still served from cache. Defaults to
+	// DefaultClockSkew (60s). Set to 0 to disable.
+	ClockSkew time.Duration
+
+	// KeyRequired controls whether a missing idempotency_key triggers
+	// MissingKeyError. Defaults to true. Set false for si_terminate_session
+	// and other tools where the spec makes the key optional; when false and
+	// no key is present, the handler runs uncached.
+	KeyRequired *bool
+
+	// Hash canonicalizes a request payload and returns a stable digest.
+	// Defaults to CanonicalJSONSHA256 (JCS canonicalization with
+	// DefaultExcludePaths stripped, SHA-256 applied). Provide a custom
+	// NewCanonicalJSONSHA256(customPaths) if you need to override the
+	// exclude list.
+	Hash HashFn
+
+	// Scope extracts the scope under which keys are unique for a given
+	// request context. Defaults to PrincipalScope, which reads the principal
+	// from context (set via WithPrincipal).
+	Scope ScopeFn
+
+	// Clock is injectable for tests. Defaults to time.Now.UTC.
+	Clock func() time.Time
+}
+
+// ScopeFn derives the storage scope for a request. Per-principal scope is a
+// security requirement: keys from different principals MUST NOT collide.
+// A handler may return a richer scope (e.g. "principal:sess") to narrow
+// uniqueness further — si_send_message scopes to (principal, session_id).
+type ScopeFn func(ctx context.Context, payload []byte) (string, error)
+
+// Store holds idempotency configuration and wraps mutating handlers.
+type Store struct {
+	opts        Options
+	keyRequired bool
+}
+
+// New returns a Store. Panics on misconfiguration — the middleware must not
+// start in a state where cache writes silently fail.
+func New(opts Options) *Store {
+	if opts.Backend == nil {
+		panic("idempotency: Options.Backend is required")
+	}
+	if opts.TTL < MinTTL || opts.TTL > MaxTTL {
+		panic(fmt.Sprintf("idempotency: Options.TTL must be in [%s, %s], got %s", MinTTL, MaxTTL, opts.TTL))
+	}
+	if opts.Hash == nil {
+		opts.Hash = CanonicalJSONSHA256
+	}
+	if opts.Scope == nil {
+		opts.Scope = PrincipalScope
+	}
+	if opts.Clock == nil {
+		opts.Clock = func() time.Time { return time.Now().UTC() }
+	}
+	if opts.ClockSkew < 0 {
+		panic("idempotency: Options.ClockSkew must be non-negative")
+	}
+	if opts.ClockSkew == 0 {
+		opts.ClockSkew = DefaultClockSkew
+	}
+	required := true
+	if opts.KeyRequired != nil {
+		required = *opts.KeyRequired
+	}
+	return &Store{opts: opts, keyRequired: required}
+}
+
+// TTL returns the configured replay window.
+func (s *Store) TTL() time.Duration { return s.opts.TTL }
+
+// Capability returns the capabilities fragment for this store. Sellers MUST
+// merge this under capabilities.adcp.idempotency in get_adcp_capabilities.
+// Use MergeCapability for a helper that wires it at the correct nesting.
+func (s *Store) Capability() map[string]any {
+	return map[string]any{
+		"replay_ttl_seconds": int64(s.opts.TTL.Seconds()),
+	}
+}
+
+// MergeCapability inserts this store's capability fragment into a capabilities
+// map at the correct nesting path (caps.adcp.idempotency). Safe to call on an
+// empty map.
+func (s *Store) MergeCapability(caps map[string]any) {
+	adcp, ok := caps["adcp"].(map[string]any)
+	if !ok {
+		adcp = map[string]any{}
+		caps["adcp"] = adcp
+	}
+	adcp["idempotency"] = s.Capability()
+}
+
+// Handler is the business handler signature the middleware wraps. Req is the
+// raw request JSON bytes; resp is the inner response payload (NOT the
+// envelope — the caller wraps this with `replayed: …` at response time).
+//
+// Contract: returning a nil error caches resp as-is. Task-level failures that
+// should NOT be cached (so a retry can re-execute) MUST be returned as a Go
+// error. The middleware cannot distinguish a "success" envelope from a
+// "failed" envelope hidden inside resp.
+type Handler func(ctx context.Context, req []byte) (resp []byte, err error)
+
+// Result is the outcome of a wrapped call. Callers read Replayed to set the
+// envelope flag. Key is empty when the caller opted out via KeyRequired=false
+// and the request omitted idempotency_key.
+type Result struct {
+	Response []byte
+	Replayed bool
+	Key      string
+}
+
+// Wrap composes a handler with the idempotency middleware. The returned
+// function expects a raw JSON request containing an `idempotency_key` field.
+func (s *Store) Wrap(h Handler) func(ctx context.Context, req []byte) (*Result, error) {
+	return func(ctx context.Context, req []byte) (*Result, error) {
+		key, err := extractKey(req)
+		if err != nil {
+			return nil, err
+		}
+		if key == "" {
+			if s.keyRequired {
+				return nil, &MissingKeyError{}
+			}
+			resp, err := h(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			return &Result{Response: resp}, nil
+		}
+		if err := Validate(key); err != nil {
+			return nil, err
+		}
+
+		scope, err := s.opts.Scope(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		hash, err := s.opts.Hash(req)
+		if err != nil {
+			return nil, err
+		}
+
+		now := s.opts.Clock()
+
+		if existing, err := s.opts.Backend.Get(ctx, scope, key); err != nil {
+			return nil, err
+		} else if existing != nil {
+			return s.evaluateExisting(existing, hash, key, now)
+		}
+
+		resp, err := h(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+
+		entry := &Entry{
+			Hash:      hash,
+			Response:  resp,
+			CreatedAt: now,
+			ExpiresAt: now.Add(s.opts.TTL),
+		}
+		winner, stored, err := s.opts.Backend.PutIfAbsent(ctx, scope, key, entry)
+		if err != nil {
+			return nil, err
+		}
+		if stored {
+			return &Result{Response: resp, Replayed: false, Key: key}, nil
+		}
+		if winner == nil {
+			// Backend reported conflict but the conflicting row vanished
+			// (sweeper or TTL). Return the freshly-computed response as
+			// non-replayed rather than erroring; the caller still gets a
+			// correct result.
+			return &Result{Response: resp, Replayed: false, Key: key}, nil
+		}
+		return s.evaluateExisting(winner, hash, key, now)
+	}
+}
+
+// evaluateExisting applies TTL (with clock skew) and hash-match rules to a
+// stored entry and returns the replay result or a typed error.
+func (s *Store) evaluateExisting(existing *Entry, hash, key string, now time.Time) (*Result, error) {
+	if !existing.ExpiresAt.IsZero() && now.After(existing.ExpiresAt.Add(s.opts.ClockSkew)) {
+		return nil, &ExpiredError{Key: key}
+	}
+	if existing.Hash != hash {
+		return nil, &ConflictError{Key: key}
+	}
+	return &Result{Response: existing.Response, Replayed: true, Key: key}, nil
+}
+
+// extractKey reads idempotency_key from the top level of a JSON request.
+func extractKey(req []byte) (string, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(req, &m); err != nil {
+		return "", fmt.Errorf("idempotency: decode request: %w", err)
+	}
+	raw, ok := m["idempotency_key"]
+	if !ok {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return "", &InvalidKeyError{Reason: "not a string"}
+	}
+	return s, nil
+}
+
+// ---- principal context ----
+
+type principalKey struct{}
+
+// WithPrincipal attaches a principal identifier to ctx for PrincipalScope.
+// Callers typically set this after authenticating the request and before
+// invoking the wrapped handler.
+func WithPrincipal(ctx context.Context, principalID string) context.Context {
+	return context.WithValue(ctx, principalKey{}, principalID)
+}
+
+// PrincipalFromContext returns the principal previously set via WithPrincipal,
+// or "" if none.
+func PrincipalFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(principalKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// PrincipalScope is the default ScopeFn. It requires a principal in context —
+// unscoped keys would let one caller observe another caller's cached responses.
+func PrincipalScope(ctx context.Context, _ []byte) (string, error) {
+	p := PrincipalFromContext(ctx)
+	if p == "" {
+		return "", errors.New("idempotency: principal missing from context; call WithPrincipal before invoking the wrapped handler")
+	}
+	return "principal:" + p, nil
+}
+
+// SessionScope scopes keys to (principal, session). Use for si_send_message,
+// where the natural unit is a logical turn within a session.
+//
+// SECURITY: the session id is read from the payload field identified by
+// sessionIDField. Callers MUST validate that the session id matches the
+// authenticated session (typically by rejecting requests where payload
+// session_id disagrees with the transport-layer session) before invoking the
+// wrapped handler. Without that check, a principal could cross-scope into
+// another session they own by submitting its id in the payload.
+func SessionScope(sessionIDField string) ScopeFn {
+	return func(ctx context.Context, payload []byte) (string, error) {
+		principal := PrincipalFromContext(ctx)
+		if principal == "" {
+			return "", errors.New("idempotency: principal missing from context")
+		}
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(payload, &m); err != nil {
+			return "", fmt.Errorf("idempotency: decode request for session scope: %w", err)
+		}
+		raw, ok := m[sessionIDField]
+		if !ok {
+			return "", fmt.Errorf("idempotency: session id field %q missing", sessionIDField)
+		}
+		var sid string
+		if err := json.Unmarshal(raw, &sid); err != nil {
+			return "", fmt.Errorf("idempotency: session id field %q is not a string", sessionIDField)
+		}
+		if sid == "" {
+			return "", fmt.Errorf("idempotency: session id field %q is empty", sessionIDField)
+		}
+		return "principal:" + principal + ":session:" + sid, nil
+	}
+}

--- a/adcp/idempotency/store_config_test.go
+++ b/adcp/idempotency/store_config_test.go
@@ -1,0 +1,122 @@
+package idempotency
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapabilityRoundTrip(t *testing.T) {
+	s := New(Options{
+		Backend: NewMemoryBackend(0),
+		TTL:     24 * time.Hour,
+	})
+	caps := map[string]any{}
+	s.MergeCapability(caps)
+	ttl, err := ParseCapability(caps, "seller")
+	require.NoError(t, err)
+	assert.Equal(t, s.TTL(), ttl)
+}
+
+func TestMergeCapabilityNestedShape(t *testing.T) {
+	s := New(Options{Backend: NewMemoryBackend(0), TTL: time.Hour})
+	caps := map[string]any{"adcp": map[string]any{"other": 1}}
+	s.MergeCapability(caps)
+	adcp := caps["adcp"].(map[string]any)
+	assert.Equal(t, 1, adcp["other"], "existing keys preserved")
+	ide := adcp["idempotency"].(map[string]any)
+	assert.Equal(t, int64(3600), ide["replay_ttl_seconds"])
+}
+
+func TestNewPanicsOnTTLBelowMin(t *testing.T) {
+	defer func() { assert.NotNil(t, recover()) }()
+	New(Options{Backend: NewMemoryBackend(0), TTL: 10 * time.Minute})
+}
+
+func TestNewPanicsOnTTLAboveMax(t *testing.T) {
+	defer func() { assert.NotNil(t, recover()) }()
+	New(Options{Backend: NewMemoryBackend(0), TTL: 30 * 24 * time.Hour})
+}
+
+func TestNewPanicsOnNegativeClockSkew(t *testing.T) {
+	defer func() { assert.NotNil(t, recover()) }()
+	New(Options{Backend: NewMemoryBackend(0), TTL: time.Hour, ClockSkew: -time.Second})
+}
+
+func TestClockSkewAllowsReplayPastTTL(t *testing.T) {
+	now := time.Now().UTC()
+	b := newMemoryBackend(0, func() time.Time { return now })
+	s := New(Options{
+		Backend:   b,
+		TTL:       time.Hour,
+		ClockSkew: 30 * time.Second,
+		Clock:     func() time.Time { return now },
+	})
+
+	var calls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte(`{}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+	req := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a"})
+
+	_, err := wrapped(ctx, req)
+	require.NoError(t, err)
+
+	// Within skew window: replay still succeeds.
+	now = now.Add(time.Hour + 20*time.Second)
+	r, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, r.Replayed, "within clock-skew window should replay")
+
+	// Past skew window: reject as expired.
+	now = now.Add(time.Minute)
+	_, err = wrapped(ctx, req)
+	var ee *ExpiredError
+	assert.True(t, errors.As(err, &ee))
+}
+
+func TestKeyRequiredFalseAllowsMissingKey(t *testing.T) {
+	now := time.Now().UTC()
+	keyRequired := false
+	s := New(Options{
+		Backend:     NewMemoryBackend(0),
+		TTL:         time.Hour,
+		KeyRequired: &keyRequired,
+		Clock:       func() time.Time { return now },
+	})
+
+	var calls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte(`{"terminated":true}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+
+	// No key → handler runs uncached, Result.Key is empty, never replays.
+	req := mustJSON(t, map[string]any{"session_id": "s1"})
+	r1, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.False(t, r1.Replayed)
+	assert.Empty(t, r1.Key)
+
+	r2, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.False(t, r2.Replayed, "no-key calls must not replay")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+
+	// Key present → normal idempotent behavior.
+	keyed := mustJSON(t, map[string]any{"idempotency_key": Generate(), "session_id": "s1"})
+	_, err = wrapped(ctx, keyed)
+	require.NoError(t, err)
+	r4, err := wrapped(ctx, keyed)
+	require.NoError(t, err)
+	assert.True(t, r4.Replayed)
+}

--- a/adcp/idempotency/store_race_test.go
+++ b/adcp/idempotency/store_race_test.go
@@ -1,0 +1,111 @@
+package idempotency
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWrapConcurrentSameKeySamePayload forces the PutIfAbsent race: many
+// goroutines issue the same idempotent request; exactly one handler run must
+// be observable, the rest must see Replayed=true.
+func TestWrapConcurrentSameKeySamePayload(t *testing.T) {
+	now := time.Now().UTC()
+	b := newMemoryBackend(0, func() time.Time { return now })
+	s := New(Options{
+		Backend: b,
+		TTL:     time.Hour,
+		Clock:   func() time.Time { return now },
+	})
+
+	var handlerCalls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		atomic.AddInt32(&handlerCalls, 1)
+		return []byte(`{"mb":"mb-1"}`), nil
+	})
+
+	ctx := WithPrincipal(context.Background(), "p1")
+	req := mustJSON(t, map[string]any{"idempotency_key": Generate(), "account": "a"})
+
+	const N = 32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	results := make([]*Result, N)
+	errs := make([]error, N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			results[i], errs[i] = wrapped(ctx, req)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	freshCount := 0
+	replayCount := 0
+	for i, r := range results {
+		require.NoError(t, errs[i])
+		require.NotNil(t, r)
+		if r.Replayed {
+			replayCount++
+		} else {
+			freshCount++
+		}
+	}
+	assert.Equal(t, 1, freshCount, "exactly one goroutine should see fresh execution")
+	assert.Equal(t, N-1, replayCount, "all others should replay")
+	// Handler may run more than once when multiple goroutines race past the
+	// initial Get miss, but the middleware MUST collapse duplicates to a
+	// single authoritative response.
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&handlerCalls), int32(1))
+}
+
+// TestWrapConflictOnPutIfAbsentPath drives the race branch directly: Get
+// returns nil (forcing handler execution), then PutIfAbsent reports the slot
+// is already taken by a different hash. The middleware MUST emit
+// ConflictError rather than the freshly-computed response.
+func TestWrapConflictOnPutIfAbsentPath(t *testing.T) {
+	now := time.Now().UTC()
+	stub := &stubBackend{
+		getResult: nil, // force handler to run
+		putExisting: &Entry{
+			Hash:      "different-hash",
+			Response:  []byte(`{"other":true}`),
+			ExpiresAt: now.Add(time.Hour),
+		},
+	}
+	s := New(Options{Backend: stub, TTL: time.Hour, Clock: func() time.Time { return now }})
+
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		return []byte(`{"ours":true}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	req := mustJSON(t, map[string]any{"idempotency_key": Generate(), "account": "a"})
+
+	_, err := wrapped(ctx, req)
+	var ce *ConflictError
+	assert.True(t, errors.As(err, &ce))
+}
+
+type stubBackend struct {
+	getResult   *Entry
+	putExisting *Entry
+}
+
+func (b *stubBackend) Get(context.Context, string, string) (*Entry, error) {
+	return b.getResult, nil
+}
+func (b *stubBackend) PutIfAbsent(_ context.Context, _, _ string, _ *Entry) (*Entry, bool, error) {
+	if b.putExisting != nil {
+		return b.putExisting, false, nil
+	}
+	return nil, true, nil
+}

--- a/adcp/idempotency/store_test.go
+++ b/adcp/idempotency/store_test.go
@@ -1,0 +1,246 @@
+package idempotency
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestStore(t *testing.T, now *time.Time) (*Store, *MemoryBackend) {
+	t.Helper()
+	b := newMemoryBackend(0, func() time.Time { return *now })
+	s := New(Options{
+		Backend: b,
+		TTL:     1 * time.Hour,
+		Clock:   func() time.Time { return *now },
+	})
+	return s, b
+}
+
+func TestWrapRequiresIdempotencyKey(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		t.Fatal("handler should not run when key missing")
+		return nil, nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	_, err := wrapped(ctx, []byte(`{"account":"a"}`))
+	var mk *MissingKeyError
+	assert.True(t, errors.As(err, &mk))
+}
+
+func TestWrapValidatesKeyFormat(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) { return []byte(`{}`), nil })
+	ctx := WithPrincipal(context.Background(), "p1")
+	_, err := wrapped(ctx, []byte(`{"idempotency_key":"bad","account":"a"}`))
+	var ik *InvalidKeyError
+	assert.True(t, errors.As(err, &ik))
+}
+
+func TestWrapCachesAndReplays(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+
+	var calls int32
+	wrapped := s.Wrap(func(_ context.Context, req []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte(`{"media_buy_id":"mb-1"}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+	req := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a"})
+
+	r1, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.False(t, r1.Replayed)
+	assert.Equal(t, key, r1.Key)
+	assert.JSONEq(t, `{"media_buy_id":"mb-1"}`, string(r1.Response))
+
+	r2, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, r2.Replayed)
+	assert.Equal(t, r1.Response, r2.Response)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestWrapDetectsConflict(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) { return []byte(`{}`), nil })
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+
+	req1 := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a", "budget": 100})
+	_, err := wrapped(ctx, req1)
+	require.NoError(t, err)
+
+	req2 := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a", "budget": 200})
+	_, err = wrapped(ctx, req2)
+	var ce *ConflictError
+	require.True(t, errors.As(err, &ce))
+	assert.Equal(t, key, ce.Key)
+}
+
+func TestWrapContextFieldsIgnoredForHash(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) { return []byte(`{}`), nil })
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+
+	req1 := mustJSON(t, map[string]any{
+		"idempotency_key": key, "account": "a", "context": map[string]any{"trace": "t1"},
+	})
+	req2 := mustJSON(t, map[string]any{
+		"idempotency_key": key, "account": "a", "context": map[string]any{"trace": "t2"},
+	})
+
+	_, err := wrapped(ctx, req1)
+	require.NoError(t, err)
+	r2, err := wrapped(ctx, req2)
+	require.NoError(t, err)
+	assert.True(t, r2.Replayed, "differing context must still replay as a match")
+}
+
+func TestWrapRejectsExpired(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) { return []byte(`{}`), nil })
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+	req := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a"})
+
+	_, err := wrapped(ctx, req)
+	require.NoError(t, err)
+
+	now = now.Add(2 * time.Hour)
+	_, err = wrapped(ctx, req)
+	var ee *ExpiredError
+	assert.True(t, errors.As(err, &ee))
+}
+
+func TestWrapHandlerErrorNotCached(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+
+	var calls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		n := atomic.AddInt32(&calls, 1)
+		if n == 1 {
+			return nil, errors.New("transient")
+		}
+		return []byte(`{"ok":true}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+	req := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a"})
+
+	_, err := wrapped(ctx, req)
+	require.Error(t, err)
+	r, err := wrapped(ctx, req)
+	require.NoError(t, err)
+	assert.False(t, r.Replayed, "retry after error must re-execute, not replay")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestWrapPerPrincipalScope(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+
+	var calls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte(`{}`), nil
+	})
+	key := Generate()
+	req := mustJSON(t, map[string]any{"idempotency_key": key, "account": "a"})
+
+	_, err := wrapped(WithPrincipal(context.Background(), "p1"), req)
+	require.NoError(t, err)
+	r2, err := wrapped(WithPrincipal(context.Background(), "p2"), req)
+	require.NoError(t, err)
+	assert.False(t, r2.Replayed, "different principals must not observe each other's cache")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestWrapRequiresPrincipal(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) { return []byte(`{}`), nil })
+	req := mustJSON(t, map[string]any{"idempotency_key": Generate(), "account": "a"})
+	_, err := wrapped(context.Background(), req)
+	assert.Error(t, err)
+}
+
+func TestSessionScope(t *testing.T) {
+	now := time.Now().UTC()
+	b := newMemoryBackend(0, func() time.Time { return now })
+	s := New(Options{
+		Backend: b,
+		TTL:     time.Hour,
+		Scope:   SessionScope("session_id"),
+		Clock:   func() time.Time { return now },
+	})
+
+	var calls int32
+	wrapped := s.Wrap(func(context.Context, []byte) ([]byte, error) {
+		atomic.AddInt32(&calls, 1)
+		return []byte(`{}`), nil
+	})
+	ctx := WithPrincipal(context.Background(), "p1")
+	key := Generate()
+
+	req1 := mustJSON(t, map[string]any{"idempotency_key": key, "session_id": "sess-A", "message": "hi"})
+	req2 := mustJSON(t, map[string]any{"idempotency_key": key, "session_id": "sess-B", "message": "hi"})
+
+	_, err := wrapped(ctx, req1)
+	require.NoError(t, err)
+	r2, err := wrapped(ctx, req2)
+	require.NoError(t, err)
+	assert.False(t, r2.Replayed)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls))
+
+	rReplay, err := wrapped(ctx, req1)
+	require.NoError(t, err)
+	assert.True(t, rReplay.Replayed)
+}
+
+func TestCapabilityFragment(t *testing.T) {
+	now := time.Now().UTC()
+	s, _ := newTestStore(t, &now)
+	cap := s.Capability()
+	assert.Equal(t, int64(3600), cap["replay_ttl_seconds"])
+}
+
+func TestNewPanicsOnMissingBackend(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r)
+	}()
+	New(Options{TTL: time.Hour})
+}
+
+func TestNewPanicsOnZeroTTL(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r)
+	}()
+	New(Options{Backend: NewMemoryBackend(0)})
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}


### PR DESCRIPTION
Closes #42.

New `adcp/idempotency` package implementing AdCP #2308 idempotency_key support on both client and server sides, stdlib-only under the existing `adcp` module.

## Summary

- **Server middleware** (`Store.Wrap`): per-principal scoping by default, `SessionScope` for si_send_message, pluggable storage (`MemoryBackend` for tests/reference, `PgBackend` for production via `database/sql`). RFC 8785 JCS canonical hashing with spec exclude list. Clock-skew tolerance at the TTL boundary. TTL bounds [1h, 7d] enforced at `New`. Refuses to start on misconfiguration.
- **Client helpers**: `Generate` (UUIDv4), `Validate`, `Freeze` / `FreezeBytes` (marshal-once, resend-verbatim), `ParseCapability` (fail-closed on missing `replay_ttl_seconds`), `ReadReplayed`, `LogKey` (prefix-truncated for safe logging).
- **Typed errors**: `ConflictError` / `ExpiredError` map to the spec enum codes. `MissingKeyError` / `InvalidKeyError` map to `INVALID_REQUEST` with `Field=\"idempotency_key\"` (custom `MISSING_IDEMPOTENCY_KEY` etc. codes avoided — not in spec enum, wouldn't round-trip).
- **Envelope**: `InjectReplayed` helper for transports to set `replayed: true` on cached responses (spec storyboard validates this field).

## Review history

Three-round expert review applied in-branch (code-reviewer, security-reviewer, ad-tech-protocol-expert).

**Landed fixes:** spec-enum error codes, SQL injection fix in `PgBackend` (dropped `WithTableName`), invalid-UTF-8 rejection in canonicalizer, `PgBackend` simplification to `ON CONFLICT DO NOTHING RETURNING`, clock-skew window, `KeyRequired` toggle for si_terminate_session, TTL bounds validation, `MergeCapability` helper for correct nesting, `FreezeBytes` corrected to reject absent keys (docstring said byte-preservation), `InjectReplayed` restored for storyboard compliance.

**Cut as overbuilt:** `CapabilityCache`, `Options.ExcludePaths`, `WithTableName`, `MemoryBackend.Delete` from interface, `prefix()` indirection.

**Tests:** 75.1% coverage, race-clean across 5× runs. Includes concurrent same-key race (32 goroutines), conflict-via-PutIfAbsent path, capability round-trip, UTF-8 rejection (keys + values), precomposed vs decomposed Unicode, clock-skew boundary, `KeyRequired=false` opt-in, `FreezeBytes` variants.

## Follow-ups filed

- #45 PgBackend integration tests (sqlmock or testcontainers)
- #46 JCS parity fuzz vs gowebpki/jcs + large-integer precision doc note

## Test plan

- [x] `go test -race ./adcp/idempotency/...` passes
- [x] `go test ./...` (root + adcp) passes, no regressions
- [x] `go vet` clean
- [x] Coverage: 75.1%
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)