### PR TITLE
chore(codeowners): add team as reviewers pre-GA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,30 +3,36 @@
 # approves. This is the enforcement layer behind the TEE hardening
 # rules in AGENTS.md — the triage prompt forbids edits here, but
 # CODEOWNERS is what actually stops them from merging.
+#
+# Pre-GA: the full team is listed on TEE-bound paths so reviews aren't
+# bottlenecked on a single person. At GA, narrow these back to @bokelley.
+
+# Default owners — any of these can approve general PRs.
+*                           @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
 
 # Agent infrastructure.
-/.agents/                   @bokelley
-/.github/                   @bokelley
-/.github/workflows/         @bokelley
+/.agents/                   @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/.github/                   @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/.github/workflows/         @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
 
 # TEE-bound code and the invariants it depends on. Any change here
 # must go through human review regardless of author.
-/identity/                  @bokelley
-/router/pinhole.go          @bokelley
-/router/pinhole_*.go        @bokelley
-/router/metrics.go          @bokelley
-/router/metrics_*.go        @bokelley
-/internal/sanitize/         @bokelley
+/identity/                  @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/router/pinhole.go          @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/router/pinhole_*.go        @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/router/metrics.go          @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/router/metrics_*.go        @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/internal/sanitize/         @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
 
 # Root-module dep surface — zero external deps is a hard invariant.
-/go.mod                     @bokelley
-/go.sum                     @bokelley
+/go.mod                     @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/go.sum                     @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
 
 # Release tooling.
-/release-please-config.json           @bokelley
-/.release-please-manifest.json        @bokelley
+/release-please-config.json           @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/.release-please-manifest.json        @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
 
 # Agent skills — wire contracts consumed verbatim by LLM agents. Sigstore
 # verifies the bundle's origin; CODEOWNERS gates the file content.
-/skills/                    @bokelley
-/adcp/schemas/download.sh   @bokelley
+/skills/                    @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018
+/adcp/schemas/download.sh   @bokelley @ohalushchak-exadel @BaiyuScope3 @lockwoodscope @EmmaLouise2018


### PR DESCRIPTION
## Summary
- Adds @ohalushchak-exadel, @BaiyuScope3, @lockwoodscope, @EmmaLouise2018 alongside @bokelley on every CODEOWNERS rule.
- Adds a default \`*\` rule so general PRs aren't gated on a single owner.
- Header note flags this as pre-GA: TEE-bound paths get narrowed back to @bokelley at GA.

## Test plan
- [ ] Confirm each added handle has Write access (CODEOWNERS silently ignores entries without it).
- [ ] Open a test PR against a TEE-bound path and verify any team member's review satisfies the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)