### PR TITLE
fix(docker): use distroless base for identity-agent and router images

### DIFF
--- a/cmd/identity-agent/Dockerfile
+++ b/cmd/identity-agent/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-RUN apk add --no-cache ca-certificates
 COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
@@ -8,8 +7,7 @@ COPY cmd/identity-agent/ cmd/identity-agent/
 WORKDIR /src/cmd/identity-agent
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /identity-agent .
 
-FROM scratch
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static-debian13:nonroot
 COPY --from=build /identity-agent /identity-agent
 EXPOSE 8080
 ENTRYPOINT ["/identity-agent"]

--- a/cmd/identity-agent/Dockerfile
+++ b/cmd/identity-agent/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.26-alpine AS build
 WORKDIR /src
+RUN apk add --no-cache ca-certificates
 COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
@@ -8,6 +9,7 @@ WORKDIR /src/cmd/identity-agent
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /identity-agent .
 
 FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /identity-agent /identity-agent
 EXPOSE 8080
 ENTRYPOINT ["/identity-agent"]

--- a/cmd/router/Dockerfile
+++ b/cmd/router/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.26-alpine AS build
 WORKDIR /src
-RUN apk add --no-cache ca-certificates
 COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
@@ -9,7 +8,6 @@ COPY cmd/router/ cmd/router/
 WORKDIR /src/cmd/router
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /router .
 
-FROM scratch
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+FROM gcr.io/distroless/static-debian13:nonroot
 COPY --from=build /router /router
 ENTRYPOINT ["/router"]

--- a/cmd/router/Dockerfile
+++ b/cmd/router/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.26-alpine AS build
 WORKDIR /src
+RUN apk add --no-cache ca-certificates
 COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
@@ -9,5 +10,6 @@ WORKDIR /src/cmd/router
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /router .
 
 FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /router /router
 ENTRYPOINT ["/router"]


### PR DESCRIPTION
## Summary

- The `cmd/identity-agent` and `cmd/router` runtime images used `FROM scratch`, which contains no root CA bundle. Any outbound HTTPS call from the Go binary fails with `x509: certificate signed by unknown authority`.
- Observed on the staging identity-agent when it tried to load its identity-config snapshot from `https://api.agentic.staging.scope3.com/api/v2/identity-match/targeting`:
  ```
  build bundle: identityconfig initial load: identityconfig: load all:
  scope3: POST https://api.agentic.staging.scope3.com/api/v2/identity-match/targeting:
  Post \"...\": tls: failed to verify certificate: x509: certificate signed by unknown authority
  ```
- Fix: switch both runtime images to `gcr.io/distroless/static-debian13:nonroot`. That base ships `ca-certificates`, tzdata, `/etc/passwd`+`/etc/group`, and a `nonroot` user (UID 65532) — so we also stop running as root.

## Why distroless/static-debian13 over `scratch` + COPYing CA certs

- **Fewer footguns to remember.** `scratch` is minimal in a way that bites Go services repeatedly: no CA bundle (this PR), no tzdata (`time.LoadLocation` fails), no `/etc/passwd` (can't run as a named non-root user), no `/tmp`. Each one is a one-line fix once you know — but the next service or the next dev starts with the same gaps.
- **Non-root by default.** Pod runs as UID 65532 with no chart changes; good baseline posture for K8s.
- **Comparable size and attack surface.** ~2 MB base. Still no shell, no package manager — same hardening profile as scratch.
- **Patched and signed by Google.** SBOMs published, cosign-signed images. We don't own a patch treadmill for things we don't use.

## Why `debian13` and not `debian12`

- Debian 13 (Trixie) is the current Debian stable as of mid-2025, on primary security support. Debian 12 transitions to LTS soon — pinning to it today commits us to a shorter window before forced upgrade.
- The `static-*` variants ship no userland (no shell, no glibc dynamic linking exposed to us), so the Debian-13-only concerns (`t64` library renames, etc.) don't apply. The contents that matter to us — CA bundle, `/etc/passwd` with `nonroot`, tzdata — are functionally identical between `static-debian12` and `static-debian13`.

The Go code is unchanged — relying on the system trust store is the correct behavior. No `InsecureSkipVerify` knob was added.

## Test plan

- [ ] CI build of the `identity-agent` image succeeds.
- [ ] Deploy `edge` tag to staging (`us-central1`) and confirm the pod reaches Ready (i.e. `identityconfig initial load` completes against `api.agentic.staging.scope3.com`).
- [ ] `/health` returns 200; no `x509: certificate signed by unknown authority` lines in pod logs.
- [ ] Confirm the pod is running as UID 65532 (`kubectl exec` isn't available on distroless — verify via the pod spec / `kubectl get pod -o jsonpath` or container runtime).
- [ ] Spot-check router image still builds (no functional path to exercise yet in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)