### PR TITLE
feat(schemas): manifest-driven sync of canonical agent skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,8 @@
 # Release tooling.
 /release-please-config.json           @bokelley
 /.release-please-manifest.json        @bokelley
+
+# Agent skills — wire contracts consumed verbatim by LLM agents. Sigstore
+# verifies the bundle's origin; CODEOWNERS gates the file content.
+/skills/                    @bokelley
+/adcp/schemas/download.sh   @bokelley

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The targeting engine (`targeting/`) is the shared evaluation core. Reference age
 | `adcp/schemas/generate.py` | JSON-schema-to-Go-struct generator. `KNOWN_TYPES` set (top of file) lists types it skips so they can be hand-written. |
 | `adcp/schemas/lint.py` | Drift linter — diffs every `KNOWN_TYPES` entry against its schema. CI fails on drift. |
 | `adcp/testcontroller.go` | `RegisterTestController` — comply_test_controller for storyboard testing. |
-| `skills/` | SKILL.md files for coding agents to generate AdCP agents (seller, signals, creative, generative-seller, retail-media, collection). |
+| `skills/` | SKILL.md files for coding agents. SDK-local (`build-*`) authored here; protocol-managed (`adcp-*`, `call-adcp-agent`) synced by `adcp/schemas/download.sh` from the published bundle — do not hand-edit. CODEOWNERS-gated. See `skills/README.md`. |
 
 ### Adding a new AdCP type
 

--- a/adcp/schemas/download.sh
+++ b/adcp/schemas/download.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Downloads AdCP JSON schemas from the published protocol bundle at the pinned version.
+# Also syncs protocol-managed agent skills (LLM wire contracts) listed in
+# `manifest.contents.skills` into the repo's top-level `skills/` tree.
 #
 # Usage:
 #   ./download.sh              # download at pinned VERSION
@@ -198,7 +200,9 @@ PY
       # Exclude the per-skill schemas/ subdir at the skill root. These are
       # byte-identical copies of the top-level schemas already in the SDK's
       # schema cache; including them would duplicate ~1.4MB per protocol.
-      rsync -a --delete --exclude='/schemas/' "$SRC_SKILL/" "$DST_SKILL/"
+      # Anchored to skill root: drop a top-level `schemas` entry whether dir,
+      # file, or anything else. Nested foo/schemas/ trees are preserved.
+      rsync -a --delete --exclude='/schemas' "$SRC_SKILL/" "$DST_SKILL/"
       echo "Synced protocol skill: $SKILL_NAME"
     done < "$SKILL_LIST"
   fi

--- a/adcp/schemas/download.sh
+++ b/adcp/schemas/download.sh
@@ -153,6 +153,57 @@ rsync -a --delete "${EXCLUDE_ARGS[@]}" "$SRC/" "$SCRIPT_DIR/"
 # the upstream artifact (meaningful for the "latest" dev snapshot).
 echo "$EXPECTED" > "$SCRIPT_DIR/.bundle-sha256"
 
+# Manifest-driven sync of protocol-managed agent skills.
+#
+# Bundles starting with adcp#3097 enumerate canonical skills under
+# `manifest.contents.skills`. Each named directory holds a `SKILL.md` (the
+# wire contract for buyers/agents) and may bundle a `schemas/` subdir that
+# duplicates the top-level schemas — verified identical at sync-time, so we
+# filter it out (the SDK already has those in its schema cache).
+#
+# Older bundles without a skills entry no-op gracefully.
+MANIFEST="$WORK/adcp-$VERSION/manifest.json"
+SKILLS_REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)/skills"
+if [ -f "$MANIFEST" ]; then
+  # Validate skill names against ^[a-zA-Z0-9_-]+$ before any filesystem use —
+  # this is a separate check from tar's path-traversal guard above and must
+  # fail closed. Names are interpolated into mkdir/rsync paths below. Write
+  # to a tempfile and check the python exit code explicitly, since command
+  # substitution swallows non-zero exits under `set -e`.
+  SKILL_LIST="$WORK/skill-names.txt"
+  python3 - "$MANIFEST" >"$SKILL_LIST" <<'PY'
+import json, re, sys
+manifest = json.load(open(sys.argv[1]))
+names = manifest.get("contents", {}).get("skills")
+if not isinstance(names, list):
+    sys.exit(0)
+pattern = re.compile(r"^[a-zA-Z0-9_-]+$")
+for n in names:
+    if not isinstance(n, str) or not pattern.match(n):
+        sys.stderr.write(f"invalid skill name in manifest: {n!r}\n")
+        sys.exit(1)
+print("\n".join(names))
+PY
+  if [ -s "$SKILL_LIST" ]; then
+    mkdir -p "$SKILLS_REPO_DIR"
+    while IFS= read -r SKILL_NAME; do
+      [ -z "$SKILL_NAME" ] && continue
+      SRC_SKILL="$WORK/adcp-$VERSION/skills/$SKILL_NAME"
+      DST_SKILL="$SKILLS_REPO_DIR/$SKILL_NAME"
+      if [ ! -d "$SRC_SKILL" ]; then
+        echo "manifest names skill '$SKILL_NAME' but bundle has no $SRC_SKILL" >&2
+        exit 1
+      fi
+      mkdir -p "$DST_SKILL"
+      # Exclude the per-skill schemas/ subdir at the skill root. These are
+      # byte-identical copies of the top-level schemas already in the SDK's
+      # schema cache; including them would duplicate ~1.4MB per protocol.
+      rsync -a --delete --exclude='/schemas/' "$SRC_SKILL/" "$DST_SKILL/"
+      echo "Synced protocol skill: $SKILL_NAME"
+    done < "$SKILL_LIST"
+  fi
+fi
+
 # Update VERSION file if a specific version was passed
 if [ -n "${1:-}" ]; then
   echo "$1" > "$VERSION_FILE"

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,16 @@
+# skills/
+
+SKILL.md files consumed verbatim by LLM coding agents. Two kinds live side
+by side:
+
+| Kind | Naming | Source of truth | Edit path |
+|------|--------|-----------------|-----------|
+| **SDK-local** — how to build a Go-flavored AdCP agent against this SDK. | `build-*` | This repo. | Edit in place; PRs reviewed via CODEOWNERS (`/skills/`). |
+| **Protocol-managed** — canonical wire contracts published by `adcontextprotocol/adcp`. | `adcp-*`, `call-adcp-agent` | The protocol tarball at `/protocol/<version>.tgz`. | Do not hand-edit — `adcp/schemas/download.sh` overwrites these on sync. Upstream changes go through `adcontextprotocol/adcp`. |
+
+Protocol-managed skills are enumerated under `manifest.contents.skills` in
+the bundle. The sync filters out per-skill `schemas/` subdirs (verified
+identical to the top-level schemas already in `adcp/schemas/`).
+
+The pinned bundle version is `adcp/schemas/VERSION`. Skills land on the
+next bump to a release that bundles them.


### PR DESCRIPTION
Closes #91.

## Summary

- `adcp/schemas/download.sh` now reads `manifest.contents.skills` after extracting the bundle and rsyncs each named skill directory into `/skills/<name>/`. Per-skill `schemas/` subdirs are excluded — verified byte-identical to the top-level schemas already in the SDK's schema cache.
- Skill names are validated against `^[a-zA-Z0-9_-]+$` before any `mkdir`/`rsync`. The validator emits zero output on failure (no partial list leak) and the script's `set -e` propagates the non-zero exit.
- Bundles without a `skills` entry no-op gracefully — SDK-local skills (`build-*`) are untouched in either path.
- `.github/CODEOWNERS` gates `/skills/` and `adcp/schemas/download.sh` behind owner review. Sigstore attests the bundle's origin; CODEOWNERS gates the file content (LLM wire contracts).

## Why no skill files in this PR

The current pin (3.0.0 GA) does not bundle skills — `adcp#3097` added bundling but that change is only in the `latest` dev snapshot. Pulling unsigned `latest` content under a "3.0.0 verified" pin would mix trust states. Skills will sync on the next `VERSION` bump to a release that bundles them.

## Triage blockers (from #91 comments)

1. **Per-skill `schemas/` filter correctness** — verified against `latest.tgz`: every per-skill schema is byte-identical to the corresponding top-level schema. Filter is correct.
2. **Skill name validation** — `^[a-zA-Z0-9_-]+$` enforced fail-closed.
3. **No `.previous` sidecar** — rsync `--delete` only, consistent with the existing schema sync pattern.
4. **CODEOWNERS** — `/skills/` and `download.sh` now require owner review.

`check-freshness.sh` is unchanged: 3.0.0 has no skills bundled, so there's nothing to drift-check yet. The bundle SHA already covers integrity at sync time. A skill-level drift linter (paralleling `lint.py` for schemas) follows when content lands.

## Test plan

- [x] `./download.sh latest` — syncs all 7 skills, filters per-skill `schemas/`, leaves `build-*` untouched
- [x] `./download.sh 3.0.0` — no-ops on skills (graceful skip), schemas sync as before
- [x] Tampered manifest with `../etc/passwd` — fail-closed, no partial sync
- [ ] Re-sync once 3.1.0 ships with skills bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)