### PR TITLE
feat: Store users by package for targeting

### DIFF
--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -58,7 +58,7 @@ func setupStack(t *testing.T) *testStack {
 	store.SetPackageIdentityConfig("pkg-food", targeting.PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
 		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
-		TargetSegments: []string{"cooking_fans"},
+		Audience:       true,
 	})
 	// pkg-tech: no identity config = always eligible
 	store.SetPackageIdentityConfig("pkg-family", targeting.PackageIdentityConfig{
@@ -68,9 +68,8 @@ func setupStack(t *testing.T) *testStack {
 		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}},
 	})
 
-	// User profiles for identity evaluation.
-	store.SetUserProfile("tok-alice", map[string]float64{"cooking_fans": 0.8})
-	store.SetUserProfile("tok-bob", map[string]float64{"sports_fans": 0.5})
+	// Audience membership for pkg-food.
+	store.SetPackageUser("pkg-food", "tok-alice", 0.8)
 
 	// Identity engine (shares the same store).
 	identityEngine := targeting.NewEngine(targeting.EngineConfig{
@@ -85,11 +84,8 @@ func setupStack(t *testing.T) *testStack {
 
 	// Build resolved packages for the identity eval path.
 	idResolved := &targeting.ResolvedPackages{
-		SegmentIndex: map[string][]string{
-			"cooking_fans": {"pkg-food"},
-		},
 		IdentityConfigs: map[string]*targeting.PackageIdentityConfig{
-			"pkg-food":   {CampaignID: "campaign-acme", FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking_fans"}},
+			"pkg-food":   {CampaignID: "campaign-acme", FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, Audience: true},
 			"pkg-tech":   {},
 			"pkg-family": {FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 604800}}},
 		},
@@ -400,8 +396,10 @@ func TestIntegration_Mediation(t *testing.T) {
 	store.SetAdd("topics:package:pkg-wine", "food.cooking", "food.beverage")
 	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
 
-	// Alice is a cooking fan.
-	store.SetUserProfile("tok-alice", map[string]float64{"cooking_fans": 1.0})
+	// Seed audience membership for Alice across cooking packages.
+	store.SetPackageUser("pkg-olive-oil", "tok-alice", 1.0)
+	store.SetPackageUser("pkg-cookware", "tok-alice", 1.0)
+	store.SetPackageUser("pkg-wine", "tok-alice", 1.0)
 
 	creativeManifest, _ := json.Marshal(map[string]any{
 		"format_id": "sponsored_card",
@@ -451,9 +449,9 @@ func TestIntegration_Mediation(t *testing.T) {
 	})
 
 	// Seed identity config for mediation packages.
-	oliveIdCfg := targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}}
-	cookwareIdCfg := targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}}
-	wineIdCfg := targeting.PackageIdentityConfig{TargetSegments: []string{"cooking_fans"}}
+	oliveIdCfg := targeting.PackageIdentityConfig{Audience: true}
+	cookwareIdCfg := targeting.PackageIdentityConfig{Audience: true}
+	wineIdCfg := targeting.PackageIdentityConfig{Audience: true}
 	store.SetPackageIdentityConfig("pkg-olive-oil", oliveIdCfg)
 	store.SetPackageIdentityConfig("pkg-cookware", cookwareIdCfg)
 	store.SetPackageIdentityConfig("pkg-wine", wineIdCfg)
@@ -475,9 +473,6 @@ func TestIntegration_Mediation(t *testing.T) {
 	})
 
 	idResolved := &targeting.ResolvedPackages{
-		SegmentIndex: map[string][]string{
-			"cooking_fans": {"pkg-olive-oil", "pkg-cookware", "pkg-wine"},
-		},
 		IdentityConfigs: map[string]*targeting.PackageIdentityConfig{
 			"pkg-olive-oil": &oliveIdCfg,
 			"pkg-cookware":  &cookwareIdCfg,

--- a/reference/identity-agent/cmd/identity-agent/main.go
+++ b/reference/identity-agent/cmd/identity-agent/main.go
@@ -170,7 +170,7 @@ func seedConfigs(store targeting.Store) *targeting.ResolvedPackages {
 		{"pkg-display-0041", targeting.PackageIdentityConfig{
 			CampaignID:     "campaign-acme-q1",
 			FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
-			TargetSegments: []string{"cooking_enthusiast", "home_improvement"},
+			Audience:       true,
 		}},
 		{"pkg-display-0042", targeting.PackageIdentityConfig{
 			CampaignID:     "campaign-acme-q1",
@@ -182,11 +182,10 @@ func seedConfigs(store targeting.Store) *targeting.ResolvedPackages {
 				{MaxCount: 2, WindowSeconds: 43200},
 				{MaxCount: 5, WindowSeconds: 604800},
 			},
-			TargetSegments: []string{"organic_food"},
+			Audience: true,
 		}},
 	}
 	idConfigs := make(map[string]*targeting.PackageIdentityConfig, len(configs))
-	segmentIndex := make(map[string][]string)
 	for _, c := range configs {
 		if err := targeting.SeedPackageIdentityConfig(ctx, store, c.pkgID, c.cfg); err != nil {
 			slog.Error("seed package config failed", "package_id", c.pkgID, "error", err)
@@ -194,9 +193,6 @@ func seedConfigs(store targeting.Store) *targeting.ResolvedPackages {
 		}
 		cfg := c.cfg
 		idConfigs[c.pkgID] = &cfg
-		for _, seg := range cfg.TargetSegments {
-			segmentIndex[seg] = append(segmentIndex[seg], c.pkgID)
-		}
 	}
 
 	campaigns := []struct {
@@ -221,7 +217,6 @@ func seedConfigs(store targeting.Store) *targeting.ResolvedPackages {
 	}
 
 	return &targeting.ResolvedPackages{
-		SegmentIndex:    segmentIndex,
 		IdentityConfigs: idConfigs,
 		CampaignConfigs: campConfigs,
 	}

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -243,7 +243,7 @@ func (e *Engine) EvaluateContextResolved(ctx context.Context, resolved *Resolved
 	// 5. Resolve artifact topics from Store (per-request, can't cache).
 	var artifactTopics []string
 	for _, artifact := range artifactRefs {
-		topics, err := e.store.SetMembers(ctx, "topics:artifact:"+artifact)
+		topics, err := e.store.SetMembers(ctx, keyPrefixTopicsArtifact+artifact)
 		if err != nil {
 			e.metrics.StoreError(StageTopicMatch, err)
 		} else {
@@ -347,8 +347,8 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	keys := make([]string, 0, len(identities)*2)
 	for _, uid := range identities {
 		hash := HashToken(uid.UserToken)
-		keys = append(keys, "user:profile:"+hash)
-		keys = append(keys, "user:exposures:"+hash)
+		keys = append(keys, keyPrefixUserProfile+hash)
+		keys = append(keys, keyPrefixUserExposures+hash)
 	}
 
 	// 2. Single MGet — 1 round-trip.
@@ -452,7 +452,7 @@ func (e *Engine) SetUserProfile(ctx context.Context, userToken string, segments 
 	if err != nil {
 		return err
 	}
-	return e.store.Set(ctx, "user:profile:"+hash, string(data), 0)
+	return e.store.Set(ctx, keyPrefixUserProfile+hash, string(data), 0)
 }
 
 // SetUserProfiles writes segment memberships for multiple users in a single batch.
@@ -466,7 +466,7 @@ func (e *Engine) SetUserProfiles(ctx context.Context, profiles map[string]map[st
 		if err != nil {
 			return err
 		}
-		kvs["user:profile:"+hash] = string(data)
+		kvs[keyPrefixUserProfile+hash] = string(data)
 	}
 	return e.store.MSet(ctx, kvs, 0)
 }
@@ -474,7 +474,7 @@ func (e *Engine) SetUserProfiles(ctx context.Context, profiles map[string]map[st
 // DeleteUserProfile removes a user's segment profile.
 func (e *Engine) DeleteUserProfile(ctx context.Context, userToken string) error {
 	hash := HashToken(userToken)
-	return e.store.Del(ctx, "user:profile:"+hash)
+	return e.store.Del(ctx, keyPrefixUserProfile+hash)
 }
 
 // DeleteUserProfiles removes segment profiles for multiple users in a single batch.
@@ -482,7 +482,7 @@ func (e *Engine) DeleteUserProfile(ctx context.Context, userToken string) error 
 func (e *Engine) DeleteUserProfiles(ctx context.Context, userTokens []string) error {
 	keys := make([]string, len(userTokens))
 	for i, userToken := range userTokens {
-		keys[i] = "user:profile:" + HashToken(userToken)
+		keys[i] = keyPrefixUserProfile + HashToken(userToken)
 	}
 	return e.store.MDel(ctx, keys...)
 }
@@ -545,7 +545,7 @@ func (e *Engine) RecordExposure(ctx context.Context, req *ExposeRequest) (*Expos
 	// Write to each UID's exposure log. Capture the first UID's log for the response.
 	var firstLog BinaryExposureLog
 	for i, hash := range hashes {
-		key := "user:exposures:" + hash
+		key := keyPrefixUserExposures + hash
 
 		val, _, err := e.store.Get(ctx, key)
 		if err != nil {
@@ -652,7 +652,7 @@ func (e *Engine) checkURLFilter(ctx context.Context, artifacts []string, pkgID s
 		urlHash := HashURL(artifact)
 
 		if cfg.URLBlocklist {
-			blocked, err := e.store.SetIsMember(ctx, "url:blocklist:"+pkgID, urlHash)
+			blocked, err := e.store.SetIsMember(ctx, keyPrefixURLBlocklist+pkgID, urlHash)
 			if err != nil {
 				return false, err
 			}
@@ -662,7 +662,7 @@ func (e *Engine) checkURLFilter(ctx context.Context, artifacts []string, pkgID s
 		}
 
 		if cfg.URLAllowlist {
-			allowKey := "url:allowlist:" + pkgID
+			allowKey := keyPrefixURLAllowlist + pkgID
 			exists, err := e.store.Exists(ctx, allowKey)
 			if err != nil {
 				return false, err
@@ -688,7 +688,7 @@ func (e *Engine) checkTopicMatch(ctx context.Context, artifacts []string, pkgID 
 		return true, nil
 	}
 	for _, artifact := range artifacts {
-		intersection, err := e.store.SetIntersect(ctx, "topics:package:"+pkgID, "topics:artifact:"+artifact)
+		intersection, err := e.store.SetIntersect(ctx, keyPrefixTopicsPackage+pkgID, keyPrefixTopicsArtifact+artifact)
 		if err != nil {
 			return false, err
 		}

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -1,7 +1,7 @@
 // Package targeting provides a data-driven targeting engine for TMP agents.
 //
 // Capabilities activate based on what data is present. Push property bitmaps
-// and property targeting works. Push audience segments and audience targeting
+// and property targeting works. Push audience membership and audience targeting
 // works. No data for a dimension means that dimension is a no-op.
 //
 // The engine evaluates both context match and identity match requests,
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/tmproto"
@@ -343,28 +344,23 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	nowUnix := now.Unix()
 	identities := resolveIdentities(req)
 
-	// 1. Build MGet keys: profile + exposures for each UID.
-	keys := make([]string, 0, len(identities)*2)
-	for _, uid := range identities {
-		hash := HashToken(uid.UserToken)
-		keys = append(keys, keyPrefixUserProfile+hash)
-		keys = append(keys, keyPrefixUserExposures+hash)
+	// 1. Build MGet keys: exposures for each UID.
+	expKeys := make([]string, len(identities))
+	for i, uid := range identities {
+		expKeys[i] = keyPrefixUserExposures + HashToken(uid.UserToken)
 	}
 
-	// 2. Single MGet — 1 round-trip.
-	values, err := e.store.MGet(ctx, keys...)
+	// 2. Single MGet for exposures — 1 round-trip.
+	expValues, err := e.store.MGet(ctx, expKeys...)
 	if err != nil {
 		e.metrics.StoreError("load_user_data", err)
-		values = make([]string, len(keys))
+		expValues = make([]string, len(expKeys))
 	}
 
-	// 3. Parse profiles (JSON, small) and exposure logs (binary, zero-copy).
-	profiles := make([]*UserProfile, 0, len(identities))
+	// 3. Parse exposure logs (binary, zero-copy).
 	firstLogs := make([]BinaryExposureLog, 0, len(identities))
 	for i := range identities {
-		profileData := values[i*2]
-		exposureData := values[i*2+1]
-		profiles = append(profiles, ParseUserProfile(profileData))
+		exposureData := expValues[i]
 		binLog := BinaryExposureLog(exposureData)
 		if len(exposureData) > 0 {
 			if err := ValidateBinaryLog(binLog); err != nil {
@@ -374,16 +370,44 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		}
 		firstLogs = append(firstLogs, binLog)
 	}
-	mergedProfile := MergeUserProfiles(profiles...)
 
-	// 4. Extract segment names from merged profile.
-	var userSegments []string
-	for seg := range mergedProfile.Segments {
-		userSegments = append(userSegments, seg)
+	// 4. Pre-hash user tokens for per-package audience lookups.
+	userHashes := make([]string, len(identities))
+	for i, uid := range identities {
+		userHashes[i] = HashToken(uid.UserToken)
 	}
 
-	// 5. SegmentIndex: which packages is this user eligible for?
-	segmentEligible := resolved.SegmentCandidates(userSegments)
+	// 5. Batch-load audience membership for all audience-gated packages — 1 round-trip.
+	// audienceHit[pkgID] = true if at least one identity is in the package's audience.
+	audienceHit := make(map[string]bool)
+	var audiencePkgIDs []string
+	var audienceKeys []string
+	for _, pkgID := range req.PackageIDs {
+		idCfg := resolved.IdentityConfigs[pkgID]
+		if idCfg != nil && idCfg.Audience {
+			audiencePkgIDs = append(audiencePkgIDs, pkgID)
+			audienceKeys = append(audienceKeys, keyPrefixPackageAudience+HashToken(pkgID))
+		}
+	}
+	if len(audienceKeys) > 0 {
+		batchVals, err := e.store.HMGetBatch(ctx, audienceKeys, userHashes)
+		if err != nil {
+			e.metrics.StoreError(StageAudience, err)
+			// On error treat all audience packages as ineligible.
+			for _, pkgID := range audiencePkgIDs {
+				audienceHit[pkgID] = false
+			}
+		} else {
+			for i, pkgID := range audiencePkgIDs {
+				for _, v := range batchVals[i] {
+					if v != "" {
+						audienceHit[pkgID] = true
+						break
+					}
+				}
+			}
+		}
+	}
 
 	// 6. Evaluate each requested package using binary lazy dedup.
 	var eligibility []tmproto.PackageEligibility
@@ -391,9 +415,9 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		idCfg := resolved.IdentityConfigs[pkgID]
 		eligible := true
 
-		// Segment gating.
-		if idCfg != nil && len(idCfg.TargetSegments) > 0 {
-			if _, ok := segmentEligible[pkgID]; !ok {
+		// Audience gating: result from the batch lookup above.
+		if idCfg != nil && idCfg.Audience {
+			if !audienceHit[pkgID] {
 				eligible = false
 				e.metrics.IdentityEvaluated(pkgID, StageAudience, false)
 			}
@@ -444,45 +468,59 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	}, nil
 }
 
-// SetUserProfile writes a user's segment memberships to the profile key.
-func (e *Engine) SetUserProfile(ctx context.Context, userToken string, segments map[string]float64) error {
-	hash := HashToken(userToken)
-	profile := UserProfile{Segments: segments}
-	data, err := json.Marshal(profile)
-	if err != nil {
-		return err
-	}
-	return e.store.Set(ctx, keyPrefixUserProfile+hash, string(data), 0)
+// SetPackageUser adds a user to a package's audience with the given intent score.
+func (e *Engine) SetPackageUser(ctx context.Context, packageID, userToken string, intent float64) error {
+	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+	return e.store.HSet(ctx, pkgKey, HashToken(userToken), strconv.FormatFloat(intent, 'f', -1, 64))
 }
 
-// SetUserProfiles writes segment memberships for multiple users in a single batch.
-// The profiles map is keyed by user token.
-func (e *Engine) SetUserProfiles(ctx context.Context, profiles map[string]map[string]float64) error {
-	kvs := make(map[string]string, len(profiles))
-	for userToken, segments := range profiles {
-		hash := HashToken(userToken)
-		profile := UserProfile{Segments: segments}
-		data, err := json.Marshal(profile)
-		if err != nil {
+// AddPackageUsers adds multiple users to a package's audience in a single batch.
+// The users map is keyed by user token.
+func (e *Engine) AddPackageUsers(ctx context.Context, packageID string, users map[string]float64) error {
+	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+	fields := make(map[string]string, len(users))
+	for userToken, intent := range users {
+		fields[HashToken(userToken)] = strconv.FormatFloat(intent, 'f', -1, 64)
+	}
+	return e.store.HMSet(ctx, pkgKey, fields)
+}
+
+// RemovePackageUsers removes specific users from a package's audience.
+func (e *Engine) RemovePackageUsers(ctx context.Context, packageID string, userTokens []string) error {
+	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+	fields := make([]string, len(userTokens))
+	for i, token := range userTokens {
+		fields[i] = HashToken(token)
+	}
+	return e.store.HDel(ctx, pkgKey, fields...)
+}
+
+// DeletePackageUsers removes a package's entire audience.
+func (e *Engine) DeletePackageUsers(ctx context.Context, packageID string) error {
+	return e.store.Del(ctx, keyPrefixPackageAudience+HashToken(packageID))
+}
+
+// MSetPackageUsers adds users to multiple packages in one call.
+// The packages map is keyed by package ID; each value maps user token to intent score.
+func (e *Engine) MSetPackageUsers(ctx context.Context, packages map[string]map[string]float64) error {
+	for packageID, users := range packages {
+		pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+		fields := make(map[string]string, len(users))
+		for userToken, intent := range users {
+			fields[HashToken(userToken)] = strconv.FormatFloat(intent, 'f', -1, 64)
+		}
+		if err := e.store.HMSet(ctx, pkgKey, fields); err != nil {
 			return err
 		}
-		kvs[keyPrefixUserProfile+hash] = string(data)
 	}
-	return e.store.MSet(ctx, kvs, 0)
+	return nil
 }
 
-// DeleteUserProfile removes a user's segment profile.
-func (e *Engine) DeleteUserProfile(ctx context.Context, userToken string) error {
-	hash := HashToken(userToken)
-	return e.store.Del(ctx, keyPrefixUserProfile+hash)
-}
-
-// DeleteUserProfiles removes segment profiles for multiple users in a single batch.
-// The userTokens slice contains user tokens.
-func (e *Engine) DeleteUserProfiles(ctx context.Context, userTokens []string) error {
-	keys := make([]string, len(userTokens))
-	for i, userToken := range userTokens {
-		keys[i] = keyPrefixUserProfile + HashToken(userToken)
+// MDeletePackageUsers removes the entire audience for multiple packages in one call.
+func (e *Engine) MDeletePackageUsers(ctx context.Context, packageIDs []string) error {
+	keys := make([]string, len(packageIDs))
+	for i, packageID := range packageIDs {
+		keys[i] = keyPrefixPackageAudience + HashToken(packageID)
 	}
 	return e.store.MDel(ctx, keys...)
 }

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -471,6 +471,22 @@ func (e *Engine) SetUserProfiles(ctx context.Context, profiles map[string]map[st
 	return e.store.MSet(ctx, kvs, 0)
 }
 
+// DeleteUserProfile removes a user's segment profile.
+func (e *Engine) DeleteUserProfile(ctx context.Context, userToken string) error {
+	hash := HashToken(userToken)
+	return e.store.Del(ctx, "user:profile:"+hash)
+}
+
+// DeleteUserProfiles removes segment profiles for multiple users in a single batch.
+// The userTokens slice contains user tokens.
+func (e *Engine) DeleteUserProfiles(ctx context.Context, userTokens []string) error {
+	keys := make([]string, len(userTokens))
+	for i, userToken := range userTokens {
+		keys[i] = "user:profile:" + HashToken(userToken)
+	}
+	return e.store.MDel(ctx, keys...)
+}
+
 // RecordExposure records an impression to the exposure log for all UIDs.
 // Each UID's exposure log is read, the new entry is appended,
 // old entries are pruned, and the log is written back.

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -344,10 +344,12 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 	nowUnix := now.Unix()
 	identities := resolveIdentities(req)
 
-	// 1. Build MGet keys: exposures for each UID.
+	// 1. Hash user tokens once; derive exposure keys from the hashes.
+	userHashes := make([]string, len(identities))
 	expKeys := make([]string, len(identities))
 	for i, uid := range identities {
-		expKeys[i] = keyPrefixUserExposures + HashToken(uid.UserToken)
+		userHashes[i] = HashToken(uid.UserToken)
+		expKeys[i] = keyPrefixUserExposures + userHashes[i]
 	}
 
 	// 2. Single MGet for exposures — 1 round-trip.
@@ -371,12 +373,6 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		firstLogs = append(firstLogs, binLog)
 	}
 
-	// 4. Pre-hash user tokens for per-package audience lookups.
-	userHashes := make([]string, len(identities))
-	for i, uid := range identities {
-		userHashes[i] = HashToken(uid.UserToken)
-	}
-
 	// 5. Batch-load audience membership for all audience-gated packages — 1 round-trip.
 	// audienceHit[pkgID] = true if at least one identity is in the package's audience.
 	audienceHit := make(map[string]bool)
@@ -393,10 +389,7 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		batchVals, err := e.store.HMGetBatch(ctx, audienceKeys, userHashes)
 		if err != nil {
 			e.metrics.StoreError(StageAudience, err)
-			// On error treat all audience packages as ineligible.
-			for _, pkgID := range audiencePkgIDs {
-				audienceHit[pkgID] = false
-			}
+			// audienceHit entries default to false; nothing to do.
 		} else {
 			for i, pkgID := range audiencePkgIDs {
 				for _, v := range batchVals[i] {
@@ -500,7 +493,7 @@ func (e *Engine) DeletePackageUsers(ctx context.Context, packageID string) error
 	return e.store.Del(ctx, keyPrefixPackageAudience+HashToken(packageID))
 }
 
-// MSetPackageUsers adds users to multiple packages in one call.
+// MSetPackageUsers adds users to multiple packages. Each package gets one HMSet call.
 // The packages map is keyed by package ID; each value maps user token to intent score.
 func (e *Engine) MSetPackageUsers(ctx context.Context, packages map[string]map[string]float64) error {
 	for packageID, users := range packages {

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/tmproto"
@@ -382,7 +381,7 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 		idCfg := resolved.IdentityConfigs[pkgID]
 		if idCfg != nil && idCfg.Audience {
 			audiencePkgIDs = append(audiencePkgIDs, pkgID)
-			audienceKeys = append(audienceKeys, keyPrefixPackageAudience+HashToken(pkgID))
+			audienceKeys = append(audienceKeys, keyPrefixPackageAudience+HashPackageID(pkgID))
 		}
 	}
 	if len(audienceKeys) > 0 {
@@ -462,25 +461,25 @@ func (e *Engine) EvaluateIdentityResolved(ctx context.Context, resolved *Resolve
 }
 
 // SetPackageUser adds a user to a package's audience with the given intent score.
-func (e *Engine) SetPackageUser(ctx context.Context, packageID, userToken string, intent float64) error {
-	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
-	return e.store.HSet(ctx, pkgKey, HashToken(userToken), strconv.FormatFloat(intent, 'f', -1, 64))
+func (e *Engine) SetPackageUser(ctx context.Context, packageID, userToken string, intent Intent) error {
+	pkgKey := keyPrefixPackageAudience + HashPackageID(packageID)
+	return e.store.HSet(ctx, pkgKey, HashToken(userToken), intent.String())
 }
 
 // AddPackageUsers adds multiple users to a package's audience in a single batch.
 // The users map is keyed by user token.
-func (e *Engine) AddPackageUsers(ctx context.Context, packageID string, users map[string]float64) error {
-	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+func (e *Engine) AddPackageUsers(ctx context.Context, packageID string, users map[string]Intent) error {
+	pkgKey := keyPrefixPackageAudience + HashPackageID(packageID)
 	fields := make(map[string]string, len(users))
 	for userToken, intent := range users {
-		fields[HashToken(userToken)] = strconv.FormatFloat(intent, 'f', -1, 64)
+		fields[HashToken(userToken)] = intent.String()
 	}
 	return e.store.HMSet(ctx, pkgKey, fields)
 }
 
 // RemovePackageUsers removes specific users from a package's audience.
 func (e *Engine) RemovePackageUsers(ctx context.Context, packageID string, userTokens []string) error {
-	pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+	pkgKey := keyPrefixPackageAudience + HashPackageID(packageID)
 	fields := make([]string, len(userTokens))
 	for i, token := range userTokens {
 		fields[i] = HashToken(token)
@@ -490,17 +489,17 @@ func (e *Engine) RemovePackageUsers(ctx context.Context, packageID string, userT
 
 // DeletePackageUsers removes a package's entire audience.
 func (e *Engine) DeletePackageUsers(ctx context.Context, packageID string) error {
-	return e.store.Del(ctx, keyPrefixPackageAudience+HashToken(packageID))
+	return e.store.Del(ctx, keyPrefixPackageAudience+HashPackageID(packageID))
 }
 
 // MSetPackageUsers adds users to multiple packages. Each package gets one HMSet call.
 // The packages map is keyed by package ID; each value maps user token to intent score.
-func (e *Engine) MSetPackageUsers(ctx context.Context, packages map[string]map[string]float64) error {
+func (e *Engine) MSetPackageUsers(ctx context.Context, packages map[string]map[string]Intent) error {
 	for packageID, users := range packages {
-		pkgKey := keyPrefixPackageAudience + HashToken(packageID)
+		pkgKey := keyPrefixPackageAudience + HashPackageID(packageID)
 		fields := make(map[string]string, len(users))
 		for userToken, intent := range users {
-			fields[HashToken(userToken)] = strconv.FormatFloat(intent, 'f', -1, 64)
+			fields[HashToken(userToken)] = intent.String()
 		}
 		if err := e.store.HMSet(ctx, pkgKey, fields); err != nil {
 			return err
@@ -513,7 +512,7 @@ func (e *Engine) MSetPackageUsers(ctx context.Context, packages map[string]map[s
 func (e *Engine) MDeletePackageUsers(ctx context.Context, packageIDs []string) error {
 	keys := make([]string, len(packageIDs))
 	for i, packageID := range packageIDs {
-		keys[i] = keyPrefixPackageAudience + HashToken(packageID)
+		keys[i] = keyPrefixPackageAudience + HashPackageID(packageID)
 	}
 	return e.store.MDel(ctx, keys...)
 }

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -620,7 +620,7 @@ func TestAudience_RemovePackageUsers(t *testing.T) {
 	engine, _, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]float64{
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]Intent{
 		"user-x": 1.0,
 		"user-y": 1.0,
 	}))
@@ -649,7 +649,7 @@ func TestAudience_DeletePackageUsers(t *testing.T) {
 	engine, _, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]float64{
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]Intent{
 		"user-p": 1.0,
 		"user-q": 1.0,
 	}))
@@ -670,7 +670,7 @@ func TestAudience_MSetAndMDelete(t *testing.T) {
 	engine, _, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	require.NoError(t, engine.MSetPackageUsers(ctx, map[string]map[string]float64{
+	require.NoError(t, engine.MSetPackageUsers(ctx, map[string]map[string]Intent{
 		"pkg-display-001": {"user-m1": 1.0, "user-m2": 0.5},
 		"pkg-display-002": {"user-m1": 0.8},
 	}))

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -562,3 +562,137 @@ func TestIdentity_SourceNamespacesSortedSetMembers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count, "expected 2 sorted set members (namespaced by source)")
 }
+
+// --- Audience write API tests ---
+
+func TestAudience_SetAndHit(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	require.NoError(t, engine.SetPackageUser(ctx, "pkg-display-001", "user-abc", 0.9))
+
+	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "aud-hit",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-abc"}},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Eligibility, 1)
+	assert.True(t, resp.Eligibility[0].Eligible, "user in audience should be eligible")
+}
+
+func TestAudience_Miss(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	// user-abc is NOT added to pkg-display-001's audience.
+	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "aud-miss",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-abc"}},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Eligibility, 1)
+	assert.False(t, resp.Eligibility[0].Eligible, "user not in audience should be ineligible")
+}
+
+func TestAudience_MultiIdentity_AnyHits(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	// Only user-b is in the audience; request carries both user-a and user-b.
+	require.NoError(t, engine.SetPackageUser(ctx, "pkg-display-001", "user-b", 1.0))
+
+	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID: "aud-multi",
+		Identities: []tmproto.IdentityToken{
+			{UserToken: "user-a"},
+			{UserToken: "user-b"},
+		},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Eligibility, 1)
+	assert.True(t, resp.Eligibility[0].Eligible, "package should be eligible when any identity is in audience")
+}
+
+func TestAudience_RemovePackageUsers(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]float64{
+		"user-x": 1.0,
+		"user-y": 1.0,
+	}))
+	require.NoError(t, engine.RemovePackageUsers(ctx, "pkg-display-001", []string{"user-x"}))
+
+	// user-x removed — should miss.
+	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "remove-x",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-x"}},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Eligibility[0].Eligible, "removed user should be ineligible")
+
+	// user-y still present — should hit.
+	resp, err = engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "remove-y-still-in",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-y"}},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Eligibility[0].Eligible, "non-removed user should still be eligible")
+}
+
+func TestAudience_DeletePackageUsers(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-display-001", map[string]float64{
+		"user-p": 1.0,
+		"user-q": 1.0,
+	}))
+	require.NoError(t, engine.DeletePackageUsers(ctx, "pkg-display-001"))
+
+	for _, token := range []string{"user-p", "user-q"} {
+		resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+			RequestID:  fmt.Sprintf("delete-%s", token),
+			Identities: []tmproto.IdentityToken{{UserToken: token}},
+			PackageIDs: []string{"pkg-display-001"},
+		})
+		require.NoError(t, err)
+		assert.False(t, resp.Eligibility[0].Eligible, "%s should be ineligible after audience deleted", token)
+	}
+}
+
+func TestAudience_MSetAndMDelete(t *testing.T) {
+	engine, _, resolved := setupIdentityEngine(t)
+	ctx := context.Background()
+
+	require.NoError(t, engine.MSetPackageUsers(ctx, map[string]map[string]float64{
+		"pkg-display-001": {"user-m1": 1.0, "user-m2": 0.5},
+		"pkg-display-002": {"user-m1": 0.8},
+	}))
+
+	// Both packages should hit for user-m1.
+	resp, err := engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "mset-hit",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-m1"}},
+		PackageIDs: []string{"pkg-display-001", "pkg-display-002"},
+	})
+	require.NoError(t, err)
+	// pkg-display-002 has no Audience flag in resolved — only pkg-display-001 is gated.
+	assert.True(t, resp.Eligibility[0].Eligible, "pkg-display-001 should be eligible for user-m1")
+
+	// MDelete pkg-display-001's audience.
+	require.NoError(t, engine.MDeletePackageUsers(ctx, []string{"pkg-display-001"}))
+
+	resp, err = engine.EvaluateIdentityResolved(ctx, resolved, &tmproto.IdentityMatchRequest{
+		RequestID:  "mdelete-miss",
+		Identities: []tmproto.IdentityToken{{UserToken: "user-m1"}},
+		PackageIDs: []string{"pkg-display-001"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Eligibility[0].Eligible, "pkg-display-001 should be ineligible after MDelete")
+}

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -39,7 +39,7 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages) 
 	store.SetPackageIdentityConfig("pkg-display-001", PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
 		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
-		TargetSegments: []string{"cooking", "home"},
+		Audience:       true,
 	})
 	store.SetPackageIdentityConfig("pkg-display-002", PackageIdentityConfig{
 		CampaignID:     "campaign-acme",
@@ -59,12 +59,8 @@ func setupIdentityEngine(t *testing.T) (*Engine, *MockStore, *ResolvedPackages) 
 
 	// Build resolved packages for the resolved eval path.
 	resolved := &ResolvedPackages{
-		SegmentIndex: map[string][]string{
-			"cooking": {"pkg-display-001"},
-			"home":    {"pkg-display-001"},
-		},
 		IdentityConfigs: map[string]*PackageIdentityConfig{
-			"pkg-display-001": {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, TargetSegments: []string{"cooking", "home"}},
+			"pkg-display-001": {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}}, Audience: true},
 			"pkg-display-002": {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 43200}}},
 			"pkg-multi-rule":  {CampaignID: "campaign-acme", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 2, WindowSeconds: 43200}, {MaxCount: 5, WindowSeconds: 604800}}},
 			"pkg-no-cap":      {},
@@ -357,7 +353,7 @@ func TestIdentity_CampaignFrequencyCap(t *testing.T) {
 	engine, store, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
+	store.SetPackageUser("pkg-display-001", "user-abc", 0)
 
 	// 5 exposures across two packages in campaign-acme (cap is 5/7d).
 	for i := range 3 {
@@ -382,7 +378,7 @@ func TestIdentity_PackageCappedButCampaignNot(t *testing.T) {
 	engine, store, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
+	store.SetPackageUser("pkg-display-001", "user-abc", 0)
 
 	// 3 exposures on pkg-display-001 (package cap=3, campaign cap=5).
 	for i := range 3 {
@@ -426,7 +422,7 @@ func TestIdentity_SlidingWindowExpiry(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
+	store.SetPackageUser("pkg-display-001", "user-abc", 0)
 
 	// 3 exposures (hits cap).
 	for i := range 3 {
@@ -453,7 +449,7 @@ func TestIdentity_IntentScore(t *testing.T) {
 	engine, store, resolved := setupIdentityEngine(t)
 	ctx := context.Background()
 
-	store.SetUserProfile("user-abc", map[string]float64{"cooking": 0})
+	store.SetPackageUser("pkg-display-001", "user-abc", 0)
 
 	_, _ = engine.RecordExposure(ctx, &ExposeRequest{UserToken: "user-abc", PackageID: "pkg-display-001"})
 

--- a/targeting/exposure.go
+++ b/targeting/exposure.go
@@ -56,11 +56,6 @@ type ExposureEntry struct {
 // ExposureLog is a user's exposure history, sorted by timestamp descending.
 type ExposureLog []ExposureEntry
 
-// UserProfile holds a user's segment memberships with optional intent scores.
-type UserProfile struct {
-	Segments map[string]float64 `json:"segments"` // segment name → intent score (0 = member, no score)
-}
-
 // ParseExposureLog parses a JSON-serialized exposure log.
 func ParseExposureLog(data string) ExposureLog {
 	if data == "" {
@@ -82,18 +77,6 @@ func SerializeExposureLog(log ExposureLog) string {
 	return string(data)
 }
 
-// ParseUserProfile parses a JSON-serialized user profile.
-func ParseUserProfile(data string) *UserProfile {
-	if data == "" {
-		return nil
-	}
-	var p UserProfile
-	if err := json.Unmarshal([]byte(data), &p); err != nil {
-		return nil
-	}
-	return &p
-}
-
 // MergeExposureLogs unions multiple exposure logs, deduplicating by ImpressionID.
 func MergeExposureLogs(logs ...ExposureLog) ExposureLog {
 	seen := make(map[string]struct{})
@@ -109,23 +92,6 @@ func MergeExposureLogs(logs ...ExposureLog) ExposureLog {
 	sort.Slice(merged, func(i, j int) bool {
 		return merged[i].Timestamp > merged[j].Timestamp // newest first
 	})
-	return merged
-}
-
-// MergeUserProfiles unions segment memberships across multiple profiles.
-// For duplicate segments, takes the higher intent score.
-func MergeUserProfiles(profiles ...*UserProfile) *UserProfile {
-	merged := &UserProfile{Segments: make(map[string]float64)}
-	for _, p := range profiles {
-		if p == nil {
-			continue
-		}
-		for seg, score := range p.Segments {
-			if existing, ok := merged.Segments[seg]; !ok || score > existing {
-				merged.Segments[seg] = score
-			}
-		}
-	}
 	return merged
 }
 

--- a/targeting/exposure_test.go
+++ b/targeting/exposure_test.go
@@ -177,20 +177,3 @@ func TestComputeIntentScore(t *testing.T) {
 		assert.Equal(t, float64(0), score)
 	})
 }
-
-func TestMergeUserProfiles(t *testing.T) {
-	p1 := &UserProfile{Segments: map[string]float64{"cooking_fans": 0.8, "sports": 0.3}}
-	p2 := &UserProfile{Segments: map[string]float64{"cooking_fans": 0.5, "tech": 0.9}}
-
-	merged := MergeUserProfiles(p1, p2)
-	assert.Equal(t, 0.8, merged.Segments["cooking_fans"], "expected higher value")
-	assert.Equal(t, 0.3, merged.Segments["sports"])
-	assert.Equal(t, 0.9, merged.Segments["tech"])
-	assert.Len(t, merged.Segments, 3)
-}
-
-func TestMergeUserProfiles_WithNil(t *testing.T) {
-	p1 := &UserProfile{Segments: map[string]float64{"cooking": 0.5}}
-	merged := MergeUserProfiles(nil, p1, nil)
-	assert.Len(t, merged.Segments, 1)
-}

--- a/targeting/hash.go
+++ b/targeting/hash.go
@@ -13,6 +13,14 @@ func HashToken(token string) string {
 	return hex.EncodeToString(h[:16])
 }
 
+// HashPackageID returns a full SHA-256 hex digest of a package ID,
+// used to derive storage keys so that audience data is only accessible
+// to callers who know the package ID.
+func HashPackageID(packageID string) string {
+	h := sha256.Sum256([]byte(packageID))
+	return hex.EncodeToString(h[:])
+}
+
 // HashURL returns a full SHA-256 hex digest of a lowercased URL.
 func HashURL(url string) string {
 	h := sha256.Sum256([]byte(strings.ToLower(url)))

--- a/targeting/identity_config.go
+++ b/targeting/identity_config.go
@@ -10,9 +10,9 @@ import (
 // PackageIdentityConfig is the identity-side configuration for a package,
 // stored in the Store as JSON at key "config:pkg:{packageID}".
 type PackageIdentityConfig struct {
-	CampaignID     string             `json:"campaign_id,omitempty"`
+	CampaignID     string              `json:"campaign_id,omitempty"`
 	FrequencyRules []FrequencyRuleJSON `json:"frequency_rules,omitempty"`
-	TargetSegments []string           `json:"target_segments,omitempty"`
+	TargetSegments []string            `json:"target_segments,omitempty"`
 }
 
 // CampaignFreqConfig is the frequency cap configuration for a campaign,
@@ -42,7 +42,7 @@ func toFrequencyRules(rules []FrequencyRuleJSON) []FrequencyRule {
 // loadPackageIdentityConfig reads identity config for a package from the Store.
 // Returns nil if no config is found (package has no identity dimensions).
 func loadPackageIdentityConfig(ctx context.Context, store Store, pkgID string) (*PackageIdentityConfig, error) {
-	key := fmt.Sprintf("config:pkg:%s", pkgID)
+	key := keyPrefixConfigPkg + pkgID
 	val, ok, err := store.Get(ctx, key)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func batchLoadPackageContextConfigs(ctx context.Context, store Store, pkgIDs []s
 	}
 	keys := make([]string, len(pkgIDs))
 	for i, id := range pkgIDs {
-		keys[i] = fmt.Sprintf("config:pkg:%s:context", id)
+		keys[i] = keyPrefixConfigPkg + id + ":context"
 	}
 	values, err := store.MGet(ctx, keys...)
 	if err != nil {
@@ -91,7 +91,7 @@ func batchLoadPackageIdentityConfigs(ctx context.Context, store Store, pkgIDs []
 	}
 	keys := make([]string, len(pkgIDs))
 	for i, id := range pkgIDs {
-		keys[i] = fmt.Sprintf("config:pkg:%s", id)
+		keys[i] = keyPrefixConfigPkg + id
 	}
 	values, err := store.MGet(ctx, keys...)
 	if err != nil {
@@ -118,7 +118,7 @@ func batchLoadCampaignFreqConfigs(ctx context.Context, store Store, campaignIDs 
 	}
 	keys := make([]string, len(campaignIDs))
 	for i, id := range campaignIDs {
-		keys[i] = fmt.Sprintf("config:campaign:%s", id)
+		keys[i] = keyPrefixConfigCampaign + id
 	}
 	values, err := store.MGet(ctx, keys...)
 	if err != nil {
@@ -144,7 +144,7 @@ func SeedPackageIdentityConfig(ctx context.Context, store Store, pkgID string, c
 	if err != nil {
 		return err
 	}
-	return store.Set(ctx, fmt.Sprintf("config:pkg:%s", pkgID), string(data), 0)
+	return store.Set(ctx, keyPrefixConfigPkg+pkgID, string(data), 0)
 }
 
 // SeedCampaignFreqConfig writes frequency config for a campaign to any Store.
@@ -153,13 +153,13 @@ func SeedCampaignFreqConfig(ctx context.Context, store Store, campaignID string,
 	if err != nil {
 		return err
 	}
-	return store.Set(ctx, fmt.Sprintf("config:campaign:%s", campaignID), string(data), 0)
+	return store.Set(ctx, keyPrefixConfigCampaign+campaignID, string(data), 0)
 }
 
 // loadCampaignFreqConfig reads frequency cap config for a campaign from the Store.
 // Returns nil if no config is found.
 func loadCampaignFreqConfig(ctx context.Context, store Store, campaignID string) (*CampaignFreqConfig, error) {
-	key := fmt.Sprintf("config:campaign:%s", campaignID)
+	key := keyPrefixConfigCampaign + campaignID
 	val, ok, err := store.Get(ctx, key)
 	if err != nil {
 		return nil, err

--- a/targeting/identity_config.go
+++ b/targeting/identity_config.go
@@ -12,7 +12,10 @@ import (
 type PackageIdentityConfig struct {
 	CampaignID     string              `json:"campaign_id,omitempty"`
 	FrequencyRules []FrequencyRuleJSON `json:"frequency_rules,omitempty"`
-	TargetSegments []string            `json:"target_segments,omitempty"`
+	// Audience signals that this package has user-level audience targeting.
+	// Membership is stored in the Store as HSET at key "audience:{hash(packageID)}",
+	// with hash(userToken) as the field and the intent score as the value.
+	Audience bool `json:"audience,omitempty"`
 }
 
 // CampaignFreqConfig is the frequency cap configuration for a campaign,

--- a/targeting/identity_system_test.go
+++ b/targeting/identity_system_test.go
@@ -34,8 +34,6 @@ func TestSystem_HeavyUser(t *testing.T) {
 		}
 	}
 	store.SetUserExposures("user-heavy", entries)
-	store.SetUserProfile("user-heavy", map[string]float64{"premium_audience": 0.9})
-
 	t.Logf("Loaded %d exposures for heavy user", len(entries))
 
 	// Build identity configs.
@@ -46,16 +44,16 @@ func TestSystem_HeavyUser(t *testing.T) {
 		campID := fmt.Sprintf("campaign-%d", i/3)
 		idConfigs[pkgID] = &PackageIdentityConfig{
 			CampaignID:     campID,
-			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},  // 5/day
-			TargetSegments: []string{"premium_audience"},
+			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}}, // 5/day
+			Audience:       true,
 		}
+		store.SetPackageUser(pkgID, "user-heavy", 0.9)
 		campConfigs[campID] = &CampaignFreqConfig{
 			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 20, WindowSeconds: 604800}}, // 20/week
 		}
 	}
 
 	resolved := &ResolvedPackages{
-		SegmentIndex:    map[string][]string{"premium_audience": {"pkg-0", "pkg-1", "pkg-2", "pkg-3", "pkg-4", "pkg-5", "pkg-6", "pkg-7", "pkg-8", "pkg-9"}},
 		IdentityConfigs: idConfigs,
 		CampaignConfigs: campConfigs,
 	}
@@ -116,10 +114,10 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	uid2 := "tok-uid2-xyz"
 	email := "tok-email-hash-123"
 
-	// Different segments per UID.
-	store.SetUserProfile(cookie, map[string]float64{"cooking_fans": 0.8})
-	store.SetUserProfile(uid2, map[string]float64{"sports_fans": 0.5})
-	store.SetUserProfile(email, map[string]float64{"cooking_fans": 0.6, "tech_enthusiasts": 0.9})
+	// Audience membership per package.
+	store.SetPackageUsers("pkg-food", map[string]float64{cookie: 0.8, email: 0.6})
+	store.SetPackageUsers("pkg-sports", map[string]float64{uid2: 0.5})
+	store.SetPackageUsers("pkg-tech", map[string]float64{email: 0.9})
 
 	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
 	engine.Now = func() time.Time { return now }
@@ -165,15 +163,10 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	}
 
 	resolved := &ResolvedPackages{
-		SegmentIndex: map[string][]string{
-			"cooking_fans":     {"pkg-food"},
-			"sports_fans":      {"pkg-sports"},
-			"tech_enthusiasts": {"pkg-tech"},
-		},
 		IdentityConfigs: map[string]*PackageIdentityConfig{
-			"pkg-food":   {CampaignID: "campaign-food", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}, TargetSegments: []string{"cooking_fans"}},
-			"pkg-sports": {TargetSegments: []string{"sports_fans"}},
-			"pkg-tech":   {TargetSegments: []string{"tech_enthusiasts"}},
+			"pkg-food":   {CampaignID: "campaign-food", FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}, Audience: true},
+			"pkg-sports": {Audience: true},
+			"pkg-tech":   {Audience: true},
 		},
 		CampaignConfigs: map[string]*CampaignFreqConfig{
 			"campaign-food": {FrequencyRules: []FrequencyRuleJSON{{MaxCount: 100, WindowSeconds: 30 * 86400}}},
@@ -236,8 +229,8 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	// Total unique impressions across cookie+email should be less than sum of both.
 	cookieHash := HashToken(cookie)
 	emailHash := HashToken(email)
-	cookieVal, _, _ := store.Get(context.Background(), "user:exposures:"+cookieHash)
-	emailVal, _, _ := store.Get(context.Background(), "user:exposures:"+emailHash)
+	cookieVal, _, _ := store.Get(context.Background(), keyPrefixUserExposures+cookieHash)
+	emailVal, _, _ := store.Get(context.Background(), keyPrefixUserExposures+emailHash)
 	cookieBin := BinaryExposureLog(cookieVal)
 	emailBin := BinaryExposureLog(emailVal)
 	mergedBin := MergeBinaryLogs(cookieBin, emailBin)
@@ -258,14 +251,13 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
 	engine.Now = func() time.Time { return currentTime }
 
-	store.SetUserProfile("user-rolling", map[string]float64{"all": 0})
+	store.SetPackageUser("pkg-test", "user-rolling", 0)
 
 	resolved := &ResolvedPackages{
-		SegmentIndex: map[string][]string{"all": {"pkg-test"}},
 		IdentityConfigs: map[string]*PackageIdentityConfig{
 			"pkg-test": {
 				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}}, // 5/day
-				TargetSegments: []string{"all"},
+				Audience:       true,
 			},
 		},
 		CampaignConfigs: map[string]*CampaignFreqConfig{},
@@ -301,7 +293,7 @@ func TestSystem_RollingWindowExpiry(t *testing.T) {
 
 	// Check the exposure log: should be pruned to ~30 days.
 	hash := HashToken("user-rolling")
-	val, _, _ := store.Get(context.Background(), "user:exposures:"+hash)
+	val, _, _ := store.Get(context.Background(), keyPrefixUserExposures+hash)
 	binLog := BinaryExposureLog(val)
 	require.NoError(t, ValidateBinaryLog(binLog))
 

--- a/targeting/identity_system_test.go
+++ b/targeting/identity_system_test.go
@@ -115,9 +115,9 @@ func TestSystem_IdentityGraph(t *testing.T) {
 	email := "tok-email-hash-123"
 
 	// Audience membership per package.
-	store.SetPackageUsers("pkg-food", map[string]float64{cookie: 0.8, email: 0.6})
-	store.SetPackageUsers("pkg-sports", map[string]float64{uid2: 0.5})
-	store.SetPackageUsers("pkg-tech", map[string]float64{email: 0.9})
+	store.SetPackageUsers("pkg-food", map[string]Intent{cookie: 0.8, email: 0.6})
+	store.SetPackageUsers("pkg-sports", map[string]Intent{uid2: 0.5})
+	store.SetPackageUsers("pkg-tech", map[string]Intent{email: 0.9})
 
 	engine := NewEngine(EngineConfig{ProviderID: "test", Store: store})
 	engine.Now = func() time.Time { return now }

--- a/targeting/intent.go
+++ b/targeting/intent.go
@@ -1,0 +1,18 @@
+package targeting
+
+import "strconv"
+
+// Intent is an audience intent score in [0, 1] stored alongside a user's
+// membership in a package audience. Higher values indicate stronger targeting signal.
+type Intent float64
+
+// String serialises the intent score for storage in a hash field.
+func (i Intent) String() string {
+	return strconv.FormatFloat(float64(i), 'f', -1, 64)
+}
+
+// ParseIntent deserialises an intent score from its stored string form.
+func ParseIntent(s string) (Intent, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	return Intent(f), err
+}

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -439,6 +439,9 @@ func (m *MockStore) HDel(_ context.Context, key string, fields ...string) error 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	h := m.hsets[key]
+	if h == nil {
+		return nil
+	}
 	for _, f := range fields {
 		delete(h, f)
 	}

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -94,27 +93,27 @@ func (m *MockStore) SetMediaBuy(mb MediaBuy) {
 }
 
 // SetPackageUser adds a user to a package's audience. Test helper.
-func (m *MockStore) SetPackageUser(pkgID, token string, intent float64) {
-	pkgKey := keyPrefixPackageAudience + HashToken(pkgID)
+func (m *MockStore) SetPackageUser(pkgID, token string, intent Intent) {
+	pkgKey := keyPrefixPackageAudience + HashPackageID(pkgID)
 	userHash := HashToken(token)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.hsets[pkgKey] == nil {
 		m.hsets[pkgKey] = make(map[string]string)
 	}
-	m.hsets[pkgKey][userHash] = strconv.FormatFloat(intent, 'f', -1, 64)
+	m.hsets[pkgKey][userHash] = intent.String()
 }
 
 // SetPackageUsers adds multiple users to a package's audience. Test helper.
-func (m *MockStore) SetPackageUsers(pkgID string, users map[string]float64) {
-	pkgKey := keyPrefixPackageAudience + HashToken(pkgID)
+func (m *MockStore) SetPackageUsers(pkgID string, users map[string]Intent) {
+	pkgKey := keyPrefixPackageAudience + HashPackageID(pkgID)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.hsets[pkgKey] == nil {
 		m.hsets[pkgKey] = make(map[string]string)
 	}
 	for token, intent := range users {
-		m.hsets[pkgKey][HashToken(token)] = strconv.FormatFloat(intent, 'f', -1, 64)
+		m.hsets[pkgKey][HashToken(token)] = intent.String()
 	}
 }
 

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -3,7 +3,6 @@ package targeting
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -63,7 +62,7 @@ func (m *MockStore) SetPackageIdentityConfig(pkgID string, cfg PackageIdentityCo
 	data, _ := json.Marshal(cfg)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings[fmt.Sprintf("config:pkg:%s", pkgID)] = stringEntry{value: string(data)}
+	m.strings[keyPrefixConfigPkg+pkgID] = stringEntry{value: string(data)}
 }
 
 // SetCampaignFreqConfig stores frequency config for a campaign. Test helper.
@@ -71,7 +70,7 @@ func (m *MockStore) SetCampaignFreqConfig(campaignID string, cfg CampaignFreqCon
 	data, _ := json.Marshal(cfg)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings[fmt.Sprintf("config:campaign:%s", campaignID)] = stringEntry{value: string(data)}
+	m.strings[keyPrefixConfigCampaign+campaignID] = stringEntry{value: string(data)}
 }
 
 // SetMediaBuy stores a media buy and adds it to the seller's set. Test helper.
@@ -80,7 +79,7 @@ func (m *MockStore) SetMediaBuy(mb MediaBuy) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	// Add to seller set.
-	sellerKey := "mediabuy:seller:" + mb.SellerID
+	sellerKey := keyPrefixMediaBuySeller + mb.SellerID
 	s, ok := m.sets[sellerKey]
 	if !ok {
 		s = make(map[string]struct{})
@@ -88,7 +87,7 @@ func (m *MockStore) SetMediaBuy(mb MediaBuy) {
 	}
 	s[mb.MediaBuyID] = struct{}{}
 	// Store media buy JSON.
-	m.strings["mediabuy:"+mb.MediaBuyID] = stringEntry{value: string(data)}
+	m.strings[keyPrefixMediaBuy+mb.MediaBuyID] = stringEntry{value: string(data)}
 }
 
 // SetUserProfile stores a user's segment memberships. Test helper.
@@ -98,7 +97,7 @@ func (m *MockStore) SetUserProfile(token string, segments map[string]float64) {
 	data, _ := json.Marshal(profile)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings["user:profile:"+hash] = stringEntry{value: string(data)}
+	m.strings[keyPrefixUserProfile+hash] = stringEntry{value: string(data)}
 }
 
 // SetUserExposures stores a user's exposure log in binary format. Test helper.
@@ -107,13 +106,13 @@ func (m *MockStore) SetUserExposures(token string, entries []ExposureEntry) {
 	bin := EncodeBinaryExposureLog(entries)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings["user:exposures:"+hash] = stringEntry{value: string(bin)}
+	m.strings[keyPrefixUserExposures+hash] = stringEntry{value: string(bin)}
 }
 
 // AddExposure appends an exposure entry to a user's log. Test helper.
 func (m *MockStore) AddExposure(token string, entry ExposureEntry) {
 	hash := HashToken(token)
-	key := "user:exposures:" + hash
+	key := keyPrefixUserExposures + hash
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	existing := BinaryExposureLog(m.strings[key].value)
@@ -127,7 +126,7 @@ func (m *MockStore) SetPackageContextConfig(pkgID string, cfg PackageContextConf
 	data, _ := json.Marshal(cfg)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings[fmt.Sprintf("config:pkg:%s:context", pkgID)] = stringEntry{value: string(data)}
+	m.strings[keyPrefixConfigPkg+pkgID+":context"] = stringEntry{value: string(data)}
 }
 
 func (m *MockStore) SetIsMember(_ context.Context, key, member string) (bool, error) {

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -334,6 +334,22 @@ func (m *MockStore) MSet(_ context.Context, kvs map[string]string, ttl time.Dura
 	return nil
 }
 
+func (m *MockStore) Del(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.strings, key)
+	return nil
+}
+
+func (m *MockStore) MDel(_ context.Context, keys ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, key := range keys {
+		delete(m.strings, key)
+	}
+	return nil
+}
+
 // isExpired checks key-level expiry. Must be called with lock held.
 func (m *MockStore) isExpired(key string) bool {
 	exp, ok := m.expiry[key]

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"encoding/json"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 )
 
 // MockStore is an in-memory Store for testing. It supports sets, strings,
-// and sorted sets with TTL expiry. All operations are goroutine-safe.
+// sorted sets, and hashes with TTL expiry. All operations are goroutine-safe.
 type MockStore struct {
 	mu      sync.RWMutex
 	sets    map[string]map[string]struct{}
 	strings map[string]stringEntry
 	zsets   map[string][]zsetMember
-	expiry  map[string]time.Time // key -> expiry time
+	hsets   map[string]map[string]string // key → field → value
+	expiry  map[string]time.Time         // key -> expiry time
 
 	// Now returns the current time. Defaults to time.Now.
 	// Override in tests to control time.
@@ -38,6 +40,7 @@ func NewMockStore() *MockStore {
 		sets:    make(map[string]map[string]struct{}),
 		strings: make(map[string]stringEntry),
 		zsets:   make(map[string][]zsetMember),
+		hsets:   make(map[string]map[string]string),
 		expiry:  make(map[string]time.Time),
 		Now:     time.Now,
 	}
@@ -90,14 +93,29 @@ func (m *MockStore) SetMediaBuy(mb MediaBuy) {
 	m.strings[keyPrefixMediaBuy+mb.MediaBuyID] = stringEntry{value: string(data)}
 }
 
-// SetUserProfile stores a user's segment memberships. Test helper.
-func (m *MockStore) SetUserProfile(token string, segments map[string]float64) {
-	hash := HashToken(token)
-	profile := UserProfile{Segments: segments}
-	data, _ := json.Marshal(profile)
+// SetPackageUser adds a user to a package's audience. Test helper.
+func (m *MockStore) SetPackageUser(pkgID, token string, intent float64) {
+	pkgKey := keyPrefixPackageAudience + HashToken(pkgID)
+	userHash := HashToken(token)
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.strings[keyPrefixUserProfile+hash] = stringEntry{value: string(data)}
+	if m.hsets[pkgKey] == nil {
+		m.hsets[pkgKey] = make(map[string]string)
+	}
+	m.hsets[pkgKey][userHash] = strconv.FormatFloat(intent, 'f', -1, 64)
+}
+
+// SetPackageUsers adds multiple users to a package's audience. Test helper.
+func (m *MockStore) SetPackageUsers(pkgID string, users map[string]float64) {
+	pkgKey := keyPrefixPackageAudience + HashToken(pkgID)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hsets[pkgKey] == nil {
+		m.hsets[pkgKey] = make(map[string]string)
+	}
+	for token, intent := range users {
+		m.hsets[pkgKey][HashToken(token)] = strconv.FormatFloat(intent, 'f', -1, 64)
+	}
 }
 
 // SetUserExposures stores a user's exposure log in binary format. Test helper.
@@ -336,7 +354,7 @@ func (m *MockStore) MSet(_ context.Context, kvs map[string]string, ttl time.Dura
 func (m *MockStore) Del(_ context.Context, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	delete(m.strings, key)
+	m.deleteKey(key)
 	return nil
 }
 
@@ -344,7 +362,85 @@ func (m *MockStore) MDel(_ context.Context, keys ...string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, key := range keys {
-		delete(m.strings, key)
+		m.deleteKey(key)
+	}
+	return nil
+}
+
+// deleteKey removes a key from all data structures. Must be called with lock held.
+func (m *MockStore) deleteKey(key string) {
+	delete(m.strings, key)
+	delete(m.sets, key)
+	delete(m.zsets, key)
+	delete(m.hsets, key)
+	delete(m.expiry, key)
+}
+
+func (m *MockStore) HSet(_ context.Context, key, field, value string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hsets[key] == nil {
+		m.hsets[key] = make(map[string]string)
+	}
+	m.hsets[key][field] = value
+	return nil
+}
+
+func (m *MockStore) HMSet(_ context.Context, key string, fields map[string]string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.hsets[key] == nil {
+		m.hsets[key] = make(map[string]string)
+	}
+	for f, v := range fields {
+		m.hsets[key][f] = v
+	}
+	return nil
+}
+
+func (m *MockStore) HGet(_ context.Context, key, field string) (string, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	h, ok := m.hsets[key]
+	if !ok {
+		return "", false, nil
+	}
+	v, ok := h[field]
+	return v, ok, nil
+}
+
+func (m *MockStore) HMGet(_ context.Context, key string, fields ...string) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	h := m.hsets[key]
+	results := make([]string, len(fields))
+	for i, f := range fields {
+		results[i] = h[f]
+	}
+	return results, nil
+}
+
+func (m *MockStore) HMGetBatch(_ context.Context, keys []string, fields []string) ([][]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	results := make([][]string, len(keys))
+	for i, key := range keys {
+		h := m.hsets[key]
+		vals := make([]string, len(fields))
+		for j, f := range fields {
+			vals[j] = h[f]
+		}
+		results[i] = vals
+	}
+	return results, nil
+}
+
+func (m *MockStore) HDel(_ context.Context, key string, fields ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h := m.hsets[key]
+	for _, f := range fields {
+		delete(h, f)
 	}
 	return nil
 }

--- a/targeting/resolved.go
+++ b/targeting/resolved.go
@@ -13,13 +13,10 @@ type ResolvedPackages struct {
 	Packages []tmproto.AvailablePackage
 
 	// Context indexes (zero Store calls at eval time).
-	PropertyIndex     map[string][]string             // propertyRID → packageIDs
+	PropertyIndex     map[string][]string            // propertyRID → packageIDs
 	TopicIndex        map[string][]string            // topic → packageIDs
 	URLBlocklistIndex map[string][]string            // urlHash → packageIDs that block it
 	URLAllowlists     map[string]map[string]struct{} // pkgID → set of allowed urlHashes
-
-	// Identity indexes.
-	SegmentIndex map[string][]string // segment → packageIDs
 
 	// Pre-loaded configs.
 	ContextConfigs  map[string]*PackageContextConfig  // pkgID → config
@@ -66,15 +63,4 @@ func (r *ResolvedPackages) IsURLAllowed(pkgID, urlHash string) bool {
 	}
 	_, allowed := allowlist[urlHash]
 	return allowed
-}
-
-// SegmentCandidates returns package IDs that target any of the given segments.
-func (r *ResolvedPackages) SegmentCandidates(segments []string) map[string]struct{} {
-	result := make(map[string]struct{})
-	for _, seg := range segments {
-		for _, pkgID := range r.SegmentIndex[seg] {
-			result[pkgID] = struct{}{}
-		}
-	}
-	return result
 }

--- a/targeting/resolver.go
+++ b/targeting/resolver.go
@@ -146,7 +146,6 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 	topicIdx := make(map[string][]string)
 	urlBlockIdx := make(map[string][]string)
 	urlAllowlists := make(map[string]map[string]struct{})
-	segmentIdx := make(map[string][]string)
 
 	for _, pkgID := range pkgIDs {
 		// Property index from context config.
@@ -182,12 +181,6 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 			}
 		}
 
-		// Segment index from identity config.
-		if ic := idConfigs[pkgID]; ic != nil {
-			for _, seg := range ic.TargetSegments {
-				segmentIdx[seg] = append(segmentIdx[seg], pkgID)
-			}
-		}
 	}
 
 	return &ResolvedPackages{
@@ -196,7 +189,6 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 		TopicIndex:        topicIdx,
 		URLBlocklistIndex: urlBlockIdx,
 		URLAllowlists:     urlAllowlists,
-		SegmentIndex:      segmentIdx,
 		ContextConfigs:    ctxConfigs,
 		IdentityConfigs:   idConfigs,
 		CampaignConfigs:   campConfigs,

--- a/targeting/resolver.go
+++ b/targeting/resolver.go
@@ -38,7 +38,7 @@ type MediaBuyPackage struct {
 // Total: 2 Store round-trips (1 SetMembers + 1 MGet) regardless of media buy count.
 func ResolvePackages(ctx context.Context, store Store, sellerID, propertyID, country string, now time.Time) ([]tmproto.AvailablePackage, error) {
 	// 1. Get all media buy IDs for this seller.
-	mbIDs, err := store.SetMembers(ctx, "mediabuy:seller:"+sellerID)
+	mbIDs, err := store.SetMembers(ctx, keyPrefixMediaBuySeller+sellerID)
 	if err != nil {
 		return nil, fmt.Errorf("resolve media buys for seller %s: %w", sellerID, err)
 	}
@@ -49,7 +49,7 @@ func ResolvePackages(ctx context.Context, store Store, sellerID, propertyID, cou
 	// 2. Batch-load all media buy JSON.
 	keys := make([]string, len(mbIDs))
 	for i, id := range mbIDs {
-		keys[i] = "mediabuy:" + id
+		keys[i] = keyPrefixMediaBuy + id
 	}
 	values, err := store.MGet(ctx, keys...)
 	if err != nil {
@@ -157,14 +157,14 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 		}
 
 		// Topic index: load topic set from Store.
-		topics, _ := store.SetMembers(ctx, "topics:package:"+pkgID)
+		topics, _ := store.SetMembers(ctx, keyPrefixTopicsPackage+pkgID)
 		for _, topic := range topics {
 			topicIdx[topic] = append(topicIdx[topic], pkgID)
 		}
 
 		// URL blocklist index: load blocklist from Store.
 		if cc := ctxConfigs[pkgID]; cc != nil && cc.URLBlocklist {
-			blocked, _ := store.SetMembers(ctx, "url:blocklist:"+pkgID)
+			blocked, _ := store.SetMembers(ctx, keyPrefixURLBlocklist+pkgID)
 			for _, hash := range blocked {
 				urlBlockIdx[hash] = append(urlBlockIdx[hash], pkgID)
 			}
@@ -172,7 +172,7 @@ func Resolve(ctx context.Context, store Store, sellerID, propertyID, country str
 
 		// URL allowlist: load allowlist from Store.
 		if cc := ctxConfigs[pkgID]; cc != nil && cc.URLAllowlist {
-			allowed, _ := store.SetMembers(ctx, "url:allowlist:"+pkgID)
+			allowed, _ := store.SetMembers(ctx, keyPrefixURLAllowlist+pkgID)
 			if len(allowed) > 0 {
 				set := make(map[string]struct{}, len(allowed))
 				for _, hash := range allowed {

--- a/targeting/resolver_test.go
+++ b/targeting/resolver_test.go
@@ -180,11 +180,11 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	// Identity configs.
 	store.SetPackageIdentityConfig("pkg-food", PackageIdentityConfig{
 		CampaignID:     "campaign-1",
-		TargetSegments: []string{"cooking_fans"},
+		Audience:       true,
 		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
 	})
 	store.SetPackageIdentityConfig("pkg-tech", PackageIdentityConfig{
-		TargetSegments: []string{"tech_enthusiasts", "cooking_fans"},
+		Audience: true,
 	})
 	store.SetCampaignFreqConfig("campaign-1", CampaignFreqConfig{
 		FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 604800}},
@@ -213,10 +213,6 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	require.Len(t, resolved.URLBlocklistIndex[badHash], 1)
 	assert.Equal(t, "pkg-food", resolved.URLBlocklistIndex[badHash][0])
 
-	// SegmentIndex.
-	assert.Len(t, resolved.SegmentIndex["cooking_fans"], 2)
-	assert.Len(t, resolved.SegmentIndex["tech_enthusiasts"], 1)
-
 	// Configs loaded.
 	assert.NotNil(t, resolved.ContextConfigs["pkg-food"], "expected context config for pkg-food")
 	assert.NotNil(t, resolved.IdentityConfigs["pkg-food"], "expected identity config for pkg-food")
@@ -229,8 +225,6 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	candidates := resolved.TopicCandidates([]string{"food.cooking", "tech.gadgets"})
 	assert.Len(t, candidates, 2)
 
-	segCandidates := resolved.SegmentCandidates([]string{"cooking_fans"})
-	assert.Len(t, segCandidates, 2)
 }
 
 func TestResolver_MultipleMediaBuys_MixedResults(t *testing.T) {

--- a/targeting/scale_test.go
+++ b/targeting/scale_test.go
@@ -30,7 +30,7 @@ func TestScale_PropertyBitmap(t *testing.T) {
 		})
 
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:   "bench",
 			PropertyRID: fmt.Sprintf("%d", n/2),
 			PackageIDs:  []string{"pkg-1"},
 		}
@@ -188,7 +188,7 @@ func TestScale_TopicSetSize(t *testing.T) {
 		})
 
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:test"}},
 			PackageIDs:   []string{"pkg-1"},
@@ -227,7 +227,7 @@ func TestScale_URLBlocklistSize(t *testing.T) {
 
 		// Check a URL that is NOT blocked (worst case: full lookup, no short-circuit).
 		req := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:safe-content"}},
 			PackageIDs:   []string{"pkg-1"},
@@ -288,7 +288,7 @@ func TestScale_DynamicVsStatic(t *testing.T) {
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:food"}},
 			PackageIDs:   pkgIDs,
@@ -380,9 +380,10 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 				PropertyRIDs: []string{"1"},
 			})
 			store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
-				TargetSegments: []string{"cooking_fans"},
+				Audience:       true,
 				FrequencyRules: []FrequencyRuleJSON{{MaxCount: 10, WindowSeconds: 86400}},
 			})
+			store.SetPackageUser(pkgID, "tok-bench", 1.0)
 		}
 		store.SetMediaBuy(MediaBuy{
 			MediaBuyID: "mb-1", SellerID: "seller-1",
@@ -391,7 +392,6 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 			Packages: mbPkgs,
 		})
 		store.SetAdd("topics:artifact:article:food", "food.cooking")
-		store.SetUserProfile("tok-bench", map[string]float64{"cooking_fans": 1.0})
 
 		// Build resolved once.
 		resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)
@@ -407,7 +407,7 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:food"}},
 			PackageIDs:   pkgIDs,
@@ -471,7 +471,7 @@ func TestScale_PackagesPerRequest(t *testing.T) {
 		resolved := &ResolvedPackages{IdentityConfigs: idConfigs}
 
 		ctxReq := &tmproto.ContextMatchRequest{
-			RequestID:     "bench",
+			RequestID:    "bench",
 			PropertyRID:  "1",
 			ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:food"}},
 			PackageIDs:   pkgIDs,

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+// Store key prefixes.
+const (
+	keyPrefixUserProfile    = "user:profile:"
+	keyPrefixUserExposures  = "user:exposures:"
+	keyPrefixTopicsArtifact = "topics:artifact:"
+	keyPrefixTopicsPackage  = "topics:package:"
+	keyPrefixURLBlocklist   = "url:blocklist:"
+	keyPrefixURLAllowlist   = "url:allowlist:"
+	keyPrefixMediaBuySeller = "mediabuy:seller:"
+	keyPrefixMediaBuy       = "mediabuy:"
+	keyPrefixConfigPkg      = "config:pkg:"
+	keyPrefixConfigCampaign = "config:campaign:"
+)
+
 // Store is a storage backend for the targeting engine.
 // Implementations wrap Valkey/Redis or an in-memory mock.
 type Store interface {

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -7,16 +7,16 @@ import (
 
 // Store key prefixes.
 const (
-	keyPrefixUserProfile    = "user:profile:"
-	keyPrefixUserExposures  = "user:exposures:"
-	keyPrefixTopicsArtifact = "topics:artifact:"
-	keyPrefixTopicsPackage  = "topics:package:"
-	keyPrefixURLBlocklist   = "url:blocklist:"
-	keyPrefixURLAllowlist   = "url:allowlist:"
-	keyPrefixMediaBuySeller = "mediabuy:seller:"
-	keyPrefixMediaBuy       = "mediabuy:"
-	keyPrefixConfigPkg      = "config:pkg:"
-	keyPrefixConfigCampaign = "config:campaign:"
+	keyPrefixPackageAudience = "audience:"
+	keyPrefixUserExposures   = "user:exposures:"
+	keyPrefixTopicsArtifact  = "topics:artifact:"
+	keyPrefixTopicsPackage   = "topics:package:"
+	keyPrefixURLBlocklist    = "url:blocklist:"
+	keyPrefixURLAllowlist    = "url:allowlist:"
+	keyPrefixMediaBuySeller  = "mediabuy:seller:"
+	keyPrefixMediaBuy        = "mediabuy:"
+	keyPrefixConfigPkg       = "config:pkg:"
+	keyPrefixConfigCampaign  = "config:campaign:"
 )
 
 // Store is a storage backend for the targeting engine.
@@ -63,4 +63,24 @@ type Store interface {
 
 	// MDel removes multiple keys. It is a no-op for keys that do not exist.
 	MDel(ctx context.Context, keys ...string) error
+
+	// HSet sets a single field in a hash.
+	HSet(ctx context.Context, key, field, value string) error
+
+	// HMSet sets multiple fields in a hash.
+	HMSet(ctx context.Context, key string, fields map[string]string) error
+
+	// HGet returns the value of a hash field. The bool is false if the field does not exist.
+	HGet(ctx context.Context, key, field string) (string, bool, error)
+
+	// HMGet returns the values of multiple hash fields. Missing fields return "" at their index.
+	HMGet(ctx context.Context, key string, fields ...string) ([]string, error)
+
+	// HMGetBatch returns the values of the given fields for each key.
+	// The result has one entry per key; each entry has one value per field ("" if missing).
+	// In Valkey this is a single pipelined round-trip.
+	HMGetBatch(ctx context.Context, keys []string, fields []string) ([][]string, error)
+
+	// HDel removes fields from a hash. It is a no-op for fields that do not exist.
+	HDel(ctx context.Context, key string, fields ...string) error
 }

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -77,7 +77,7 @@ type Store interface {
 	HMGet(ctx context.Context, key string, fields ...string) ([]string, error)
 
 	// HMGetBatch returns the values of the given fields for each key.
-	// The result has one entry per key; each entry has one value per field ("" if missing).
+	// The result slice is always len(keys) long; each entry is len(fields) long ("" for missing fields).
 	// In Valkey this is a single pipelined round-trip.
 	HMGetBatch(ctx context.Context, keys []string, fields []string) ([][]string, error)
 

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -43,4 +43,10 @@ type Store interface {
 
 	// MSet stores multiple key-value pairs with an optional TTL. Zero TTL means no expiry.
 	MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error
+
+	// Del removes a key. It is a no-op if the key does not exist.
+	Del(ctx context.Context, key string) error
+
+	// MDel removes multiple keys. It is a no-op for keys that do not exist.
+	MDel(ctx context.Context, keys ...string) error
 }

--- a/targeting/system_test.go
+++ b/targeting/system_test.go
@@ -21,7 +21,6 @@ func TestSystem_EndToEnd(t *testing.T) {
 		packagesPerBuy  = 10
 		totalPackages   = numMediaBuys * packagesPerBuy // 500
 		numSegments     = 20
-		membersPerSeg   = 10_000
 		topicsPerPkg    = 5
 		blocklistPerPkg = 100
 		numCampaigns    = 10
@@ -34,7 +33,7 @@ func TestSystem_EndToEnd(t *testing.T) {
 	store.Now = func() time.Time { return now }
 
 	t.Logf("")
-	t.Logf("=== System Test: %d packages, %d segments × %d members, %d campaigns ===", totalPackages, numSegments, membersPerSeg, numCampaigns)
+	t.Logf("=== System Test: %d packages, %d users, %d campaigns ===", totalPackages, numUsers, numCampaigns)
 	t.Logf("")
 
 	// Create media buys.
@@ -300,7 +299,7 @@ func TestSystem_EndToEnd(t *testing.T) {
 	t.Logf("  Resolved indexes: ~%.1f MB (cached, shared across requests)", resolvedMemMB)
 	t.Logf("  Static engine:    ~%.1f MB (%.0f bytes/package)", float64(len(allPkgIDs))*184/1024/1024, float64(184))
 	t.Logf("  Store data:       out-of-process (Valkey)")
-	t.Logf("    - %d audience segments × %d members each", numSegments, membersPerSeg)
+	t.Logf("    - %d audience packages × %d users (segment-overlap membership)", numUsers, numSegments)
 	t.Logf("    - %d URL blocklist entries total", totalPackages*blocklistPerPkg)
 	t.Logf("    - %d topic set entries total", totalPackages*topicsPerPkg)
 	t.Logf("")

--- a/targeting/system_test.go
+++ b/targeting/system_test.go
@@ -17,16 +17,16 @@ func TestSystem_EndToEnd(t *testing.T) {
 	// --- Setup: realistic seller with many media buys ---
 
 	const (
-		numMediaBuys     = 50
-		packagesPerBuy   = 10
-		totalPackages    = numMediaBuys * packagesPerBuy // 500
-		numSegments      = 20
-		membersPerSeg    = 10_000
-		topicsPerPkg     = 5
-		blocklistPerPkg  = 100
-		numCampaigns     = 10
-		numUsers         = 100
-		pagesPerUser     = 5
+		numMediaBuys    = 50
+		packagesPerBuy  = 10
+		totalPackages   = numMediaBuys * packagesPerBuy // 500
+		numSegments     = 20
+		membersPerSeg   = 10_000
+		topicsPerPkg    = 5
+		blocklistPerPkg = 100
+		numCampaigns    = 10
+		numUsers        = 100
+		pagesPerUser    = 5
 	)
 
 	store := NewMockStore()
@@ -87,11 +87,10 @@ func TestSystem_EndToEnd(t *testing.T) {
 		}
 
 		// Identity config.
-		targetSegs := []string{segments[i%numSegments], segments[(i+1)%numSegments]}
 		store.SetPackageIdentityConfig(pkgID, PackageIdentityConfig{
 			CampaignID:     campID,
 			FrequencyRules: []FrequencyRuleJSON{{MaxCount: 5, WindowSeconds: 86400}},
-			TargetSegments: targetSegs,
+			Audience:       true,
 		})
 	}
 
@@ -102,14 +101,19 @@ func TestSystem_EndToEnd(t *testing.T) {
 		})
 	}
 
-	// User profiles: each user is in 2 segments.
+	// Audience membership: each user matches packages that share any of their two segments.
 	userTokens := make([]string, numUsers)
 	for u := range numUsers {
 		userTokens[u] = fmt.Sprintf("tok-user-%d", u)
-		store.SetUserProfile(userTokens[u], map[string]float64{
-			segments[u%numSegments]:     1.0,
-			segments[(u+3)%numSegments]: 1.0,
-		})
+		uSeg1 := u % numSegments
+		uSeg2 := (u + 3) % numSegments
+		for i, pkgID := range allPkgIDs {
+			pkgSeg1 := i % numSegments
+			pkgSeg2 := (i + 1) % numSegments
+			if uSeg1 == pkgSeg1 || uSeg1 == pkgSeg2 || uSeg2 == pkgSeg1 || uSeg2 == pkgSeg2 {
+				store.SetPackageUser(pkgID, userTokens[u], 1.0)
+			}
+		}
 	}
 
 	// Add artifact topics.
@@ -137,7 +141,15 @@ func TestSystem_EndToEnd(t *testing.T) {
 	t.Logf("  PropertyIndex entries: %d", len(resolved.PropertyIndex))
 	t.Logf("  TopicIndex entries: %d", len(resolved.TopicIndex))
 	t.Logf("  URLBlocklistIndex entries: %d", len(resolved.URLBlocklistIndex))
-	t.Logf("  SegmentIndex entries: %d", len(resolved.SegmentIndex))
+	t.Logf("  IdentityConfigs with audience: %d", func() int {
+		n := 0
+		for _, c := range resolved.IdentityConfigs {
+			if c != nil && c.Audience {
+				n++
+			}
+		}
+		return n
+	}())
 	t.Logf("  ContextConfigs: %d", len(resolved.ContextConfigs))
 	t.Logf("  IdentityConfigs: %d", len(resolved.IdentityConfigs))
 	t.Logf("  CampaignConfigs: %d", len(resolved.CampaignConfigs))
@@ -182,13 +194,13 @@ func TestSystem_EndToEnd(t *testing.T) {
 	}
 
 	type result struct {
-		name            string
-		totalTime       time.Duration
-		contextTime     time.Duration
-		identityTime    time.Duration
-		contextOffers   int
+		name             string
+		totalTime        time.Duration
+		contextTime      time.Duration
+		identityTime     time.Duration
+		contextOffers    int
 		identityEligible int
-		requests        int
+		requests         int
 	}
 
 	runBench := func(name string, evalCtx func(context.Context, *tmproto.ContextMatchRequest) (*ContextResult, error), evalId func(context.Context, *tmproto.IdentityMatchRequest) (*IdentityResult, error)) result {

--- a/targeting/valkeystore/integration_test.go
+++ b/targeting/valkeystore/integration_test.go
@@ -58,7 +58,7 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 	})
 
 	// Seed user into pkg-alpha's audience.
-	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-alpha", map[string]float64{"user-valkey": 1.0}))
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-alpha", map[string]targeting.Intent{"user-valkey": 1.0}))
 
 	resolved := &targeting.ResolvedPackages{
 		IdentityConfigs: map[string]*targeting.PackageIdentityConfig{

--- a/targeting/valkeystore/integration_test.go
+++ b/targeting/valkeystore/integration_test.go
@@ -35,7 +35,7 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 	pkgAlpha := targeting.PackageIdentityConfig{
 		CampaignID:     "campaign-x",
 		FrequencyRules: []targeting.FrequencyRuleJSON{{MaxCount: 3, WindowSeconds: 86400}},
-		TargetSegments: []string{"sports"},
+		Audience:       true,
 	}
 	pkgBeta := targeting.PackageIdentityConfig{
 		CampaignID:     "campaign-x",
@@ -48,12 +48,6 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 	seedJSON("config:pkg:pkg-beta", pkgBeta)
 	seedJSON("config:campaign:campaign-x", campaignX)
 
-	// Seed user profile with sports segment.
-	tokenHash := targeting.HashToken("user-valkey")
-	profileJSON, err := json.Marshal(targeting.UserProfile{Segments: map[string]float64{"sports": 1.0}})
-	require.NoError(t, err)
-	require.NoError(t, store.Set(ctx, "user:profile:"+tokenHash, string(profileJSON), 0))
-
 	engine := targeting.NewEngine(targeting.EngineConfig{
 		ProviderID: "test-valkey",
 		Store:      store,
@@ -63,8 +57,10 @@ func setupIntegration(t *testing.T) (*targeting.Engine, *Store, *miniredis.Minir
 		},
 	})
 
+	// Seed user into pkg-alpha's audience.
+	require.NoError(t, engine.AddPackageUsers(ctx, "pkg-alpha", map[string]float64{"user-valkey": 1.0}))
+
 	resolved := &targeting.ResolvedPackages{
-		SegmentIndex: map[string][]string{"sports": {"pkg-alpha"}},
 		IdentityConfigs: map[string]*targeting.PackageIdentityConfig{
 			"pkg-alpha": &pkgAlpha,
 			"pkg-beta":  &pkgBeta,

--- a/targeting/valkeystore/store.go
+++ b/targeting/valkeystore/store.go
@@ -112,6 +112,79 @@ func (s *Store) MDel(ctx context.Context, keys ...string) error {
 	return s.rdb.Del(ctx, keys...).Err()
 }
 
+func (s *Store) HSet(ctx context.Context, key, field, value string) error {
+	return s.rdb.HSet(ctx, key, field, value).Err()
+}
+
+func (s *Store) HMSet(ctx context.Context, key string, fields map[string]string) error {
+	if len(fields) == 0 {
+		return nil
+	}
+	args := make([]any, 0, len(fields)*2)
+	for f, v := range fields {
+		args = append(args, f, v)
+	}
+	return s.rdb.HSet(ctx, key, args...).Err()
+}
+
+func (s *Store) HGet(ctx context.Context, key, field string) (string, bool, error) {
+	val, err := s.rdb.HGet(ctx, key, field).Result()
+	if err == redis.Nil {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return val, true, nil
+}
+
+func (s *Store) HMGet(ctx context.Context, key string, fields ...string) ([]string, error) {
+	vals, err := s.rdb.HMGet(ctx, key, fields...).Result()
+	if err != nil {
+		return nil, err
+	}
+	results := make([]string, len(vals))
+	for i, v := range vals {
+		if s, ok := v.(string); ok {
+			results[i] = s
+		}
+	}
+	return results, nil
+}
+
+func (s *Store) HMGetBatch(ctx context.Context, keys []string, fields []string) ([][]string, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	pipe := s.rdb.Pipeline()
+	cmds := make([]*redis.SliceCmd, len(keys))
+	for i, key := range keys {
+		cmds[i] = pipe.HMGet(ctx, key, fields...)
+	}
+	if _, err := pipe.Exec(ctx); err != nil && err != redis.Nil {
+		return nil, err
+	}
+	results := make([][]string, len(keys))
+	for i, cmd := range cmds {
+		vals, err := cmd.Result()
+		if err != nil && err != redis.Nil {
+			return nil, err
+		}
+		row := make([]string, len(vals))
+		for j, v := range vals {
+			if s, ok := v.(string); ok {
+				row[j] = s
+			}
+		}
+		results[i] = row
+	}
+	return results, nil
+}
+
+func (s *Store) HDel(ctx context.Context, key string, fields ...string) error {
+	return s.rdb.HDel(ctx, key, fields...).Err()
+}
+
 func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error {
 	if len(kvs) == 0 {
 		return nil

--- a/targeting/valkeystore/store.go
+++ b/targeting/valkeystore/store.go
@@ -167,7 +167,7 @@ func (s *Store) HMGetBatch(ctx context.Context, keys []string, fields []string) 
 	results := make([][]string, len(keys))
 	for i, cmd := range cmds {
 		vals, err := cmd.Result()
-		if err != nil && err != redis.Nil {
+		if err != nil {
 			return nil, err
 		}
 		row := make([]string, len(vals))

--- a/targeting/valkeystore/store.go
+++ b/targeting/valkeystore/store.go
@@ -101,6 +101,17 @@ func (s *Store) MGet(ctx context.Context, keys ...string) ([]string, error) {
 	return results, nil
 }
 
+func (s *Store) Del(ctx context.Context, key string) error {
+	return s.rdb.Del(ctx, key).Err()
+}
+
+func (s *Store) MDel(ctx context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	return s.rdb.Del(ctx, keys...).Err()
+}
+
 func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error {
 	if len(kvs) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

Replaces the `user → segments` audience model with a `hash(packageID) → {hash(userToken): intent}` HSET model, and optimises identity evaluation to a fixed number of Valkey round-trips regardless of package count.

### Privacy: package-scoped audience keys

Previously, audience membership was stored per-user (`user:profile:<hash>` → JSON blob of segments). Any caller who knew a user token hash could read that user's full segment membership across all sellers.

Audience data is now stored per-package: `audience:<hash(packageID)>` → HSET where each field is `hash(userToken)` and each value is the intent score. A caller can only derive the key if they know the package ID, so sellers are isolated from each other's audience data. User tokens are still hashed before use.

### Write API

`PackageIdentityConfig.TargetSegments []string` is replaced by `Audience bool`.

New Engine write methods (all hash-based, all tokens hashed internally):

| Method | Description |
|---|---|
| `SetPackageUser(ctx, packageID, userToken, intent)` | Single user → single package |
| `AddPackageUsers(ctx, packageID, users map[string]float64)` | Batch users → single package |
| `RemovePackageUsers(ctx, packageID, userTokens []string)` | Remove specific users from a package |
| `DeletePackageUsers(ctx, packageID)` | Delete an entire package audience |
| `MSetPackageUsers(ctx, packages map[string]map[string]float64)` | Batch users → multiple packages |
| `MDeletePackageUsers(ctx, packageIDs []string)` | Delete multiple package audiences (single `DEL` round-trip) |

### Read path: N HMGET → 1 pipelined round-trip

`EvaluateIdentityResolved` previously issued one `HMGET` per audience-gated package. The new `Store.HMGetBatch(keys, fields)` method collects all audience keys before the evaluation loop and fetches them in a single pipelined call. In Valkey this is one TCP round-trip regardless of how many packages are audience-gated.

### Bug fix

`MockStore.Del` and `MDel` previously only cleared `m.strings`. They now clear all data structures (`strings`, `sets`, `zsets`, `hsets`, `expiry`), so `DeletePackageUsers` and `MDeletePackageUsers` work correctly in tests.