### PR TITLE
fix(agents): webhook-miss sweep grace period (no double-fire)

### DIFF
--- a/.github/workflows/triage-webhook-miss-sweep.yml
+++ b/.github/workflows/triage-webhook-miss-sweep.yml
@@ -42,18 +42,27 @@ jobs:
             exit 0
           fi
 
-          cutoff=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          echo "Looking for untriaged issues created since $cutoff..."
+          # Two-bound filter: only sweep issues created between 30 min and
+          # 24 hours ago. The 30-min grace period prevents double-firing on
+          # issues where the original `issues.opened` webhook fired but the
+          # routine just hasn't applied the `claude-triaging` label yet (max
+          # observed ~4 min in practice; 30 min is safety margin). Without
+          # this grace period, the sweep races with normal triage and burns
+          # tokens on duplicate routine fires.
+          floor=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          ceiling=$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+          echo "Looking for untriaged issues created between $floor and $ceiling..."
 
-          # Open issues created in last 24h, not PRs, not bot-authored,
+          # Open issues, not PRs, not bot-authored, created in the window,
           # not already labeled claude-triaged or claude-triaging.
           mapfile -t numbers < <(
-            gh api "repos/$REPO/issues?state=open&since=$cutoff&per_page=100" --paginate \
+            gh api "repos/$REPO/issues?state=open&since=$floor&per_page=100" --paginate \
               --jq '.[] | select(
                 .pull_request == null
                 and (.user.type != "Bot")
                 and ((.user.login | endswith("[bot]")) | not)
-                and (.created_at >= "'"$cutoff"'")
+                and (.created_at >= "'"$floor"'")
+                and (.created_at <= "'"$ceiling"'")
                 and ([.labels[].name] | (contains(["claude-triaged"]) or contains(["claude-triaging"])) | not)
               ) | .number'
           )


### PR DESCRIPTION
Adds a 30-minute grace period to the webhook-miss sweep so it doesn't double-fire on issues where the original `issues.opened` webhook fired and the routine just hasn't applied the `claude-triaging` label yet.

## Observed bug

At 15:28:11Z (adcp), the sweep saw #3167 (created 15:26:48Z, 80s old) and #3166 (created 15:26:02Z, 2m old) as candidates and fired the routine on both. But the original triage runs were already in progress — `claude-triaging` landed on #3167 at 15:28:40Z and on #3166 at 15:28:50Z, **30+ seconds after the sweep had already re-fired**. Two routine runs raced on each issue, wasting tokens and risking comment/label write races.

## Fix

Two-bound filter on creation time:

- **Floor:** 24 hours ago (existing — don't sweep ancient issues)
- **Ceiling:** 30 minutes ago (**NEW** — give the original webhook + routine time to at least land the lifecycle label)

Max observed time from issue creation to `claude-triaging` label was ~4m16s across the recent #3145/#3152/#3156/#3162/#3166/#3167 sample. 30 min is a generous safety margin while keeping recovery latency under ~90 min for a real webhook miss (sweep runs hourly at :17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
