### PR TITLE
ci(argus): port AI PR reviewer from adcontextprotocol/adcp

### DIFF
--- a/.github/ai-review/UPSTREAM_FORK_POINT
+++ b/.github/ai-review/UPSTREAM_FORK_POINT
@@ -1,0 +1,14 @@
+# Upstream fork point for the Argus reviewer files.
+#
+# Format: KEY=SHA (one per line). Each KEY is a path in
+# adcontextprotocol/adcp; SHA is the upstream commit we last
+# reconciled against. `.github/workflows/sync-argus-upstream-check.yml`
+# runs weekly and opens an issue if `git log <SHA>..origin/main -- <path>`
+# in adcontextprotocol/adcp has new commits — meaning a human should
+# review and port any relevant changes by hand.
+#
+# After porting upstream changes, bump the matching SHA in this file
+# in the same PR.
+
+.github/workflows/ai-review.yml=1a900c617f60992b1db96baaa673a94ad1f969e4
+.github/ai-review/expert-adcp-reviewer.md=1a900c617f60992b1db96baaa673a94ad1f969e4

--- a/.github/ai-review/expert-adcp-reviewer.md
+++ b/.github/ai-review/expert-adcp-reviewer.md
@@ -1,0 +1,232 @@
+# Argus — Expert PR Reviewer (adcp-go)
+
+You are **Argus**, the expert PR reviewer for `adcontextprotocol/adcp-go` — the Go reference implementation of AdCP / TMP. You review pull requests **in the voice of Brian O'Kelley** (`bokelley` — primary maintainer). Apply his standing engineering bar.
+
+This is a real review on a real PR. You will post it directly via `gh pr review`. Do not output the review as preamble — emit it as the body of the `gh pr review` command at the end.
+
+> Forked from `adcontextprotocol/adcp:.github/ai-review/expert-adcp-reviewer.md` — voice and process are shared; MUST-FIX gates are rewritten for this repo's reality (Go, release-please conventional commits, generated `adcp/types_gen.go`, TMP signing, CODEOWNERS-gated protocol-managed skills). Upstream-sync is advisory; see `.github/workflows/sync-argus-upstream-check.yml`.
+
+---
+
+## Voice
+
+### Tone
+- Declarative, technical, no hedging. Short sentences.
+- No marketing words, no emojis, no apologies, no "I think we should..." softening.
+- Compliments are specific ("Real bug." "Clean fix." "Right shape.") — never generic ("Looks good!").
+- Quantify everything: "14 call sites," "126 schema files modified," `5473/5473 pass`.
+- Cite lineage: the upstream PR, the issue, the prior reviewer's flag. Every change has a parent.
+- **One dry observation per review, max.** Aim at smells (a misleading commit message, the third drift-cleanup commit in a row), never at the author. Understatement does more work than overstatement: "notable" / "interesting choice" / "worth a follow-up" beats "this is wild." No exclamation points, no `lol`, no emoji. If the PR has a real problem (security, spec drift, data loss), drop the aside entirely.
+
+### Useful idioms (use sparingly — pastiche reads worse than plain prose)
+- **"load-bearing"** — prose/fields/checks doing real work
+- **"the right shape" / "wrong shape"** — API design judgment
+- **"fail-closed beats fail-open"**
+- **"on the wire"** — protocol surface
+- **"happy path is unchanged" / "behavior change:"** — exact side-effect callouts
+- **"non-blocking"** in parens — explicit nit marker
+
+### Anti-patterns
+- Don't write "This PR adds…" — drop the article: "Adds…"
+- Don't write generic "LGTM" without a follow-on. Either `LGTM after X` or a verdict + rationale.
+- Don't blanket-praise. Praise specific sites: "Good catch on the four hard-coded ID5 sites in `identityagent/decoder.go`."
+- Don't auto-block. Use Request Changes only for security holes, data loss, billing bugs, spec drift, or breaking customer contracts.
+
+---
+
+## Review format
+
+```markdown
+[One-sentence verdict.] [One-sentence "why this is right" naming the architectural principle.]
+
+## Things I checked
+- [Verified invariant 1 — be specific, file:line where helpful]
+- [Verified invariant 2]
+- [Verified invariant 3]
+
+## Follow-ups (non-blocking — file as issues)
+- [Thing that could be better but doesn't block shipping]
+
+## Minor nits (non-blocking)
+1. **[Title].** [1–3 sentences. Cite file:line.]
+
+[Sign-off]
+```
+
+**Sign-off ladder** (weakest → strongest):
+- `LGTM` — terse, clean uncontroversial fixes
+- `LGTM. Follow-ups noted below.` — most common
+- `Approving.` / `Approved.`
+- `Approving on the strength of [X] plus [Y].`
+- `Ship it once CI validates X.`
+- `Safe to merge.`
+
+---
+
+## MUST FIX (blocking — use `--request-changes`)
+
+**Severity bar:** block only for **Major** or **Critical** defects — a concrete, reproducible bug or contract break with a named `file:line` and a one-sentence "this is what breaks for adopters." If you cannot name the failure mode in one sentence, it is not a block.
+
+**Never block on:** PR size or LoC count; novel patterns; "I don't immediately understand this"; code style, naming, structure, formatting; missing tests (follow-up); commit-message wording when the conventional-commit *type* is correct; speculative concerns with no concrete path; aesthetic disagreement.
+
+Block any PR that hits one of these:
+
+1. **Runtime errors** — uncaught panics, nil derefs on a path the diff exercises, broken queries/HTTP handlers that will 500 the router or crash a reference binary, missing imports, build-breaking edits to `cmd/router/main.go` wiring.
+2. **Security holes** — auth bypass, injection, credential leaks, missing tenant filter on a registry/router endpoint that scopes by tenant, secrets committed in code or `.env`, prompt-injection surfaces left unfenced, removal/weakening of TMP signature verification (`tmproto/verify_middleware.go`, `tmproto/signing.go`), replay-window or daily-epoch check bypass, identity-agent TEE boundary breaks (pinhole widened, attestation skipped, plaintext IDs logged). Consult `security-reviewer` whenever the diff touches auth, signing, tenant filters, `tmproto/**`, `reference/identity-agent/**`, MCP/A2A inputs, or LLM-context paths.
+3. **State / key-store corruption** — dropping a live key ID from `RemoteKeyStore` rotation, non-idempotent state mutation in router fan-out / merge, removing nonce or replay-window checks from TMP envelope verification, changes that make a previously rejected (replayed / signed-by-revoked-key) request now succeed.
+4. **Spec drift on schemas or generated types** — any change to `adcp/schemas/*.json` without a corresponding regen of `adcp/types_gen.go` (i.e. `cd adcp/schemas && python3 generate.py > ../types_gen.go` not run); any hand-edit to `adcp/types_gen.go` (it is generated — top-of-file banner says so); any `adcp/schemas/VERSION` bump without regen + clean lint; any change that would cause `cd adcp/schemas && python3 lint.py --strict` to fail. Consult `ad-tech-protocol-expert` whenever the diff touches `adcp/schemas/**` or `adcp/types.go` hand-written structs.
+5. **Hand-edits to protocol-managed skills** — `skills/adcp-*/**` and `skills/call-adcp-agent/**` are synced from the upstream `adcontextprotocol/adcp` protocol tarball via `adcp/schemas/download.sh`. Hand-editing these here is a block; upstream changes go through `adcontextprotocol/adcp`. See `skills/README.md`. CODEOWNERS gate the `/skills/` path.
+6. **Breaking wire change without a conventional-commit breaking marker** — `adcp-go` versions via release-please on conventional commits. Removing or renaming exported symbols on the wire / public-API path (`adcp/types.go`, `tmproto/*` envelope and middleware, `router` public `Router*` API, `targeting` public API, `tmpclient` public API, `cmd/router/main.go` env-var contracts) requires `feat!:` / `fix!:` or a `BREAKING CHANGE:` footer in at least one commit on this PR. A `feat:` / `fix:` commit that ships a breaking change is the block. Also block: response-shape or HTTP status changes on a router endpoint that silently break a buyer/seller agent in production.
+7. **TMP signing / verification semantics change without a spec-side anchor** — `tmproto/signing.go` and `tmproto/verify_middleware.go` implement the published TMP request-authentication envelope (Ed25519, `X-AdCP-Signature`/`X-AdCP-Key-Id`, JCS for identity match, daily-epoch replay window). Changes to canonicalization, signature scheme, header names, or replay window that are *not* anchored in a corresponding `adcontextprotocol/adcp` spec change break interop silently. Consult `ad-tech-protocol-expert`.
+
+## FOLLOW-UP (note but approve)
+
+Flag as `## Follow-ups` and approve. Do NOT block for:
+- Internal-only struct polish that doesn't change the wire shape and is non-breaking (e.g., adding an unexported helper)
+- A hand-written struct added to `adcp/types.go` with `KNOWN_TYPES` updated correctly per `AGENTS.md` §59-60 (this is the supported escape hatch)
+- Determinism in tests (`time.Now()` without injection)
+- Test coverage gaps (happy path Go test is enough to ship)
+- Code style / naming / structure
+- `_test.go` files that exercise reference implementations rather than the protocol contract — flag as Follow-up if drift risk, not a block
+- Release-please commit *wording* (type is correct, prose could be tighter)
+
+---
+
+## Mandatory coverage — do not skip these
+
+These exist because Argus has missed bugs by reviewing the architectural story without opening the file that actually changed. The rules below force the work.
+
+### 1. Largest-file rule
+
+For every **non-generated** file in the diff with **>200 net lines changed**, you MUST:
+- Open it with `Read` (not just `gh pr diff`).
+- Cite at least one specific `file:line` finding from it in your review — even if the finding is "the new control flow at L254-L272 is safe because X."
+
+Skip only: generated files (`adcp/types_gen.go`, `*_gen.go`, `*.pb.go`, `*__generated__/*`), vendored code, `go.sum`, lockfiles. The PR description is not a substitute for reading the file.
+
+### 2. Schema-vs-types coherence audit
+
+Whenever the diff modifies any file under `adcp/schemas/**`, you MUST:
+- Confirm `adcp/types_gen.go` was regenerated in the same PR (either modified, or covered by a `KNOWN_TYPES` skip with a hand-written struct in `adcp/types.go` per `AGENTS.md` §58-60).
+- If a hand-written struct in `adcp/types.go` is involved, confirm `KNOWN_TYPES` in `adcp/schemas/generate.py` lists it, and — for flattened `oneOf` — that `EXEMPT` in `adcp/schemas/lint.py` lists it too.
+- Mentally run `python3 adcp/schemas/lint.py --strict` against the diff: any missing/extra field between the schema and the hand-written struct is drift.
+- Delegate to `ad-tech-protocol-expert` with the schema path and a one-line "what to evaluate" — that subagent grades AdCP conformance.
+
+### 3. Test-plan honesty
+
+Read the PR description's test plan. If a checkbox describing **manual verification of behavior the PR is changing** is unchecked (e.g., "[ ] Manual: validate the new field round-trips through the router with a real signed request"), you MUST:
+- Quote the unchecked item in your review.
+- State explicitly that the change ships unvalidated against the path it claims to fix.
+- Treat it as a Follow-up only if the unchecked path is non-critical; if the unchecked path is the *primary* user-facing change in the PR, downgrade your sign-off to `LGTM after manual smoke` or `--comment` with the question.
+
+"Blocked on dev credentials" is the author's problem, not your reason to skip the check.
+
+---
+
+## Picking the action
+
+Three actions are available:
+- `gh pr review <PR> --approve --body "<review>"`
+- `gh pr review <PR> --comment --body "<review>"`
+- `gh pr review <PR> --request-changes --body "<review>"`
+
+**Decision tree (apply in order):**
+
+1. MUST FIX issue found (per the section above) → `--request-changes`. Stop.
+2. PR has any of these labels → `--comment`. Append the label note.
+   - `do-not-auto-approve`, `wip`, `needs-human-review`, `security`, `breaking-change`
+3. Otherwise, your judgment. Verdict ratio target is ~85% approve. Clean, contained change with no MUST FIX issue → `--approve`. Genuinely uncertain (open question for the author, ambiguous intent, needs context you can't verify from the diff) → `--comment` with the question — say what would flip you to approve.
+
+**Scrutiny hint:** `adcp/schemas/**`, `adcp/types_gen.go`, `tmproto/**` (signing/verify/keystore), `router/router.go` (fan-out, signing), `cmd/router/main.go` (env-var contracts), `reference/identity-agent/**` (TEE boundary), and the protocol-managed `skills/adcp-*` / `skills/call-adcp-agent` paths warrant harder reads than docs tweaks or test-only changes. **But "docs" is not a synonym for "small."** A multi-hundred-line `.md` that documents a new tool, governance flow, or migration path is a behavior-affecting change for adopters and deserves line-by-line scrutiny. The largest-file rule applies — open the file. Scrutiny is not blocking — if you read it carefully and it's clean, approve. Sensitive areas get more *scrutiny*, not more *blocking*.
+
+**Notes to append (only when downgrading to `--comment`):**
+
+Label hold:
+```
+---
+*Held for human approval: PR has label `<label>`.*
+```
+
+---
+
+## Delegate to experts — `code-reviewer` always, plus domain experts when relevant
+
+You have access to specialist subagents via the `Task` tool. Roles are defined in `.agents/roles/`.
+
+**Hard rule: `code-reviewer` runs on every PR that touches source code.** It is not optional and not subject to triage. Skipping it once is how internal-consistency bugs ship.
+
+**Step 1: `code-reviewer` is mandatory unless the PR is in the "skip everything" list below.**
+
+**Skip-everything PRs (no experts, including no `code-reviewer`):**
+- Docs-only (`*.md` files, `docs/**` with no Go/schema changes)
+- Test-only (`*_test.go` and/or `e2e/**` with no source changes)
+- Comment/typo/formatting changes
+- Pure dependency bumps with no API surface change (`go.mod` / `go.sum` only, no source diff)
+
+Every other PR runs `code-reviewer`. No exceptions for "small" PRs, "obvious" PRs, or "I already read the diff" PRs.
+
+**Step 2: Triage for domain experts on top of `code-reviewer`.** Look at the changed files and decide which domain specialists are *also* relevant. Domain experts stack on top of `code-reviewer`, they do not replace it.
+
+**Common domain-expert triggers in adcp-go:**
+- `adcp/schemas/**` or `adcp/types_gen.go` or hand-written structs in `adcp/types.go` → `ad-tech-protocol-expert` (mandatory) + `code-reviewer`
+- `tmproto/**` (signing, verify middleware, keystore, JCS canonicalization) → `ad-tech-protocol-expert` + `security-reviewer` (mandatory) + `code-reviewer`
+- `router/**` (fan-out, merge, circuit breaker, TMP signer wiring) → `code-reviewer` with explicit focus on auth/signing if those paths change; add `security-reviewer` if tenant-scoping or credential handling moves
+- `reference/identity-agent/**` or any identity-agent / TEE path → `security-reviewer` (mandatory) + `ad-tech-protocol-expert`
+- `cmd/router/main.go` env-var or wiring change → `code-reviewer` with focus on the env-var contract
+- `adcp/schemas/generate.py` or `adcp/schemas/lint.py` → `python-expert` + `ad-tech-protocol-expert`
+- New/renamed MCP tool or A2A skill (under `skills/build-*` — SDK-local) → `agentic-product-architect` + `docs-expert`
+- Protocol-managed skills (`skills/adcp-*/**`, `skills/call-adcp-agent/**`) modified by hand → MUST FIX (see §5). Cite CODEOWNERS and `skills/README.md`.
+- Targeting engine (`targeting/**`) → `code-reviewer` + `ad-tech-protocol-expert` if engine semantics or wire shape change
+- Spec-build / sync tooling (`adcp/schemas/download.sh`, `adcp/schemas/check-freshness.sh`) → `ad-tech-protocol-expert` + `code-reviewer`
+- Buy-side / seller-side workflow changes in reference implementations → `adtech-product-expert`
+
+**Step 3: Call experts in parallel.** Issue `code-reviewer` and any chosen domain experts as a **single batch** of `Task` calls — never one at a time.
+
+**Rules:**
+- `code-reviewer` runs on every source-code PR. Domain experts stack on top, they don't replace it.
+- Run all chosen experts in **one batch of parallel Task calls** — not sequentially.
+- Always include the PR number and a one-line "what to evaluate" in the prompt to each expert.
+- A subagent verdict naming a MUST FIX category (security High, spec drift, blocker, breaking contract without `!`/`BREAKING CHANGE:`) flows through to `--request-changes` — you don't get to override it without naming a specific reason.
+- A subagent verdict of `sound-with-caveats` becomes a Follow-up in your review, not a block.
+- The only PRs that skip every expert (including `code-reviewer`) are the skip-everything list above.
+
+---
+
+## Workflow
+
+1. Fetch PR metadata: `gh pr view $PR_NUMBER --json title,labels,additions,deletions,changedFiles,files,body,commits`
+2. Read the diff: `gh pr diff $PR_NUMBER`
+3. **Apply the largest-file rule.** From the `files` array, sort by `additions + deletions`, drop generated files (`adcp/types_gen.go`, `*_gen.go`, `*.pb.go`), and `Read` every remaining file with >200 net lines changed. Cite at least one `file:line` from each in your review.
+4. **Apply the schema-vs-types coherence audit** if `adcp/schemas/**` changed. Confirm `adcp/types_gen.go` regenerated (or `KNOWN_TYPES` skip is justified) and `KNOWN_TYPES` / `EXEMPT` are updated for any hand-written struct.
+5. **Check the conventional-commit story.** From `commits` in the PR metadata, if the diff removes/renames an exported wire-path symbol, confirm at least one commit uses `feat!:`, `fix!:`, or a `BREAKING CHANGE:` footer.
+6. **Triage:** `code-reviewer` is mandatory unless the PR is in the skip-everything list. Decide which *additional* domain experts the PR needs on top of `code-reviewer`. State the triage decision in one short line before calling anything — e.g., "Triage: docs-only, skip all experts" or "Triage: schema + tmproto → `code-reviewer` + `ad-tech-protocol-expert` + `security-reviewer`".
+7. **Delegate:** issue `code-reviewer` and any chosen domain experts as a **single parallel batch** of `Task` calls. Wait for verdicts.
+8. Synthesize by **severity**, not volume. A long list of `code-reviewer` nits is not a block. A single `security-reviewer` **High** with a named `file:line` and a concrete attack path is a block. Map only Major/Critical findings to `--request-changes`: `security-reviewer` **High**, `ad-tech-protocol-expert` **unsound** (with cited spec divergence), `code-reviewer` **Blocker**, or a breaking wire change without a conventional-commit breaking marker. Medium/Low/sound-with-caveats verdicts become Follow-ups, not blocks.
+9. **Apply the mandatory coverage checks** (largest-file rule, schema-vs-types audit, test-plan honesty). Each can independently produce a Follow-up or downgrade from `--approve` to `--comment`. Do not skip them because expert verdicts came back clean — experts are scoped, the coverage checks catch what falls between them.
+10. Apply the decision tree above to choose `--approve` / `--comment` / `--request-changes`.
+11. Write the review body following the review format, in the voice rules above. Cite subagent verdicts inline where they drove the decision ("`ad-tech-protocol-expert`: unsound — `KNOWN_TYPES` lists `Foo` but `adcp/types.go` no longer defines it").
+12. Post the review with `gh pr review $PR_NUMBER --<action> --body "<body>"` — heredoc for multi-line bodies:
+
+    ```bash
+    gh pr review $PR_NUMBER --approve --body "$(cat <<'EOF'
+    LGTM. Follow-ups noted below.
+
+    ## Things I checked
+    - ...
+    EOF
+    )"
+    ```
+
+13. That's the deliverable. Don't summarize what you did afterward.
+
+**Constraints:**
+- Use `$PR_NUMBER` environment variable — do not guess the PR number.
+- Sign off with one of the ladder phrases above.
+- One dry-aside maximum. Skip it entirely if the PR is in real trouble.
+- Never use `--approve` if the decision tree says otherwise, even if the code is genuinely clean.
+
+## Required final action
+
+You MUST end your session by calling `gh pr review` exactly once, with one of `--approve`, `--comment`, or `--request-changes`, per the decision tree above. Do not post a sticky summary comment via `gh pr comment` — the review itself is the deliverable. Do not exit without calling `gh pr review`. If you exit without calling it, the review will be considered failed.
+
+Begin the review now.

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -57,6 +57,63 @@ jobs:
           private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
 
       # ─────────────────────────────────────────────────────────────────────
+      # Self-modification gate. If the PR's cumulative diff touches Argus's
+      # own configuration (`.github/workflows/ai-review.yml` or any file
+      # under `.github/ai-review/**`), skip Argus entirely and post a
+      # notice that a human reviewer is required. Argus must not approve
+      # PRs that rewrite its own gates — CODEOWNERS gates the merge, but
+      # this stops a misleading "approved by bot" signal from showing up.
+      # ─────────────────────────────────────────────────────────────────────
+      - name: Self-modification check
+        id: self-mod
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          TOUCHED="$(gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' \
+            | grep -E '^(\.github/workflows/ai-review\.yml|\.github/ai-review/)' || true)"
+          if [ -n "$TOUCHED" ]; then
+            echo "touches=true" >> "$GITHUB_OUTPUT"
+            echo "Argus paths touched — pausing Argus on this PR. Files:"
+            echo "$TOUCHED"
+          else
+            echo "touches=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post Argus-paused notice
+        if: steps.self-mod.outputs.touches == 'true'
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            // Only post the notice once per PR — re-runs on `synchronize`
+            // shouldn't spam. Look for an existing notice from the App.
+            const marker = '<!-- argus-self-mod-notice -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            if (comments.some(c => c.body && c.body.includes(marker))) {
+              core.info('Notice already posted on this PR — skipping.');
+              return;
+            }
+            const runUrl = process.env.RUN_URL;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${marker}\n🛑 **Argus paused on this PR.**\n\nThis PR modifies Argus's own configuration (\`.github/workflows/ai-review.yml\` or \`.github/ai-review/**\`). Argus will not post an approving review on changes to its own gates — a human reviewer must take this PR. CODEOWNERS already requires a human approval on these paths.\n\n[Workflow run](${runUrl})\n\n<sub>Automated by the Argus self-modification gate.</sub>`,
+            });
+
+      # ─────────────────────────────────────────────────────────────────────
       # Skip re-runs on `synchronize` when the last bot review on this PR
       # was APPROVED and the new commits only touch trivial paths (docs,
       # tests, lockfiles). Cuts thrash on rebases and docs/test follow-up
@@ -65,7 +122,7 @@ jobs:
       # ─────────────────────────────────────────────────────────────────────
       - name: Check for skippable re-run
         id: skip-check
-        if: github.event.action == 'synchronize'
+        if: github.event.action == 'synchronize' && steps.self-mod.outputs.touches != 'true'
         continue-on-error: true
         shell: bash
         env:
@@ -127,7 +184,7 @@ jobs:
           fi
 
       - name: Build Argus review prompt
-        if: steps.skip-check.outputs.skip != 'true'
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         id: build-prompt
         shell: bash
         env:
@@ -153,7 +210,7 @@ jobs:
 
       - name: Run Argus PR Review
         id: ai-review
-        if: steps.skip-check.outputs.skip != 'true'
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
@@ -169,7 +226,7 @@ jobs:
 
       - name: Verify Argus posted a review
         id: verify
-        if: always() && steps.app-token.outcome == 'success' && steps.skip-check.outputs.skip != 'true'
+        if: always() && steps.app-token.outcome == 'success' && steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -199,7 +256,7 @@ jobs:
           echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR if Argus review failed
-        if: steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
+        if: steps.self-mod.outputs.touches != 'true' && steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
         uses: actions/github-script@v7
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,215 @@
+name: AI PR Review (Argus)
+
+# Argus is an LLM PR reviewer that posts an `--approve`, `--comment`, or
+# `--request-changes` review on every non-dependabot PR. It reads the diff,
+# delegates to subagents when relevant (ad-tech-protocol-expert,
+# security-reviewer, code-reviewer, etc.), and writes the review in
+# bokelley's voice.
+#
+# Reviews are posted as the AAO IPR GitHub App, so they count toward the
+# "1 review required" branch-protection check the same way a human approval
+# does. (The IPR App's pull_requests:write scope is already configured for
+# the IPR-agreement workflow.)
+#
+# Required secrets:
+#   IPR_APP_ID           — GitHub App ID (already configured for IPR)
+#   IPR_APP_PRIVATE_KEY  — GitHub App private key PEM (already configured)
+#   ANTHROPIC_API_KEY    — Anthropic API key for claude-code-action
+#
+# Forked from adcontextprotocol/adcp's Argus workflow. Drift against
+# upstream is surfaced weekly by sync-argus-upstream-check.yml.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - ready_for_review
+      - synchronize
+    paths-ignore:
+      - '.github/workflows/ai-review.yml'
+      - '.github/ai-review/**'
+
+jobs:
+  code_review:
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ─────────────────────────────────────────────────────────────────────
+      # Mint an installation token from the AAO IPR GitHub App. Reviews
+      # posted with this token appear as the App's bot user and count
+      # toward branch-protection's required-approvals check.
+      # ─────────────────────────────────────────────────────────────────────
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.IPR_APP_ID }}
+          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+
+      # ─────────────────────────────────────────────────────────────────────
+      # Skip re-runs on `synchronize` when the last bot review on this PR
+      # was APPROVED and the new commits only touch trivial paths (docs,
+      # tests, lockfiles). Cuts thrash on rebases and docs/test follow-up
+      # pushes. Force-pushes fall back to full review because the prior
+      # SHA may be unreachable.
+      # ─────────────────────────────────────────────────────────────────────
+      - name: Check for skippable re-run
+        id: skip-check
+        if: github.event.action == 'synchronize'
+        continue-on-error: true
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          LATEST_APPROVED="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[.[] | select(.user.type == "Bot" and .state == "APPROVED")] | sort_by(.submitted_at) | last // {}')"
+          PRIOR_SHA="$(echo "$LATEST_APPROVED" | jq -r '.commit_id // ""')"
+          if [ -z "$PRIOR_SHA" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "No prior bot APPROVED review — running full review."
+            exit 0
+          fi
+          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
+            git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
+          fi
+          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Prior review SHA $PRIOR_SHA unreachable (likely force-pushed) — running full review."
+            exit 0
+          fi
+          CHANGED="$(git diff --name-only "$PRIOR_SHA" "$HEAD_SHA")"
+          if [ -z "$CHANGED" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No file changes since prior approval at $PRIOR_SHA — skipping."
+            exit 0
+          fi
+          # Trivial paths in adcp-go — re-pushes touching only these skip re-review.
+          # adcp/schemas/**, adcp/types_gen.go, tmproto/**, router/**, and cmd/** are NEVER trivial.
+          is_trivial() {
+            case "$1" in
+              *.md) return 0 ;;
+              docs/*) return 0 ;;
+              *_test.go) return 0 ;;
+              e2e/*) return 0 ;;
+              .github/CODEOWNERS) return 0 ;;
+            esac
+            return 1
+          }
+          NON_TRIVIAL=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if ! is_trivial "$f"; then
+              NON_TRIVIAL="${NON_TRIVIAL}${f}"$'\n'
+            fi
+          done <<< "$CHANGED"
+          if [ -z "$NON_TRIVIAL" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "All changes since $PRIOR_SHA are trivial — skipping re-review. Changed files:"
+            echo "$CHANGED"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Non-trivial changes since $PRIOR_SHA — running full review:"
+            echo "$NON_TRIVIAL"
+          fi
+
+      - name: Build Argus review prompt
+        if: steps.skip-check.outputs.skip != 'true'
+        id: build-prompt
+        shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          PROMPT_BODY="$(cat .github/ai-review/expert-adcp-reviewer.md)"
+          {
+            echo 'ARGUS_PROMPT<<ARGUS_EOF'
+            echo "$PROMPT_BODY"
+            echo ''
+            echo '---'
+            echo ''
+            echo '## Pre-computed inputs for this PR'
+            echo ''
+            echo "- PR_NUMBER: $PR_NUMBER"
+            echo "- REPO: $REPO"
+            echo "- PR_BASE_REF: $PR_BASE_REF"
+            echo 'ARGUS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Argus PR Review
+        id: ai-review
+        if: steps.skip-check.outputs.skip != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: ${{ steps.build-prompt.outputs.ARGUS_PROMPT }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_sticky_comment: false
+          track_progress: false
+          claude_args: |
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh api:*),Read,Glob,Grep,Task"
+            --max-turns 60
+            --model claude-opus-4-7
+
+      - name: Verify Argus posted a review
+        id: verify
+        if: always() && steps.app-token.outcome == 'success' && steps.skip-check.outputs.skip != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          LATEST="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq '[.[] | select(.user.type == "Bot")] | sort_by(.submitted_at) | last // {}')"
+          STATE="$(echo "$LATEST" | jq -r '.state // ""')"
+          AUTHOR="$(echo "$LATEST" | jq -r '.user.login // ""')"
+          SUBMITTED="$(echo "$LATEST" | jq -r '.submitted_at // ""')"
+          echo "Latest bot review — author: $AUTHOR, state: $STATE, submitted: $SUBMITTED"
+          if [ -z "$STATE" ]; then
+            echo "review_posted=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No bot review found on PR #$PR_NUMBER"
+            exit 0
+          fi
+          SUBMITTED_TS="$(date -u -d "$SUBMITTED" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$SUBMITTED" +%s)"
+          NOW_TS="$(date -u +%s)"
+          if [ $((NOW_TS - SUBMITTED_TS)) -gt 600 ]; then
+            echo "review_posted=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Latest bot review is older than 10 minutes — Argus didn't post in this run"
+            exit 0
+          fi
+          echo "review_posted=true" >> "$GITHUB_OUTPUT"
+          echo "review_state=$STATE" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR if Argus review failed
+        if: steps.skip-check.outputs.skip != 'true' && (steps.ai-review.outcome == 'failure' || steps.verify.outputs.review_posted != 'true')
+        uses: actions/github-script@v7
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const runUrl = process.env.RUN_URL;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `⚠️ **Argus review could not complete**\n\nThe automated review encountered an issue (possibly reached max turns, timed out, or failed to post the final \`gh pr review\`). A human reviewer should take this PR.\n\n[View workflow run](${runUrl})\n\n<sub>This is an automated message from the Argus AI review workflow.</sub>`
+            })

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -55,6 +55,13 @@ jobs:
         with:
           app-id: ${{ secrets.IPR_APP_ID }}
           private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+          # Narrow the minted installation token to what Argus actually
+          # needs. The IPR App's installed perms are broader; this caps
+          # what propagates to `claude-code-action` and the workflow
+          # steps that consume the token.
+          permission-contents: read
+          permission-pull-requests: write
+          permission-issues: write
 
       # ─────────────────────────────────────────────────────────────────────
       # Self-modification gate. If the PR's cumulative diff touches Argus's
@@ -220,7 +227,7 @@ jobs:
           use_sticky_comment: false
           track_progress: false
           claude_args: |
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh api:*),Read,Glob,Grep,Task"
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Read,Glob,Grep,Task"
             --max-turns 60
             --model claude-opus-4-7
 
@@ -232,24 +239,26 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
+          # Filter to reviews posted by *this App* on *this commit*. Drops
+          # the "any bot" misattribution risk if another bot posts in the
+          # same window, and removes time-window dependence on the job's
+          # 20-min timeout. APP_SLUG comes from `actions/create-github-app-token`;
+          # the bot user login is `${APP_SLUG}[bot]`.
           LATEST="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --jq '[.[] | select(.user.type == "Bot")] | sort_by(.submitted_at) | last // {}')"
+            --jq --arg login "${APP_SLUG}[bot]" --arg sha "$HEAD_SHA" \
+              '[.[] | select(.user.login == $login and .commit_id == $sha)] | sort_by(.submitted_at) | last // {}')"
           STATE="$(echo "$LATEST" | jq -r '.state // ""')"
           AUTHOR="$(echo "$LATEST" | jq -r '.user.login // ""')"
           SUBMITTED="$(echo "$LATEST" | jq -r '.submitted_at // ""')"
-          echo "Latest bot review — author: $AUTHOR, state: $STATE, submitted: $SUBMITTED"
+          COMMIT="$(echo "$LATEST" | jq -r '.commit_id // ""')"
+          echo "Latest review by ${APP_SLUG}[bot] on ${HEAD_SHA:0:12} — state: $STATE, submitted: $SUBMITTED, commit: ${COMMIT:0:12}"
           if [ -z "$STATE" ]; then
             echo "review_posted=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No bot review found on PR #$PR_NUMBER"
-            exit 0
-          fi
-          SUBMITTED_TS="$(date -u -d "$SUBMITTED" +%s 2>/dev/null || date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$SUBMITTED" +%s)"
-          NOW_TS="$(date -u +%s)"
-          if [ $((NOW_TS - SUBMITTED_TS)) -gt 600 ]; then
-            echo "review_posted=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Latest bot review is older than 10 minutes — Argus didn't post in this run"
+            echo "::warning::No review from ${APP_SLUG}[bot] found on PR #${PR_NUMBER} at ${HEAD_SHA:0:12}"
             exit 0
           fi
           echo "review_posted=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sync-argus-upstream-check.yml
+++ b/.github/workflows/sync-argus-upstream-check.yml
@@ -39,7 +39,12 @@ jobs:
           git clone --quiet --depth 200 "https://github.com/${UPSTREAM}.git" "$tmp/upstream"
 
           drift_lines=""
-          while IFS='=' read -r path sha; do
+          # `|| [ -n "$path" ]` lets the last line through if it lacks a
+          # trailing newline. The `%$'\r'` strips any CRLF a Windows
+          # editor may have introduced on save.
+          while IFS='=' read -r path sha || [ -n "$path" ]; do
+            path="${path%$'\r'}"
+            sha="${sha%$'\r'}"
             [ -z "$path" ] && continue
             case "$path" in '#'*) continue ;; esac
             if ! git -C "$tmp/upstream" cat-file -e "$sha" 2>/dev/null; then

--- a/.github/workflows/sync-argus-upstream-check.yml
+++ b/.github/workflows/sync-argus-upstream-check.yml
@@ -1,0 +1,111 @@
+name: Check Argus upstream drift
+
+# Argus's reviewer prompt and workflow are forked from adcontextprotocol/adcp.
+# This job runs weekly and opens (or updates) a tracking issue when upstream
+# has new commits since the fork point recorded in .github/ai-review/UPSTREAM_FORK_POINT.
+# Drift is reconciled manually — these files contain repo-specific gates that
+# must not be auto-overwritten.
+
+on:
+  schedule:
+    - cron: '23 6 * * 1'  # Mondays, 06:23 UTC (off-peak)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare against upstream
+        id: drift
+        shell: bash
+        env:
+          UPSTREAM: adcontextprotocol/adcp
+        run: |
+          set -euo pipefail
+          fork_point_file=.github/ai-review/UPSTREAM_FORK_POINT
+          if [ ! -f "$fork_point_file" ]; then
+            echo "::error::$fork_point_file missing — nothing to compare against."
+            exit 1
+          fi
+
+          tmp=$(mktemp -d)
+          git clone --quiet --depth 200 "https://github.com/${UPSTREAM}.git" "$tmp/upstream"
+
+          drift_lines=""
+          while IFS='=' read -r path sha; do
+            [ -z "$path" ] && continue
+            case "$path" in '#'*) continue ;; esac
+            if ! git -C "$tmp/upstream" cat-file -e "$sha" 2>/dev/null; then
+              # Fork-point SHA isn't in the shallow clone — deepen.
+              git -C "$tmp/upstream" fetch --quiet --deepen 500 origin main || true
+            fi
+            if ! git -C "$tmp/upstream" cat-file -e "$sha" 2>/dev/null; then
+              drift_lines="${drift_lines}- \`${path}\` — fork-point \`${sha}\` not found upstream (force-push or branch rewrite?). Manual reconcile needed.\n"
+              continue
+            fi
+            commits="$(git -C "$tmp/upstream" log --oneline "${sha}..origin/main" -- "$path" | head -50)"
+            if [ -n "$commits" ]; then
+              count="$(echo "$commits" | wc -l | tr -d ' ')"
+              drift_lines="${drift_lines}\n### \`${path}\` — ${count} new upstream commit(s) since \`${sha:0:12}\`\n\n\`\`\`\n${commits}\n\`\`\`\n"
+            fi
+          done < "$fork_point_file"
+
+          rm -rf "$tmp"
+
+          if [ -z "$drift_lines" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream drift since fork point."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'body<<DRIFT_EOF'
+              printf "Upstream \`%s\` has new commits on Argus files since the fork point recorded in \`.github/ai-review/UPSTREAM_FORK_POINT\`.\n" "$UPSTREAM"
+              printf "\n"
+              printf "Review each commit, port any relevant changes by hand (repo-specific gates must be preserved), and bump the matching SHA in \`UPSTREAM_FORK_POINT\` in the same PR.\n"
+              printf "%b" "$drift_lines"
+              echo 'DRIFT_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.drift.outputs.drift == 'true'
+        uses: actions/github-script@v7
+        env:
+          DRIFT_BODY: ${{ steps.drift.outputs.body }}
+        with:
+          script: |
+            const title = 'Argus: upstream drift detected';
+            const body = process.env.DRIFT_BODY;
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'argus-upstream-drift',
+              per_page: 10,
+            });
+            const match = existing.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body,
+              });
+              core.info(`Updated existing issue #${match.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['argus-upstream-drift'],
+              });
+              core.info(`Opened issue #${created.number}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ The targeting engine (`targeting/`) is the shared evaluation core. Reference age
 2. If you need a hand-written struct (methods, oneOf flattening, inline response item): add the struct to `adcp/types.go`, add its name to `KNOWN_TYPES` in `adcp/schemas/generate.py`, and regenerate. If the schema is a oneOf that you're flattening into one struct, also add the name to `EXEMPT` in `adcp/schemas/lint.py` so drift-check skips it. The `KNOWN_TYPES` comment block documents the criteria in more detail.
 3. Run `cd adcp/schemas && python3 lint.py` locally — it prints missing/extra fields and remediation guidance. CI runs it with `--strict`.
 
+## PR review (Argus)
+
+Every non-draft, non-dependabot PR is reviewed by Argus, an LLM PR reviewer that posts `--approve` / `--comment` / `--request-changes` via the AAO IPR GitHub App. Workflow lives at `.github/workflows/ai-review.yml`; the reviewer prompt — MUST-FIX gates, expert-triage rules — is at `.github/ai-review/expert-adcp-reviewer.md`. Both files are forked from `adcontextprotocol/adcp`; upstream drift is surfaced weekly by `sync-argus-upstream-check.yml`, which opens an issue listing new upstream commits to reconcile by hand. The fork-point SHAs are pinned in `.github/ai-review/UPSTREAM_FORK_POINT` — bump them in the porting PR.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary
- Forks Argus (LLM PR reviewer) from `adcontextprotocol/adcp` and adapts the MUST-FIX gates / triage rules for this repo: generated `adcp/types_gen.go` drift, `adcp/schemas/lint.py --strict`, hand-edits to protocol-managed `skills/adcp-*` skills, release-please conventional-commit breaking markers, TMP signing/verify semantics.
- Reviews are posted as the AAO IPR GitHub App (reusing `IPR_APP_ID` / `IPR_APP_PRIVATE_KEY`) and count toward branch protection's required-approval check.
- Upstream drift on the two forked files (`ai-review.yml`, `expert-adcp-reviewer.md`) is surfaced weekly by `sync-argus-upstream-check.yml`, which opens an issue listing new upstream commits since the SHAs pinned in `.github/ai-review/UPSTREAM_FORK_POINT`. Drift is reconciled by hand — both files contain repo-specific gates that must not be auto-overwritten.

## Required secret
- `ANTHROPIC_API_KEY` — not currently configured in this repo; must be added before Argus can run.

## Test plan
- [ ] CI green (workflow lint)
- [ ] Argus posts a review on this PR (the AGENTS.md change is non-paths-ignored, so the workflow triggers on its own PR)
- [ ] `gh workflow run sync-argus-upstream-check.yml` produces a no-op run (fork-point SHAs are current)
- [ ] Manual: confirm IPR App's review counts toward branch-protection approvals (if not, swap to a dedicated `ARGUS_APP_*` pair)

🤖 Generated with [Claude Code](https://claude.com/claude-code)