### PR TITLE
feat(signing): tri-state VerifyRequest + JWK.Public + MIGRATION.md

### DIFF
--- a/adcp/signing/MIGRATION.md
+++ b/adcp/signing/MIGRATION.md
@@ -1,0 +1,157 @@
+# Migrating to signed AdCP requests
+
+Rolling out RFC 9421 request signing against an existing AdCP integration is a two-track exercise: **bootstrap** once, then **enforce** in stages per operation. Key **rotation** follows the same pattern and is meant to be routine.
+
+This guide covers the operator-facing mechanics. Spec reference: [Signed Requests (Transport Layer)](https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer).
+
+## 1. Bootstrap
+
+One-time work to make an agent able to sign (as a buyer) or verify (as a seller).
+
+### Generate and publish a key
+
+```bash
+go run github.com/adcontextprotocol/adcp-go/adcp/cmd/adcp-signing-keygen \
+  -alg ed25519 \
+  -kid my-agent-2026-01 \
+  -out signing.pem
+```
+
+Prefer Ed25519 over ES256 unless a regulatory constraint forces NIST curves. Ed25519 is deterministic by construction — no RNG participates at sign time, which simplifies replay analysis. ES256 via Go's `crypto/ecdsa` is also nonce-safe (the stdlib injects hedged deterministic nonces), but a non-Go counterparty without the equivalent guarantee carries the historical bad-RNG tail risk.
+
+The command writes `signing.pem` (PKCS#8 private key) and prints a JWK with `use: "sig"`, `key_ops: ["verify"]`, and `adcp_use: "request-signing"`. Publish the JWK at your agent's `jwks_uri`:
+
+```json
+{ "keys": [ { "kid": "my-agent-2026-01", "kty": "OKP", ... } ] }
+```
+
+Hold the PEM in your secret store. If you need to serialize a JWK that carries a private half (for instance, when persisting a loaded key), call `JWK.Public()` before marshaling for publication — it zeros `d` / `_private_d_for_test_only`.
+
+### Advertise signing on `get_adcp_capabilities`
+
+Set `request_signing` on your capabilities response with an empty `supported_for` / `warn_for` / `required_for` to start. Counterparties probing your capabilities can now see the block exists.
+
+```json
+"request_signing": {
+  "supported_for": [],
+  "warn_for":      [],
+  "required_for":  []
+}
+```
+
+## 2. Staged enforcement (per operation)
+
+Never flip an operation straight from unsigned to required. Stage it through three stops:
+
+### Step A — `supported_for`
+
+Add the operation to `supported_for`. Counterparties MAY sign; your verifier MUST accept signed requests but does not yet reject unsigned ones.
+
+Code — middleware stays permissive, but `Resolver` / `Replay` / `Revocation` are all wired:
+
+```go
+mw := signing.Middleware(signing.MiddlewareOptions{
+    Resolver:          jwksResolver,
+    Replay:            signing.NewMemoryReplayStore(0),
+    Revocation:        signing.NewStaticRevocationList(nil),
+    OperationResolver: signing.DefaultOperationResolver,
+    RequiredFor:       nil, // nothing rejected yet
+})
+```
+
+Success signal: signed requests arrive, `signing.VerifiedSignerFromContext(ctx)` returns non-nil on the verified path.
+
+### Step B — `warn_for`
+
+Move the operation to `warn_for`. Verification still runs and failures are logged; traffic is unaffected. Watch your failure rate and walk down the long tail of "some counterparty is misbehaving" before flipping to reject.
+
+This is the spec's shadow-mode stop. The SDK exposes it via `MiddlewareOptions.ObserveOnly` (tracked in [#53](https://github.com/adcontextprotocol/adcp-go/issues/53)); until that lands, approximate it with an `OnReject` that logs-and-passes-through:
+
+```go
+// WARNING: step-B shim only. Delete before enabling RequiredFor in step C —
+// this turns every required-signed op into an unsigned op.
+OnReject: func(w http.ResponseWriter, r *http.Request, e *signing.Error) {
+    logger.Warn("signature would reject", "code", e.Code, "detail", e.Detail)
+    // fall through to the next handler — request is NOT rejected.
+},
+```
+
+Success signal: grep your logs for the `request signature rejected` message (field `code` = `request_signature_*`) and watch the rate fall to zero — or to a known-and-tolerated set of counterparties — over a window long enough to cover your slowest integrator's deploy cadence.
+
+### Step C — `required_for`
+
+Move the operation to `required_for` and populate `MiddlewareOptions.RequiredFor`. Don't enable `DigestRequired` yet — body-modifying intermediaries are the most common surprise failure in production rollouts and they only break the digest path. Land `RequiredFor` first:
+
+```go
+mw := signing.Middleware(signing.MiddlewareOptions{
+    Resolver:          jwksResolver,
+    Replay:            signing.NewMemoryReplayStore(0),
+    Revocation:        signing.NewStaticRevocationList(nil),
+    OperationResolver: signing.DefaultOperationResolver,
+    RequiredFor:       []string{"create_media_buy"},
+})
+```
+
+A rollout later, once you've confirmed no `request_signature_digest_mismatch` in step-B logs, tighten to `DigestRequired`:
+
+```go
+mw := signing.Middleware(signing.MiddlewareOptions{
+    // ... same as above ...
+    ContentDigestPolicy: signing.DigestRequired,
+})
+```
+
+Unsigned or invalid requests are now rejected with `401 Unauthorized` + `WWW-Authenticate: Signature error="<code>"`.
+
+### Rollback from step C
+
+If production breaks after flipping `RequiredFor`:
+
+1. Revert the middleware config — drop the operation from `MiddlewareOptions.RequiredFor` (and from `ContentDigestPolicy: DigestRequired` if set). Redeploy.
+2. Do **not** touch `jwks_uri` or the revocation list. Counterparties that are already signing correctly will keep doing so, harmlessly.
+3. Update `get_adcp_capabilities.request_signing.required_for` on the next deploy to match the rolled-back middleware — counterparties probing capabilities must not be told "required" while the verifier is back to permissive.
+
+Returning to step B's shadow mode is the safe resting state while you diagnose.
+
+## 3. Key rotation
+
+Schedule rotation routinely — monthly to quarterly is the common range — so the path is exercised and a compromise-driven rotation isn't the first time you run it.
+
+### Routine rotation
+
+Two JWKS publishes plus a signer cutover:
+
+1. **Publish new kid alongside old kid.** Update `jwks_uri` to list both keys. Wait for counterparties' JWKS caches to refresh — the SDK's `HTTPJWKSResolver` holds a 30-second refetch cooldown on kid-miss, so one minute is a safe floor.
+2. **Cut over the signer.** Flip `SignerOptions.KeyID` / `PrivateKey` to the new kid on every instance.
+3. **Grace period.** Hold both kids in the JWKS for at least **2× the max validity window** (10 minutes with the default 300-second window). Reasoning: one window for the last request you signed under the old kid to reach its `expires`, plus one window for its replay-cache entry to age out so you can't distinguish a real replay from a drained entry. Add operational headroom on top (1–2× the deploy cadence of your slowest counterparty) so in-flight retries under the old kid still verify.
+4. **Remove the old kid.** Publish a JWKS with only the new kid.
+
+### Compromise rotation
+
+Ordering is different — the old kid must stop being trusted *before* anything else happens, because during routine step 1 ("publish both"), counterparties still accept signatures under the old kid for the full JWKS-propagation window:
+
+1. **Revoke first.** Add the burned kid to your revocation list with an `effective_at` covering the compromise window. Counterparties polling the revocation list will reject anything signed by the burned kid, even if their JWKS cache hasn't refreshed yet.
+2. **Publish the new kid.** Update `jwks_uri` to include the new kid. (The old kid can stay in the JWKS or be removed immediately — revocation beats presence.)
+3. **Cut over the signer** to the new kid on every instance.
+4. **Remove the old kid** from the JWKS once the compromise-window revocation entry is no longer needed. Keep the revocation entry active for at least the historical audit window (whatever your governance requires).
+
+## 4. Common pitfalls
+
+- **Body-modifying intermediaries break `content-digest` coverage.** CDNs, WAFs, and API gateways that recompress or re-serialize request bodies cause `request_signature_digest_mismatch`. Diagnose by comparing signer-side body bytes to verifier-side body bytes — they must be byte-identical. Either preserve bytes end-to-end or stay on `DigestEither` for the affected operation.
+- **Forgetting `CheckRedirect` on signed clients.** `@target-uri` is part of the signature base. If the server 301s to a new URL, the signature still binds to the original URL. Set `http.Client.CheckRedirect` to `func(...) error { return http.ErrUseLastResponse }` on any client using the signing `RoundTripper`.
+- **Clock skew > 60s.** Verifiers reject with `request_signature_window_invalid` when `created` is > 60s in the future or `expires` is > 60s in the past. NTP-sync both sides; investigate container hosts that drift after suspend/resume.
+- **Custom `HTTPClient` losing SSRF protection.** If you supply `HTTPJWKSResolver.HTTPClient`, start from `signing.NewSafeHTTPClient()` — otherwise you lose the DNS-rebinding / private-IP / loopback guards, and an attacker who controls a `jwks_uri` can pivot against your internal network.
+- **Per-keyid replay cap.** The default in-memory replay store caps at 1,000,000 entries per keyid. Sustained > 3k QPS per signing key will trip `request_signature_rate_abuse`. Deploy a distributed replay store (Redis or equivalent, tracked in [#54](https://github.com/adcontextprotocol/adcp-go/issues/54)) before you get there.
+- **`OnReject` that logs-and-passes-through past step B.** The step-B shim above is a footgun if it survives into production — it silently turns every required-signed op into an unsigned op. Before flipping `RequiredFor`, grep your middleware wiring for `OnReject` and confirm the shim is gone. Months later, if you inherit the repo, re-grep.
+
+## 5. Verification checklist before enforcing
+
+- [ ] At least one signed request from a staging counterparty has been verified end-to-end — `signing.VerifiedSignerFromContext` returns non-nil in your handler — before flipping `required_for`.
+- [ ] `jwks_uri` returns your current kid (and only your current kid, once rotation is complete).
+- [ ] `get_adcp_capabilities.request_signing.required_for` matches `MiddlewareOptions.RequiredFor`.
+- [ ] Revocation source is configured (not `nil` — the middleware logs a warning when `RequiredFor` is non-empty and `Revocation` is nil).
+- [ ] Replay store is either in-memory (single instance) or a shared backing store (distributed).
+- [ ] Logs from step B show zero unexpected failures over at least one full deploy cycle of your slowest counterparty.
+- [ ] No `OnReject` pass-through shim remains in the middleware wiring (grep for `OnReject`).
+- [ ] `CheckRedirect` is set on every signing client.
+- [ ] Clock sync monitoring is in place on signer and verifier hosts.

--- a/adcp/signing/README.md
+++ b/adcp/signing/README.md
@@ -4,7 +4,7 @@ RFC 9421 request-signing for the Ad Context Protocol.
 
 Optional in AdCP 3.0 and capability-advertised via `request_signing` on `get_adcp_capabilities`. Required for spend-committing operations in AdCP 4.0.
 
-Spec: [Signed Requests (Transport Layer)](https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer).
+Spec: [Signed Requests (Transport Layer)](https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer). Rolling out from unsigned to signed, or rotating keys: see [MIGRATION.md](./MIGRATION.md).
 
 ## Conformance
 
@@ -61,6 +61,41 @@ http.ListenAndServe(":8080", mw(yourHandler))
 ```
 
 For MCP / JSON-RPC integrations that need a protocol-specific error envelope, supply an `OnReject` callback to translate the typed `*signing.Error` into your wire format instead of the default 401 text/plain response.
+
+### Verifying from a handler
+
+`VerifyRequest` is a tri-state wrapper around the lower-level `VerifyRequestSignature` and is the right call when your handler verifies directly (outside the middleware):
+
+```go
+switch res := signing.VerifyRequest(r, opts); res.Status {
+case signing.StatusVerified:
+    handleAuthenticated(res.Signer)
+case signing.StatusUnsigned:
+    handleBearerOnly(r)
+case signing.StatusRejected:
+    w.Header().Set("WWW-Authenticate", `Signature error="`+string(res.Error.Code)+`"`)
+    http.Error(w, "unauthorized", http.StatusUnauthorized)
+}
+```
+
+Use `VerifyRequestSignature` directly only where the `(signer, err)` shape is convenient. Its `(nil, nil)` return means "unsigned, not required" — `if _, err := VerifyRequestSignature(...); err == nil { trust(...) }` silently trusts unsigned requests. That misread is the bug `VerifyRequest` exists to make impossible.
+
+When the middleware is permissive (no `RequiredFor` entry for an op) but a specific handler wants to gate its route on a signature — e.g., the requirement depends on a decoded body field — call `signing.RequireSigned(r.Context())` inside the handler:
+
+```go
+func handleCreate(w http.ResponseWriter, r *http.Request) {
+    var body CreatePlanRequest
+    _ = json.NewDecoder(r.Body).Decode(&body)
+    if body.CommitsSpend {
+        if err := signing.RequireSigned(r.Context()); err != nil {
+            w.Header().Set("WWW-Authenticate", `Signature error="`+string(err.Code)+`"`)
+            http.Error(w, "unauthorized", http.StatusUnauthorized)
+            return
+        }
+    }
+    // ...
+}
+```
 
 ### Caveats
 

--- a/adcp/signing/jwk.go
+++ b/adcp/signing/jwk.go
@@ -11,8 +11,8 @@ import (
 )
 
 // JWK is the subset of RFC 7517 members the AdCP profile relies on, plus the
-// AdCP `adcp_use` discriminator. Unknown members are preserved via the Extra
-// map so serializers can round-trip.
+// AdCP `adcp_use` discriminator. Unknown members from JWKS documents are
+// discarded on decode (the profile's required set is fully typed here).
 type JWK struct {
 	Kid     string   `json:"kid"`
 	Kty     string   `json:"kty"`
@@ -25,12 +25,31 @@ type JWK struct {
 	Y       string   `json:"y,omitempty"`
 
 	// PrivateD is only populated for private-key JWKs used by the signer CLI
-	// and test vectors. Public JWKS never include it.
+	// and test vectors. Public JWKS never include it. Call JWK.Public before
+	// serializing for publication at jwks_uri to guarantee this member is
+	// zeroed regardless of how the JWK was loaded.
 	PrivateD string `json:"d,omitempty"`
 
 	// TestOnlyPrivateD is the `_private_d_for_test_only` member used by the
 	// spec conformance vector keys.json. Publicly-served JWKs never include it.
+	// JWK.Public zeroes this too.
 	TestOnlyPrivateD string `json:"_private_d_for_test_only,omitempty"`
+}
+
+// Public returns a copy of k with all private-key components zeroed. Use
+// this before serializing a JWK that originated from a private source (a
+// loaded PEM, a test vector with `_private_d_for_test_only`, or any other
+// path where PrivateD / TestOnlyPrivateD may be populated) for publication
+// at `jwks_uri`.
+//
+// Round-tripping a freshly-generated JWK from GenerateSigningKey is already
+// safe because PrivateD is never set on that path; Public is a
+// defense-in-depth affordance for the library-user who stores a JWK with
+// its private half attached and later marshals it for a JWKS document.
+func (k JWK) Public() JWK {
+	k.PrivateD = ""
+	k.TestOnlyPrivateD = ""
+	return k
 }
 
 // JWKS is a JWK set.

--- a/adcp/signing/jwk_test.go
+++ b/adcp/signing/jwk_test.go
@@ -3,7 +3,9 @@ package signing
 import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
+	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,4 +51,35 @@ func TestParseSpecKeysJSON(t *testing.T) {
 	gov := jwks.Find("test-gov-2026")
 	require.NotNil(t, gov)
 	assert.Equal(t, "governance-signing", gov.AdcpUse)
+}
+
+func TestJWKPublicStripsPrivateComponents(t *testing.T) {
+	data, err := os.ReadFile("testdata/request-signing/keys.json")
+	require.NoError(t, err)
+	jwks, err := ParseJWKS(data)
+	require.NoError(t, err)
+
+	ed := jwks.Find("test-ed25519-2026")
+	require.NotNil(t, ed)
+	require.NotEmpty(t, ed.TestOnlyPrivateD, "precondition: spec vector carries private component")
+
+	pub := ed.Public()
+	assert.Empty(t, pub.PrivateD)
+	assert.Empty(t, pub.TestOnlyPrivateD)
+	assert.Equal(t, ed.Kid, pub.Kid)
+	assert.Equal(t, ed.X, pub.X)
+
+	marshaled, err := json.Marshal(pub)
+	require.NoError(t, err)
+	assert.NotContains(t, string(marshaled), `"d"`)
+	assert.NotContains(t, string(marshaled), "_private_d_for_test_only")
+
+	// Public must not mutate the receiver.
+	assert.NotEmpty(t, ed.TestOnlyPrivateD, "Public must return a copy, not mutate")
+
+	// Also covers the PrivateD (standard "d") path.
+	k := JWK{Kid: "x", Kty: "OKP", Crv: "Ed25519", PrivateD: "AAAA"}
+	out, err := json.Marshal(k.Public())
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(out), `"d":`), "standard d member must be stripped")
 }

--- a/adcp/signing/verifyrequest.go
+++ b/adcp/signing/verifyrequest.go
@@ -1,0 +1,117 @@
+package signing
+
+import (
+	"context"
+	"net/http"
+)
+
+// VerifyStatus reports the outcome of VerifyRequest.
+//
+// The zero value is StatusUnknown so a default-initialized VerifyResult never
+// silently presents as verified. Always switch on Status — reading Signer
+// without checking Status is the footgun this type exists to prevent.
+type VerifyStatus int
+
+const (
+	// StatusUnknown is the zero value. A VerifyResult returned by
+	// VerifyRequest will never have this status; it exists so that
+	// default-constructed VerifyResult values do not masquerade as verified.
+	StatusUnknown VerifyStatus = iota
+
+	// StatusVerified means the request carried a signature that passed every
+	// check in the verifier checklist. Signer is non-nil.
+	StatusVerified
+
+	// StatusUnsigned means the request had no Signature / Signature-Input
+	// headers and the operation was not in RequiredFor. Caller MAY proceed
+	// with bearer-only auth. Signer and Error are both nil.
+	StatusUnsigned
+
+	// StatusRejected means verification failed (including missing-but-required).
+	// Error is non-nil and its Code is safe to emit in
+	// `WWW-Authenticate: Signature error="<code>"`.
+	StatusRejected
+)
+
+// String returns the status name for logs.
+func (s VerifyStatus) String() string {
+	switch s {
+	case StatusVerified:
+		return "verified"
+	case StatusUnsigned:
+		return "unsigned"
+	case StatusRejected:
+		return "rejected"
+	default:
+		return "unknown"
+	}
+}
+
+// VerifyResult is the tri-state outcome returned by VerifyRequest. Exactly
+// one of Signer or Error is non-nil, determined by Status; the third case
+// (Status == StatusUnsigned) has both nil.
+type VerifyResult struct {
+	Status VerifyStatus
+	Signer *VerifiedSigner
+	Error  *Error
+}
+
+// VerifyRequest is a tri-state wrapper around VerifyRequestSignature that
+// makes it impossible for a caller to silently trust an unsigned request.
+//
+// Prefer this over VerifyRequestSignature in handler code:
+//
+//	switch res := signing.VerifyRequest(r, opts); res.Status {
+//	case signing.StatusVerified:
+//	    handleAuthenticated(res.Signer)
+//	case signing.StatusUnsigned:
+//	    handleBearerOnly(r)
+//	case signing.StatusRejected:
+//	    w.Header().Set("WWW-Authenticate", `Signature error="`+string(res.Error.Code)+`"`)
+//	    http.Error(w, "unauthorized", http.StatusUnauthorized)
+//	}
+//
+// The underlying VerifyRequestSignature remains the lower-level primitive the
+// middleware uses directly and is the right choice when callers want to
+// handle the (signer, err) tuple themselves.
+func VerifyRequest(r *http.Request, opts VerifyOptions) VerifyResult {
+	signer, err := VerifyRequestSignature(r, opts)
+	switch {
+	case err != nil:
+		// VerifyRequestSignature always returns *Error on the error path;
+		// any other type is a library-side contract break, not a caller
+		// condition — panic so the regression surfaces immediately rather
+		// than masquerading as a CodeInvalid (which means crypto-verify-failed).
+		e := AsError(err)
+		if e == nil {
+			panic("signing: VerifyRequestSignature returned non-*Error error: " + err.Error())
+		}
+		return VerifyResult{Status: StatusRejected, Error: e}
+	case signer != nil:
+		return VerifyResult{Status: StatusVerified, Signer: signer}
+	default:
+		return VerifyResult{Status: StatusUnsigned}
+	}
+}
+
+// RequireSigned is the handler-level escape hatch for gating an operation on
+// a signature when MiddlewareOptions.RequiredFor can't express the rule —
+// for example, when the requirement depends on a field decoded from the
+// request body, or on the authenticated tenant. Returns nil when ctx
+// carries a VerifiedSigner, or a *Error with CodeRequired otherwise.
+//
+//	if err := signing.RequireSigned(r.Context()); err != nil {
+//	    w.Header().Set("WWW-Authenticate", `Signature error="`+string(err.Code)+`"`)
+//	    http.Error(w, "unauthorized", http.StatusUnauthorized)
+//	    return
+//	}
+//
+// Prefer MiddlewareOptions.RequiredFor when the gate is statically known per
+// operation — it enforces earlier (before the handler runs) and doesn't
+// require every handler author to remember this call.
+func RequireSigned(ctx context.Context) *Error {
+	if VerifiedSignerFromContext(ctx) != nil {
+		return nil
+	}
+	return newError(CodeRequired, "operation requires signature")
+}

--- a/adcp/signing/verifyrequest_test.go
+++ b/adcp/signing/verifyrequest_test.go
@@ -1,0 +1,111 @@
+package signing
+
+import (
+	"context"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyRequestTriState(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	kid := "kid-tri-state"
+	jwk := &JWK{
+		Kid: kid, Kty: "OKP", Crv: "Ed25519", Alg: "EdDSA",
+		Use: "sig", KeyOps: []string{"verify"}, AdcpUse: "request-signing",
+		X: b64UrlEncodeRaw(pub),
+	}
+	resolver := NewStaticJWKSResolver()
+	resolver.Put(kid, jwk, "https://agent.example.com")
+
+	opts := VerifyOptions{
+		OperationName: "create_media_buy",
+		RequiredFor:   []string{"create_media_buy"},
+		Resolver:      resolver,
+		Replay:        NewMemoryReplayStore(0),
+	}
+
+	// StatusVerified — signed, valid signature.
+	signer, err := NewSigner(SignerOptions{KeyID: kid, PrivateKey: priv})
+	require.NoError(t, err)
+	body := strings.NewReader(`{"plan_id":"p1"}`)
+	signed, _ := http.NewRequest("POST", "https://seller.example.com/adcp/create_media_buy", body)
+	signed.Header.Set("Content-Type", "application/json")
+	require.NoError(t, signer.SignRequest(signed, SignOptions{CoverContentDigest: true}))
+
+	res := VerifyRequest(signed, opts)
+	assert.Equal(t, StatusVerified, res.Status)
+	require.NotNil(t, res.Signer)
+	assert.Equal(t, kid, res.Signer.KeyID)
+	assert.Nil(t, res.Error)
+
+	// StatusRejected — op in RequiredFor but request unsigned.
+	req := httptest.NewRequest("POST", "https://seller.example.com/adcp/create_media_buy", nil)
+	res = VerifyRequest(req, opts)
+	assert.Equal(t, StatusRejected, res.Status)
+	require.NotNil(t, res.Error)
+	assert.Equal(t, CodeRequired, res.Error.Code)
+	assert.Nil(t, res.Signer)
+
+	// StatusUnsigned — op not in RequiredFor, unsigned.
+	optsOpen := opts
+	optsOpen.OperationName = "get_products"
+	req = httptest.NewRequest("POST", "https://seller.example.com/adcp/get_products", nil)
+	res = VerifyRequest(req, optsOpen)
+	assert.Equal(t, StatusUnsigned, res.Status)
+	assert.Nil(t, res.Signer)
+	assert.Nil(t, res.Error)
+
+	// StatusRejected — signed but tampered. The underlying *Error's Code
+	// (non-CodeRequired) must survive into VerifyResult untouched.
+	body = strings.NewReader(`{"plan_id":"p2"}`)
+	tampered, _ := http.NewRequest("POST", "https://seller.example.com/adcp/create_media_buy", body)
+	tampered.Header.Set("Content-Type", "application/json")
+	require.NoError(t, signer.SignRequest(tampered, SignOptions{CoverContentDigest: true}))
+	// Change the method after signing so @method canonical diverges — crypto
+	// verify fails deterministically without depending on base64 content.
+	tampered.Method = "PUT"
+	// Fresh replay store per scenario so we're not colliding with the nonce
+	// consumed by the verified-request assertion above.
+	tamperedOpts := opts
+	tamperedOpts.Replay = NewMemoryReplayStore(0)
+	res = VerifyRequest(tampered, tamperedOpts)
+	assert.Equal(t, StatusRejected, res.Status)
+	require.NotNil(t, res.Error)
+	assert.NotEqual(t, CodeRequired, res.Error.Code,
+		"rejection for crypto / header tampering must not masquerade as CodeRequired")
+	assert.Nil(t, res.Signer)
+}
+
+func TestVerifyStatusZeroValueIsUnknown(t *testing.T) {
+	// A default-constructed VerifyResult must not claim verification.
+	var res VerifyResult
+	assert.Equal(t, StatusUnknown, res.Status)
+	assert.NotEqual(t, StatusVerified, res.Status,
+		"zero value must not be StatusVerified — that would be the footgun this helper exists to prevent")
+	assert.Equal(t, "unknown", res.Status.String())
+}
+
+func TestVerifyStatusString(t *testing.T) {
+	assert.Equal(t, "verified", StatusVerified.String())
+	assert.Equal(t, "unsigned", StatusUnsigned.String())
+	assert.Equal(t, "rejected", StatusRejected.String())
+}
+
+func TestRequireSignedFromContext(t *testing.T) {
+	// No signer on context → CodeRequired.
+	err := RequireSigned(context.Background())
+	require.NotNil(t, err)
+	assert.Equal(t, CodeRequired, err.Code)
+
+	// Signer on context → nil.
+	ctx := context.WithValue(context.Background(), contextKey{}, &VerifiedSigner{KeyID: "x"})
+	assert.Nil(t, RequireSigned(ctx))
+}


### PR DESCRIPTION
## Summary

Three follow-ups on the RFC 9421 signing package that shipped in #58. All three were raised during expert review of that PR and filed as #52, #55, #57.

**#52 — VerifyRequest tri-state.** `VerifyRequestSignature` returns three states through two return values; the `(nil, nil)` middle case (unsigned-and-not-required) is trivially misread as "verified" by `if signer, err := Verify(); err == nil { trust(signer) }`. Adds `VerifyRequest` returning a `VerifyResult{Status, Signer, Error}` with an explicit `StatusUnsigned`. The original function stays in place as the lower-level primitive the middleware uses.

`StatusUnknown = 0` is the zero value (diverging deliberately from the issue's `StatusVerified = iota` proposal) so a default-constructed `VerifyResult` can never silently claim verified. `TestVerifyStatusZeroValueIsUnknown` pins this.

Also adds `RequireSigned(ctx) *Error` as the handler-level escape hatch when `MiddlewareOptions.RequiredFor` can't express the gate (e.g., requirement depends on a decoded body field).

**#57 — `JWK.Public()` helper.** Returns a value-copy with `PrivateD` and `TestOnlyPrivateD` zeroed. Defense-in-depth so a loaded private JWK round-tripped through `json.Marshal` never leaks `d`. `TestJWKPublicStripsPrivateComponents` asserts the marshaled JSON lacks both members and that the receiver is not mutated.

**#55 — `adcp/signing/MIGRATION.md`.** Operator guide for the unsigned → signed rollout (`supported_for` → `warn_for` → `required_for`), routine and compromise key rotation, rollback from step C, common pitfalls, and a pre-enforcement checklist. Cross-references #53 (ObserveOnly / signingtest) and #54 (Redis replay store).

## Expert review pass

Run through code-reviewer, security-reviewer, dx-expert, and docs-expert before push. Fixes applied in the final commit:

- Dropped dead `CodeInvalid` fallback in `VerifyRequest` (collided with real crypto-verify-failed code; panic now surfaces the library invariant).
- Added tamper sub-test so `StatusRejected`'s non-`CodeRequired` Code is proven to survive into `VerifyResult`.
- Deleted stale `Extra` map comment on the JWK struct (field doesn't exist).
- Rewrote §3 key rotation: fixed 2×TTL math (= 10 min, not 6), split routine from compromise rotation with different ordering (compromise revokes first, then publishes new kid — routine did the opposite).
- Added rollback-from-step-C section.
- Tightened Ed25519 vs ES256 framing in bootstrap (Go's `crypto/ecdsa` is nonce-safe).
- Split step-C code block so `DigestRequired` is a separate deploy.
- Fenced the step-B `OnReject` shadow-mode shim with an inline "delete before step C" warning and pinned the `OnReject`-grep check in the pre-enforcement checklist.
- Replaced README prose about `RequireSigned` with a worked snippet.

## Test plan

- [x] `go test ./signing/...` passes in `adcp/` (all new tests + full existing suite).
- [x] `go vet ./signing/...` clean.
- [x] `go test ./...` and `go vet ./...` clean in both root and `adcp/` modules.
- [x] No pre-existing staticcheck warnings regressed (the two `ec.X`/`ec.Y` `SA1019` hits in `jwk_test.go` predate this branch).
- [ ] CI green on both Go 1.25 and 1.26 matrices.
- [ ] golangci-lint v2.11 clean on root.

## Closes

- Closes #52
- Closes #55
- Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)