### PR TITLE
ci(ipr): use adcp's reusable callable workflow + GitHub App

### DIFF
--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -1,0 +1,23 @@
+name: IPR Agreement
+
+# Delegates to the reusable workflow in adcontextprotocol/adcp. Signatures
+# land in the central ledger at adcontextprotocol/adcp:signatures/ipr-signatures.json.
+# See https://github.com/adcontextprotocol/adcp/blob/main/governance/ipr-bot-setup.md
+# for the GitHub App configuration and how to rotate / revoke credentials.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  statuses: write
+
+jobs:
+  check:
+    uses: adcontextprotocol/adcp/.github/workflows/ipr-check-callable.yml@main
+    secrets:
+      IPR_APP_ID: ${{ secrets.IPR_APP_ID }}
+      IPR_APP_PRIVATE_KEY: ${{ secrets.IPR_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Replaces the IPR signing workflow with a delegation to the reusable workflow at [adcontextprotocol/adcp/.github/workflows/ipr-check-callable.yml](https://github.com/adcontextprotocol/adcp/blob/main/.github/workflows/ipr-check-callable.yml) (landed via [adcontextprotocol/adcp#3134](https://github.com/adcontextprotocol/adcp/pull/3134)).

Same change as [adcp-client#985](https://github.com/adcontextprotocol/adcp-client/pull/985), already merged + canary-verified.

## What changes

- Cross-repo signature writes use a **GitHub App installation token** (short-lived, org-scoped to adcontextprotocol/adcp only) instead of a long-lived PAT
- PR author's GitHub identity is the signing fact, not commit-author email — same fix from [adcontextprotocol/adcp#3011](https://github.com/adcontextprotocol/adcp/pull/3011)
- Workflow shrinks to a 22-line caller stub

## Pre-requisites

- [x] AAO IPR Bot installed on this repo
- [x] `IPR_APP_ID` and `IPR_APP_PRIVATE_KEY` org secrets accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)