### PR TITLE
feat(agents): triage PR ergonomics — refs adcp#3121

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -364,7 +364,9 @@ unit tests pass.
 2. **If build or tests fail:** read the errors, fix the code,
    re-run. Cap at **2 build→fix iterations.** If still failing,
    abandon the PR and Flag for human review with the build log
-   in the comment.
+   in the comment. **Do not declare "approved" in the pre-PR
+   review block while build is red** — that's a trust-eroding
+   signal (per adcp#3121).
 3. Do **not** skip tests locally because "CI will run them." The
    point of this gate is to not ship known-broken code even as a
    draft, because (a) review noise, (b) a human reviewer may
@@ -416,8 +418,40 @@ have read the diff before a human reviewer does.
 - Branch: `claude/issue-<N>-<short-slug>`
 - Status: **draft**
 - Title: conventional-commits (`fix(router): …`, `fix: …`)
-- Body: `Closes #N`, summary, what-tested, **Pre-PR review** block with
-  security-reviewer explicitly called out, `Session:` link
+- Body, in order:
+  - `Closes #N`
+  - One-paragraph summary
+  - What-tested list (go build / vet / test / golangci-lint results)
+  - **Pre-PR review** block with both experts' one-line sign-off
+    (security-reviewer always called out for this repo's posture)
+  - **Triage-managed PR block** — append this verbatim before the
+    `Session:` link so reviewers know the iteration policy:
+
+    ```
+    > **Triage-managed PR.** This bot does not currently iterate on
+    > review comments or PR conversation threads (only on the source
+    > issue). To unblock:
+    >
+    > - **Push fixup commits directly:** `gh pr checkout <num>` →
+    >   fix → push.
+    > - **Or re-trigger:** comment `/triage execute` on the source
+    >   issue.
+    >
+    > See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
+    > for context.
+    ```
+  - `Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID}`
+- **After `gh pr create` succeeds**, label the PR `claude-triaged`
+  so it's searchable from PR list views (mirrors the issue label):
+
+  ```
+  gh pr edit <PR#> --repo <owner>/<repo> --add-label claude-triaged
+  ```
+
+  (Don't apply `claude-triaging` to the PR — that label is the
+  routine's "I'm working on this **issue**" signal, not a PR
+  ownership marker.)
+
 - Before pushing:
   - `go build ./...`
   - `go vet ./...`


### PR DESCRIPTION
Mirrors the changes from adcontextprotocol/adcp#3172 — three coordinated edits to `.agents/routines/triage-prompt.md` from issue adcp#3121.

## What changes

**1. Pre-PR build + test gate.** Adds explicit "do not declare 'approved' in the pre-PR review block while build is red" rule, per adcp#3121 evidence that the bot's "approved" verdict next to red CI was a trust-eroding signal across 5+ recent PRs.

**2. PR body now carries a "Triage-managed PR" block** documenting the no-iteration policy:

```
> **Triage-managed PR.** This bot does not currently iterate on review
> comments or PR conversation threads (only on the source issue).
> To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` → fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121) for context.
```

Reviewers no longer have to guess whether to wait, push, or send back manually.

**3. `claude-triaged` label applied to the PR after `gh pr create`** (mirrors the issue label):

```bash
gh pr edit <PR#> --repo <owner>/<repo> --add-label claude-triaged
```

Makes triage-managed PRs searchable in PR list views, complements the `claude/issue-NNNN-*` branch pattern as a PR-ownership signal.

## Repo-specific

This repo's pre-PR build commands stay as documented in PR constraints (no command change here, just the "don't approve while red" rule and the PR-body / label additions). adcp's PR uses `npm run build && npm run typecheck` since adcp's `build` chains the storyboard / compliance lint surface that motivated the original ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
