### PR TITLE
fix(identity-agent): align with 3.0.12 identity-match spec

### DIFF
--- a/cmd/identity-agent/example.cluster.env
+++ b/cmd/identity-agent/example.cluster.env
@@ -35,19 +35,24 @@ STRICT_CONTENT_TYPE=true
 ACCESS_LOG_ENABLED=false
 # ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
 # listener on that port so they can carry a different network policy than
-# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
-# TMP protocol surface routers probe externally. Unset (=0) keeps everything
-# on HTTP_PORT.
+# /identity. /health stays on HTTP_PORT regardless — it's part of the TMP
+# protocol surface routers probe externally. Unset (=0) keeps everything on
+# HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s
+
+# SUPPORTED_ADCP_MAJOR_VERSIONS is the comma-separated set of AdCP major
+# versions this agent will accept on inbound `adcp_major_version`. Requests
+# carrying an unsupported value are rejected with HTTP 400.
+SUPPORTED_ADCP_MAJOR_VERSIONS=3
 
 # --- Logging -----------------------------------------------------------------
 LOG_LEVEL=info
 
 # --- TMP signature verification ---------------------------------------------
 TMP_REGISTRY_URL=<https://router.example.com/registry/snapshot>
-TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/tmp/identity>
+TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/identity>
 TMP_ALLOW_UNSIGNED=false
 
 # --- TMPX (optional; leave all blank to disable) ----------------------------

--- a/cmd/identity-agent/example.cluster.env
+++ b/cmd/identity-agent/example.cluster.env
@@ -33,9 +33,11 @@ STRICT_CONTENT_TYPE=true
 # ACCESS_LOG_ENABLED emits one INFO log line per request. Off by default
 # at 10k QPS; useful in staging or for incident triage.
 ACCESS_LOG_ENABLED=false
-# ADMIN_PORT, when > 0, splits /metrics, /live, /health, /debug/pprof onto
-# a separate listener on that port so they can carry a different network
-# policy than /tmp/identity. Unset (=0) keeps everything on HTTP_PORT.
+# ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
+# listener on that port so they can carry a different network policy than
+# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
+# TMP protocol surface routers probe externally. Unset (=0) keeps everything
+# on HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s

--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -34,9 +34,11 @@ STRICT_CONTENT_TYPE=true
 # ACCESS_LOG_ENABLED emits one INFO log line per request. Off by default
 # at 10k QPS; useful in staging or for incident triage.
 ACCESS_LOG_ENABLED=false
-# ADMIN_PORT, when > 0, splits /metrics, /live, /health, /debug/pprof onto
-# a separate listener on that port so they can carry a different network
-# policy than /tmp/identity. Unset (=0) keeps everything on HTTP_PORT.
+# ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
+# listener on that port so they can carry a different network policy than
+# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
+# TMP protocol surface routers probe externally. Unset (=0) keeps everything
+# on HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s

--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -36,19 +36,24 @@ STRICT_CONTENT_TYPE=true
 ACCESS_LOG_ENABLED=false
 # ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
 # listener on that port so they can carry a different network policy than
-# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
-# TMP protocol surface routers probe externally. Unset (=0) keeps everything
-# on HTTP_PORT.
+# /identity. /health stays on HTTP_PORT regardless — it's part of the TMP
+# protocol surface routers probe externally. Unset (=0) keeps everything on
+# HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s
+
+# SUPPORTED_ADCP_MAJOR_VERSIONS is the comma-separated set of AdCP major
+# versions this agent will accept on inbound `adcp_major_version`. Requests
+# carrying an unsupported value are rejected with HTTP 400.
+SUPPORTED_ADCP_MAJOR_VERSIONS=3
 
 # --- Logging -----------------------------------------------------------------
 LOG_LEVEL=info
 
 # --- TMP signature verification ---------------------------------------------
 TMP_REGISTRY_URL=<https://router.example.com/registry/snapshot>
-TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/tmp/identity>
+TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/identity>
 TMP_ALLOW_UNSIGNED=false
 
 # --- TMPX (optional; leave all blank to disable) ----------------------------

--- a/cmd/identity-agent/example.standalone.env
+++ b/cmd/identity-agent/example.standalone.env
@@ -34,12 +34,17 @@ STRICT_CONTENT_TYPE=true
 ACCESS_LOG_ENABLED=false
 # ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
 # listener on that port so they can carry a different network policy than
-# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
-# TMP protocol surface routers probe externally. Unset (=0) keeps everything
-# on HTTP_PORT.
+# /identity. /health stays on HTTP_PORT regardless — it's part of the TMP
+# protocol surface routers probe externally. Unset (=0) keeps everything on
+# HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s
+
+# SUPPORTED_ADCP_MAJOR_VERSIONS is the comma-separated set of AdCP major
+# versions this agent will accept on inbound `adcp_major_version`. Requests
+# carrying an unsupported value are rejected with HTTP 400.
+SUPPORTED_ADCP_MAJOR_VERSIONS=3
 
 # --- Logging -----------------------------------------------------------------
 LOG_LEVEL=info
@@ -47,7 +52,7 @@ LOG_LEVEL=info
 # --- TMP signature verification ---------------------------------------------
 # Required unless TMP_ALLOW_UNSIGNED=true (not recommended for production).
 TMP_REGISTRY_URL=<https://router.example.com/registry/snapshot>
-TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/tmp/identity>
+TMP_OWN_ENDPOINT_URL=<https://identity-agent.example.com/identity>
 TMP_ALLOW_UNSIGNED=false
 
 # --- TMPX (optional; leave all blank to disable) ----------------------------

--- a/cmd/identity-agent/example.standalone.env
+++ b/cmd/identity-agent/example.standalone.env
@@ -32,9 +32,11 @@ STRICT_CONTENT_TYPE=true
 # ACCESS_LOG_ENABLED emits one INFO log line per request. Off by default
 # at 10k QPS; useful in staging or for incident triage.
 ACCESS_LOG_ENABLED=false
-# ADMIN_PORT, when > 0, splits /metrics, /live, /health, /debug/pprof onto
-# a separate listener on that port so they can carry a different network
-# policy than /tmp/identity. Unset (=0) keeps everything on HTTP_PORT.
+# ADMIN_PORT, when > 0, splits /metrics, /live, /debug/pprof onto a separate
+# listener on that port so they can carry a different network policy than
+# /tmp/identity. /health stays on HTTP_PORT regardless — it's part of the
+# TMP protocol surface routers probe externally. Unset (=0) keeps everything
+# on HTTP_PORT.
 ADMIN_PORT=0
 SHUTDOWN_GRACE=1s
 SHUTDOWN_TIMEOUT=10s

--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -109,7 +109,7 @@ func agentHandler(ctxEngine *targeting.ContextEngine, idEngine *targeting.Identi
 	mux := http.NewServeMux()
 
 	if ctxEngine != nil {
-		mux.HandleFunc("POST /tmp/context", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /context", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 			if err != nil {
 				writeAgentError(w, "", "failed to read body")
@@ -135,7 +135,7 @@ func agentHandler(ctxEngine *targeting.ContextEngine, idEngine *targeting.Identi
 	}
 
 	if idEngine != nil {
-		mux.HandleFunc("POST /tmp/identity", func(w http.ResponseWriter, r *http.Request) {
+		mux.HandleFunc("POST /identity", func(w http.ResponseWriter, r *http.Request) {
 			body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 			if err != nil {
 				writeAgentError(w, "", "failed to read body")

--- a/reference/identity-agent/cmd/identity-agent/main.go
+++ b/reference/identity-agent/cmd/identity-agent/main.go
@@ -23,7 +23,7 @@ var version = "dev"
 func main() {
 	addr := flag.String("addr", "", "Listen address")
 	registryURL := flag.String("registry-url", "", "URL of the router's /registry/snapshot endpoint for signing-key discovery")
-	allowUnsigned := flag.Bool("allow-unsigned", false, "Accept /tmp/identity requests without a TMP signature. Default is deny — TMP signing is normative in the spec. Use only for migration windows or local dev.")
+	allowUnsigned := flag.Bool("allow-unsigned", false, "Accept /identity requests without a TMP signature. Default is deny — TMP signing is normative in the spec. Use only for migration windows or local dev.")
 	ownEndpointURL := flag.String("own-endpoint-url", "", "This provider's registered endpoint URL (must match the router's provider registration). Required when --registry-url is set.")
 	tmpxEncryptJWKSURL := flag.String("tmpx-encrypt-jwks-url", "", "URL of the buyer's JWKS endpoint that publishes the active TMPX recipient key (X25519, adcp_use=tmpx-encrypt). Enables TMPX token generation when set.")
 	tmpxEncryptJWKSTTL := flag.Duration("tmpx-encrypt-jwks-ttl", 5*time.Minute, "How often to re-poll the TMPX encryption JWKS for key rotation.")
@@ -105,7 +105,7 @@ func main() {
 		os.Exit(1)
 	}
 	if !requireSig {
-		slog.Warn("/tmp/identity accepts unsigned requests — TMP signing should be required in production")
+		slog.Warn("/identity accepts unsigned requests — TMP signing should be required in production")
 	}
 
 	// The reference agent preserves the TMP_IDENTITY_TMPX_REFERENCE_STUB_ACK
@@ -131,18 +131,18 @@ func main() {
 		body, err := io.ReadAll(io.LimitReader(r.Body, 64*1024))
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: "failed to read request body"})
+			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Type: tmproto.TypeError, Code: tmproto.ErrorCodeInvalidRequest, Message: "failed to read request body"})
 			return
 		}
 		var req tmproto.IdentityMatchRequest
 		if err := json.Unmarshal(body, &req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Code: tmproto.ErrorCodeInvalidRequest, Message: "request body is not valid JSON"})
+			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Type: tmproto.TypeError, Code: tmproto.ErrorCodeInvalidRequest, Message: "request body is not valid JSON"})
 			return
 		}
 		if err := tmproto.ValidateIdentityRequest(&req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{RequestID: req.RequestID, Code: tmproto.ErrorCodeInvalidRequest, Message: err.Error()})
+			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Type: tmproto.TypeError, RequestID: req.RequestID, Code: tmproto.ErrorCodeInvalidRequest, Message: err.Error()})
 			return
 		}
 		effectivePkgIDs, idConfigs := identityconfig.ResolveRequest(configSvc, req.SellerAgentURL, req.PackageIDs)
@@ -152,16 +152,17 @@ func main() {
 		if err != nil {
 			slog.Error("EvaluateIdentityResolved failed", "request_id", req.RequestID, "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
-			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{RequestID: req.RequestID, Code: tmproto.ErrorCodeInternalError, Message: "internal error"})
+			_ = json.NewEncoder(w).Encode(tmproto.ErrorResponse{Type: tmproto.TypeError, RequestID: req.RequestID, Code: tmproto.ErrorCodeInternalError, Message: "internal error"})
 			return
 		}
-		var eligible []string
+		eligible := make([]string, 0, len(result.Eligibility))
 		for _, e := range result.Eligibility {
 			if e.Eligible {
 				eligible = append(eligible, e.PackageID)
 			}
 		}
 		resp := &tmproto.IdentityMatchResponse{
+			Type:               tmproto.TypeIdentityMatchResponse,
 			RequestID:          result.RequestID,
 			EligiblePackageIDs: eligible,
 			TTLSec:             60,
@@ -183,22 +184,19 @@ func main() {
 	// who care about authenticated fan-outs MUST set --registry-url and
 	// --require-signature (or TMP_IDENTITY_REQUIRE_SIGNATURE=1).
 	if keystore != nil {
-		mux.Handle("POST /tmp/identity", tmproto.VerifyIdentityMatchHandler(identityHandler, tmproto.VerifyOptions{
+		mux.Handle("POST /identity", tmproto.VerifyIdentityMatchHandler(identityHandler, tmproto.VerifyOptions{
 			KeyStore:         keystore,
 			OwnEndpointURL:   ownURL,
 			RequireSignature: requireSig,
 		}))
 	} else {
-		mux.Handle("POST /tmp/identity", identityHandler)
+		mux.Handle("POST /identity", identityHandler)
 	}
 
 	mux.Handle("GET /metrics", metrics.Registry.Handler())
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"status":  "ok",
-			"version": version,
-		})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	})
 
 	srv := &http.Server{

--- a/router/registry_test.go
+++ b/router/registry_test.go
@@ -180,6 +180,7 @@ func TestRegistry_RouterEnrichesPropertyRID(t *testing.T) {
 	router.registry = reg
 
 	reqBody := `{
+		"type": "context_match_request",
 		"request_id": "ctx-rid",
 		"property_id": "pub-oakwood",
 		"property_type": "website",

--- a/router/router.go
+++ b/router/router.go
@@ -37,8 +37,8 @@ type Router struct {
 	// (e.g., for local dev). Production deployments MUST set a signer — the
 	// spec mandates Ed25519 request authentication on all router→provider
 	// fan-outs.
-	signer       *tmproto.Signer
-	contextSigs  *contextSignatureCache
+	signer      *tmproto.Signer
+	contextSigs *contextSignatureCache
 }
 
 // RouterOption configures a Router.
@@ -74,9 +74,9 @@ func WithFanOutMetrics(m FanOutMetrics) RouterOption {
 }
 
 // WithTMPSigner attaches an Ed25519 signer that the router uses to sign
-// every outbound /tmp/context and /tmp/identity request per the TMP
-// specification. Required for any deployment that talks to spec-conformant
-// providers. The router holds onto signer for the rest of its lifetime.
+// every outbound /context and /identity request per the TMP specification.
+// Required for any deployment that talks to spec-conformant providers. The
+// router holds onto signer for the rest of its lifetime.
 func WithTMPSigner(signer *tmproto.Signer) RouterOption {
 	return func(r *Router) { r.signer = signer }
 }
@@ -295,7 +295,7 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 			sigHeaders := r.signContextHeaders(signed, p.Endpoint)
 
 			var cmResp tmproto.ContextMatchResponse
-			if err := r.callProvider(callCtx, p.Endpoint+"/tmp/context", callBody, sigHeaders, &cmResp); err != nil {
+			if err := r.callProvider(callCtx, p.Endpoint+"/context", callBody, sigHeaders, &cmResp); err != nil {
 				if r.health != nil {
 					if callCtx.Err() != nil {
 						r.health.RecordTimeout(p.ID)
@@ -352,7 +352,7 @@ func (r *Router) fanOutIdentity(ctx context.Context, providers []ProviderConfig,
 			}
 
 			var imResp tmproto.IdentityMatchResponse
-			if err := r.callProvider(callCtx, p.Endpoint+"/tmp/identity", body, sigHeaders, &imResp); err != nil {
+			if err := r.callProvider(callCtx, p.Endpoint+"/identity", body, sigHeaders, &imResp); err != nil {
 				if r.health != nil {
 					if callCtx.Err() != nil {
 						r.health.RecordTimeout(p.ID)
@@ -405,6 +405,7 @@ func (r *Router) callProvider(ctx context.Context, endpoint string, body []byte,
 // mergeContextResponses combines offers and signals from multiple providers.
 func mergeContextResponses(requestID string, responses []*tmproto.ContextMatchResponse) *tmproto.ContextMatchResponse {
 	merged := &tmproto.ContextMatchResponse{
+		Type:      tmproto.TypeContextMatchResponse,
 		RequestID: requestID,
 		Offers:    []tmproto.Offer{},
 	}
@@ -455,6 +456,7 @@ func mergeIdentityResponses(requestID string, providerIDs []string, responses []
 	}
 
 	merged := &tmproto.IdentityMatchResponse{
+		Type:               tmproto.TypeIdentityMatchResponse,
 		RequestID:          requestID,
 		EligiblePackageIDs: eligible,
 		TTLSec:             minTTL,
@@ -496,6 +498,7 @@ func (r *Router) writeError(w http.ResponseWriter, requestID string, code tmprot
 	}
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(tmproto.ErrorResponse{
+		Type:      tmproto.TypeError,
 		RequestID: requestID,
 		Code:      code,
 		Message:   message,

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -29,6 +29,7 @@ func testRouter(providers []ProviderConfig) *Router {
 
 func TestValidateContextRequest_Valid(t *testing.T) {
 	req := &tmproto.ContextMatchRequest{
+		Type:         tmproto.TypeContextMatchRequest,
 		RequestID:    "ctx-001",
 		PropertyID:   "pub-oakwood",
 		PropertyType: tmproto.PropertyTypeWebsite,
@@ -171,6 +172,7 @@ func TestRouterContextMatch_EndToEnd(t *testing.T) {
 	})
 
 	reqBody := `{
+		"type": "context_match_request",
 		"request_id": "ctx-e2e",
 		"property_id": "pub-test",
 		"property_type": "website",
@@ -204,6 +206,7 @@ func TestRouterContextMatch_StripsArtifactAccess(t *testing.T) {
 	})
 
 	cm := tmproto.ContextMatchRequest{
+		Type:         tmproto.TypeContextMatchRequest,
 		RequestID:    "ctx-strip",
 		PropertyID:   "pub-test",
 		PropertyType: "website",
@@ -424,6 +427,7 @@ func TestRouterTimeout_ProviderExcluded(t *testing.T) {
 	})
 
 	reqBody := `{
+		"type": "context_match_request",
 		"request_id": "ctx-timeout",
 		"property_id": "pub-test",
 		"property_type": "website",

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -56,6 +56,7 @@ func TestValidateContextRequest_MissingFields(t *testing.T) {
 
 func TestValidateIdentityRequest_Valid(t *testing.T) {
 	req := &tmproto.IdentityMatchRequest{
+		Type:           tmproto.TypeIdentityMatchRequest,
 		RequestID:      "id-001",
 		SellerAgentURL: "https://seller.example.com/agent",
 		Identities:     []tmproto.IdentityToken{{UserToken: "tok_abc", UIDType: tmproto.UIDTypeUID2}},
@@ -247,6 +248,7 @@ func TestRouterIdentityMatch_EndToEnd(t *testing.T) {
 	})
 
 	reqBody := `{
+		"type": "identity_match_request",
 		"request_id": "id-e2e",
 		"seller_agent_url": "https://seller.example.com/agent",
 		"identities": [{"user_token": "tok_test_abc", "uid_type": "uid2"}],
@@ -355,6 +357,7 @@ func TestRouterIdentityMatch_StripsCountry(t *testing.T) {
 	})
 
 	reqBody := `{
+		"type": "identity_match_request",
 		"request_id": "id-strip",
 		"seller_agent_url": "https://seller.example.com/agent",
 		"identities": [{"user_token": "tok_test", "uid_type": "uid2"}],

--- a/router/signing_test.go
+++ b/router/signing_test.go
@@ -104,6 +104,7 @@ func TestRouter_SignsIdentityMatchPerProvider(t *testing.T) {
 	})
 
 	body := `{
+		"type":"identity_match_request",
 		"request_id":"id-sign",
 		"seller_agent_url":"https://seller.example.com/agent",
 		"identities":[{"user_token":"tok","uid_type":"uid2"}],

--- a/router/signing_test.go
+++ b/router/signing_test.go
@@ -43,6 +43,7 @@ func TestRouter_SignsContextMatchFanOut(t *testing.T) {
 	})
 
 	body := `{
+		"type":"context_match_request",
 		"request_id":"ctx-sign",
 		"property_id":"pub",
 		"property_rid":"00000000-0000-0000-0000-000000000001",
@@ -139,7 +140,7 @@ func TestRouter_NoSigner_DoesNotSetHeaders(t *testing.T) {
 	router := testRouter([]ProviderConfig{
 		{ID: "p1", Endpoint: provider.URL, ContextMatch: true, Timeout: 5 * time.Second},
 	})
-	body := `{"request_id":"x","property_id":"p","property_type":"website","placement_id":"s","package_ids":["a"]}`
+	body := `{"type":"context_match_request","request_id":"x","property_id":"p","property_type":"website","placement_id":"s","package_ids":["a"]}`
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body))
 	router.HandleContextMatch(w, req)

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/redisstore"
@@ -39,7 +40,7 @@ type Config struct {
 	ShutdownGrace   time.Duration
 	ShutdownTimeout time.Duration
 
-	// RequestBodyLimitBytes is the maximum POST /tmp/identity body size in
+	// RequestBodyLimitBytes is the maximum POST /identity body size in
 	// bytes. Anything larger is rejected at decode time.
 	RequestBodyLimitBytes int
 
@@ -71,13 +72,20 @@ type Config struct {
 	AccessLogEnabled bool
 
 	// AdminPort, when > 0, moves /metrics, /live, and /debug/pprof onto a
-	// second HTTP listener on that port. /tmp/identity and /health stay on
-	// HTTPPort — /health is part of the TMP protocol surface that publisher
-	// routers probe externally, so it MUST share the listener serving
-	// /tmp/identity. When 0 (default) all endpoints share HTTPPort.
-	// Splitting lets ops apply different network policies to observability
-	// vs the public attack surface.
+	// second HTTP listener on that port. /identity and /health stay on
+	// HTTPPort — both are part of the TMP protocol surface that publisher
+	// routers probe externally, so they MUST share the listener serving
+	// /identity. When 0 (default) all endpoints share HTTPPort. Splitting
+	// lets ops apply different network policies to observability vs the
+	// public attack surface.
 	AdminPort int
+
+	// SupportedADCPMajorVersions enumerates the AdCP major versions this
+	// agent accepts on inbound `adcp_major_version`. Requests carrying an
+	// unsupported value are rejected with HTTP 400. Empty means "accept any
+	// value" — but Validate rejects empty, so deployments must declare
+	// support explicitly.
+	SupportedADCPMajorVersions []int
 
 	LogLevel string
 
@@ -93,20 +101,20 @@ type Config struct {
 	Pprof   PprofConfig
 }
 
-// TMPConfig drives TMP signature verification on /tmp/identity.
+// TMPConfig drives TMP signature verification on /identity.
 type TMPConfig struct {
-	RegistryURL     string
-	OwnEndpointURL  string
-	AllowUnsigned   bool
+	RegistryURL    string
+	OwnEndpointURL string
+	AllowUnsigned  bool
 }
 
 // TMPXConfig drives TMPX response sealing. Disabled when EncryptJWKSURL is
 // empty.
 type TMPXConfig struct {
-	EncryptJWKSURL  string
-	EncryptJWKSTTL  time.Duration
-	Country         string
-	Priority        string
+	EncryptJWKSURL   string
+	EncryptJWKSTTL   time.Duration
+	Country          string
+	Priority         string
 	ReferenceStubAck bool
 }
 
@@ -117,7 +125,7 @@ type TMPXConfig struct {
 //   - "retry"       (default) — block startup retrying until StartRetryDeadline
 //   - "fail-fast"             — exit on the first failure
 //   - "best-effort"           — start with an empty snapshot; rely on the
-//                               normal refresh tick to populate
+//     normal refresh tick to populate
 //
 // StartRetryDeadline bounds the StartMode=retry retry loop. Ignored for
 // the other modes. A pod whose config source is down for longer than this
@@ -186,30 +194,35 @@ const (
 	// 40ms per-request internal budget. The four HTTP server timeouts below
 	// are outer slow-client absorbing bounds; tightened from the values used
 	// when the listener didn't have a per-request timeout above it.
-	defaultRequestTimeout         = 40 * time.Millisecond
-	defaultHTTPReadHeaderTimeout  = 200 * time.Millisecond
-	defaultHTTPReadTimeout        = 500 * time.Millisecond
-	defaultHTTPWriteTimeout       = 1 * time.Second
-	defaultHTTPIdleTimeout        = 30 * time.Second
-	defaultShutdownGrace          = 1 * time.Second
-	defaultShutdownTimeout        = 10 * time.Second
-	defaultRequestBodyLimitBytes  = 64 * 1024
-	defaultMaxHeaderBytes         = 8 * 1024
-	defaultMaxOpenConnections     = 1024
-	defaultResponseTTL            = 60 * time.Second
-	defaultStrictContentType      = true
-	defaultAccessLogEnabled       = false
-	defaultAdminPort              = 0
-	defaultLogLevel               = "info"
-	defaultJWKSTTL                = 5 * time.Minute
-	defaultConfigTimeout          = 30 * time.Second
-	defaultRefreshInterval        = 5 * time.Minute
-	defaultStartMode              = "retry"
-	defaultStartRetryDeadline     = 5 * time.Minute
-	defaultAudienceTimeout        = 10 * time.Millisecond
-	defaultFCapTimeout            = 10 * time.Millisecond
-	defaultNamespace              = "identity_agent"
+	defaultRequestTimeout        = 40 * time.Millisecond
+	defaultHTTPReadHeaderTimeout = 200 * time.Millisecond
+	defaultHTTPReadTimeout       = 500 * time.Millisecond
+	defaultHTTPWriteTimeout      = 1 * time.Second
+	defaultHTTPIdleTimeout       = 30 * time.Second
+	defaultShutdownGrace         = 1 * time.Second
+	defaultShutdownTimeout       = 10 * time.Second
+	defaultRequestBodyLimitBytes = 64 * 1024
+	defaultMaxHeaderBytes        = 8 * 1024
+	defaultMaxOpenConnections    = 1024
+	defaultResponseTTL           = 60 * time.Second
+	defaultStrictContentType     = true
+	defaultAccessLogEnabled      = false
+	defaultAdminPort             = 0
+	defaultLogLevel              = "info"
+	defaultJWKSTTL               = 5 * time.Minute
+	defaultConfigTimeout         = 30 * time.Second
+	defaultRefreshInterval       = 5 * time.Minute
+	defaultStartMode             = "retry"
+	defaultStartRetryDeadline    = 5 * time.Minute
+	defaultAudienceTimeout       = 10 * time.Millisecond
+	defaultFCapTimeout           = 10 * time.Millisecond
+	defaultNamespace             = "identity_agent"
 )
+
+// defaultSupportedADCPMajorVersions is the AdCP major-version set the agent
+// accepts when SUPPORTED_ADCP_MAJOR_VERSIONS is unset. Tracks the latest
+// stable major surface.
+var defaultSupportedADCPMajorVersions = []int{3}
 
 // Valid CONFIG_START_MODE values. Exported so callers and tests can refer
 // to them by name rather than literal strings.
@@ -326,6 +339,10 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	supportedVersions, err := lookupIntList("SUPPORTED_ADCP_MAJOR_VERSIONS", defaultSupportedADCPMajorVersions)
+	if err != nil {
+		errs = append(errs, err)
+	}
 
 	audienceBlock, blockErrs := loadValkeyBlock("AUDIENCE")
 	errs = append(errs, blockErrs...)
@@ -333,22 +350,23 @@ func LoadConfigFromEnv() (Config, error) {
 	errs = append(errs, blockErrs...)
 
 	cfg := Config{
-		HTTPPort:              port,
-		RequestTimeout:        reqTimeout,
-		HTTPReadHeaderTimeout: readHeaderTimeout,
-		HTTPReadTimeout:       readTimeout,
-		HTTPWriteTimeout:      writeTimeout,
-		HTTPIdleTimeout:       idleTimeout,
-		ShutdownGrace:         shutdownGrace,
-		ShutdownTimeout:       shutdownTimeout,
-		RequestBodyLimitBytes: bodyLimit,
-		MaxHeaderBytes:        maxHeader,
-		MaxOpenConnections:    maxConns,
-		ResponseTTL:           responseTTL,
-		StrictContentType:     strictCT,
-		AccessLogEnabled:      accessLog,
-		AdminPort:             adminPort,
-		LogLevel:              lookupString("LOG_LEVEL", defaultLogLevel),
+		HTTPPort:                   port,
+		RequestTimeout:             reqTimeout,
+		HTTPReadHeaderTimeout:      readHeaderTimeout,
+		HTTPReadTimeout:            readTimeout,
+		HTTPWriteTimeout:           writeTimeout,
+		HTTPIdleTimeout:            idleTimeout,
+		ShutdownGrace:              shutdownGrace,
+		ShutdownTimeout:            shutdownTimeout,
+		RequestBodyLimitBytes:      bodyLimit,
+		MaxHeaderBytes:             maxHeader,
+		MaxOpenConnections:         maxConns,
+		ResponseTTL:                responseTTL,
+		StrictContentType:          strictCT,
+		AccessLogEnabled:           accessLog,
+		AdminPort:                  adminPort,
+		SupportedADCPMajorVersions: supportedVersions,
+		LogLevel:                   lookupString("LOG_LEVEL", defaultLogLevel),
 		TMP: TMPConfig{
 			RegistryURL:    os.Getenv("TMP_REGISTRY_URL"),
 			OwnEndpointURL: os.Getenv("TMP_OWN_ENDPOINT_URL"),
@@ -446,6 +464,14 @@ func (c Config) Validate() error {
 	}
 	if c.ResponseTTL <= 0 {
 		errs = append(errs, errors.New("RESPONSE_TTL must be positive"))
+	}
+	if len(c.SupportedADCPMajorVersions) == 0 {
+		errs = append(errs, errors.New("SUPPORTED_ADCP_MAJOR_VERSIONS must declare at least one major version"))
+	}
+	for _, v := range c.SupportedADCPMajorVersions {
+		if v < 1 || v > 99 {
+			errs = append(errs, fmt.Errorf("SUPPORTED_ADCP_MAJOR_VERSIONS entry %d is out of range [1,99]", v))
+		}
 	}
 	if c.AudienceTimeout <= 0 {
 		errs = append(errs, errors.New("AUDIENCE_TIMEOUT must be positive"))
@@ -606,6 +632,33 @@ func lookupDuration(name string, def time.Duration) (time.Duration, error) {
 	return d, nil
 }
 
+// lookupIntList parses a comma-separated list of integers from env. Returns
+// a copy of def when the variable is unset; the copy isolates callers from
+// later mutation of the default slice. Empty entries are rejected so a
+// trailing comma surfaces as a config error rather than a silent typo.
+func lookupIntList(name string, def []int) ([]int, error) {
+	v := os.Getenv(name)
+	if v == "" {
+		out := make([]int, len(def))
+		copy(out, def)
+		return out, nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil, fmt.Errorf("%s=%q contains an empty entry", name, v)
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("%s=%q has non-integer entry %q: %w", name, v, p, err)
+		}
+		out = append(out, n)
+	}
+	return out, nil
+}
+
 // isValidPromName mirrors the Prometheus metric name grammar
 // ([a-zA-Z_][a-zA-Z0-9_]*) used for namespace prefixes.
 func isValidPromName(s string) bool {
@@ -624,4 +677,3 @@ func isValidPromName(s string) bool {
 	}
 	return true
 }
-

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -70,11 +70,13 @@ type Config struct {
 	// incident triage.
 	AccessLogEnabled bool
 
-	// AdminPort, when > 0, moves /metrics, /live, /health, and /debug/pprof
-	// onto a second HTTP listener on that port. /tmp/identity stays on
-	// HTTPPort. When 0 (default) all endpoints share HTTPPort. Splitting
-	// lets ops apply different network policies to observability vs the
-	// public attack surface.
+	// AdminPort, when > 0, moves /metrics, /live, and /debug/pprof onto a
+	// second HTTP listener on that port. /tmp/identity and /health stay on
+	// HTTPPort — /health is part of the TMP protocol surface that publisher
+	// routers probe externally, so it MUST share the listener serving
+	// /tmp/identity. When 0 (default) all endpoints share HTTPPort.
+	// Splitting lets ops apply different network policies to observability
+	// vs the public attack surface.
 	AdminPort int
 
 	LogLevel string

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -11,23 +11,24 @@ import (
 func TestConfigValidate(t *testing.T) {
 	base := func() Config {
 		return Config{
-			HTTPPort:              8080,
-			RequestTimeout:        40 * time.Millisecond,
-			HTTPReadHeaderTimeout: 200 * time.Millisecond,
-			HTTPReadTimeout:       500 * time.Millisecond,
-			HTTPWriteTimeout:      1 * time.Second,
-			HTTPIdleTimeout:       30 * time.Second,
-			ShutdownGrace:         time.Second,
-			ShutdownTimeout:       10 * time.Second,
-			RequestBodyLimitBytes: 64 * 1024,
-			MaxHeaderBytes:        8 * 1024,
-			MaxOpenConnections:    1024,
-			ResponseTTL:           60 * time.Second,
-			StrictContentType:     true,
-			AccessLogEnabled:      false,
-			AdminPort:             0,
-			AudienceTimeout:       10 * time.Millisecond,
-			FCapTimeout:           10 * time.Millisecond,
+			HTTPPort:                   8080,
+			RequestTimeout:             40 * time.Millisecond,
+			HTTPReadHeaderTimeout:      200 * time.Millisecond,
+			HTTPReadTimeout:            500 * time.Millisecond,
+			HTTPWriteTimeout:           1 * time.Second,
+			HTTPIdleTimeout:            30 * time.Second,
+			ShutdownGrace:              time.Second,
+			ShutdownTimeout:            10 * time.Second,
+			RequestBodyLimitBytes:      64 * 1024,
+			MaxHeaderBytes:             8 * 1024,
+			MaxOpenConnections:         1024,
+			ResponseTTL:                60 * time.Second,
+			StrictContentType:          true,
+			AccessLogEnabled:           false,
+			AdminPort:                  0,
+			SupportedADCPMajorVersions: []int{3},
+			AudienceTimeout:            10 * time.Millisecond,
+			FCapTimeout:                10 * time.Millisecond,
 			IdentityConfig: IdentityConfigSourceConfig{
 				URL:                "https://config.example/",
 				Token:              "tok",
@@ -37,12 +38,12 @@ func TestConfigValidate(t *testing.T) {
 			},
 			TMP: TMPConfig{
 				RegistryURL:    "https://registry.example/snapshot",
-				OwnEndpointURL: "https://self.example/tmp/identity",
+				OwnEndpointURL: "https://self.example/identity",
 			},
 			FCapValkey: ValkeyBlock{
-				Enabled:  true,
-				Mode:     "standalone",
-				Shards:   map[string]string{"0": "h:1"},
+				Enabled: true,
+				Mode:    "standalone",
+				Shards:  map[string]string{"0": "h:1"},
 			},
 		}
 	}
@@ -239,6 +240,20 @@ func TestConfigValidate(t *testing.T) {
 				c.Metrics.Enabled = true
 				c.Metrics.Namespace = "identity_agent"
 			},
+		},
+		{
+			name:    "empty supported major versions",
+			mutate:  func(c *Config) { c.SupportedADCPMajorVersions = nil },
+			wantErr: "SUPPORTED_ADCP_MAJOR_VERSIONS",
+		},
+		{
+			name:    "supported major version out of range",
+			mutate:  func(c *Config) { c.SupportedADCPMajorVersions = []int{100} },
+			wantErr: "out of range",
+		},
+		{
+			name:   "multiple supported major versions ok",
+			mutate: func(c *Config) { c.SupportedADCPMajorVersions = []int{2, 3} },
 		},
 	}
 	for _, tc := range cases {

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -107,6 +107,11 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.AdcpMajorVersion != 0 {
 		if _, ok := h.supportedADCPMajorVersions[req.AdcpMajorVersion]; !ok {
+			// adcp/schemas/tmp/identity-match-request.json's description
+			// names VERSION_UNSUPPORTED here, but the error.json schema's
+			// `code` enum does not include it. Use invalid_request — the
+			// closest valid code — until the spec is internally
+			// consistent. The message preserves diagnostic detail.
 			h.writeError(w, req.RequestID, http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest,
 				fmt.Sprintf("adcp_major_version %d is not supported", req.AdcpMajorVersion))
 			h.recordCompletion(ctx, start, "bad_request")

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -11,7 +12,7 @@ import (
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
-// identityHandler is the http.Handler for POST /tmp/identity. It decodes an
+// identityHandler is the http.Handler for POST /identity. It decodes an
 // IdentityMatchRequest under a hard request-timeout budget, runs
 // Service.Evaluate, optionally seals a TMPX token, and writes the
 // IdentityMatchResponse. Budget overruns produce a 200 response with an
@@ -21,13 +22,14 @@ import (
 // The handler is wrapped by TMP signature verification at a higher layer
 // (see ServeMux assembly in server.go).
 type identityHandler struct {
-	service          *Service
-	tmpx             *TMPXSealer
-	requestTimeout   time.Duration
-	requestBodyLimit int64
-	responseTTL      time.Duration
-	recorder         Recorder
-	logger           *slog.Logger
+	service                    *Service
+	tmpx                       *TMPXSealer
+	requestTimeout             time.Duration
+	requestBodyLimit           int64
+	responseTTL                time.Duration
+	supportedADCPMajorVersions map[int]struct{}
+	recorder                   Recorder
+	logger                     *slog.Logger
 }
 
 // IdentityHandlerConfig packages the inputs for NewIdentityHandler.
@@ -37,11 +39,17 @@ type IdentityHandlerConfig struct {
 	RequestTimeout   time.Duration
 	RequestBodyLimit int64
 	ResponseTTL      time.Duration
-	Recorder         Recorder
-	Logger           *slog.Logger
+	// SupportedADCPMajorVersions enumerates the AdCP major versions this
+	// agent will accept on inbound `adcp_major_version`. When the field is
+	// present on a request and not in this set, the handler rejects with
+	// HTTP 400 and ErrorCodeInvalidRequest. When the field is omitted, the
+	// seller assumes its highest supported version (per the TMP schema).
+	SupportedADCPMajorVersions []int
+	Recorder                   Recorder
+	Logger                     *slog.Logger
 }
 
-// NewIdentityHandler returns the http.Handler for POST /tmp/identity.
+// NewIdentityHandler returns the http.Handler for POST /identity.
 // Callers must supply positive RequestTimeout, RequestBodyLimit, and
 // ResponseTTL; the agent's Config.Validate enforces this at startup.
 func NewIdentityHandler(cfg IdentityHandlerConfig) http.Handler {
@@ -51,14 +59,19 @@ func NewIdentityHandler(cfg IdentityHandlerConfig) http.Handler {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
+	supported := make(map[int]struct{}, len(cfg.SupportedADCPMajorVersions))
+	for _, v := range cfg.SupportedADCPMajorVersions {
+		supported[v] = struct{}{}
+	}
 	return &identityHandler{
-		service:          cfg.Service,
-		tmpx:             cfg.TMPXSealer,
-		requestTimeout:   cfg.RequestTimeout,
-		requestBodyLimit: cfg.RequestBodyLimit,
-		responseTTL:      cfg.ResponseTTL,
-		recorder:         cfg.Recorder,
-		logger:           cfg.Logger,
+		service:                    cfg.Service,
+		tmpx:                       cfg.TMPXSealer,
+		requestTimeout:             cfg.RequestTimeout,
+		requestBodyLimit:           cfg.RequestBodyLimit,
+		responseTTL:                cfg.ResponseTTL,
+		supportedADCPMajorVersions: supported,
+		recorder:                   cfg.Recorder,
+		logger:                     cfg.Logger,
 	}
 }
 
@@ -92,17 +105,27 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.recordCompletion(ctx, start, "bad_request")
 		return
 	}
+	if req.AdcpMajorVersion != 0 {
+		if _, ok := h.supportedADCPMajorVersions[req.AdcpMajorVersion]; !ok {
+			h.writeError(w, req.RequestID, http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest,
+				fmt.Sprintf("adcp_major_version %d is not supported", req.AdcpMajorVersion))
+			h.recordCompletion(ctx, start, "bad_request")
+			return
+		}
+	}
 
 	result := h.service.Evaluate(ctx, &req)
 
-	// Fail closed on budget overrun: return the standard wire shape with no
-	// eligible packages, matching what callers see for any other fail-closed
-	// outcome. RequestID is preserved so the buyer can correlate.
+	// Fail closed on budget overrun: return the standard wire shape with an
+	// empty eligible-packages array, matching what callers see for any other
+	// fail-closed outcome. RequestID is preserved so the buyer can correlate.
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		status := "timeout"
 		if !h.writeResponse(w, &tmproto.IdentityMatchResponse{
-			RequestID: req.RequestID,
-			TTLSec:    int(h.responseTTL.Seconds()),
+			Type:               tmproto.TypeIdentityMatchResponse,
+			RequestID:          req.RequestID,
+			EligiblePackageIDs: []string{},
+			TTLSec:             int(h.responseTTL.Seconds()),
 		}) {
 			status = "write_error"
 		}
@@ -118,6 +141,7 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := &tmproto.IdentityMatchResponse{
+		Type:               tmproto.TypeIdentityMatchResponse,
 		RequestID:          result.RequestID,
 		EligiblePackageIDs: eligible,
 		TTLSec:             int(h.responseTTL.Seconds()),
@@ -171,6 +195,7 @@ func (h *identityHandler) writeResponse(w http.ResponseWriter, resp *tmproto.Ide
 
 func (h *identityHandler) writeError(w http.ResponseWriter, requestID string, status int, code tmproto.ErrorCode, message string) {
 	body, err := json.Marshal(tmproto.ErrorResponse{
+		Type:      tmproto.TypeError,
 		RequestID: requestID,
 		Code:      code,
 		Message:   message,

--- a/targeting/identityagent/middleware.go
+++ b/targeting/identityagent/middleware.go
@@ -60,6 +60,7 @@ func recoverMiddleware(next http.Handler, recorder Recorder, logger *slog.Logger
 // shape lets clients pattern-match without inspecting a stack trace.
 var panicResponseBody = func() []byte {
 	body, _ := json.Marshal(tmproto.ErrorResponse{
+		Type:    tmproto.TypeError,
 		Code:    tmproto.ErrorCodeInternalError,
 		Message: "handler panic",
 	})
@@ -97,11 +98,10 @@ func requestIDFromRequest(r *http.Request) string {
 	return r.Header.Get(requestIDHeader)
 }
 
-// contentTypeMiddleware rejects any /tmp/identity request whose
-// Content-Type is not application/json (case-insensitive, parameters
-// ignored) with 415 Unsupported Media Type. Pass strict=false to disable
-// the check for legacy callers — Config.StrictContentType controls this
-// at startup.
+// contentTypeMiddleware rejects any /identity request whose Content-Type is
+// not application/json (case-insensitive, parameters ignored) with 415
+// Unsupported Media Type. Pass strict=false to disable the check for legacy
+// callers — Config.StrictContentType controls this at startup.
 func contentTypeMiddleware(next http.Handler, strict bool) http.Handler {
 	if !strict {
 		return next
@@ -178,6 +178,7 @@ func writeJSONErrorResponse(w http.ResponseWriter, requestID string, status int,
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	body, err := json.Marshal(tmproto.ErrorResponse{
+		Type:      tmproto.TypeError,
 		RequestID: requestID,
 		Code:      code,
 		Message:   message,

--- a/targeting/identityagent/middleware_test.go
+++ b/targeting/identityagent/middleware_test.go
@@ -21,7 +21,7 @@ func TestContentTypeMiddleware_RejectsNonJSON(t *testing.T) {
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
 	h := contentTypeMiddleware(inner, true)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodPost, "/identity", strings.NewReader(""))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -36,7 +36,7 @@ func TestContentTypeMiddleware_AcceptsJSONWithCharset(t *testing.T) {
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
 	h := contentTypeMiddleware(inner, true)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", strings.NewReader("{}"))
+	req := httptest.NewRequest(http.MethodPost, "/identity", strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -50,7 +50,7 @@ func TestContentTypeMiddleware_DisabledIsPassThrough(t *testing.T) {
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called = true })
 	h := contentTypeMiddleware(inner, false)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", strings.NewReader(""))
+	req := httptest.NewRequest(http.MethodPost, "/identity", strings.NewReader(""))
 	req.Header.Set("Content-Type", "text/plain")
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -67,7 +67,7 @@ func TestRecoverMiddleware_TrapsPanic(t *testing.T) {
 	})
 	h := recoverMiddleware(inner, rec, logger)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", nil)
+	req := httptest.NewRequest(http.MethodPost, "/identity", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
@@ -93,7 +93,7 @@ func TestRequestIDMiddleware_EchoesHeader(t *testing.T) {
 	})
 	h := requestIDMiddleware(inner)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", nil)
+	req := httptest.NewRequest(http.MethodPost, "/identity", nil)
 	req.Header.Set("X-Request-ID", "abc-123")
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -106,7 +106,7 @@ func TestRequestIDMiddleware_MissingHeaderNoEcho(t *testing.T) {
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 	h := requestIDMiddleware(inner)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", nil)
+	req := httptest.NewRequest(http.MethodPost, "/identity", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
@@ -119,7 +119,7 @@ func TestAccessLogMiddleware_Disabled(t *testing.T) {
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(204) })
 	h := accessLogMiddleware(inner, false, logger)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", nil)
+	req := httptest.NewRequest(http.MethodPost, "/identity", nil)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 
@@ -135,7 +135,7 @@ func TestAccessLogMiddleware_EnabledEmitsOnce(t *testing.T) {
 	})
 	h := accessLogMiddleware(inner, true, logger)
 
-	req := httptest.NewRequest(http.MethodPost, "/tmp/identity", nil)
+	req := httptest.NewRequest(http.MethodPost, "/identity", nil)
 	req.Header.Set("X-Request-ID", "req-xyz")
 	rr := httptest.NewRecorder()
 	// The access log reads the request id from context, which is set by

--- a/targeting/identityagent/server.go
+++ b/targeting/identityagent/server.go
@@ -21,9 +21,11 @@ import (
 // listener bounds — the per-request 40ms budget is enforced inside the
 // identity handler via context.WithTimeout.
 //
-// When AdminPort > 0 the four observability endpoints (/live, /health,
-// /metrics, /debug/pprof) move onto a second listener built by
-// NewAdminServer. /tmp/identity always stays on Port.
+// /tmp/identity and /health always stay on Port — /health is part of the
+// TMP protocol surface that publisher routers probe externally, so it
+// MUST share the listener that serves /tmp/identity. When AdminPort > 0
+// the operator-facing endpoints (/live, /metrics, /debug/pprof) move
+// onto a second listener built by NewAdminServer.
 type ServerConfig struct {
 	Port            int
 	IdentityHandler http.Handler
@@ -56,10 +58,12 @@ type ServerConfig struct {
 	Logger   *slog.Logger
 }
 
-// NewServer builds the *http.Server for /tmp/identity. When AdminPort == 0,
-// the observability endpoints also mount on this server's mux. When
-// AdminPort > 0 they're omitted here and the caller wires NewAdminServer
-// onto a second listener.
+// NewServer builds the *http.Server for /tmp/identity and /health. When
+// AdminPort == 0 the operator endpoints (/live, /metrics, /debug/pprof)
+// also mount on this server's mux. When AdminPort > 0 those are omitted
+// here and the caller wires NewAdminServer onto a second listener; /health
+// stays on the main mux unconditionally because it's part of the TMP
+// protocol surface that publisher routers probe externally.
 //
 // The handler chain on POST /tmp/identity reads outermost-to-innermost:
 //
@@ -88,8 +92,9 @@ func NewServer(cfg ServerConfig) *http.Server {
 	identity = otelhttp.NewHandler(identity, "POST /tmp/identity")
 	mux.Handle("POST /tmp/identity", identity)
 
+	mountHealthEndpoint(mux, cfg.IsRunning)
 	if cfg.AdminPort == 0 {
-		mountAdminEndpoints(mux, cfg.Registry, cfg.IsRunning, cfg.Version, cfg.PprofEnabled)
+		mountOperatorEndpoints(mux, cfg.Registry, cfg.Version, cfg.PprofEnabled)
 	}
 
 	return &http.Server{
@@ -108,7 +113,6 @@ func NewServer(cfg ServerConfig) *http.Server {
 type AdminServerConfig struct {
 	Port         int
 	Registry     *prometheus.Registry
-	IsRunning    func() bool
 	Version      string
 	PprofEnabled bool
 
@@ -122,13 +126,15 @@ type AdminServerConfig struct {
 	Logger   *slog.Logger
 }
 
-// NewAdminServer builds the *http.Server hosting /metrics, /live, /health,
-// and (when enabled) /debug/pprof on a separate port. The mux is wrapped in
-// recoverMiddleware so a panic in any observability handler doesn't take
-// the process down with it.
+// NewAdminServer builds the *http.Server hosting /metrics, /live, and
+// (when enabled) /debug/pprof on a separate port. /health stays on the
+// main server (see NewServer) — it's part of the protocol surface and
+// must share the listener publisher routers reach externally. The mux
+// is wrapped in recoverMiddleware so a panic in any observability handler
+// doesn't take the process down with it.
 func NewAdminServer(cfg AdminServerConfig) *http.Server {
 	mux := http.NewServeMux()
-	mountAdminEndpoints(mux, cfg.Registry, cfg.IsRunning, cfg.Version, cfg.PprofEnabled)
+	mountOperatorEndpoints(mux, cfg.Registry, cfg.Version, cfg.PprofEnabled)
 
 	return &http.Server{
 		Addr:              ":" + strconv.Itoa(cfg.Port),
@@ -141,25 +147,33 @@ func NewAdminServer(cfg AdminServerConfig) *http.Server {
 	}
 }
 
-// mountAdminEndpoints registers /live, /health, /metrics (when Registry is
-// non-nil), and pprof endpoints (when enabled) on the supplied mux. Shared
-// by NewServer (when AdminPort == 0) and NewAdminServer.
-func mountAdminEndpoints(mux *http.ServeMux, reg *prometheus.Registry, isRunning func() bool, version string, pprofEnabled bool) {
-	mux.HandleFunc("GET /live", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, `{"status":"ok","version":%q}`, version)
-	})
-
+// mountHealthEndpoint registers GET /health on the supplied mux. The
+// response body is constrained by the TMP spec: it MUST be exactly
+// {"status":"ok"} when ready (200) or {"status":"not ready"} when not
+// (503), with no version, build hash, hostname, or subsystem detail.
+// Differentiating bodies or status codes by failing subsystem would be
+// a side channel mapping external probes onto internal topology.
+func mountHealthEndpoint(mux *http.ServeMux, isRunning func() bool) {
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if isRunning != nil && isRunning() {
 			w.WriteHeader(http.StatusOK)
-			_, _ = fmt.Fprintf(w, `{"status":"ok","version":%q}`, version)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
 			return
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"status":"not ready"}`))
+	})
+}
+
+// mountOperatorEndpoints registers /live, /metrics (when Registry is
+// non-nil), and pprof endpoints (when enabled) on the supplied mux.
+// Shared by NewServer (when AdminPort == 0) and NewAdminServer.
+func mountOperatorEndpoints(mux *http.ServeMux, reg *prometheus.Registry, version string, pprofEnabled bool) {
+	mux.HandleFunc("GET /live", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"status":"ok","version":%q}`, version)
 	})
 
 	if reg != nil {

--- a/targeting/identityagent/server.go
+++ b/targeting/identityagent/server.go
@@ -21,11 +21,11 @@ import (
 // listener bounds — the per-request 40ms budget is enforced inside the
 // identity handler via context.WithTimeout.
 //
-// /tmp/identity and /health always stay on Port — /health is part of the
-// TMP protocol surface that publisher routers probe externally, so it
-// MUST share the listener that serves /tmp/identity. When AdminPort > 0
-// the operator-facing endpoints (/live, /metrics, /debug/pprof) move
-// onto a second listener built by NewAdminServer.
+// /identity and /health always stay on Port — both are part of the TMP
+// protocol surface that publisher routers probe externally, so they MUST
+// share the listener exposed at the registered base URL. When AdminPort > 0
+// the operator-facing endpoints (/live, /metrics, /debug/pprof) move onto
+// a second listener built by NewAdminServer.
 type ServerConfig struct {
 	Port            int
 	IdentityHandler http.Handler
@@ -58,14 +58,14 @@ type ServerConfig struct {
 	Logger   *slog.Logger
 }
 
-// NewServer builds the *http.Server for /tmp/identity and /health. When
+// NewServer builds the *http.Server for /identity and /health. When
 // AdminPort == 0 the operator endpoints (/live, /metrics, /debug/pprof)
 // also mount on this server's mux. When AdminPort > 0 those are omitted
 // here and the caller wires NewAdminServer onto a second listener; /health
 // stays on the main mux unconditionally because it's part of the TMP
 // protocol surface that publisher routers probe externally.
 //
-// The handler chain on POST /tmp/identity reads outermost-to-innermost:
+// The handler chain on POST /identity reads outermost-to-innermost:
 //
 //	otelhttp.NewHandler                # extract inbound traceparent
 //	→ recoverMiddleware                # trap panics, record + log + 500
@@ -89,8 +89,8 @@ func NewServer(cfg ServerConfig) *http.Server {
 	identity = accessLogMiddleware(identity, cfg.AccessLogEnabled, cfg.Logger)
 	identity = requestIDMiddleware(identity)
 	identity = recoverMiddleware(identity, cfg.Recorder, cfg.Logger)
-	identity = otelhttp.NewHandler(identity, "POST /tmp/identity")
-	mux.Handle("POST /tmp/identity", identity)
+	identity = otelhttp.NewHandler(identity, "POST /identity")
+	mux.Handle("POST /identity", identity)
 
 	mountHealthEndpoint(mux, cfg.IsRunning)
 	if cfg.AdminPort == 0 {

--- a/targeting/identityagent/server.go
+++ b/targeting/identityagent/server.go
@@ -97,9 +97,13 @@ func NewServer(cfg ServerConfig) *http.Server {
 		mountOperatorEndpoints(mux, cfg.Registry, cfg.Version, cfg.PprofEnabled)
 	}
 
+	// Outer recoverMiddleware catches panics from /health and the operator
+	// endpoints (when AdminPort == 0). The identity chain has its own
+	// recoverMiddleware deeper in the stack; that inner one fires first, so
+	// the outer wrapper only fires for handlers that don't have their own.
 	return &http.Server{
 		Addr:              ":" + strconv.Itoa(cfg.Port),
-		Handler:           mux,
+		Handler:           recoverMiddleware(mux, cfg.Recorder, cfg.Logger),
 		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 		ReadTimeout:       cfg.ReadTimeout,
 		WriteTimeout:      cfg.WriteTimeout,

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -58,18 +58,19 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string) e
 	}
 
 	identityHandler := NewIdentityHandler(IdentityHandlerConfig{
-		Service:          bundle.service,
-		TMPXSealer:       bundle.tmpx,
-		RequestTimeout:   cfg.RequestTimeout,
-		RequestBodyLimit: int64(cfg.RequestBodyLimitBytes),
-		ResponseTTL:      cfg.ResponseTTL,
-		Recorder:         metricsProvider.Recorder,
-		Logger:           logger,
+		Service:                    bundle.service,
+		TMPXSealer:                 bundle.tmpx,
+		RequestTimeout:             cfg.RequestTimeout,
+		RequestBodyLimit:           int64(cfg.RequestBodyLimitBytes),
+		ResponseTTL:                cfg.ResponseTTL,
+		SupportedADCPMajorVersions: cfg.SupportedADCPMajorVersions,
+		Recorder:                   metricsProvider.Recorder,
+		Logger:                     logger,
 	})
 
 	requireSig := !cfg.TMP.AllowUnsigned
 	if !requireSig {
-		logger.Warn("/tmp/identity accepts unsigned requests — TMP signing should be required in production")
+		logger.Warn("/identity accepts unsigned requests — TMP signing should be required in production")
 	}
 	if requireSig && cfg.TMP.OwnEndpointURL == "" {
 		return errors.New("TMP_OWN_ENDPOINT_URL is required when signature verification is enabled")

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -40,7 +40,7 @@ const (
 // value but the function still returns.
 //
 // The supplied logger is used for structured event logs. version is stamped
-// into /live and /health responses.
+// into /live responses; /health intentionally omits it per the TMP spec.
 func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string) error {
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
@@ -103,7 +103,6 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string) e
 		adminSrv = NewAdminServer(AdminServerConfig{
 			Port:              cfg.AdminPort,
 			Registry:          metricsProvider.Registry,
-			IsRunning:         running.Load,
 			Version:           version,
 			PprofEnabled:      cfg.Pprof.Enabled,
 			ReadHeaderTimeout: cfg.HTTPReadHeaderTimeout,

--- a/tmpclient/client.go
+++ b/tmpclient/client.go
@@ -80,10 +80,13 @@ func (c *Client) ContextMatch(ctx context.Context, req *tmproto.ContextMatchRequ
 }
 
 // IdentityMatch sends an identity match request to the router.
-// Populates RequestID if empty.
+// Populates RequestID and Type if empty.
 func (c *Client) IdentityMatch(ctx context.Context, req *tmproto.IdentityMatchRequest) (*tmproto.IdentityMatchResponse, error) {
 	if req.RequestID == "" {
 		req.RequestID = c.genRequestID()
+	}
+	if req.Type == "" {
+		req.Type = tmproto.TypeIdentityMatchRequest
 	}
 	if err := tmproto.ValidateIdentityRequest(req); err != nil {
 		return nil, fmt.Errorf("validate identity request: %w", err)
@@ -115,6 +118,7 @@ func (c *Client) Activate(ctx context.Context, params *ActivateParams) (*Activat
 	}
 
 	idReq := &tmproto.IdentityMatchRequest{
+		Type:           tmproto.TypeIdentityMatchRequest,
 		RequestID:      idReqID,
 		SellerAgentURL: params.SellerAgentURL,
 		Identities: []tmproto.IdentityToken{

--- a/tmpclient/client.go
+++ b/tmpclient/client.go
@@ -63,10 +63,13 @@ func NewClient(routerURL string, opts ...Option) *Client {
 }
 
 // ContextMatch sends a context match request to the router.
-// Populates RequestID if empty.
+// Populates RequestID and Type if empty.
 func (c *Client) ContextMatch(ctx context.Context, req *tmproto.ContextMatchRequest) (*tmproto.ContextMatchResponse, error) {
 	if req.RequestID == "" {
 		req.RequestID = c.genRequestID()
+	}
+	if req.Type == "" {
+		req.Type = tmproto.TypeContextMatchRequest
 	}
 	if err := tmproto.ValidateContextRequest(req); err != nil {
 		return nil, fmt.Errorf("validate context request: %w", err)
@@ -108,6 +111,7 @@ func (c *Client) Activate(ctx context.Context, params *ActivateParams) (*Activat
 	idReqID := c.genRequestID()
 
 	ctxReq := &tmproto.ContextMatchRequest{
+		Type:         tmproto.TypeContextMatchRequest,
 		RequestID:    ctxReqID,
 		PropertyID:   params.PropertyID,
 		PropertyType: params.PropertyType,

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -64,8 +64,14 @@ func validateProtocolVersion(v string) error {
 	return errors.New("unsupported protocol_version")
 }
 
-// ValidateContextRequest checks that required fields are present on a context match request.
+// ValidateContextRequest checks that required fields are present on a
+// context match request and that the message-type discriminator matches the
+// endpoint per the TMP spec: a mismatched or missing `type` must be
+// rejected.
 func ValidateContextRequest(req *ContextMatchRequest) error {
+	if req.Type != TypeContextMatchRequest {
+		return fmt.Errorf("type must be %q", TypeContextMatchRequest)
+	}
 	if err := validateProtocolVersion(req.ProtocolVersion); err != nil {
 		return err
 	}

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -6,6 +6,18 @@ import (
 	"strings"
 )
 
+// Message type discriminators required on every TMP envelope. The spec
+// instructs agents to reject requests whose `type` does not match the
+// endpoint, and to stamp the corresponding response type on outbound
+// payloads.
+const (
+	TypeContextMatchRequest   = "context_match_request"
+	TypeContextMatchResponse  = "context_match_response"
+	TypeIdentityMatchRequest  = "identity_match_request"
+	TypeIdentityMatchResponse = "identity_match_response"
+	TypeError                 = "error"
+)
+
 // Maximum sizes for request arrays to prevent denial-of-service.
 const (
 	MaxPackagesPerRequest     = 500
@@ -14,6 +26,21 @@ const (
 	// — matches the TMPX plaintext budget (~120 bytes after HPKE overhead).
 	MaxIdentitiesPerRequest = 3
 )
+
+// validUIDTypes is the closed set of identifier types the TMP schema allows
+// on identity-match identities. Drawn from /schemas/enums/uid-type.json.
+var validUIDTypes = map[UIDType]struct{}{
+	UIDTypeRampID:              {},
+	UIDTypeRampIDDerived:       {},
+	UIDTypeID5:                 {},
+	UIDTypeUID2:                {},
+	UIDTypeEUID:                {},
+	UIDTypePairID:              {},
+	UIDTypeMAID:                {},
+	UIDTypeHashedEmail:         {},
+	UIDTypePublisherFirstParty: {},
+	UIDTypeOther:               {},
+}
 
 // MaxIDLength caps identifier fields to prevent oversized store keys.
 const MaxIDLength = 256
@@ -80,8 +107,13 @@ func ValidateContextRequest(req *ContextMatchRequest) error {
 	return nil
 }
 
-// ValidateIdentityRequest checks that required fields are present on an identity match request.
+// ValidateIdentityRequest checks that required fields are present on an
+// identity match request and that the message-type discriminator matches the
+// endpoint per the TMP spec: a mismatched or missing `type` must be rejected.
 func ValidateIdentityRequest(req *IdentityMatchRequest) error {
+	if req.Type != TypeIdentityMatchRequest {
+		return fmt.Errorf("type must be %q", TypeIdentityMatchRequest)
+	}
 	if err := validateProtocolVersion(req.ProtocolVersion); err != nil {
 		return err
 	}
@@ -110,6 +142,9 @@ func ValidateIdentityRequest(req *IdentityMatchRequest) error {
 		if id.UIDType == "" {
 			return fmt.Errorf("identities[%d].uid_type is required", i)
 		}
+		if _, ok := validUIDTypes[id.UIDType]; !ok {
+			return fmt.Errorf("identities[%d].uid_type %q is not a recognized TMP identity type", i, id.UIDType)
+		}
 	}
 	if req.Country != "" {
 		req.Country = strings.ToUpper(req.Country)
@@ -127,4 +162,3 @@ func ValidateIdentityRequest(req *IdentityMatchRequest) error {
 	}
 	return nil
 }
-

--- a/tmproto/validate_test.go
+++ b/tmproto/validate_test.go
@@ -1,0 +1,113 @@
+package tmproto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIdentityRequest(t *testing.T) {
+	valid := func() IdentityMatchRequest {
+		return IdentityMatchRequest{
+			Type:           TypeIdentityMatchRequest,
+			RequestID:      "id-1",
+			SellerAgentURL: "https://seller.example.com/agent",
+			Identities:     []IdentityToken{{UserToken: "tok", UIDType: UIDTypeUID2}},
+		}
+	}
+
+	cases := []struct {
+		name    string
+		mutate  func(*IdentityMatchRequest)
+		wantErr string
+	}{
+		{name: "ok", mutate: func(*IdentityMatchRequest) {}},
+		{
+			name:    "missing type rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.Type = "" },
+			wantErr: `type must be "identity_match_request"`,
+		},
+		{
+			name:    "mismatched type rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.Type = TypeContextMatchRequest },
+			wantErr: `type must be "identity_match_request"`,
+		},
+		{
+			name:    "missing request_id rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.RequestID = "" },
+			wantErr: "request_id is required",
+		},
+		{
+			name:    "missing seller_agent_url rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.SellerAgentURL = "" },
+			wantErr: "seller_agent_url is required",
+		},
+		{
+			name:    "empty identities rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.Identities = nil },
+			wantErr: "identities must not be empty",
+		},
+		{
+			name: "too many identities rejected",
+			mutate: func(r *IdentityMatchRequest) {
+				r.Identities = []IdentityToken{
+					{UserToken: "a", UIDType: UIDTypeUID2},
+					{UserToken: "b", UIDType: UIDTypeID5},
+					{UserToken: "c", UIDType: UIDTypeEUID},
+					{UserToken: "d", UIDType: UIDTypeRampID},
+				}
+			},
+			wantErr: "identities exceeds maximum of 3",
+		},
+		{
+			name: "unknown uid_type rejected",
+			mutate: func(r *IdentityMatchRequest) {
+				r.Identities = []IdentityToken{{UserToken: "tok", UIDType: UIDType("made_up")}}
+			},
+			wantErr: "uid_type \"made_up\" is not a recognized TMP identity type",
+		},
+		{
+			name: "every spec uid_type accepted",
+			mutate: func(r *IdentityMatchRequest) {
+				r.Identities = []IdentityToken{
+					{UserToken: "tok", UIDType: UIDTypeHashedEmail},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := valid()
+			tc.mutate(&req)
+			err := ValidateIdentityRequest(&req)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestValidateIdentityRequest_AllValidUIDTypes(t *testing.T) {
+	types := []UIDType{
+		UIDTypeRampID, UIDTypeRampIDDerived, UIDTypeID5, UIDTypeUID2,
+		UIDTypeEUID, UIDTypePairID, UIDTypeMAID, UIDTypeHashedEmail,
+		UIDTypePublisherFirstParty, UIDTypeOther,
+	}
+	for _, ut := range types {
+		t.Run(strings.ReplaceAll(string(ut), " ", "_"), func(t *testing.T) {
+			req := IdentityMatchRequest{
+				Type:           TypeIdentityMatchRequest,
+				RequestID:      "id-1",
+				SellerAgentURL: "https://seller.example.com/agent",
+				Identities:     []IdentityToken{{UserToken: "tok", UIDType: ut}},
+			}
+			require.NoError(t, ValidateIdentityRequest(&req))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Brings `cmd/identity-agent`, `targeting/identityagent`, `tmproto`, and the router fan-out into compliance with the 3.0.12 TMP identity-match spec.

| # | Problem | Fix |
|---|---|---|
| 1 | Identity-agent listener at `POST /tmp/identity` — spec requires `POST /identity` | Route renamed; env examples + `TMP_OWN_ENDPOINT_URL` updated |
| 2 | `IdentityMatchResponse.type` left empty (schema requires const `identity_match_response`) | Handler stamps `Type` on every response |
| 3 | Fail-closed / timeout path emitted `eligible_package_ids: null` | Explicit `[]string{}` |
| 4 | `ValidateIdentityRequest` skipped the `type` discriminator | Validator rejects missing/mismatched `type` |
| 5 | `ValidateIdentityRequest` accepted any `uid_type` | Validator checks the closed enum |
| 6 | No `adcp_major_version` enforcement | New `SUPPORTED_ADCP_MAJOR_VERSIONS` env var (default `3`); handler returns HTTP 400 on mismatch |

Plus the `/health` listener + body fixes from the first commit (audit item 7).

### Review-driven follow-ups (third commit)

- **Router fan-out path**: `router/router.go` now calls providers at `/context` and `/identity` (was `/tmp/...`) — production router + identity-agent stay aligned. Publisher↔router contract is unchanged.
- **Router-merged response `type`**: `mergeContextResponses` / `mergeIdentityResponses` stamp the response `type` field. `Router.writeError` stamps `type: "error"`.
- **Reference identity-agent** (`reference/identity-agent/...`): same response-shape fixes — `Type` set on every response, empty-array initialisation, `/health` body trimmed.
- **`/health` panic recovery**: main mux is wrapped in `recoverMiddleware`; the identity chain's inner recovery still fires first for `/identity`.
- **`ValidateContextRequest`** also enforces `type` now; `tmpclient.ContextMatch` / `Activate` auto-populate.
- **`adcp_major_version` rejection** carries an inline comment explaining the spec inconsistency around `VERSION_UNSUPPORTED` (the field-level prose names a code that isn't in the `error.json` enum).

### Side fixes carried through

- `ErrorResponse` payloads emitted by the identity-agent handler, identity-agent middleware, router, and reference agent now set `type: "error"`.
- `tmpclient.Client.IdentityMatch`, `ContextMatch`, and `Activate` auto-populate request `type` so existing callers don't have to.

### Configuration surface

New env var, applied in all three `cmd/identity-agent/example.*.env`:

```
# Comma-separated set of AdCP major versions this agent accepts on
# inbound `adcp_major_version`. Requests carrying an unsupported value
# are rejected with HTTP 400.
SUPPORTED_ADCP_MAJOR_VERSIONS=3
```

Validation rejects empty lists and out-of-range values (`[1, 99]` per schema).

### Breaking changes

This PR ships breaking validator changes — `ValidateIdentityRequest` and `ValidateContextRequest` now reject missing `type` with HTTP 400. The route rename (`/tmp/identity` → `/identity`, `/tmp/context` → `/context`) is also breaking for any operator who had registered the old paths.

Acknowledged and intentional — no deprecation window. Consumers using `tmpclient` are insulated (auto-populates `type`); raw Go consumers that construct requests by hand must set `Type: tmproto.TypeIdentityMatchRequest` / `tmproto.TypeContextMatchRequest`. Publisher-side router registrations must update endpoint paths.

### Not in scope

- Per-IP `/health` rate limiting (spec recommends ~1 req/s/source IP).
- `tmproto.ErrorCode` does not yet include `version_unsupported` — the field-level description in `identity-match-request.json` names it, but the canonical `error.json` enum omits it. Using `invalid_request` with a descriptive message until the spec is internally consistent.

## Test plan

- [x] `go build ./...` clean across all modules
- [x] `go test -count=1 ./...` passes (pre-existing flake in `registry/TestSyncer_AppliesAuthorizationRevoked` and intermittent e2e flakiness under `-count=N` are not introduced here)
- [x] `tmproto/validate_test.go` covers type-discriminator + uid_type enum rejection paths
- [x] `targeting/identityagent/config_test.go` covers `SUPPORTED_ADCP_MAJOR_VERSIONS` validation (empty, out-of-range, multi-value)
- [ ] Manual: `curl POST /identity` with `"type":"identity_match_request"` succeeds; missing/mismatched `type` returns 400
- [ ] Manual: `adcp_major_version: 99` returns 400 with `invalid_request`
- [ ] Manual: timeout path returns `{"type":"identity_match_response","request_id":"…","eligible_package_ids":[],"ttl_sec":…}`
- [ ] Manual: with `ADMIN_PORT > 0`, `/identity` and `/health` stay on `HTTP_PORT`; `/live`, `/metrics`, `/debug/pprof` move to admin port
- [ ] Manual: confirm publisher router fan-out resolves the new path correctly after re-registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
