### PR TITLE
chore: Add SetUserProfiles method

### DIFF
--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -455,6 +455,22 @@ func (e *Engine) SetUserProfile(ctx context.Context, userToken string, segments 
 	return e.store.Set(ctx, "user:profile:"+hash, string(data), 0)
 }
 
+// SetUserProfiles writes segment memberships for multiple users in a single batch.
+// The profiles map is keyed by user token.
+func (e *Engine) SetUserProfiles(ctx context.Context, profiles map[string]map[string]float64) error {
+	kvs := make(map[string]string, len(profiles))
+	for userToken, segments := range profiles {
+		hash := HashToken(userToken)
+		profile := UserProfile{Segments: segments}
+		data, err := json.Marshal(profile)
+		if err != nil {
+			return err
+		}
+		kvs["user:profile:"+hash] = string(data)
+	}
+	return e.store.MSet(ctx, kvs, 0)
+}
+
 // RecordExposure records an impression to the exposure log for all UIDs.
 // Each UID's exposure log is read, the new entry is appended,
 // old entries are pruned, and the log is written back.

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -321,6 +321,19 @@ func (m *MockStore) MGet(_ context.Context, keys ...string) ([]string, error) {
 	return results, nil
 }
 
+func (m *MockStore) MSet(_ context.Context, kvs map[string]string, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, v := range kvs {
+		entry := stringEntry{value: v}
+		if ttl > 0 {
+			entry.expiry = m.Now().Add(ttl)
+		}
+		m.strings[k] = entry
+	}
+	return nil
+}
+
 // isExpired checks key-level expiry. Must be called with lock held.
 func (m *MockStore) isExpired(key string) bool {
 	exp, ok := m.expiry[key]

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -40,4 +40,7 @@ type Store interface {
 
 	// MGet returns the values for the given keys. Missing keys return "" at their index.
 	MGet(ctx context.Context, keys ...string) ([]string, error)
+
+	// MSet stores multiple key-value pairs with an optional TTL. Zero TTL means no expiry.
+	MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error
 }

--- a/targeting/valkeystore/store.go
+++ b/targeting/valkeystore/store.go
@@ -100,3 +100,22 @@ func (s *Store) MGet(ctx context.Context, keys ...string) ([]string, error) {
 	}
 	return results, nil
 }
+
+func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error {
+	if len(kvs) == 0 {
+		return nil
+	}
+	if ttl == 0 {
+		args := make([]any, 0, len(kvs)*2)
+		for k, v := range kvs {
+			args = append(args, k, v)
+		}
+		return s.rdb.MSet(ctx, args...).Err()
+	}
+	pipe := s.rdb.Pipeline()
+	for k, v := range kvs {
+		pipe.Set(ctx, k, v, ttl)
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}


### PR DESCRIPTION
Summary

  - Add MSet to the Store interface for bulk key-value writes with optional TTL
  - Implement MSet in valkeystore using Redis MSET (single round-trip) when TTL=0, falling back to a pipeline for TTL>0
  - Add MSet to MockStore with consistent TTL/expiry semantics
  - Add Engine.SetUserProfiles to write segment memberships for many users in a single store call instead of one-by-one

  Motivation

  At tens/hundreds of thousands of user profiles, calling SetUserProfile in a loop produces one Redis round-trip per user. SetUserProfiles collapses the entire batch into a single MSET command,
  eliminating that overhead.