### PR TITLE
feat(signing): default replay store + NewSignedHTTPClient preset

### DIFF
--- a/adcp/signing/README.md
+++ b/adcp/signing/README.md
@@ -34,9 +34,17 @@ _ = signer.SignRequest(req, signing.SignOptions{CoverContentDigest: true})
 
 // Option B: signing round-tripper — every outbound request is signed automatically.
 client := &http.Client{Transport: signer.RoundTripper(nil, true)}
+
+// Option C: bundled preset — Signer + RoundTripper + redirect-safe *http.Client in one call.
+client, _ := signing.NewSignedHTTPClient(signing.SignedHTTPClientOptions{
+    KeyID:              "my-agent-ed25519-2026",
+    PrivateKey:         priv,
+    CoverContentDigest: true,        // seller advertised covers_content_digest=required
+    Timeout:            30 * time.Second,
+})
 ```
 
-Important: signed requests MUST NOT follow HTTP redirects — `@target-uri` coverage would bind the signature to the original URL, not the redirected one. Set `http.Client.CheckRedirect` to `func(...) error { return http.ErrUseLastResponse }` when using a signing client.
+Important: signed requests MUST NOT follow HTTP redirects — `@target-uri` coverage would bind the signature to the original URL, not the redirected one. `NewSignedHTTPClient` disables redirect-following for you; if you build the client by hand (Options A/B above), set `http.Client.CheckRedirect` to `func(...) error { return http.ErrUseLastResponse }` yourself.
 
 The signer:
 
@@ -51,7 +59,9 @@ The signer:
 ```go
 mw := signing.Middleware(signing.MiddlewareOptions{
     Resolver:            jwksResolver,
-    Replay:              signing.NewMemoryReplayStore(0),
+    // Replay defaults to a fresh NewMemoryReplayStore(0) when nil — fine
+    // for single-instance verifiers. Wire an explicit shared store
+    // (Redis, etc.) for multi-replica deployments.
     Revocation:          signing.NewStaticRevocationList(nil), // pass nil only in dev
     OperationResolver:   signing.DefaultOperationResolver,     // /adcp/<op>
     RequiredFor:         []string{"create_media_buy"},

--- a/adcp/signing/client.go
+++ b/adcp/signing/client.go
@@ -1,0 +1,101 @@
+package signing
+
+import (
+	"errors"
+	"net/http"
+	"time"
+)
+
+// SignedHTTPClientOptions configures NewSignedHTTPClient.
+type SignedHTTPClientOptions struct {
+	// KeyID, PrivateKey, Profile, ValidityWindow, Clock, NonceReader are
+	// passed through to NewSigner.
+	KeyID          string
+	PrivateKey     any
+	Profile        Profile
+	ValidityWindow time.Duration
+	// Clock and NonceReader are typically set only in tests.
+	Clock       func() time.Time
+	NonceReader interface{ Read([]byte) (int, error) }
+
+	// CoverContentDigest controls whether the signature base covers
+	// content-digest. Set true when the seller's request_signing capability
+	// has covers_content_digest="required" (or "either" and you prefer the
+	// stricter body-bound option).
+	CoverContentDigest bool
+
+	// Inner is the transport the signing layer wraps. Defaults to
+	// http.DefaultTransport. Pass a custom transport (mTLS, retries,
+	// telemetry) to compose with signing.
+	Inner http.RoundTripper
+
+	// Timeout is set on the returned *http.Client. Zero means no timeout
+	// (the http stdlib default). Most production callers should set one —
+	// 30s is a reasonable default for AdCP RPC.
+	Timeout time.Duration
+}
+
+// NewSignedHTTPClient returns an *http.Client preconfigured to sign every
+// outbound request with the supplied key. The client has redirect-following
+// disabled — @target-uri is part of the signature base, so a 3xx redirect
+// would silently re-target the binding and break verification.
+//
+// Use this preset for adapters that talk to a single seller (or want every
+// outbound request signed regardless of target). For capability-gated
+// signing (sign only operations the seller listed in required_for /
+// warn_for / supported_for), wrap with a per-call decision or keep separate
+// clients for the signed and unsigned paths.
+//
+//	client, err := signing.NewSignedHTTPClient(signing.SignedHTTPClientOptions{
+//	    KeyID:              "my-agent-2026",
+//	    PrivateKey:         priv,
+//	    CoverContentDigest: true,                   // seller advertised covers_content_digest=required
+//	    Timeout:            30 * time.Second,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	resp, err := client.Post("https://seller.example.com/adcp/create_media_buy", "application/json", body)
+//
+// For lower-level integration (you already have an http.Client and just want
+// the signing transport), see (*Signer).RoundTripper.
+func NewSignedHTTPClient(opts SignedHTTPClientOptions) (*http.Client, error) {
+	if opts.KeyID == "" {
+		return nil, errors.New("signing.NewSignedHTTPClient: KeyID is required")
+	}
+	if opts.PrivateKey == nil {
+		return nil, errors.New("signing.NewSignedHTTPClient: PrivateKey is required")
+	}
+	signerOpts := SignerOptions{
+		KeyID:          opts.KeyID,
+		PrivateKey:     opts.PrivateKey,
+		Profile:        opts.Profile,
+		Clock:          opts.Clock,
+		ValidityWindow: opts.ValidityWindow,
+	}
+	if opts.NonceReader != nil {
+		signerOpts.NonceReader = opts.NonceReader
+	}
+	signer, err := NewSigner(signerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	inner := opts.Inner
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	transport := signer.RoundTripper(inner, opts.CoverContentDigest)
+
+	return &http.Client{
+		Transport: transport,
+		// @target-uri is signed, so a 3xx redirect re-targets the binding
+		// and the verifier rejects with request_signature_invalid. Refuse to
+		// follow — callers that need to handle redirects can read the 3xx
+		// response and re-issue the request explicitly.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Timeout: opts.Timeout,
+	}, nil
+}

--- a/adcp/signing/client.go
+++ b/adcp/signing/client.go
@@ -1,10 +1,20 @@
 package signing
 
 import (
+	"bytes"
 	"errors"
+	"io"
 	"net/http"
 	"time"
+
+	"github.com/adcontextprotocol/adcp-go/adcp"
 )
+
+// CapabilityProvider returns the seller's request_signing capability for the
+// outbound request. Returning nil signals "seller doesn't sign / unknown" and
+// the preset skips signing for that request — same fall-through semantics as
+// the Python `capability_provider` and the TS `getCapability`.
+type CapabilityProvider func(*http.Request) *adcp.RequestSigningCapabilities
 
 // SignedHTTPClientOptions configures NewSignedHTTPClient.
 type SignedHTTPClientOptions struct {
@@ -18,15 +28,39 @@ type SignedHTTPClientOptions struct {
 	Clock       func() time.Time
 	NonceReader interface{ Read([]byte) (int, error) }
 
-	// CoverContentDigest controls whether the signature base covers
-	// content-digest. Set true when the seller's request_signing capability
-	// has covers_content_digest="required" (or "either" and you prefer the
+	// CoverContentDigest is the always-sign default for content-digest
+	// coverage. Used when CapabilityProvider is nil OR the provider returns
+	// nil. Set true when targeting a seller that advertises
+	// covers_content_digest="required" (or "either" and you prefer the
 	// stricter body-bound option).
 	CoverContentDigest bool
 
+	// CapabilityProvider, when non-nil, is consulted per-request. Returning
+	// a RequestSigningCapabilities lets the preset:
+	//   - decide whether to sign (read required_for / warn_for /
+	//     supported_for; signs if the operation is in any of those lists,
+	//     skips otherwise);
+	//   - resolve covers_content_digest per-call ("required" → cover,
+	//     "forbidden" → don't, "either"/absent → fall back to
+	//     CoverContentDigest).
+	// Operation name comes from OperationResolver if set, else from the
+	// last segment of the request path (`/adcp/<op>` convention).
+	// When nil, every request is signed unconditionally with
+	// CoverContentDigest as the digest decision — matches the original
+	// preset behavior.
+	CapabilityProvider CapabilityProvider
+
+	// OperationResolver derives the AdCP operation name from the outbound
+	// request — typically the AdCP method being called. Defaults to
+	// PathSuffixOperationResolver, which reads the last path segment of
+	// `/adcp/<op>`. Only consulted when CapabilityProvider is also set.
+	OperationResolver func(*http.Request) string
+
 	// Inner is the transport the signing layer wraps. Defaults to
-	// http.DefaultTransport. Pass a custom transport (mTLS, retries,
-	// telemetry) to compose with signing.
+	// http.DefaultTransport. http.DefaultTransport honors HTTP_PROXY env
+	// vars and shares its connection pool process-wide; pass a custom
+	// transport when you need isolation (per-tenant proxies, custom mTLS,
+	// retry middleware, telemetry).
 	Inner http.RoundTripper
 
 	// Timeout is set on the returned *http.Client. Zero means no timeout
@@ -35,30 +69,42 @@ type SignedHTTPClientOptions struct {
 	Timeout time.Duration
 }
 
-// NewSignedHTTPClient returns an *http.Client preconfigured to sign every
-// outbound request with the supplied key. The client has redirect-following
-// disabled — @target-uri is part of the signature base, so a 3xx redirect
-// would silently re-target the binding and break verification.
+// PathSuffixOperationResolver derives the AdCP operation name from the last
+// segment of the request path (`/adcp/<op>` convention) — the same shape as
+// signing.DefaultOperationResolver on the verifier side.
+func PathSuffixOperationResolver(r *http.Request) string {
+	return DefaultOperationResolver(r)
+}
+
+// NewSignedHTTPClient returns an *http.Client preconfigured to sign outbound
+// requests. The client has redirect-following disabled — @target-uri is part
+// of the signature base, so a 3xx redirect would silently re-target the
+// binding and break verification.
 //
-// Use this preset for adapters that talk to a single seller (or want every
-// outbound request signed regardless of target). For capability-gated
-// signing (sign only operations the seller listed in required_for /
-// warn_for / supported_for), wrap with a per-call decision or keep separate
-// clients for the signed and unsigned paths.
+// Two modes:
 //
-//	client, err := signing.NewSignedHTTPClient(signing.SignedHTTPClientOptions{
-//	    KeyID:              "my-agent-2026",
-//	    PrivateKey:         priv,
-//	    CoverContentDigest: true,                   // seller advertised covers_content_digest=required
-//	    Timeout:            30 * time.Second,
-//	})
-//	if err != nil {
-//	    return err
-//	}
-//	resp, err := client.Post("https://seller.example.com/adcp/create_media_buy", "application/json", body)
+//   - Always-sign (CapabilityProvider == nil): every outbound request is
+//     signed with CoverContentDigest as the digest decision. Use this when
+//     the buyer talks to a single seller whose policy you already know.
+//
+//   - Capability-aware (CapabilityProvider != nil): per-request, the preset
+//     consults the seller's RequestSigningCapabilities and signs only when
+//     the operation appears in required_for / warn_for / supported_for.
+//     covers_content_digest is honored from the capability ("required" →
+//     cover, "forbidden" → don't, "either"/absent → fall back to
+//     CoverContentDigest). This matches the Python `capability_provider`
+//     and the TS `getCapability` shapes.
+//
+//     client, err := signing.NewSignedHTTPClient(signing.SignedHTTPClientOptions{
+//     KeyID:              "my-agent-2026",
+//     PrivateKey:         priv,
+//     CoverContentDigest: true,                   // fallback when capability is absent
+//     CapabilityProvider: func(*http.Request) *adcp.RequestSigningCapabilities { return cachedCaps },
+//     Timeout:            30 * time.Second,
+//     })
 //
 // For lower-level integration (you already have an http.Client and just want
-// the signing transport), see (*Signer).RoundTripper.
+// the always-sign signing transport), see (*Signer).RoundTripper.
 func NewSignedHTTPClient(opts SignedHTTPClientOptions) (*http.Client, error) {
 	if opts.KeyID == "" {
 		return nil, errors.New("signing.NewSignedHTTPClient: KeyID is required")
@@ -85,7 +131,23 @@ func NewSignedHTTPClient(opts SignedHTTPClientOptions) (*http.Client, error) {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	transport := signer.RoundTripper(inner, opts.CoverContentDigest)
+
+	var transport http.RoundTripper
+	if opts.CapabilityProvider == nil {
+		transport = signer.RoundTripper(inner, opts.CoverContentDigest)
+	} else {
+		opResolver := opts.OperationResolver
+		if opResolver == nil {
+			opResolver = PathSuffixOperationResolver
+		}
+		transport = &capabilityAwareSigningTransport{
+			signer:               signer,
+			inner:                inner,
+			capabilityProvider:   opts.CapabilityProvider,
+			operationResolver:    opResolver,
+			fallbackCoverContent: opts.CoverContentDigest,
+		}
+	}
 
 	return &http.Client{
 		Transport: transport,
@@ -98,4 +160,80 @@ func NewSignedHTTPClient(opts SignedHTTPClientOptions) (*http.Client, error) {
 		},
 		Timeout: opts.Timeout,
 	}, nil
+}
+
+// capabilityAwareSigningTransport reads the seller's request_signing
+// capability per request and signs only when the operation appears in
+// required_for / warn_for / supported_for. covers_content_digest is honored
+// from the capability ("required" → cover, "forbidden" → don't,
+// "either"/absent → fall back to fallbackCoverContent).
+type capabilityAwareSigningTransport struct {
+	signer               *Signer
+	inner                http.RoundTripper
+	capabilityProvider   CapabilityProvider
+	operationResolver    func(*http.Request) string
+	fallbackCoverContent bool
+}
+
+func (t *capabilityAwareSigningTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Buffer the body once — both the always-sign and skip paths need to
+	// preserve the inner request's body bytes for replay/idempotency.
+	cloned := r.Clone(r.Context())
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		cloned.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
+	capability := t.capabilityProvider(cloned)
+	op := t.operationResolver(cloned)
+	if !shouldSignByCapability(capability, op) {
+		return t.inner.RoundTrip(cloned)
+	}
+
+	cover := t.fallbackCoverContent
+	if capability != nil {
+		switch capability.CoversContentDigest {
+		case "required":
+			cover = true
+		case "forbidden":
+			cover = false
+		}
+	}
+
+	if err := t.signer.SignRequest(cloned, SignOptions{CoverContentDigest: cover}); err != nil {
+		return nil, err
+	}
+	return t.inner.RoundTrip(cloned)
+}
+
+// shouldSignByCapability classifies an outbound operation against the
+// seller's advertised policy. Mirrors the Python `operation_needs_signing`
+// helper but without the warn-vs-supported distinction (Go currently treats
+// any presence in any list as "sign"). Returns false when capability is nil,
+// supported=false, or the operation is in none of the three lists.
+func shouldSignByCapability(capability *adcp.RequestSigningCapabilities, operation string) bool {
+	if capability == nil || !capability.Supported || operation == "" {
+		return false
+	}
+	for _, op := range capability.RequiredFor {
+		if op == operation {
+			return true
+		}
+	}
+	for _, op := range capability.WarnFor {
+		if op == operation {
+			return true
+		}
+	}
+	for _, op := range capability.SupportedFor {
+		if op == operation {
+			return true
+		}
+	}
+	return false
 }

--- a/adcp/signing/client_test.go
+++ b/adcp/signing/client_test.go
@@ -1,0 +1,268 @@
+package signing
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Helper: builds a verifying server backed by the supplied JWK resolver and
+// returns it along with its base URL.
+func newVerifyingServer(t *testing.T, kid string, pub ed25519.PublicKey) *httptest.Server {
+	t.Helper()
+	jwk := &JWK{
+		Kid:     kid,
+		Kty:     "OKP",
+		Crv:     "Ed25519",
+		Alg:     "EdDSA",
+		Use:     "sig",
+		KeyOps:  []string{"verify"},
+		AdcpUse: "request-signing",
+		X:       b64UrlEncodeRaw(pub),
+	}
+	resolver := NewStaticJWKSResolver()
+	resolver.Put(kid, jwk, "https://buyer.example.com")
+
+	mw := Middleware(MiddlewareOptions{
+		Resolver:          resolver,
+		OperationResolver: func(r *http.Request) string { return "create_media_buy" },
+		RequiredFor:       []string{"create_media_buy"},
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		signer := VerifiedSignerFromContext(r.Context())
+		require.NotNil(t, signer, "expected verified signer on the success path")
+		w.WriteHeader(http.StatusOK)
+	}))
+	return httptest.NewServer(handler)
+}
+
+func TestNewSignedHTTPClientRoundTripsAgainstVerifier(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	srv := newVerifyingServer(t, "test-kid", pub)
+	defer srv.Close()
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "test-kid",
+		PrivateKey:         priv,
+		CoverContentDigest: true,
+		Inner:              srv.Client().Transport,
+		Timeout:            5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(
+		"POST",
+		srv.URL+"/adcp/create_media_buy",
+		strings.NewReader(`{"plan_id":"p1"}`),
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestNewSignedHTTPClientRejectsRedirects(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	// Server that always 301s to itself. The signing client must NOT follow
+	// — @target-uri is part of the signature base, so following the redirect
+	// silently re-targets the binding.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/elsewhere", http.StatusMovedPermanently)
+	}))
+	defer srv.Close()
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:      "test-kid",
+		PrivateKey: priv,
+		Inner:      srv.Client().Transport,
+	})
+	require.NoError(t, err)
+
+	resp, err := client.Post(srv.URL+"/adcp/create_media_buy", "application/json", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	// CheckRedirect returns http.ErrUseLastResponse → caller sees the 3xx
+	// directly rather than the redirect's body.
+	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
+}
+
+func TestNewSignedHTTPClientRequiresKeyMaterial(t *testing.T) {
+	_, err := NewSignedHTTPClient(SignedHTTPClientOptions{})
+	require.Error(t, err)
+
+	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{KeyID: "kid"})
+	require.Error(t, err)
+
+	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{PrivateKey: ed25519.PrivateKey([]byte("not-a-key"))})
+	require.Error(t, err)
+}
+
+func TestNewSignedHTTPClientRespectsCustomInnerTransport(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	// Inner that captures requests to confirm the wrapping order is
+	// caller-inner-then-signing rather than signing-then-default.
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:      "test-kid",
+		PrivateKey: priv,
+		Inner:      inner,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/x", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	assert.NotEmpty(t, got.Header.Get("Signature"))
+	assert.NotEmpty(t, got.Header.Get("Signature-Input"))
+}
+
+type roundTripperFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestMiddlewareDefaultsReplayStoreToInMemory(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	jwk := &JWK{
+		Kid:     "kid",
+		Kty:     "OKP",
+		Crv:     "Ed25519",
+		Alg:     "EdDSA",
+		Use:     "sig",
+		KeyOps:  []string{"verify"},
+		AdcpUse: "request-signing",
+		X:       b64UrlEncodeRaw(pub),
+	}
+	resolver := NewStaticJWKSResolver()
+	resolver.Put("kid", jwk, "https://buyer.example.com")
+
+	// No Replay supplied → middleware must default to in-memory.
+	mw := Middleware(MiddlewareOptions{
+		Resolver:          resolver,
+		OperationResolver: func(r *http.Request) string { return "create_media_buy" },
+		RequiredFor:       []string{"create_media_buy"},
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	signer, err := NewSigner(SignerOptions{KeyID: "kid", PrivateKey: priv})
+	require.NoError(t, err)
+
+	signAndSend := func() *http.Response {
+		body := strings.NewReader(`{"plan_id":"p1"}`)
+		req, err := http.NewRequest("POST", srv.URL+"/adcp/create_media_buy", body)
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		require.NoError(t, signer.SignRequest(req, SignOptions{CoverContentDigest: true}))
+		resp, err := srv.Client().Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	// First signed request: 200.
+	resp := signAndSend()
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Each new request gets a fresh nonce, so two distinct signed requests
+	// both succeed — proves the default store accepts new (kid, nonce) pairs.
+	resp = signAndSend()
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestMiddlewareDefaultReplayStoreRejectsActualReplay(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	jwk := &JWK{
+		Kid:     "kid",
+		Kty:     "OKP",
+		Crv:     "Ed25519",
+		Alg:     "EdDSA",
+		Use:     "sig",
+		KeyOps:  []string{"verify"},
+		AdcpUse: "request-signing",
+		X:       b64UrlEncodeRaw(pub),
+	}
+	resolver := NewStaticJWKSResolver()
+	resolver.Put("kid", jwk, "https://buyer.example.com")
+
+	mw := Middleware(MiddlewareOptions{
+		Resolver:          resolver,
+		OperationResolver: func(r *http.Request) string { return "create_media_buy" },
+		RequiredFor:       []string{"create_media_buy"},
+	})
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	signer, err := NewSigner(SignerOptions{KeyID: "kid", PrivateKey: priv})
+	require.NoError(t, err)
+
+	// Sign once, then replay the exact wire form: same headers (which carry
+	// Signature / Signature-Input / Content-Digest) and same body.
+	bodyBytes := []byte(`{"plan_id":"p1"}`)
+	tmpl, err := http.NewRequest("POST", srv.URL+"/adcp/create_media_buy", bytes.NewReader(bodyBytes))
+	require.NoError(t, err)
+	tmpl.Header.Set("Content-Type", "application/json")
+	require.NoError(t, signer.SignRequest(tmpl, SignOptions{CoverContentDigest: true}))
+
+	signedHeaders := tmpl.Header.Clone()
+	build := func() *http.Request {
+		r, err := http.NewRequest("POST", srv.URL+"/adcp/create_media_buy", bytes.NewReader(bodyBytes))
+		require.NoError(t, err)
+		for k, vs := range signedHeaders {
+			for _, v := range vs {
+				r.Header.Add(k, v)
+			}
+		}
+		return r
+	}
+
+	// First → 200.
+	resp1, err := srv.Client().Do(build())
+	require.NoError(t, err)
+	resp1.Body.Close()
+	assert.Equal(t, http.StatusOK, resp1.StatusCode)
+
+	// Same (kid, nonce, body) → the default in-memory store must reject.
+	resp2, err := srv.Client().Do(build())
+	require.NoError(t, err)
+	resp2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
+	assert.Contains(t, resp2.Header.Get("WWW-Authenticate"), `error="request_signature_replayed"`)
+}

--- a/adcp/signing/client_test.go
+++ b/adcp/signing/client_test.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/adcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -102,13 +104,28 @@ func TestNewSignedHTTPClientRejectsRedirects(t *testing.T) {
 
 func TestNewSignedHTTPClientRequiresKeyMaterial(t *testing.T) {
 	_, err := NewSignedHTTPClient(SignedHTTPClientOptions{})
-	require.Error(t, err)
+	require.Error(t, err, "empty options must error")
+	assert.Contains(t, err.Error(), "KeyID is required")
 
 	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{KeyID: "kid"})
-	require.Error(t, err)
+	require.Error(t, err, "missing PrivateKey must error")
+	assert.Contains(t, err.Error(), "PrivateKey is required")
 
-	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{PrivateKey: ed25519.PrivateKey([]byte("not-a-key"))})
+	// PrivateKey present but no KeyID → KeyID-required path (early-return).
+	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{PrivateKey: ed25519.PrivateKey(make([]byte, ed25519.PrivateKeySize))})
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "KeyID is required")
+
+	// Both fields present but key material an unsupported type → NewSigner
+	// rejects. Original test asserted on a byte-slice cast to
+	// ed25519.PrivateKey; that doesn't fail at construction (NewSigner
+	// only switches on the static type, not byte length). Use a type
+	// the signer can't recognize at all to exercise the validation path.
+	_, err = NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:      "kid",
+		PrivateKey: []byte("not-an-ed25519-key"),
+	})
+	require.Error(t, err, "unsupported key type must error from NewSigner")
 }
 
 func TestNewSignedHTTPClientRespectsCustomInnerTransport(t *testing.T) {
@@ -145,6 +162,233 @@ type roundTripperFunc func(r *http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+// Capability-aware signing tests — exercise the per-request CapabilityProvider
+// path that mirrors Python's capability_provider and TS's getCapability.
+
+func TestCapabilityProviderSignsRequiredFor(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		return &adcp.RequestSigningCapabilities{
+			Supported:           true,
+			RequiredFor:         []string{"create_media_buy"},
+			CoversContentDigest: "either",
+		}
+	}
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/create_media_buy", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	assert.NotEmpty(t, got.Header.Get("Signature"), "required_for op must be signed")
+}
+
+func TestCapabilityProviderSkipsUnlistedOperation(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		return &adcp.RequestSigningCapabilities{
+			Supported:   true,
+			RequiredFor: []string{"create_media_buy"},
+		}
+	}
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/get_products", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	assert.Empty(t, got.Header.Get("Signature"), "op not in any list must NOT be signed")
+}
+
+func TestCapabilityProviderReturningNilSkipsSigning(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	var providerCalls atomic.Int32
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		providerCalls.Add(1)
+		return nil
+	}
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/create_media_buy", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, int32(1), providerCalls.Load())
+	got := <-captured
+	assert.Empty(t, got.Header.Get("Signature"), "nil capability ⇒ skip signing")
+}
+
+func TestCapabilityProviderHonorsCoversContentDigestRequired(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		return &adcp.RequestSigningCapabilities{
+			Supported:           true,
+			RequiredFor:         []string{"create_media_buy"},
+			CoversContentDigest: "required",
+		}
+	}
+
+	// Fallback CoverContentDigest=false; capability="required" overrides.
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CoverContentDigest: false,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/create_media_buy", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	sigInput := got.Header.Get("Signature-Input")
+	require.NotEmpty(t, sigInput)
+	// The covered components are listed in parens before the params block.
+	assert.Contains(t, sigInput, "content-digest", "covers='required' ⇒ digest must be covered")
+}
+
+func TestCapabilityProviderHonorsCoversContentDigestForbidden(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		return &adcp.RequestSigningCapabilities{
+			Supported:           true,
+			RequiredFor:         []string{"create_media_buy"},
+			CoversContentDigest: "forbidden",
+		}
+	}
+
+	// Fallback CoverContentDigest=true; capability="forbidden" overrides.
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CoverContentDigest: true,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/create_media_buy", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	sigInput := got.Header.Get("Signature-Input")
+	require.NotEmpty(t, sigInput)
+	assert.NotContains(t, sigInput, "content-digest", "covers='forbidden' ⇒ digest must NOT be covered")
+}
+
+func TestCapabilityProviderSkipsWhenSupportedFalse(t *testing.T) {
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	captured := make(chan *http.Request, 1)
+	inner := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		captured <- r
+		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+	})
+
+	// Even with required_for populated, supported=false means treat as
+	// unsupported (matches verifier-side and Python operation_needs_signing).
+	provider := func(*http.Request) *adcp.RequestSigningCapabilities {
+		return &adcp.RequestSigningCapabilities{
+			Supported:   false,
+			RequiredFor: []string{"create_media_buy"},
+		}
+	}
+
+	client, err := NewSignedHTTPClient(SignedHTTPClientOptions{
+		KeyID:              "kid",
+		PrivateKey:         priv,
+		Inner:              inner,
+		CapabilityProvider: provider,
+	})
+	require.NoError(t, err)
+
+	req, err := http.NewRequest("POST", "https://example.com/adcp/create_media_buy", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	got := <-captured
+	assert.Empty(t, got.Header.Get("Signature"), "supported=false ⇒ skip signing")
 }
 
 func TestMiddlewareDefaultsReplayStoreToInMemory(t *testing.T) {

--- a/adcp/signing/middleware.go
+++ b/adcp/signing/middleware.go
@@ -58,10 +58,13 @@ type MiddlewareOptions struct {
 	// agent mappings.
 	Resolver JWKSResolver
 
-	// Replay deduplicates (keyid, nonce) pairs. NewMemoryReplayStore(0) is
-	// appropriate for single-instance verifiers; distributed deployments
-	// SHOULD supply a shared backing store (Redis, etc.) implementing
-	// ReplayStore with atomic cap+insert semantics at step 13.
+	// Replay deduplicates (keyid, nonce) pairs. Defaults to a fresh
+	// NewMemoryReplayStore(0) when nil — appropriate for single-instance
+	// verifiers; distributed deployments SHOULD supply a shared backing
+	// store (Redis, etc.) implementing ReplayStore with atomic cap+insert
+	// semantics at step 13. Defaulting to nil silently disabled the replay
+	// check, the exact security regression AdCP verifier checklist step 13
+	// exists to prevent.
 	Replay ReplayStore
 
 	// Revocation reports per-keyid revocation state and whether the verifier's
@@ -136,6 +139,15 @@ func Middleware(opts MiddlewareOptions) func(http.Handler) http.Handler {
 	if profile.Tag == "" {
 		profile = ProfileRequestSigning
 	}
+	// Construct the default replay store once at wire-up so every request
+	// served by this middleware shares the same dedup state — lazy
+	// per-request construction would defeat replay detection entirely.
+	// Pass an explicit shared store (Redis, etc.) for multi-replica
+	// deployments where replay state must be coordinated across processes.
+	replay := opts.Replay
+	if replay == nil {
+		replay = NewMemoryReplayStore(0)
+	}
 	if len(opts.RequiredFor) > 0 && opts.Revocation == nil {
 		logger.Warn("signing.Middleware: RequiredFor is non-empty but Revocation is nil — verifier will not enforce key revocation")
 	}
@@ -161,7 +173,7 @@ func Middleware(opts MiddlewareOptions) func(http.Handler) http.Handler {
 				Scheme:              scheme,
 				Resolver:            opts.Resolver,
 				Revocation:          opts.Revocation,
-				Replay:              opts.Replay,
+				Replay:              replay,
 				MaxBodyBytes:        opts.MaxBodyBytes,
 			})
 			if err != nil {


### PR DESCRIPTION
## Summary

Two ergonomic upgrades to bring \`adcp-go\` into parity with the cross-SDK signing ergonomics work:

- **TypeScript** ([adcp-client#917](https://github.com/adcontextprotocol/adcp-client/pull/917), merged): defaults on \`verifySignatureAsAuthenticator\` + \`createExpressVerifier\`, default fetch on \`buildAgentSigningFetch\`, new \`createAgentSignedFetch\` preset.
- **Python** ([adcp-client-python#272](https://github.com/adcontextprotocol/adcp-client-python/pull/272)): default \`replay_store\`, \`install_signing_event_hook\` preset, migration guide.
- **Go** (this PR): default replay store, \`NewSignedHTTPClient\` preset.

Both backwards compatible — existing callers that pass explicit \`Replay\` or build the signing client by hand are unaffected.

### 1. \`Middleware\` defaults \`Replay\` to in-memory

\`MiddlewareOptions.Replay\` was a required field — passing nil silently disabled replay-check, the security regression AdCP verifier checklist step 13 exists to prevent. Now defaults to a fresh \`NewMemoryReplayStore(0)\` when nil, constructed once at wire-up so every request served by the middleware shares the same dedup state. Multi-replica deployments still pass an explicit shared store (Redis, etc.) to coordinate state across processes.

\`Revocation\` stays nil-on-omission — the existing wire-up warning ('RequiredFor is non-empty but Revocation is nil — verifier will not enforce key revocation') is the right behavior because revocation is operator-driven; defaulting it would silence a useful diagnostic.

### 2. \`NewSignedHTTPClient(SignedHTTPClientOptions)\` preset

Single-call buyer preset that bundles \`NewSigner\` + \`RoundTripper\` + a redirect-safe \`*http.Client\`. Disables \`CheckRedirect\` for you — \`@target-uri\` is part of the signature base, so a 3xx redirect would silently re-target the binding (the existing MIGRATION.md calls this out as a common production failure). Adapter authors who want this safety baked in get it without remembering to set \`CheckRedirect\` themselves:

\`\`\`go
client, err := signing.NewSignedHTTPClient(signing.SignedHTTPClientOptions{
    KeyID:              \"my-agent-2026\",
    PrivateKey:         priv,
    CoverContentDigest: true,
    Timeout:            30 * time.Second,
})
\`\`\`

Lower-level callers still reach for \`NewSigner\` + \`RoundTripper\` directly — those primitives are unchanged.

## Test plan

- [x] **6 new tests** in \`adcp/signing/client_test.go\`:
  - \`TestNewSignedHTTPClientRoundTripsAgainstVerifier\` — preset → middleware round trip with Ed25519 key and seller-side verification.
  - \`TestNewSignedHTTPClientRejectsRedirects\` — confirms \`CheckRedirect\` is wired so a 3xx is surfaced to the caller, not followed.
  - \`TestNewSignedHTTPClientRequiresKeyMaterial\` — both empty options and missing fields error cleanly.
  - \`TestNewSignedHTTPClientRespectsCustomInnerTransport\` — inner transport composition order proven.
  - \`TestMiddlewareDefaultsReplayStoreToInMemory\` — middleware accepts signed requests with no \`Replay\` field set.
  - \`TestMiddlewareDefaultReplayStoreRejectsActualReplay\` — same (kid, nonce, body) replayed gets a 401 with \`request_signature_replayed\`.
- [x] \`go test ./...\` clean across \`adcp\`, \`adcp/idempotency\`, \`adcp/signing\`, \`adcp/webhook\`.
- [x] \`go vet ./...\` clean.
- [x] \`gofmt\` clean.

## Migration impact

None. Existing callers:
- \`Middleware(MiddlewareOptions{Replay: myStore, ...})\` → unchanged.
- \`Middleware(MiddlewareOptions{...})\` without \`Replay\` → previously had no replay protection, now has in-memory protection. Anyone affected was relying on a footgun.
- Manual \`signer.RoundTripper(...)\` integration → unchanged.

cc [@benminer](https://github.com/benminer) — this lands the Go half of the cross-SDK ergonomics work we discussed on [adcp#3064](https://github.com/adcontextprotocol/adcp/pull/3064). The Python sibling is at [adcp-client-python#272](https://github.com/adcontextprotocol/adcp-client-python/pull/272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)