### PR TITLE
feat(identityagent): support extra headers on Scope3 config source

### DIFF
--- a/cmd/identity-agent/example.cluster.env
+++ b/cmd/identity-agent/example.cluster.env
@@ -87,6 +87,11 @@ CONFIG_REFRESH_INTERVAL=5m
 #   best-effort — start with an empty snapshot; rely on refresh
 CONFIG_START_MODE=retry
 CONFIG_START_RETRY_DEADLINE=5m
+# CONFIG_SOURCE_EXTRA_HEADERS adds arbitrary headers to every config-source
+# request on top of the managed Authorization/Content-Type/Accept set. JSON
+# object of name→value; collisions with the managed headers are rejected at
+# startup. Leave unset (or empty) to send no extras.
+# CONFIG_SOURCE_EXTRA_HEADERS={"X-Header-A":"value-a","X-Header-B":"value-b"}
 
 # --- Audience Valkey (optional) ---------------------------------------------
 AUDIENCE_VALKEY_MODE=cluster

--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -85,6 +85,11 @@ CONFIG_REFRESH_INTERVAL=5m
 #   best-effort — start with an empty snapshot; rely on refresh
 CONFIG_START_MODE=retry
 CONFIG_START_RETRY_DEADLINE=5m
+# CONFIG_SOURCE_EXTRA_HEADERS adds arbitrary headers to every config-source
+# request on top of the managed Authorization/Content-Type/Accept set. JSON
+# object of name→value; collisions with the managed headers are rejected at
+# startup. Leave unset (or empty) to send no extras.
+# CONFIG_SOURCE_EXTRA_HEADERS={"X-Header-A":"value-a","X-Header-B":"value-b"}
 
 # --- Audience Valkey (optional) ---------------------------------------------
 AUDIENCE_VALKEY_MODE=shadow

--- a/cmd/identity-agent/example.standalone.env
+++ b/cmd/identity-agent/example.standalone.env
@@ -84,6 +84,11 @@ CONFIG_REFRESH_INTERVAL=5m
 #   best-effort — start with an empty snapshot; rely on refresh
 CONFIG_START_MODE=retry
 CONFIG_START_RETRY_DEADLINE=5m
+# CONFIG_SOURCE_EXTRA_HEADERS adds arbitrary headers to every config-source
+# request on top of the managed Authorization/Content-Type/Accept set. JSON
+# object of name→value; collisions with the managed headers are rejected at
+# startup. Leave unset (or empty) to send no extras.
+# CONFIG_SOURCE_EXTRA_HEADERS={"X-Header-A":"value-a","X-Header-B":"value-b"}
 
 # --- Audience Valkey (optional; omit AUDIENCE_VALKEY_SHARDS to disable) -----
 # When unconfigured, any package with a non-empty TargetSegments rule is

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -155,6 +155,13 @@ type IdentityConfigSourceConfig struct {
 	RefreshInterval    time.Duration
 	StartMode          string
 	StartRetryDeadline time.Duration
+
+	// ExtraHeaders are added to every outbound config-source request on top
+	// of the headers the source manages itself (Authorization, Content-Type,
+	// Accept). Loaded from CONFIG_SOURCE_EXTRA_HEADERS as a JSON object of
+	// name→value pairs. Collisions with the managed headers are rejected by
+	// the source constructor.
+	ExtraHeaders map[string]string
 }
 
 // ValkeyBlock is the per-backend Valkey configuration. Use ToRedisStoreConfig
@@ -345,6 +352,10 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	extraHeaders, err := lookupStringMapJSON("CONFIG_SOURCE_EXTRA_HEADERS")
+	if err != nil {
+		errs = append(errs, err)
+	}
 	audienceTimeout, err := lookupDuration("AUDIENCE_TIMEOUT", defaultAudienceTimeout)
 	if err != nil {
 		errs = append(errs, err)
@@ -412,6 +423,7 @@ func LoadConfigFromEnv() (Config, error) {
 			RefreshInterval:    refreshInterval,
 			StartMode:          lookupString("CONFIG_START_MODE", defaultStartMode),
 			StartRetryDeadline: startRetryDeadline,
+			ExtraHeaders:       extraHeaders,
 		},
 		AudienceValkey:  audienceBlock,
 		FCapValkey:      fcapBlock,
@@ -689,6 +701,27 @@ func lookupIntList(name string, def []int) ([]int, error) {
 			return nil, fmt.Errorf("%s=%q has non-integer entry %q: %w", name, v, p, err)
 		}
 		out = append(out, n)
+	}
+	return out, nil
+}
+
+// lookupStringMapJSON parses an env var as a JSON object of string→string.
+// Returns nil (with nil error) when the variable is unset or empty. Rejects
+// any non-object payload and empty keys so configuration errors surface at
+// startup rather than at first refresh.
+func lookupStringMapJSON(name string) (map[string]string, error) {
+	v := os.Getenv(name)
+	if v == "" {
+		return nil, nil
+	}
+	out := map[string]string{}
+	if err := json.Unmarshal([]byte(v), &out); err != nil {
+		return nil, fmt.Errorf("%s is not a JSON object of string→string: %w", name, err)
+	}
+	for k := range out {
+		if strings.TrimSpace(k) == "" {
+			return nil, fmt.Errorf("%s contains an empty key", name)
+		}
 	}
 	return out, nil
 }

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -262,6 +262,42 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFromEnv_ExtraHeaders(t *testing.T) {
+	// Minimal env required by LoadConfigFromEnv to produce a populated Config.
+	t.Setenv("CONFIG_SOURCE_URL", "https://config.example/")
+	t.Setenv("CONFIG_SOURCE_TOKEN", "tok")
+
+	t.Run("unset yields nil map", func(t *testing.T) {
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.Nil(t, cfg.IdentityConfig.ExtraHeaders)
+	})
+
+	t.Run("valid JSON object is parsed", func(t *testing.T) {
+		t.Setenv("CONFIG_SOURCE_EXTRA_HEADERS", `{"X-Custom-A":"alpha","X-Custom-B":"beta"}`)
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"X-Custom-A": "alpha",
+			"X-Custom-B": "beta",
+		}, cfg.IdentityConfig.ExtraHeaders)
+	})
+
+	t.Run("invalid JSON surfaces as error", func(t *testing.T) {
+		t.Setenv("CONFIG_SOURCE_EXTRA_HEADERS", `not-json`)
+		_, err := LoadConfigFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CONFIG_SOURCE_EXTRA_HEADERS")
+	})
+
+	t.Run("empty key surfaces as error", func(t *testing.T) {
+		t.Setenv("CONFIG_SOURCE_EXTRA_HEADERS", `{"":"value"}`)
+		_, err := LoadConfigFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty key")
+	})
+}
+
 func TestIsValidPromName(t *testing.T) {
 	cases := map[string]bool{
 		"identity_agent": true,

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -299,7 +299,12 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 	}()
 
 	// Identity-config service (refreshed periodically).
-	source, err := scope3.New(cfg.IdentityConfig.URL, cfg.IdentityConfig.Token, scope3.WithHTTPTimeout(cfg.IdentityConfig.Timeout))
+	source, err := scope3.New(
+		cfg.IdentityConfig.URL,
+		cfg.IdentityConfig.Token,
+		scope3.WithHTTPTimeout(cfg.IdentityConfig.Timeout),
+		scope3.WithExtraHeaders(cfg.IdentityConfig.ExtraHeaders),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("init scope3 source: %w", err)
 	}

--- a/targeting/identityconfig/scope3/source.go
+++ b/targeting/identityconfig/scope3/source.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting"
@@ -42,22 +43,29 @@ import (
 // Source posts identity-config queries to a configurable URL with Bearer
 // authentication and parses the JSON response into identityconfig types.
 type Source struct {
-	url            string
-	token          string
-	client         *http.Client
-	customClient   bool // true when client was set via WithHTTPClient
+	url          string
+	token        string
+	client       *http.Client
+	customClient bool // true when client was set via WithHTTPClient
+	extraHeaders http.Header
 }
 
+// reservedHeaderNames are the headers Source sets itself. WithExtraHeaders
+// rejects entries that collide with these — silently overriding Authorization
+// would be a surprising footgun.
+var reservedHeaderNames = []string{"Authorization", "Content-Type", "Accept"}
+
 // Option configures the Source at construction time.
-type Option func(*Source)
+type Option func(*Source) error
 
 // WithHTTPClient supplies a pre-configured *http.Client. Useful for custom
 // transports, dial timeouts, or test fakes. Suppresses WithHTTPTimeout — the
 // caller's client owns its own timeout.
 func WithHTTPClient(client *http.Client) Option {
-	return func(s *Source) {
+	return func(s *Source) error {
 		s.client = client
 		s.customClient = true
+		return nil
 	}
 }
 
@@ -66,11 +74,44 @@ func WithHTTPClient(client *http.Client) Option {
 // caller's client as authoritative, so its Timeout is not mutated regardless
 // of option order.
 func WithHTTPTimeout(d time.Duration) Option {
-	return func(s *Source) {
+	return func(s *Source) error {
 		if s.customClient {
-			return
+			return nil
 		}
 		s.client.Timeout = d
+		return nil
+	}
+}
+
+// WithExtraHeaders adds caller-supplied headers to every outbound request.
+// Names are matched case-insensitively against the headers Source manages
+// itself (Authorization, Content-Type, Accept) and a collision is rejected
+// so a misconfigured value can't silently strip auth. Empty names are also
+// rejected. Values are sent verbatim.
+//
+// Repeated calls merge: later values for the same canonical header name
+// overwrite earlier ones.
+func WithExtraHeaders(headers map[string]string) Option {
+	return func(s *Source) error {
+		if len(headers) == 0 {
+			return nil
+		}
+		if s.extraHeaders == nil {
+			s.extraHeaders = http.Header{}
+		}
+		for name, value := range headers {
+			if strings.TrimSpace(name) == "" {
+				return errors.New("scope3: extra header name must be non-empty")
+			}
+			canonical := http.CanonicalHeaderKey(name)
+			for _, reserved := range reservedHeaderNames {
+				if canonical == reserved {
+					return fmt.Errorf("scope3: extra header %q collides with reserved header %q", name, reserved)
+				}
+			}
+			s.extraHeaders.Set(canonical, value)
+		}
+		return nil
 	}
 }
 
@@ -84,7 +125,9 @@ func New(url, bearerToken string, opts ...Option) (*Source, error) {
 	}
 	s := &Source{url: url, token: bearerToken, client: &http.Client{Timeout: 30 * time.Second}}
 	for _, opt := range opts {
-		opt(s)
+		if err := opt(s); err != nil {
+			return nil, err
+		}
 	}
 	return s, nil
 }
@@ -170,6 +213,9 @@ func (s *Source) post(ctx context.Context, body requestBody) (out *responseBody,
 	req.Header.Set("Authorization", "Bearer "+s.token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
+	for name, values := range s.extraHeaders {
+		req.Header[name] = values
+	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/targeting/identityconfig/scope3/source_test.go
+++ b/targeting/identityconfig/scope3/source_test.go
@@ -42,6 +42,52 @@ func TestWithHTTPTimeout_SetsDefaultClientTimeout(t *testing.T) {
 	assert.Equal(t, 123*time.Millisecond, src.client.Timeout)
 }
 
+func TestWithExtraHeaders_SetsCustomHeadersOnRequest(t *testing.T) {
+	var receivedHeaders atomic.Value
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders.Store(r.Header.Clone())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lastUpdatedAt": "2026-05-13T10:42:43Z", "targetingConfigs": [], "removedTargetingConfigs": []}`))
+	}))
+	defer srv.Close()
+
+	src, err := New(srv.URL, "secret-token", WithExtraHeaders(map[string]string{
+		"X-Custom-One": "alpha",
+		"x-custom-two": "beta",
+	}))
+	require.NoError(t, err)
+
+	_, err = src.LoadAll(context.Background())
+	require.NoError(t, err)
+
+	got, _ := receivedHeaders.Load().(http.Header)
+	require.NotNil(t, got)
+	assert.Equal(t, "Bearer secret-token", got.Get("Authorization"))
+	assert.Equal(t, "alpha", got.Get("X-Custom-One"))
+	assert.Equal(t, "beta", got.Get("X-Custom-Two"), "header names should be canonicalized")
+}
+
+func TestWithExtraHeaders_RejectsReservedNames(t *testing.T) {
+	for _, name := range []string{"Authorization", "authorization", "Content-Type", "accept"} {
+		_, err := New("https://example", "tok", WithExtraHeaders(map[string]string{name: "x"}))
+		require.Error(t, err, "extra header %q must be rejected", name)
+		assert.Contains(t, err.Error(), "reserved header")
+	}
+}
+
+func TestWithExtraHeaders_RejectsEmptyName(t *testing.T) {
+	_, err := New("https://example", "tok", WithExtraHeaders(map[string]string{"   ": "x"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty")
+}
+
+func TestWithExtraHeaders_EmptyMapIsNoop(t *testing.T) {
+	src, err := New("https://example", "tok", WithExtraHeaders(nil), WithExtraHeaders(map[string]string{}))
+	require.NoError(t, err)
+	assert.Nil(t, src.extraHeaders)
+}
+
 func TestLoadAll_SendsBearerAndParsesResponse(t *testing.T) {
 	var receivedAuth atomic.Value
 	var receivedBody atomic.Value


### PR DESCRIPTION
## Summary
- Adds `WithExtraHeaders` option to the Scope3 identity-config source so callers can attach arbitrary headers to every outbound request.
- Wires it through `IdentityConfigSourceConfig` and a new `CONFIG_SOURCE_EXTRA_HEADERS` env var (JSON object of name→value).
- Rejects collisions with the managed `Authorization`/`Content-Type`/`Accept` headers and empty names at startup so a misconfig surfaces immediately instead of silently stripping auth.

## Test plan
- [x] `go test ./targeting/identityconfig/scope3/... ./targeting/identityagent/...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] New unit tests cover: headers sent and canonicalized, reserved-name rejection (case-insensitive), empty-key rejection, env JSON parsing (valid / invalid / empty key / unset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)