### PR TITLE
feat(targeting): add shadow-replica fan-out to redisstore and glidestore

### DIFF
--- a/targeting/glidestore/audience_store.go
+++ b/targeting/glidestore/audience_store.go
@@ -11,10 +11,12 @@ import (
 
 var _ audience.Store = (*Store)(nil)
 
-// HSetBatch performs HSET for multiple (key, field, value) triples in one
-// pipelined round-trip. Items targeting the same key are grouped into a
-// single HSET command.
+// HSetBatch performs HSET for multiple (key, field, value) triples in
+// one pipelined round-trip. Returns ErrReadOnly in shadow-shards mode.
 func (s *Store) HSetBatch(ctx context.Context, items []audience.HSetItem) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(items) == 0 {
 		return nil
 	}
@@ -35,40 +37,50 @@ func (s *Store) HSetBatch(ctx context.Context, items []audience.HSetItem) error 
 	return err
 }
 
-// HExistsBatch checks one (key, field) pair per lookup, returning results in
-// the same order. Pipelined.
+// HExistsBatch checks one (key, field) pair per lookup, returning
+// results in the same order. In shadow mode the per-shard batches run
+// in parallel.
 func (s *Store) HExistsBatch(ctx context.Context, lookups []audience.HLookup) ([]bool, error) {
 	if len(lookups) == 0 {
 		return nil, nil
 	}
-	batch := pipeline.NewStandaloneBatch(false)
-	for _, l := range lookups {
-		batch.HExists(l.Key, l.Field)
+	keys := make([]string, len(lookups))
+	for i, l := range lookups {
+		keys[i] = l.Key
 	}
-	results, err := s.client.Exec(ctx, *batch, true)
+	out := make([]bool, len(lookups))
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		batch := pipeline.NewStandaloneBatch(false)
+		for _, i := range indices {
+			batch.HExists(lookups[i].Key, lookups[i].Field)
+		}
+		results, err := s.clientForGroup(group).Exec(ctx, *batch, true)
+		if err != nil {
+			return err
+		}
+		if len(results) != len(indices) {
+			return fmt.Errorf("glidestore: HEXISTS batch returned %d results, expected %d", len(results), len(indices))
+		}
+		for j, r := range results {
+			b, ok := r.(bool)
+			if !ok {
+				return fmt.Errorf("glidestore: HEXISTS result %d: expected bool, got %T", indices[j], r)
+			}
+			out[indices[j]] = b
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if len(results) != len(lookups) {
-		return nil, fmt.Errorf("glidestore: HEXISTS batch returned %d results, expected %d", len(results), len(lookups))
-	}
-	out := make([]bool, len(results))
-	for i, r := range results {
-		// HEXISTS arrives as plain bool from valkey-glide/go/v2 batch results.
-		// Surface unexpected types loudly so a wire-format change is caught
-		// rather than silently returning false.
-		b, ok := r.(bool)
-		if !ok {
-			return nil, fmt.Errorf("glidestore: HEXISTS result %d: expected bool, got %T", i, r)
-		}
-		out[i] = b
 	}
 	return out, nil
 }
 
-// HGetAll returns every (field, value) under key. Empty map for missing keys.
+// HGetAll returns every (field, value) under key. Empty map for missing
+// keys.
 func (s *Store) HGetAll(ctx context.Context, key string) (map[string]string, error) {
-	res, err := s.client.HGetAll(ctx, key)
+	res, err := s.clientFor(key).HGetAll(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -78,40 +90,50 @@ func (s *Store) HGetAll(ctx context.Context, key string) (map[string]string, err
 	return res, nil
 }
 
-// HGetAllBatch returns HGETALL results for each key in input order. Missing
-// keys produce empty maps at their index.
+// HGetAllBatch returns HGETALL results for each key in input order.
+// Missing keys produce non-nil empty maps at their index.
 func (s *Store) HGetAllBatch(ctx context.Context, keys []string) ([]map[string]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	batch := pipeline.NewStandaloneBatch(false)
-	for _, k := range keys {
-		batch.HGetAll(k)
-	}
-	results, err := s.client.Exec(ctx, *batch, true)
+	out := make([]map[string]string, len(keys))
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		batch := pipeline.NewStandaloneBatch(false)
+		for _, i := range indices {
+			batch.HGetAll(keys[i])
+		}
+		results, err := s.clientForGroup(group).Exec(ctx, *batch, true)
+		if err != nil {
+			return err
+		}
+		if len(results) != len(indices) {
+			return fmt.Errorf("glidestore: HGETALL batch returned %d results, expected %d", len(results), len(indices))
+		}
+		for j, r := range results {
+			switch v := r.(type) {
+			case map[string]string:
+				out[indices[j]] = v
+			case nil:
+				out[indices[j]] = map[string]string{}
+			default:
+				return fmt.Errorf("glidestore: HGETALL result %d: expected map[string]string, got %T", indices[j], r)
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if len(results) != len(keys) {
-		return nil, fmt.Errorf("glidestore: HGETALL batch returned %d results, expected %d", len(results), len(keys))
-	}
-	out := make([]map[string]string, len(results))
-	for i, r := range results {
-		switch v := r.(type) {
-		case map[string]string:
-			out[i] = v
-		case nil:
-			out[i] = map[string]string{}
-		default:
-			return nil, fmt.Errorf("glidestore: HGETALL result %d: expected map[string]string, got %T", i, r)
-		}
 	}
 	return out, nil
 }
 
-// HDelBatch performs HDEL for multiple (key, fields) pairs in one pipelined
-// round-trip.
+// HDelBatch performs HDEL for multiple (key, fields) pairs in one
+// pipelined round-trip. Returns ErrReadOnly in shadow-shards mode.
 func (s *Store) HDelBatch(ctx context.Context, items []audience.HDelItem) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(items) == 0 {
 		return nil
 	}

--- a/targeting/glidestore/shadow_integration_test.go
+++ b/targeting/glidestore/shadow_integration_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package glidestore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	glide "github.com/valkey-io/valkey-glide/go/v2"
+	"github.com/valkey-io/valkey-glide/go/v2/config"
+	glideoptions "github.com/valkey-io/valkey-glide/go/v2/options"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/identityhash"
+)
+
+// startValkeyShards spins up n independent Valkey 9 containers and
+// returns a shadow-mode Store routing across them.
+func startValkeyShards(t *testing.T, n int) (*Store, []*glide.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	clients := make([]*glide.Client, n)
+	for i := 0; i < n; i++ {
+		req := testcontainers.ContainerRequest{
+			Image:        "valkey/valkey:9-alpine",
+			ExposedPorts: []string{"6379/tcp"},
+			WaitingFor:   wait.ForListeningPort("6379/tcp").WithStartupTimeout(30 * time.Second),
+		}
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			t.Skipf("Docker not available, skipping integration test: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = container.Terminate(context.Background())
+		})
+
+		host, err := container.Host(ctx)
+		require.NoError(t, err)
+		port, err := container.MappedPort(ctx, "6379/tcp")
+		require.NoError(t, err)
+		portInt, err := strconv.Atoi(port.Port())
+		require.NoError(t, err)
+
+		cfg := config.NewClientConfiguration().WithAddress(&config.NodeAddress{Host: host, Port: portInt})
+		c, err := glide.NewClient(cfg)
+		require.NoError(t, err)
+		t.Cleanup(c.Close)
+		clients[i] = c
+	}
+
+	store, err := NewShadow(clients)
+	require.NoError(t, err)
+	return store, clients
+}
+
+// seedFcapShadow writes a single fcap marker directly to the shard that
+// owns key.
+func seedFcapShadow(t *testing.T, clients []*glide.Client, key, field string, expireAt time.Time) {
+	t.Helper()
+	idx := clusterslot.Shard(key, len(clients))
+	opts := glideoptions.NewHSetExOptions().SetExpiry(glideoptions.NewExpiryAt(expireAt))
+	_, err := clients[idx].HSetEx(context.Background(), key, map[string]string{field: "1"}, opts)
+	require.NoError(t, err)
+}
+
+func TestIntegration_Shadow_SingleShard(t *testing.T) {
+	store, clients := startValkeyShards(t, 1)
+	require.Equal(t, 1, store.NumShards())
+	require.Len(t, clients, 1)
+
+	ctx := context.Background()
+	key := "fcap:user-1"
+	field := "https://seller.example.com/agent:pkg-1"
+	seedFcapShadow(t, clients, key, field, time.Now().Add(2*time.Minute))
+
+	exists, err := store.FieldExists(ctx, key, field)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = store.FieldExists(ctx, key, "https://other:pkg-2")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestIntegration_Shadow_FcapBatchAcrossShards(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	require.Equal(t, 3, store.NumShards())
+	ctx := context.Background()
+	expireAt := time.Now().Add(5 * time.Minute)
+
+	keys := make([]string, 3)
+	for i := 0; i < 200 && (keys[0] == "" || keys[1] == "" || keys[2] == ""); i++ {
+		k := fmt.Sprintf("fcap:user-%d", i)
+		sh := clusterslot.Shard(k, 3)
+		if keys[sh] == "" {
+			keys[sh] = k
+			seedFcapShadow(t, clients, k, "url:pkg", expireAt)
+		}
+	}
+	for sh, k := range keys {
+		require.NotEmpty(t, k, "no candidate key landed on shard %d", sh)
+	}
+
+	lookups := make([]fcap.FieldLookup, 0, len(keys)*2)
+	want := make([]bool, 0, len(keys)*2)
+	for _, k := range keys {
+		lookups = append(lookups, fcap.FieldLookup{Key: k, Field: "url:pkg"})
+		want = append(want, true)
+		lookups = append(lookups, fcap.FieldLookup{Key: k, Field: "url:pkg-miss"})
+		want = append(want, false)
+	}
+
+	got, err := store.FieldExistsBatch(ctx, lookups)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestIntegration_Shadow_WritesAreReadOnly(t *testing.T) {
+	store, _ := startValkeyShards(t, 2)
+	ctx := context.Background()
+	expireAt := time.Now().Add(time.Minute)
+
+	err := store.SetFields(ctx, "fcap:x", map[string]string{"f": "1"}, expireAt)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.SetFieldsBatch(ctx, []fcap.FieldsBatch{{Key: "fcap:x", Fields: map[string]string{"f": "1"}, ExpireAt: expireAt}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.HSetBatch(ctx, []audience.HSetItem{{Key: "audience:user:x", Field: "a", Value: "1"}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.HDelBatch(ctx, []audience.HDelItem{{Key: "audience:user:x", Fields: []string{"a"}}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.Set(ctx, "k", "v", 0)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.MSet(ctx, map[string]string{"k": "v"}, 0)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+}
+
+func TestIntegration_Shadow_AudienceMultiShard(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	ctx := context.Background()
+
+	keys := make([]string, 0, 6)
+	for i := 0; len(keys) < 6; i++ {
+		k := fmt.Sprintf("audience:user:%d", i)
+		idx := clusterslot.Shard(k, 3)
+		_, err := clients[idx].HSet(ctx, k, map[string]string{"cooking": "0.9", "tech": "0.4"})
+		require.NoError(t, err)
+		keys = append(keys, k)
+	}
+
+	m, err := store.HGetAll(ctx, keys[0])
+	require.NoError(t, err)
+	assert.Equal(t, "0.9", m["cooking"])
+
+	maps, err := store.HGetAllBatch(ctx, append(keys, "audience:user:missing"))
+	require.NoError(t, err)
+	require.Len(t, maps, len(keys)+1)
+	for i := range keys {
+		assert.Equal(t, "0.9", maps[i]["cooking"])
+		assert.Equal(t, "0.4", maps[i]["tech"])
+	}
+	assert.Equal(t, map[string]string{}, maps[len(keys)])
+
+	lookups := []audience.HLookup{
+		{Key: keys[0], Field: "cooking"},
+		{Key: keys[1], Field: "missing"},
+		{Key: "audience:user:missing", Field: "cooking"},
+	}
+	hits, err := store.HExistsBatch(ctx, lookups)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, false}, hits)
+}
+
+func TestIntegration_Shadow_FcapServiceWiring(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	svc := fcap.New(store)
+	ctx := context.Background()
+
+	expireAt := time.Now().Add(2 * time.Minute)
+	identities := []string{"id5-a", "id5-b", "id5-c"}
+	for _, id := range identities {
+		seedFcapShadow(t, clients, "fcap:"+identityhash.Hash(id), "https://seller:pkg-a", expireAt)
+	}
+
+	field := fcap.Field{SellerAgentURL: "https://seller", PackageID: "pkg-a"}
+	hits, err := svc.IsCappedBatch(ctx, []fcap.CapLookup{
+		{UserIdentity: "id5-a", Field: field},
+		{UserIdentity: "id5-b", Field: field},
+		{UserIdentity: "id5-c", Field: field},
+		{UserIdentity: "id5-unknown", Field: field},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, true, true, false}, hits)
+}
+
+func TestIntegration_Shadow_SetIntersect_CrossShardFails(t *testing.T) {
+	store, _ := startValkeyShards(t, 3)
+	ctx := context.Background()
+
+	var a, b string
+	for i := 0; i < 200; i++ {
+		k := fmt.Sprintf("k-%d", i)
+		if a == "" {
+			a = k
+			continue
+		}
+		if clusterslot.Shard(k, 3) != clusterslot.Shard(a, 3) {
+			b = k
+			break
+		}
+	}
+	require.NotEmpty(t, b, "could not find cross-shard candidate")
+
+	_, err := store.SetIntersect(ctx, a, b)
+	assert.True(t, errors.Is(err, ErrCrossShard))
+}

--- a/targeting/glidestore/store.go
+++ b/targeting/glidestore/store.go
@@ -124,9 +124,17 @@ func (s *Store) fanOut(ctx context.Context, byGroup map[int][]int, fn func(ctx c
 		return nil
 	}
 	if len(byGroup) == 1 {
-		for g, idxs := range byGroup {
-			return fn(ctx, g, idxs)
+		// Single-group fast path: skip goroutine overhead. Extract the
+		// sole entry up front rather than relying on a return inside a
+		// for-range body, which would silently fall through if the body
+		// is ever refactored to continue.
+		var (
+			group   int
+			indices []int
+		)
+		for group, indices = range byGroup { //nolint:revive // single iteration: extracts the only entry
 		}
+		return fn(ctx, group, indices)
 	}
 	derived, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/targeting/glidestore/store.go
+++ b/targeting/glidestore/store.go
@@ -1,14 +1,28 @@
 // Package glidestore provides Valkey-backed implementations of
-// targeting.Store and targeting/fcap.Store using valkey-glide/go/v2.
+// targeting.Store, targeting/fcap.Store, and targeting/audience.Store
+// using valkey-glide/go/v2.
 //
-// One Store wraps a single glide client and satisfies both interfaces, so
-// callers share connection state between the targeting engine and the
-// frequency-cap service.
+// Two topologies are supported through a single Store type:
+//
+//   - Standalone: one Valkey endpoint. Construct via New with a
+//     *glide.Client.
+//   - Shadow shards: N independent standalone endpoints that mirror a
+//     central cluster's per-shard keyspace. Construct via NewShadow
+//     with one *glide.Client per shard ordinal. Reads route by
+//     app-level CRC16; writes return ErrReadOnly.
+//
+// Cluster topology via *glide.ClusterClient is not currently wired
+// here; the redisstore package supports it.
+//
+// See the redisstore package doc for routing details — both packages
+// share the same slot/shard contract via targeting/internal/clusterslot.
 package glidestore
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	glide "github.com/valkey-io/valkey-glide/go/v2"
@@ -17,6 +31,7 @@ import (
 
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
 )
 
 var (
@@ -24,27 +39,144 @@ var (
 	_ fcap.Store      = (*Store)(nil)
 )
 
-// Store wraps a glide client and implements targeting.Store and fcap.Store.
+// ErrReadOnly is returned by every write method when Store is in
+// shadow-shards mode.
+var ErrReadOnly = errors.New("glidestore: write not supported on shadow replica")
+
+// ErrCrossShard is returned when a multi-key operation receives keys
+// that span shards. Co-locate keys with a `{hashtag}` to keep them on
+// one shard.
+var ErrCrossShard = errors.New("glidestore: cross-shard keys are not supported")
+
+// Store implements targeting.Store, fcap.Store, and audience.Store on
+// top of valkey-glide.
 type Store struct {
-	client *glide.Client
+	client   *glide.Client
+	shards   []*glide.Client
+	shardMap *clusterslot.ShardMap
 }
 
-// New constructs a Store from a glide client.
+// New constructs a Store backed by a single standalone glide client.
 func New(client *glide.Client) *Store {
 	return &Store{client: client}
+}
+
+// NewShadow constructs a read-only Store that fans out reads across
+// shards. shards[i] is the standalone client for shard ordinal i; index
+// order is load-bearing for routing. Returns an error if shards is
+// empty or any element is nil.
+func NewShadow(shards []*glide.Client) (*Store, error) {
+	if len(shards) == 0 {
+		return nil, errors.New("glidestore: at least one shadow shard is required")
+	}
+	for i, c := range shards {
+		if c == nil {
+			return nil, fmt.Errorf("glidestore: shadow shard at ordinal %d is nil", i)
+		}
+	}
+	return &Store{shards: shards, shardMap: clusterslot.NewShardMap(len(shards))}, nil
+}
+
+// NumShards reports the shard count for a shadow-shards Store. Returns
+// 1 for the standalone topology.
+func (s *Store) NumShards() int {
+	if len(s.shards) > 0 {
+		return len(s.shards)
+	}
+	return 1
+}
+
+func (s *Store) shadow() bool { return len(s.shards) > 0 }
+
+func (s *Store) clientFor(key string) *glide.Client {
+	if s.shadow() {
+		return s.shards[s.shardMap.Shard(key)]
+	}
+	return s.client
+}
+
+func (s *Store) clientForGroup(group int) *glide.Client {
+	if s.shadow() {
+		return s.shards[group]
+	}
+	return s.client
+}
+
+func (s *Store) groupKeys(keys []string) map[int][]int {
+	if !s.shadow() {
+		all := make([]int, len(keys))
+		for i := range keys {
+			all[i] = i
+		}
+		return map[int][]int{0: all}
+	}
+	numShards := len(s.shards)
+	out := make(map[int][]int, numShards)
+	for i, k := range keys {
+		sh := s.shardMap.Shard(k)
+		out[sh] = append(out[sh], i)
+	}
+	return out
+}
+
+func (s *Store) fanOut(ctx context.Context, byGroup map[int][]int, fn func(ctx context.Context, group int, indices []int) error) error {
+	if len(byGroup) == 0 {
+		return nil
+	}
+	if len(byGroup) == 1 {
+		for g, idxs := range byGroup {
+			return fn(ctx, g, idxs)
+		}
+	}
+	derived, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		firstErr error
+	)
+	wg.Add(len(byGroup))
+	for g, idxs := range byGroup {
+		g, idxs := g, idxs
+		go func() {
+			defer wg.Done()
+			if err := fn(derived, g, idxs); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					cancel()
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return firstErr
 }
 
 // --- targeting.Store ---
 
 func (s *Store) SetIsMember(ctx context.Context, key, member string) (bool, error) {
-	return s.client.SIsMember(ctx, key, member)
+	return s.clientFor(key).SIsMember(ctx, key, member)
 }
 
 func (s *Store) SetIntersect(ctx context.Context, keys ...string) ([]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	set, err := s.client.SInter(ctx, keys)
+	var c *glide.Client
+	if s.shadow() {
+		shard := s.shardMap.Shard(keys[0])
+		for _, k := range keys[1:] {
+			if s.shardMap.Shard(k) != shard {
+				return nil, ErrCrossShard
+			}
+		}
+		c = s.shards[shard]
+	} else {
+		c = s.client
+	}
+	set, err := c.SInter(ctx, keys)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +188,7 @@ func (s *Store) SetIntersect(ctx context.Context, keys ...string) ([]string, err
 }
 
 func (s *Store) Get(ctx context.Context, key string) (string, bool, error) {
-	res, err := s.client.Get(ctx, key)
+	res, err := s.clientFor(key).Get(ctx, key)
 	if err != nil {
 		return "", false, err
 	}
@@ -67,6 +199,9 @@ func (s *Store) Get(ctx context.Context, key string) (string, bool, error) {
 }
 
 func (s *Store) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if ttl <= 0 {
 		_, err := s.client.Set(ctx, key, value)
 		return err
@@ -77,7 +212,7 @@ func (s *Store) Set(ctx context.Context, key, value string, ttl time.Duration) e
 }
 
 func (s *Store) Exists(ctx context.Context, key string) (bool, error) {
-	n, err := s.client.Exists(ctx, []string{key})
+	n, err := s.clientFor(key).Exists(ctx, []string{key})
 	if err != nil {
 		return false, err
 	}
@@ -85,7 +220,7 @@ func (s *Store) Exists(ctx context.Context, key string) (bool, error) {
 }
 
 func (s *Store) SetMembers(ctx context.Context, key string) ([]string, error) {
-	set, err := s.client.SMembers(ctx, key)
+	set, err := s.clientFor(key).SMembers(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -103,19 +238,30 @@ func (s *Store) MGet(ctx context.Context, keys ...string) ([]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	results, err := s.client.MGet(ctx, keys)
+	out := make([]string, len(keys))
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		groupKeys := make([]string, len(indices))
+		for j, i := range indices {
+			groupKeys[j] = keys[i]
+		}
+		results, err := s.clientForGroup(group).MGet(ctx, groupKeys)
+		if err != nil {
+			return err
+		}
+		if len(results) != len(groupKeys) {
+			return fmt.Errorf("glidestore: MGET returned %d results for %d keys", len(results), len(groupKeys))
+		}
+		for j, r := range results {
+			if r.IsNil() {
+				continue
+			}
+			out[indices[j]] = r.Value()
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if len(results) != len(keys) {
-		return nil, fmt.Errorf("glidestore: MGET returned %d results for %d keys", len(results), len(keys))
-	}
-	out := make([]string, len(results))
-	for i, r := range results {
-		if r.IsNil() {
-			continue
-		}
-		out[i] = r.Value()
 	}
 	return out, nil
 }
@@ -124,12 +270,13 @@ func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Durati
 	if len(kvs) == 0 {
 		return nil
 	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if ttl <= 0 {
 		_, err := s.client.MSet(ctx, kvs)
 		return err
 	}
-	// MSET in Valkey doesn't accept a TTL. With TTL, we batch SET+EXPIRE per
-	// key in a single non-atomic batch.
 	batch := pipeline.NewStandaloneBatch(false)
 	expiryOpts := *options.NewSetOptions().SetExpiry(options.NewExpiryIn(ttl))
 	for k, v := range kvs {
@@ -142,6 +289,9 @@ func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Durati
 // --- fcap.Store ---
 
 func (s *Store) SetFields(ctx context.Context, key string, fields map[string]string, expireAt time.Time) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(fields) == 0 {
 		return nil
 	}
@@ -151,6 +301,9 @@ func (s *Store) SetFields(ctx context.Context, key string, fields map[string]str
 }
 
 func (s *Store) SetFieldsBatch(ctx context.Context, batches []fcap.FieldsBatch) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(batches) == 0 {
 		return nil
 	}
@@ -172,34 +325,42 @@ func (s *Store) SetFieldsBatch(ctx context.Context, batches []fcap.FieldsBatch) 
 }
 
 func (s *Store) FieldExists(ctx context.Context, key, field string) (bool, error) {
-	return s.client.HExists(ctx, key, field)
+	return s.clientFor(key).HExists(ctx, key, field)
 }
 
 func (s *Store) FieldExistsBatch(ctx context.Context, lookups []fcap.FieldLookup) ([]bool, error) {
 	if len(lookups) == 0 {
 		return nil, nil
 	}
-	batch := pipeline.NewStandaloneBatch(false)
-	for _, l := range lookups {
-		batch.HExists(l.Key, l.Field)
+	keys := make([]string, len(lookups))
+	for i, l := range lookups {
+		keys[i] = l.Key
 	}
-	results, err := s.client.Exec(ctx, *batch, true)
+	out := make([]bool, len(lookups))
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		batch := pipeline.NewStandaloneBatch(false)
+		for _, i := range indices {
+			batch.HExists(lookups[i].Key, lookups[i].Field)
+		}
+		results, err := s.clientForGroup(group).Exec(ctx, *batch, true)
+		if err != nil {
+			return err
+		}
+		if len(results) != len(indices) {
+			return fmt.Errorf("glidestore: HEXISTS batch returned %d results, expected %d", len(results), len(indices))
+		}
+		for j, r := range results {
+			b, ok := r.(bool)
+			if !ok {
+				return fmt.Errorf("glidestore: HEXISTS result %d: expected bool, got %T", indices[j], r)
+			}
+			out[indices[j]] = b
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if len(results) != len(lookups) {
-		return nil, fmt.Errorf("glidestore: HEXISTS batch returned %d results, expected %d", len(results), len(lookups))
-	}
-	out := make([]bool, len(results))
-	for i, r := range results {
-		// Validated against valkey-glide/go/v2 v2.3.1: HEXISTS in a batch
-		// arrives as a plain bool. Surface the actual type if that ever
-		// changes so the failure mode is loud rather than silently false.
-		b, ok := r.(bool)
-		if !ok {
-			return nil, fmt.Errorf("glidestore: HEXISTS result %d: expected bool, got %T", i, r)
-		}
-		out[i] = b
 	}
 	return out, nil
 }

--- a/targeting/internal/clusterslot/clusterslot.go
+++ b/targeting/internal/clusterslot/clusterslot.go
@@ -1,0 +1,166 @@
+// Package clusterslot implements the Valkey/Redis Cluster CRC16 slot
+// algorithm and the slot-to-shard-ordinal mapping that adcp-go Stores
+// use when fanning out reads across independent standalone replicas
+// (shadow-replica mode).
+//
+// The slot algorithm is the same one the cluster protocol uses, so an
+// app-level CRC16 here selects the same slot a cluster-aware client
+// would route to.
+//
+// The slot-to-shard mapping mirrors the slot allocation produced by
+// `valkey-cli --cluster create` for N primaries. The reference
+// implementation in valkey/src/valkey-cli.c walks a floating-point
+// cursor (`slots_per_node = 16384 / N`) and rounds to the nearest
+// integer on each step (`lround(cursor + slots_per_node - 1)`), with
+// the last primary clamped to slot 16383. ShardMap precomputes the
+// resulting boundaries so per-key lookups are a short linear scan.
+package clusterslot
+
+import (
+	"math"
+	"strings"
+)
+
+// Total is the size of the Valkey/Redis Cluster slot space.
+const Total = 16384
+
+// Slot returns the cluster slot for key, applying the standard hashtag
+// rule (a substring between the first '{' and the next non-empty '}'
+// is hashed in place of the full key). Empty keys hash to slot 0.
+func Slot(key string) int {
+	return int(crc16(hashTag(key))) % Total
+}
+
+// ShardMap routes keys to shard ordinals using the slot allocation
+// `valkey-cli --cluster create` produces for a fixed number of primary
+// shards. Construct once and reuse — boundary computation is O(N) and
+// per-key lookups are O(N) over a small slice.
+type ShardMap struct {
+	// lastSlot[i] is the highest slot owned by shard ordinal i.
+	lastSlot []int
+}
+
+// NewShardMap precomputes shard boundaries for numShards primary nodes.
+// numShards <= 1 produces a map that routes every key to shard 0.
+func NewShardMap(numShards int) *ShardMap {
+	if numShards <= 1 {
+		return &ShardMap{lastSlot: []int{Total - 1}}
+	}
+	last := make([]int, numShards)
+	slotsPerNode := float64(Total) / float64(numShards)
+	cursor := 0.0
+	first := 0
+	for i := 0; i < numShards; i++ {
+		end := int(math.Round(cursor + slotsPerNode - 1))
+		if end > Total-1 || i == numShards-1 {
+			end = Total - 1
+		}
+		if end < first {
+			end = first
+		}
+		last[i] = end
+		first = end + 1
+		cursor += slotsPerNode
+	}
+	return &ShardMap{lastSlot: last}
+}
+
+// NumShards reports the number of shards this map routes across.
+func (m *ShardMap) NumShards() int { return len(m.lastSlot) }
+
+// LastSlots returns the highest slot each shard ordinal owns. The
+// returned slice is a defensive copy.
+func (m *ShardMap) LastSlots() []int {
+	out := make([]int, len(m.lastSlot))
+	copy(out, m.lastSlot)
+	return out
+}
+
+// Shard returns the destination shard ordinal for key. Always in
+// [0, NumShards()).
+func (m *ShardMap) Shard(key string) int {
+	if len(m.lastSlot) <= 1 {
+		return 0
+	}
+	return m.ShardForSlot(Slot(key))
+}
+
+// ShardForSlot returns the destination shard ordinal for slot. Useful
+// when slot is known directly (e.g., from CLUSTER SLOTS) and CRC16
+// inversion would be wasteful.
+func (m *ShardMap) ShardForSlot(slot int) int {
+	if len(m.lastSlot) <= 1 {
+		return 0
+	}
+	for i, end := range m.lastSlot {
+		if slot <= end {
+			return i
+		}
+	}
+	return len(m.lastSlot) - 1
+}
+
+// Shard is a convenience for one-off lookups. For repeated lookups,
+// build a ShardMap once with NewShardMap and reuse it.
+func Shard(key string, numShards int) int {
+	return NewShardMap(numShards).Shard(key)
+}
+
+// hashTag returns the substring between the first '{' and the next '}'
+// if non-empty; otherwise it returns key.
+func hashTag(key string) string {
+	s := strings.IndexByte(key, '{')
+	if s < 0 {
+		return key
+	}
+	e := strings.IndexByte(key[s+1:], '}')
+	if e <= 0 {
+		return key
+	}
+	return key[s+1 : s+1+e]
+}
+
+// crc16 implements CRC-16/XMODEM (CCITT), the algorithm Valkey Cluster
+// uses for slot assignment.
+func crc16(s string) uint16 {
+	var crc uint16
+	for i := 0; i < len(s); i++ {
+		crc = (crc << 8) ^ crc16tab[byte(crc>>8)^s[i]]
+	}
+	return crc
+}
+
+var crc16tab = [256]uint16{
+	0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
+	0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
+	0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
+	0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de,
+	0x2462, 0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485,
+	0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+	0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4,
+	0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc,
+	0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
+	0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b,
+	0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
+	0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a,
+	0x6ca6, 0x7c87, 0x4ce4, 0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41,
+	0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49,
+	0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70,
+	0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78,
+	0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f,
+	0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
+	0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+	0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256,
+	0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d,
+	0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+	0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c,
+	0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615, 0x5634,
+	0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab,
+	0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3,
+	0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
+	0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92,
+	0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9,
+	0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1,
+	0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
+	0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0,
+}

--- a/targeting/internal/clusterslot/clusterslot_test.go
+++ b/targeting/internal/clusterslot/clusterslot_test.go
@@ -1,0 +1,98 @@
+package clusterslot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHashTag(t *testing.T) {
+	cases := []struct {
+		key, want string
+	}{
+		{"plain", "plain"},
+		{"", ""},
+		{"{tag}rest", "tag"},
+		{"prefix{tag}suffix", "tag"},
+		{"{}empty", "{}empty"},
+		{"{unterminated", "{unterminated"},
+		{"no-open}close", "no-open}close"},
+		{"{a}{b}", "a"},
+		{"{", "{"},
+		{"a{", "a{"},
+		{"}", "}"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, hashTag(tc.key), "hashTag(%q)", tc.key)
+	}
+}
+
+func TestSlot(t *testing.T) {
+	assert.Equal(t, uint16(0x31C3), crc16("123456789"))
+	assert.Equal(t, 12739, Slot("123456789"))
+	assert.Equal(t, 0, Slot(""))
+	assert.Equal(t, Slot("foo"), Slot("{foo}bar"))
+	assert.NotEqual(t, Slot("foo"), Slot("{}foo"))
+}
+
+// TestShardMap_BoundariesMatchValkeyCli verifies that the per-shard
+// last-slot boundaries match the slot allocation `valkey-cli --cluster
+// create` produces. Reference values were captured by running
+// `valkey-cli --cluster create` against valkey:9 with N nodes and
+// reading CLUSTER SLOTS.
+func TestShardMap_BoundariesMatchValkeyCli(t *testing.T) {
+	cases := []struct {
+		n        int
+		lastSlot []int
+	}{
+		{1, []int{16383}},
+		{2, []int{8191, 16383}},
+		{3, []int{5460, 10922, 16383}},
+		{4, []int{4095, 8191, 12287, 16383}},
+		{5, []int{3276, 6553, 9829, 13106, 16383}},
+		{6, []int{2730, 5460, 8191, 10922, 13652, 16383}},
+		{8, []int{2047, 4095, 6143, 8191, 10239, 12287, 14335, 16383}},
+	}
+	for _, tc := range cases {
+		m := NewShardMap(tc.n)
+		assert.Equalf(t, tc.lastSlot, m.LastSlots(), "n=%d", tc.n)
+		assert.Equal(t, tc.n, m.NumShards())
+	}
+}
+
+func TestShardMap_SingleShardAbsorbsEverything(t *testing.T) {
+	m := NewShardMap(1)
+	for _, k := range []string{"", "a", "fcap:123", "audience:user:abc"} {
+		assert.Equal(t, 0, m.Shard(k), "single shard must absorb key %q", k)
+	}
+}
+
+func TestShardMap_ShardInRange(t *testing.T) {
+	for _, n := range []int{1, 2, 3, 4, 5, 8} {
+		m := NewShardMap(n)
+		for s := 0; s < Total; s++ {
+			got := lookup(m, s)
+			require.Truef(t, got >= 0 && got < n, "n=%d slot=%d returned shard %d", n, s, got)
+		}
+	}
+}
+
+func TestShardMap_BoundaryAdjacentSlots(t *testing.T) {
+	// For N=3, slot 10922 owned by shard 1, slot 10923 owned by shard 2.
+	// This is the off-by-one zone where a naive integer-division mapping
+	// would mis-route slot 10922 to shard 2.
+	m := NewShardMap(3)
+	assert.Equal(t, 1, lookup(m, 10922), "slot 10922 belongs to shard 1 per valkey-cli")
+	assert.Equal(t, 2, lookup(m, 10923), "slot 10923 belongs to shard 2 per valkey-cli")
+	assert.Equal(t, 0, lookup(m, 5460), "slot 5460 belongs to shard 0")
+	assert.Equal(t, 1, lookup(m, 5461), "slot 5461 belongs to shard 1")
+}
+
+func lookup(m *ShardMap, slot int) int {
+	return m.ShardForSlot(slot)
+}
+
+func TestShard_DelegatesToShardMap(t *testing.T) {
+	assert.Equal(t, NewShardMap(3).Shard("fcap:abc"), Shard("fcap:abc", 3))
+}

--- a/targeting/redisstore/audience_store.go
+++ b/targeting/redisstore/audience_store.go
@@ -13,8 +13,11 @@ var _ audience.Store = (*Store)(nil)
 
 // HSetBatch performs HSET for multiple (key, field, value) triples in one
 // pipelined round-trip. Items targeting the same key are grouped into a
-// single HSET command.
+// single HSET command. Returns ErrReadOnly in shadow-shards mode.
 func (s *Store) HSetBatch(ctx context.Context, items []audience.HSetItem) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(items) == 0 {
 		return nil
 	}
@@ -35,65 +38,87 @@ func (s *Store) HSetBatch(ctx context.Context, items []audience.HSetItem) error 
 	return err
 }
 
-// HExistsBatch checks one (key, field) pair per lookup, returning results in
-// the same order. Pipelined.
+// HExistsBatch checks one (key, field) pair per lookup, returning results
+// in the same order. Pipelined per shard; in shadow mode the per-shard
+// pipelines run in parallel.
 func (s *Store) HExistsBatch(ctx context.Context, lookups []audience.HLookup) ([]bool, error) {
 	if len(lookups) == 0 {
 		return nil, nil
 	}
-	pipe := s.client.Pipeline()
-	cmds := make([]*redis.BoolCmd, len(lookups))
+	keys := make([]string, len(lookups))
 	for i, l := range lookups {
-		cmds[i] = pipe.HExists(ctx, l.Key, l.Field)
-	}
-	if _, err := pipe.Exec(ctx); err != nil {
-		return nil, err
+		keys[i] = l.Key
 	}
 	out := make([]bool, len(lookups))
-	for i, c := range cmds {
-		b, err := c.Result()
-		if err != nil {
-			return nil, fmt.Errorf("redisstore: HEXISTS result %d: %w", i, err)
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		pipe := s.pipelineFor(group)
+		cmds := make([]*redis.BoolCmd, len(indices))
+		for j, i := range indices {
+			cmds[j] = pipe.HExists(ctx, lookups[i].Key, lookups[i].Field)
 		}
-		out[i] = b
+		if _, err := pipe.Exec(ctx); err != nil {
+			return err
+		}
+		for j, c := range cmds {
+			b, err := c.Result()
+			if err != nil {
+				return fmt.Errorf("redisstore: HEXISTS result %d: %w", indices[j], err)
+			}
+			out[indices[j]] = b
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }
 
-// HGetAll returns every (field, value) under key. Empty map for missing keys —
-// go-redis returns an empty map rather than nil for unknown keys.
+// HGetAll returns every (field, value) under key. Empty map for missing
+// keys — go-redis returns an empty map rather than nil.
 func (s *Store) HGetAll(ctx context.Context, key string) (map[string]string, error) {
-	return s.client.HGetAll(ctx, key).Result()
+	return s.cmdableFor(key).HGetAll(ctx, key).Result()
 }
 
-// HGetAllBatch returns HGETALL results for each key in input order. Missing
-// keys produce empty maps at their index.
+// HGetAllBatch returns HGETALL results for each key in input order.
+// Missing keys produce empty maps at their index.
 func (s *Store) HGetAllBatch(ctx context.Context, keys []string) ([]map[string]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	pipe := s.client.Pipeline()
-	cmds := make([]*redis.MapStringStringCmd, len(keys))
-	for i, k := range keys {
-		cmds[i] = pipe.HGetAll(ctx, k)
-	}
-	if _, err := pipe.Exec(ctx); err != nil {
-		return nil, err
-	}
 	out := make([]map[string]string, len(keys))
-	for i, c := range cmds {
-		m, err := c.Result()
-		if err != nil {
-			return nil, fmt.Errorf("redisstore: HGETALL result %d: %w", i, err)
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		pipe := s.pipelineFor(group)
+		cmds := make([]*redis.MapStringStringCmd, len(indices))
+		for j, i := range indices {
+			cmds[j] = pipe.HGetAll(ctx, keys[i])
 		}
-		out[i] = m
+		if _, err := pipe.Exec(ctx); err != nil {
+			return err
+		}
+		for j, c := range cmds {
+			m, err := c.Result()
+			if err != nil {
+				return fmt.Errorf("redisstore: HGETALL result %d: %w", indices[j], err)
+			}
+			out[indices[j]] = m
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }
 
-// HDelBatch performs HDEL for multiple (key, fields) pairs in one pipelined
-// round-trip.
+// HDelBatch performs HDEL for multiple (key, fields) pairs in one
+// pipelined round-trip. Returns ErrReadOnly in shadow-shards mode.
 func (s *Store) HDelBatch(ctx context.Context, items []audience.HDelItem) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(items) == 0 {
 		return nil
 	}

--- a/targeting/redisstore/cluster_parity_integration_test.go
+++ b/targeting/redisstore/cluster_parity_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package redisstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcnetwork "github.com/testcontainers/testcontainers-go/network"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
+)
+
+// startValkeyCluster bootstraps a real N-primary Valkey 9 cluster via
+// `valkey-cli --cluster create` and returns a standalone client to
+// each node in the same order they were passed to cluster create.
+func startValkeyCluster(t *testing.T, n int) []*redis.Client {
+	t.Helper()
+	ctx := context.Background()
+
+	net, err := tcnetwork.New(ctx)
+	if err != nil {
+		t.Skipf("Docker network unavailable, skipping cluster parity test: %v", err)
+	}
+	t.Cleanup(func() { _ = net.Remove(context.Background()) })
+
+	containers := make([]testcontainers.Container, n)
+	standalone := make([]*redis.Client, n)
+	internalAddrs := make([]string, n)
+
+	for i := 0; i < n; i++ {
+		alias := fmt.Sprintf("vk-%d", i)
+		req := testcontainers.ContainerRequest{
+			Image: "valkey/valkey:9-alpine",
+			Cmd: []string{
+				"valkey-server",
+				"--port", "6379",
+				"--cluster-enabled", "yes",
+				"--cluster-config-file", "nodes.conf",
+				"--cluster-node-timeout", "5000",
+				"--appendonly", "no",
+				"--save", "",
+			},
+			ExposedPorts: []string{"6379/tcp"},
+			Hostname:     alias,
+			Networks:     []string{net.Name},
+			NetworkAliases: map[string][]string{
+				net.Name: {alias},
+			},
+			WaitingFor: wait.ForListeningPort("6379/tcp").WithStartupTimeout(30 * time.Second),
+		}
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			t.Skipf("Docker unavailable, skipping cluster parity test: %v", err)
+		}
+		t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+		containers[i] = container
+
+		host, err := container.Host(ctx)
+		require.NoError(t, err)
+		port, err := container.MappedPort(ctx, "6379/tcp")
+		require.NoError(t, err)
+		c := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("%s:%s", host, port.Port())})
+		t.Cleanup(func() { _ = c.Close() })
+		standalone[i] = c
+		internalAddrs[i] = fmt.Sprintf("%s:6379", alias)
+	}
+
+	createCmd := append([]string{"valkey-cli", "--cluster", "create"}, internalAddrs...)
+	createCmd = append(createCmd, "--cluster-replicas", "0", "--cluster-yes")
+	code, _, err := containers[0].Exec(ctx, createCmd)
+	require.NoErrorf(t, err, "cluster create exec: %v", err)
+	require.Equalf(t, 0, code, "cluster create returned non-zero exit")
+
+	require.Eventuallyf(t, func() bool {
+		info, err := standalone[0].ClusterInfo(ctx).Result()
+		return err == nil && strings.Contains(info, "cluster_state:ok")
+	}, 30*time.Second, 200*time.Millisecond, "cluster did not reach state:ok")
+
+	return standalone
+}
+
+// reportedBoundaries returns, in node-ordinal order, the highest slot
+// each cluster node owns according to CLUSTER SLOTS on that node. Node
+// ordinals match the order passed to `valkey-cli --cluster create`,
+// which we identify by querying each standalone client for its node
+// id and matching against the CLUSTER SLOTS report.
+func reportedBoundaries(t *testing.T, clients []*redis.Client) []int {
+	t.Helper()
+	ctx := context.Background()
+
+	nodeIDs := make([]string, len(clients))
+	for i, c := range clients {
+		id, err := c.ClusterMyID(ctx).Result()
+		require.NoErrorf(t, err, "CLUSTER MYID for client %d", i)
+		require.NotEmptyf(t, id, "empty node id for client %d", i)
+		nodeIDs[i] = id
+	}
+
+	slots, err := clients[0].ClusterSlots(ctx).Result()
+	require.NoError(t, err)
+
+	endByNode := make(map[string]int, len(clients))
+	for _, sr := range slots {
+		require.NotEmpty(t, sr.Nodes, "CLUSTER SLOTS returned a range with no nodes")
+		nodeID := sr.Nodes[0].ID
+		if sr.End > endByNode[nodeID] {
+			endByNode[nodeID] = sr.End
+		}
+	}
+
+	out := make([]int, len(clients))
+	for i, id := range nodeIDs {
+		end, ok := endByNode[id]
+		require.Truef(t, ok, "node %d (id=%s) has no slots in CLUSTER SLOTS", i, id)
+		out[i] = end
+	}
+	return out
+}
+
+// TestIntegration_ShardMapMatchesClusterSlots is the safety net for
+// frequency-writer interop: it bootstraps a real Valkey cluster the
+// same way rtkv-bootstrap does, reads back the slot allocation Valkey
+// produced, and asserts every boundary matches ShardMap's. If a
+// future Valkey release changes `--cluster create`'s slot
+// distribution, this test fails loudly.
+func TestIntegration_ShardMapMatchesClusterSlots(t *testing.T) {
+	for _, n := range []int{3, 4, 5} {
+		t.Run(fmt.Sprintf("N=%d", n), func(t *testing.T) {
+			clients := startValkeyCluster(t, n)
+			want := reportedBoundaries(t, clients)
+			got := clusterslot.NewShardMap(n).LastSlots()
+			assert.Equalf(t, want, got, "ShardMap boundaries must match Valkey cluster slot allocation for N=%d", n)
+		})
+	}
+}

--- a/targeting/redisstore/shadow_integration_test.go
+++ b/targeting/redisstore/shadow_integration_test.go
@@ -1,0 +1,225 @@
+//go:build integration
+
+package redisstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/identityhash"
+)
+
+// startValkeyShards spins up n independent Valkey 9 containers and
+// returns a shadow-mode Store routing across them.
+func startValkeyShards(t *testing.T, n int) (*Store, []*redis.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	clients := make([]*redis.Client, n)
+	for i := 0; i < n; i++ {
+		req := testcontainers.ContainerRequest{
+			Image:        "valkey/valkey:9-alpine",
+			ExposedPorts: []string{"6379/tcp"},
+			WaitingFor:   wait.ForListeningPort("6379/tcp").WithStartupTimeout(30 * time.Second),
+		}
+		container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+		if err != nil {
+			t.Skipf("Docker not available, skipping integration test: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = container.Terminate(context.Background())
+		})
+
+		host, err := container.Host(ctx)
+		require.NoError(t, err)
+		port, err := container.MappedPort(ctx, "6379/tcp")
+		require.NoError(t, err)
+
+		c := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("%s:%s", host, port.Port())})
+		t.Cleanup(func() { _ = c.Close() })
+		clients[i] = c
+	}
+
+	store, err := NewShadow(clients)
+	require.NoError(t, err)
+	return store, clients
+}
+
+// seedFcapShadow writes a single fcap marker directly to the shard that
+// owns key, simulating the data a cluster master would have replicated
+// into its shadow.
+func seedFcapShadow(t *testing.T, clients []*redis.Client, key, field string, expireAt time.Time) {
+	t.Helper()
+	idx := clusterslot.Shard(key, len(clients))
+	opts := &redis.HSetEXOptions{
+		ExpirationType: redis.HSetEXExpirationPXAT,
+		ExpirationVal:  expireAt.UnixMilli(),
+	}
+	require.NoError(t, clients[idx].HSetEXWithArgs(context.Background(), key, opts, field, "1").Err())
+}
+
+func TestIntegration_Shadow_SingleShard(t *testing.T) {
+	store, clients := startValkeyShards(t, 1)
+	require.Equal(t, 1, store.NumShards())
+	require.Len(t, clients, 1)
+
+	ctx := context.Background()
+	key := "fcap:user-1"
+	field := "https://seller.example.com/agent:pkg-1"
+	seedFcapShadow(t, clients, key, field, time.Now().Add(2*time.Minute))
+
+	exists, err := store.FieldExists(ctx, key, field)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = store.FieldExists(ctx, key, "https://other:pkg-2")
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestIntegration_Shadow_FcapBatchAcrossShards(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	require.Equal(t, 3, store.NumShards())
+	ctx := context.Background()
+	expireAt := time.Now().Add(5 * time.Minute)
+
+	keys := make([]string, 3)
+	for i := 0; i < 200 && (keys[0] == "" || keys[1] == "" || keys[2] == ""); i++ {
+		k := fmt.Sprintf("fcap:user-%d", i)
+		sh := clusterslot.Shard(k, 3)
+		if keys[sh] == "" {
+			keys[sh] = k
+			seedFcapShadow(t, clients, k, "url:pkg", expireAt)
+		}
+	}
+	for sh, k := range keys {
+		require.NotEmpty(t, k, "no candidate key landed on shard %d", sh)
+	}
+
+	lookups := make([]fcap.FieldLookup, 0, len(keys)*2)
+	want := make([]bool, 0, len(keys)*2)
+	for _, k := range keys {
+		lookups = append(lookups, fcap.FieldLookup{Key: k, Field: "url:pkg"})
+		want = append(want, true)
+		lookups = append(lookups, fcap.FieldLookup{Key: k, Field: "url:pkg-miss"})
+		want = append(want, false)
+	}
+
+	got, err := store.FieldExistsBatch(ctx, lookups)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestIntegration_Shadow_WritesAreReadOnly(t *testing.T) {
+	store, _ := startValkeyShards(t, 2)
+	ctx := context.Background()
+	expireAt := time.Now().Add(time.Minute)
+
+	err := store.SetFields(ctx, "fcap:x", map[string]string{"f": "1"}, expireAt)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.SetFieldsBatch(ctx, []fcap.FieldsBatch{{Key: "fcap:x", Fields: map[string]string{"f": "1"}, ExpireAt: expireAt}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.HSetBatch(ctx, []audience.HSetItem{{Key: "audience:user:x", Field: "a", Value: "1"}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.HDelBatch(ctx, []audience.HDelItem{{Key: "audience:user:x", Fields: []string{"a"}}})
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.Set(ctx, "k", "v", 0)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+	err = store.MSet(ctx, map[string]string{"k": "v"}, 0)
+	assert.True(t, errors.Is(err, ErrReadOnly))
+}
+
+func TestIntegration_Shadow_AudienceMultiShard(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	ctx := context.Background()
+
+	keys := make([]string, 0, 6)
+	for i := 0; len(keys) < 6; i++ {
+		k := fmt.Sprintf("audience:user:%d", i)
+		idx := clusterslot.Shard(k, 3)
+		require.NoError(t, clients[idx].HSet(ctx, k, "cooking", "0.9", "tech", "0.4").Err())
+		keys = append(keys, k)
+	}
+
+	m, err := store.HGetAll(ctx, keys[0])
+	require.NoError(t, err)
+	assert.Equal(t, "0.9", m["cooking"])
+
+	maps, err := store.HGetAllBatch(ctx, append(keys, "audience:user:missing"))
+	require.NoError(t, err)
+	require.Len(t, maps, len(keys)+1)
+	for i := range keys {
+		assert.Equal(t, "0.9", maps[i]["cooking"])
+		assert.Equal(t, "0.4", maps[i]["tech"])
+	}
+	assert.Equal(t, map[string]string{}, maps[len(keys)])
+
+	lookups := []audience.HLookup{
+		{Key: keys[0], Field: "cooking"},
+		{Key: keys[1], Field: "missing"},
+		{Key: "audience:user:missing", Field: "cooking"},
+	}
+	hits, err := store.HExistsBatch(ctx, lookups)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, false, false}, hits)
+}
+
+func TestIntegration_Shadow_FcapServiceWiring(t *testing.T) {
+	store, clients := startValkeyShards(t, 3)
+	svc := fcap.New(store)
+	ctx := context.Background()
+
+	expireAt := time.Now().Add(2 * time.Minute)
+	identities := []string{"id5-a", "id5-b", "id5-c"}
+	for _, id := range identities {
+		seedFcapShadow(t, clients, "fcap:"+identityhash.Hash(id), "https://seller:pkg-a", expireAt)
+	}
+
+	field := fcap.Field{SellerAgentURL: "https://seller", PackageID: "pkg-a"}
+	hits, err := svc.IsCappedBatch(ctx, []fcap.CapLookup{
+		{UserIdentity: "id5-a", Field: field},
+		{UserIdentity: "id5-b", Field: field},
+		{UserIdentity: "id5-c", Field: field},
+		{UserIdentity: "id5-unknown", Field: field},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true, true, true, false}, hits)
+}
+
+func TestIntegration_Shadow_SetIntersect_CrossShardFails(t *testing.T) {
+	store, _ := startValkeyShards(t, 3)
+	ctx := context.Background()
+
+	// Find two keys that land on different shards.
+	var a, b string
+	for i := 0; i < 200; i++ {
+		k := fmt.Sprintf("k-%d", i)
+		if a == "" {
+			a = k
+			continue
+		}
+		if clusterslot.Shard(k, 3) != clusterslot.Shard(a, 3) {
+			b = k
+			break
+		}
+	}
+	require.NotEmpty(t, b, "could not find cross-shard candidate")
+
+	_, err := store.SetIntersect(ctx, a, b)
+	assert.True(t, errors.Is(err, ErrCrossShard))
+}

--- a/targeting/redisstore/store.go
+++ b/targeting/redisstore/store.go
@@ -200,9 +200,17 @@ func (s *Store) fanOut(ctx context.Context, byGroup map[int][]int, fn func(ctx c
 		return nil
 	}
 	if len(byGroup) == 1 {
-		for g, idxs := range byGroup {
-			return fn(ctx, g, idxs)
+		// Single-group fast path: skip goroutine overhead. Extract the
+		// sole entry up front rather than relying on a return inside a
+		// for-range body, which would silently fall through if the body
+		// is ever refactored to continue.
+		var (
+			group   int
+			indices []int
+		)
+		for group, indices = range byGroup { //nolint:revive // single iteration: extracts the only entry
 		}
+		return fn(ctx, group, indices)
 	}
 	derived, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/targeting/redisstore/store.go
+++ b/targeting/redisstore/store.go
@@ -1,21 +1,87 @@
 // Package redisstore provides Valkey-backed implementations of
-// targeting.Store and targeting/fcap.Store using github.com/redis/go-redis/v9.
+// targeting.Store, targeting/fcap.Store, and targeting/audience.Store
+// using github.com/redis/go-redis/v9.
 //
-// One Store wraps a single go-redis client and satisfies both interfaces, so
-// callers share connection state between the targeting engine and the
-// frequency-cap service.
+// Three topologies are supported through a single Store type:
+//
+//   - Standalone: a single Valkey endpoint. Construct via New with a
+//     *redis.Client.
+//   - Cluster: a Valkey Cluster. Construct via New with a
+//     *redis.ClusterClient. Slot routing happens inside go-redis.
+//   - Shadow shards: N independent standalone Valkey endpoints that
+//     mirror a central cluster's per-shard keyspace and do not
+//     participate in cluster gossip. Construct via NewShadow with one
+//     *redis.Client per shard ordinal. Reads route by app-level CRC16;
+//     writes return ErrReadOnly.
+//
+// One Store satisfies targeting.Store, fcap.Store, and audience.Store
+// in every topology, so callers share connection state between the
+// targeting engine and the frequency-cap / audience services.
+//
+// # Shadow-shard routing
+//
+// shadowstore mode computes slot = CRC16(hashtag(key)) % 16384 and
+// derives the shard ordinal as floor(slot / (16384 / N)), where N is
+// the number of configured shadows; the last shard absorbs the
+// remainder. This matches Valkey Cluster's positional
+// `valkey-cli --cluster create` allocation, so shadow ordinal K serves
+// the same slot range as cluster master K.
+//
+// Single-shard shadow deployments are valid: with N=1 every key routes
+// to the single endpoint. Changing N (a resharding event on the
+// upstream cluster) is a breaking change for in-flight reads — the
+// slot-to-ordinal mapping shifts and a fraction of keys land on the
+// wrong shadow. A deployment that straddles a migration must change
+// this package to fall back to a second shadow on miss while the slot
+// allocation converges.
+//
+// # Wiring from a Terraform-shaped shard map
+//
+// The Terraform configmap exposes shadow endpoints as a JSON map
+// keyed by shard ordinal: `VALKEY_SHARDS = '{"0":"host:port","1":...}'`.
+// Build the *redis.Client slice in numeric ordinal order:
+//
+//	var addrs map[string]string
+//	_ = json.Unmarshal([]byte(os.Getenv("VALKEY_SHARDS")), &addrs)
+//
+//	ordinals := make([]int, 0, len(addrs))
+//	for k := range addrs {
+//	    i, err := strconv.Atoi(k)
+//	    if err != nil { return err }
+//	    ordinals = append(ordinals, i)
+//	}
+//	sort.Ints(ordinals)
+//
+//	clients := make([]*redis.Client, len(ordinals))
+//	for i, ord := range ordinals {
+//	    if ord != i {
+//	        return fmt.Errorf("non-contiguous shard ordinals: %v", ordinals)
+//	    }
+//	    clients[i] = redis.NewClient(&redis.Options{
+//	        Addr:     addrs[strconv.Itoa(ord)],
+//	        Password: os.Getenv("VALKEY_PASSWORD"),
+//	        DB:       db,
+//	    })
+//	}
+//	store, err := redisstore.NewShadow(clients)
+//
+// Index order in the slice is load-bearing for routing. Caller closes
+// each client at shutdown.
 package redisstore
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
 )
 
 var (
@@ -23,32 +89,190 @@ var (
 	_ fcap.Store      = (*Store)(nil)
 )
 
-// Store wraps a go-redis client and implements targeting.Store and fcap.Store.
+// ErrReadOnly is returned by every write method when Store is in
+// shadow-shards mode. Shadow replicas are receive-only targets; writes
+// must go to a cluster master through a cluster-aware client.
+var ErrReadOnly = errors.New("redisstore: write not supported on shadow replica")
+
+// ErrCrossShard is returned when a multi-key operation receives keys
+// that span shards (shadow mode) or slots (cluster mode). The two
+// affected callers are SetIntersect (Valkey SINTER requires same-slot
+// keys) and any future multi-key command with the same constraint.
+// Callers must co-locate related keys with a `{hashtag}` to keep them
+// on one shard.
+var ErrCrossShard = errors.New("redisstore: cross-shard keys are not supported")
+
+// Store implements targeting.Store, fcap.Store, and audience.Store on
+// top of go-redis.
+//
+// In single-client mode (standalone or cluster) client is set and
+// shards is nil. In shadow-shards mode shards is set, client is nil,
+// shardMap precomputes slot boundaries, and writes return ErrReadOnly.
 type Store struct {
-	client redis.UniversalClient
+	client   redis.UniversalClient
+	shards   []*redis.Client
+	shardMap *clusterslot.ShardMap
 }
 
-// New constructs a Store from a go-redis client. Accepts *redis.Client,
-// *redis.ClusterClient, or any redis.UniversalClient.
+// New constructs a Store backed by a single go-redis client. Pass
+// *redis.Client for standalone or *redis.ClusterClient for cluster
+// topology — go-redis routes commands inside the client.
 func New(client redis.UniversalClient) *Store {
 	return &Store{client: client}
+}
+
+// NewShadow constructs a read-only Store that fans out reads across
+// shards. shards[i] is the standalone client for shard ordinal i; index
+// order is load-bearing for routing. Returns an error if shards is
+// empty or any element is nil.
+func NewShadow(shards []*redis.Client) (*Store, error) {
+	if len(shards) == 0 {
+		return nil, errors.New("redisstore: at least one shadow shard is required")
+	}
+	for i, c := range shards {
+		if c == nil {
+			return nil, fmt.Errorf("redisstore: shadow shard at ordinal %d is nil", i)
+		}
+	}
+	return &Store{shards: shards, shardMap: clusterslot.NewShardMap(len(shards))}, nil
+}
+
+// NumShards reports the shard count for a shadow-shards Store. Returns
+// 1 for single-client topologies.
+func (s *Store) NumShards() int {
+	if len(s.shards) > 0 {
+		return len(s.shards)
+	}
+	return 1
+}
+
+// shadow reports whether Store is in shadow-shards mode.
+func (s *Store) shadow() bool { return len(s.shards) > 0 }
+
+// cmdableFor returns the go-redis Cmdable that serves single-key
+// commands on key. In single-client mode this is the wrapped client; in
+// shadow mode it is the per-shard client.
+func (s *Store) cmdableFor(key string) redis.Cmdable {
+	if s.shadow() {
+		return s.shards[s.shardMap.Shard(key)]
+	}
+	return s.client
+}
+
+// pipelineFor returns a Pipeliner for the given destination group. In
+// single-client mode the group identifier is ignored; in shadow mode
+// the group is the shard ordinal.
+func (s *Store) pipelineFor(group int) redis.Pipeliner {
+	if s.shadow() {
+		return s.shards[group].Pipeline()
+	}
+	return s.client.Pipeline()
+}
+
+// groupKeys maps each input index to its destination group. In
+// single-client mode every index falls into group 0; in shadow mode
+// indices are bucketed by shard ordinal.
+func (s *Store) groupKeys(keys []string) map[int][]int {
+	if !s.shadow() {
+		all := make([]int, len(keys))
+		for i := range keys {
+			all[i] = i
+		}
+		return map[int][]int{0: all}
+	}
+	numShards := len(s.shards)
+	out := make(map[int][]int, numShards)
+	for i, k := range keys {
+		sh := s.shardMap.Shard(k)
+		out[sh] = append(out[sh], i)
+	}
+	return out
+}
+
+// fanOut runs fn once per destination group. If only one group exists
+// (single-client mode, or a shadow batch that lands on one shard), fn
+// runs inline. With multiple groups fn runs per goroutine so a
+// multi-shard batch costs one shard's round-trip of wall-clock
+// latency. The first error from any shard cancels the derived context
+// so in-flight peers bail rather than waiting out their own RTTs.
+func (s *Store) fanOut(ctx context.Context, byGroup map[int][]int, fn func(ctx context.Context, group int, indices []int) error) error {
+	if len(byGroup) == 0 {
+		return nil
+	}
+	if len(byGroup) == 1 {
+		for g, idxs := range byGroup {
+			return fn(ctx, g, idxs)
+		}
+	}
+	derived, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var (
+		wg       sync.WaitGroup
+		mu       sync.Mutex
+		firstErr error
+	)
+	wg.Add(len(byGroup))
+	for g, idxs := range byGroup {
+		g, idxs := g, idxs
+		go func() {
+			defer wg.Done()
+			if err := fn(derived, g, idxs); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					cancel()
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	return firstErr
 }
 
 // --- targeting.Store ---
 
 func (s *Store) SetIsMember(ctx context.Context, key, member string) (bool, error) {
-	return s.client.SIsMember(ctx, key, member).Result()
+	return s.cmdableFor(key).SIsMember(ctx, key, member).Result()
 }
 
+// SetIntersect computes SINTER over keys. All keys must land on the
+// same shard (in shadow mode) or the same slot (in cluster mode); the
+// caller co-locates them via `{hashtag}`. Returns ErrCrossShard
+// uniformly across topologies when that constraint is violated.
 func (s *Store) SetIntersect(ctx context.Context, keys ...string) ([]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	return s.client.SInter(ctx, keys...).Result()
+	if s.shadow() {
+		shard := s.shardMap.Shard(keys[0])
+		for _, k := range keys[1:] {
+			if s.shardMap.Shard(k) != shard {
+				return nil, ErrCrossShard
+			}
+		}
+		res, err := s.shards[shard].SInter(ctx, keys...).Result()
+		return res, mapCrossSlotErr(err)
+	}
+	res, err := s.client.SInter(ctx, keys...).Result()
+	return res, mapCrossSlotErr(err)
+}
+
+// mapCrossSlotErr surfaces Valkey/Redis Cluster CROSSSLOT errors as
+// ErrCrossShard so callers see the same sentinel across topologies.
+func mapCrossSlotErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	if strings.HasPrefix(msg, "CROSSSLOT") || strings.Contains(msg, "keys don't hash to the same slot") {
+		return ErrCrossShard
+	}
+	return err
 }
 
 func (s *Store) Get(ctx context.Context, key string) (string, bool, error) {
-	val, err := s.client.Get(ctx, key).Result()
+	val, err := s.cmdableFor(key).Get(ctx, key).Result()
 	if errors.Is(err, redis.Nil) {
 		return "", false, nil
 	}
@@ -59,11 +283,14 @@ func (s *Store) Get(ctx context.Context, key string) (string, bool, error) {
 }
 
 func (s *Store) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	return s.client.Set(ctx, key, value, ttl).Err()
 }
 
 func (s *Store) Exists(ctx context.Context, key string) (bool, error) {
-	n, err := s.client.Exists(ctx, key).Result()
+	n, err := s.cmdableFor(key).Exists(ctx, key).Result()
 	if err != nil {
 		return false, err
 	}
@@ -71,7 +298,7 @@ func (s *Store) Exists(ctx context.Context, key string) (bool, error) {
 }
 
 func (s *Store) SetMembers(ctx context.Context, key string) ([]string, error) {
-	res, err := s.client.SMembers(ctx, key).Result()
+	res, err := s.cmdableFor(key).SMembers(ctx, key).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -85,21 +312,40 @@ func (s *Store) MGet(ctx context.Context, keys ...string) ([]string, error) {
 	if len(keys) == 0 {
 		return nil, nil
 	}
-	results, err := s.client.MGet(ctx, keys...).Result()
+	out := make([]string, len(keys))
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		groupKeys := make([]string, len(indices))
+		for j, i := range indices {
+			groupKeys[j] = keys[i]
+		}
+		var (
+			results []any
+			err     error
+		)
+		if s.shadow() {
+			results, err = s.shards[group].MGet(ctx, groupKeys...).Result()
+		} else {
+			results, err = s.client.MGet(ctx, groupKeys...).Result()
+		}
+		if err != nil {
+			return err
+		}
+		if len(results) != len(groupKeys) {
+			return fmt.Errorf("redisstore: MGET returned %d results for %d keys", len(results), len(groupKeys))
+		}
+		for j, r := range results {
+			if r == nil {
+				continue
+			}
+			if str, ok := r.(string); ok {
+				out[indices[j]] = str
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
-	}
-	if len(results) != len(keys) {
-		return nil, fmt.Errorf("redisstore: MGET returned %d results for %d keys", len(results), len(keys))
-	}
-	out := make([]string, len(results))
-	for i, r := range results {
-		if r == nil {
-			continue
-		}
-		if str, ok := r.(string); ok {
-			out[i] = str
-		}
 	}
 	return out, nil
 }
@@ -108,8 +354,10 @@ func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Durati
 	if len(kvs) == 0 {
 		return nil
 	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if ttl <= 0 {
-		// go-redis MSet accepts a map directly; no manual flatten needed.
 		return s.client.MSet(ctx, kvs).Err()
 	}
 	// MSET in Valkey doesn't accept a TTL. With TTL, batch SET-with-expiry per
@@ -126,6 +374,9 @@ func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Durati
 // --- fcap.Store ---
 
 func (s *Store) SetFields(ctx context.Context, key string, fields map[string]string, expireAt time.Time) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(fields) == 0 {
 		return nil
 	}
@@ -138,6 +389,9 @@ func (s *Store) SetFields(ctx context.Context, key string, fields map[string]str
 }
 
 func (s *Store) SetFieldsBatch(ctx context.Context, batches []fcap.FieldsBatch) error {
+	if s.shadow() {
+		return ErrReadOnly
+	}
 	if len(batches) == 0 {
 		return nil
 	}
@@ -163,28 +417,39 @@ func (s *Store) SetFieldsBatch(ctx context.Context, batches []fcap.FieldsBatch) 
 }
 
 func (s *Store) FieldExists(ctx context.Context, key, field string) (bool, error) {
-	return s.client.HExists(ctx, key, field).Result()
+	return s.cmdableFor(key).HExists(ctx, key, field).Result()
 }
 
 func (s *Store) FieldExistsBatch(ctx context.Context, lookups []fcap.FieldLookup) ([]bool, error) {
 	if len(lookups) == 0 {
 		return nil, nil
 	}
-	pipe := s.client.Pipeline()
-	cmds := make([]*redis.BoolCmd, len(lookups))
+	keys := make([]string, len(lookups))
 	for i, l := range lookups {
-		cmds[i] = pipe.HExists(ctx, l.Key, l.Field)
-	}
-	if _, err := pipe.Exec(ctx); err != nil {
-		return nil, err
+		keys[i] = l.Key
 	}
 	out := make([]bool, len(lookups))
-	for i, c := range cmds {
-		b, err := c.Result()
-		if err != nil {
-			return nil, fmt.Errorf("redisstore: HEXISTS result %d: %w", i, err)
+	byGroup := s.groupKeys(keys)
+	err := s.fanOut(ctx, byGroup, func(ctx context.Context, group int, indices []int) error {
+		pipe := s.pipelineFor(group)
+		cmds := make([]*redis.BoolCmd, len(indices))
+		for j, i := range indices {
+			cmds[j] = pipe.HExists(ctx, lookups[i].Key, lookups[i].Field)
 		}
-		out[i] = b
+		if _, err := pipe.Exec(ctx); err != nil {
+			return err
+		}
+		for j, c := range cmds {
+			b, err := c.Result()
+			if err != nil {
+				return fmt.Errorf("redisstore: HEXISTS result %d: %w", indices[j], err)
+			}
+			out[indices[j]] = b
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Adds a third Store topology — **shadow shards** — to both `targeting/redisstore` and `targeting/glidestore`, so the bidder / identity-match-service read path can serve regional reads from independent standalone Valkey replicas that mirror a central cluster's per-shard keyspace but don't participate in cluster gossip.

## What's new

- **`targeting/internal/clusterslot`** — shared CRC16/XMODEM + Valkey Cluster slot allocation. `ShardMap` precomputes per-shard slot boundaries once and routes each key in O(N). Implements valkey-cli's float-cursor algorithm (`lround` per boundary, last shard clamped to 16383), not the simple integer divide.
- **`redisstore.NewShadow([]*redis.Client) (*Store, error)`** — read-only fan-out across N standalone Valkey clients. Reads route by CRC16; per-shard pipelines run in parallel so a multi-shard batch costs one shard's round-trip of wall-clock latency. Writes return `ErrReadOnly`. Cross-shard `SetIntersect` returns `ErrCrossShard`, matching the sentinel cluster-mode `CROSSSLOT` errors are mapped to.
- **`glidestore.NewShadow([]*glide.Client) (*Store, error)`** — same shape, same behavior. Cluster mode via `*glide.ClusterClient` is deliberately not wired here (redisstore covers cluster topologies for now).
- **`Store.fanOut`** cancels a derived context on first shard error so in-flight peers bail rather than waiting out their own RTTs.
- One `Store` type per package now satisfies `fcap.Store`, `audience.Store`, and (for redisstore) `targeting.Store` in every topology — standalone, cluster, or shadow.

## Why the bespoke routing math

This is the load-bearing fix. The Terraform docstring claimed `valkey-cli --cluster create` allocates slots as \`[N*5461, (N+1)*5461 - 1]\` with \"the last shard absorbing the remainder.\" Empirically that's **wrong** — for N=3 the *middle* shard holds 5462 slots, not the last:

| shard  | slots          | count |
|--------|----------------|-------|
| rtkv-0 | \`[0, 5460]\`     | 5461  |
| rtkv-1 | \`[5461, 10922]\` | **5462** ← middle absorbs remainder |
| rtkv-2 | \`[10923, 16383]\` | 5461  |

\`valkey-cli\` walks a float cursor and rounds each boundary with \`lround\` (see \`valkey/src/valkey-cli.c:6871-6888\`). Slot 10922 — exactly the boundary case — would mis-route to the wrong shadow under a naive \`slot / 5461\` mapping and silently miss. For frequency caps that translates to under-counting → over-serving a small fraction of impressions.

\`ShardMap\` implements the matching algorithm. Confirmed against the prod rtkv cluster via CLUSTER NODES (rtkv-1 holds 5462 slots). Terraform docstring fix tracked in [scope3data/terraform#2429](https://github.com/scope3data/terraform/pull/2429).

## Test plan

- [x] Unit tests in \`targeting/internal/clusterslot\` assert per-shard boundaries match empirically captured \`valkey-cli --cluster create\` output for N in {1, 2, 3, 4, 5, 6, 8}.
- [x] \`cluster_parity_integration_test.go\` bootstraps a real N-primary Valkey 9 cluster via testcontainers, reads back CLUSTER SLOTS, and asserts \`ShardMap\` boundaries exactly match for N in {3, 4, 5}. Future Valkey allocation changes fail loudly here.
- [x] Per-package shadow integration tests cover single-shard, multi-shard fan-out, read-only enforcement, end-to-end \`fcap.Service\` wiring, audience batch reads, and cross-shard \`SetIntersect\` rejection.
- [x] All standalone integration tests in both packages still pass unchanged.
- [x] \`go test -race -tags integration ./...\` green end-to-end.
- [ ] Confirm \`gh\` CI is green on this PR.

## Wiring from a Terraform-shaped shard map

Documented in the redisstore package doc. Caller code is ~10 lines:

\`\`\`go
var addrs map[string]string
_ = json.Unmarshal([]byte(os.Getenv(\"VALKEY_SHARDS\")), &addrs)

ordinals := make([]int, 0, len(addrs))
for k := range addrs { i, _ := strconv.Atoi(k); ordinals = append(ordinals, i) }
sort.Ints(ordinals)

clients := make([]*redis.Client, len(ordinals))
for i, ord := range ordinals {
    if ord != i { return fmt.Errorf(\"non-contiguous shard ordinals\") }
    clients[i] = redis.NewClient(&redis.Options{
        Addr:     addrs[strconv.Itoa(ord)],
        Password: os.Getenv(\"VALKEY_PASSWORD\"),
    })
}
store, err := redisstore.NewShadow(clients)
\`\`\`

frequency-writer's write path is unaffected: it uses \`redis.NewClusterClient\` which learns slot ownership via CLUSTER SLOTS at runtime and ignores the shard-map keying entirely.

## Resharding caveat

Increasing the shadow shard count is a breaking change for in-flight reads — the slot-to-ordinal mapping shifts and a fraction of keys land on the wrong shadow. A deployment that straddles a migration needs a code change in this package to fall back to a second shadow on miss while the slot allocation converges. Called out in both package docs.