### PR TITLE
[codex] Add Go reference seller storyboard harness

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -249,7 +249,7 @@ jobs:
           # 20-min timeout. APP_SLUG comes from `actions/create-github-app-token`;
           # the bot user login is `${APP_SLUG}[bot]`.
           LATEST="$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
-            --jq --arg login "${APP_SLUG}[bot]" --arg sha "$HEAD_SHA" \
+            | jq --arg login "${APP_SLUG}[bot]" --arg sha "$HEAD_SHA" \
               '[.[] | select(.user.login == $login and .commit_id == $sha)] | sort_by(.submitted_at) | last // {}')"
           STATE="$(echo "$LATEST" | jq -r '.state // ""')"
           AUTHOR="$(echo "$LATEST" | jq -r '.user.login // ""')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  ADCP_SDK_VERSION: "7.11.0"
+
 jobs:
   test:
     name: Build & Test
@@ -52,6 +55,10 @@ jobs:
         working-directory: reference/context-agent
         run: go test -race -count=1 ./...
 
+      - name: Test seller agent
+        working-directory: reference/seller-agent
+        run: go test -race -count=1 ./...
+
       - name: Test e2e
         working-directory: e2e
         run: go test -race -count=1 ./...
@@ -83,3 +90,42 @@ jobs:
           version: v2.11
           working-directory: reference/context-agent
           args: ./...
+
+      - name: Run golangci-lint (seller agent)
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
+        with:
+          version: v2.11
+          working-directory: reference/seller-agent
+          args: ./...
+
+  storyboard:
+    name: Reference Seller Storyboard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "22"
+
+      - name: Run reference seller storyboard harness
+        env:
+          ADCP_PORT: "3003"
+          STORYBOARD_RESULT_PATH: storyboard-result-go.json
+          SELLER_LOG_PATH: storyboard-seller-go.log
+        run: ./scripts/ci/run_storyboard_reference_seller.sh
+
+      - name: Upload storyboard artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: go-reference-seller-storyboard
+          if-no-files-found: ignore
+          path: |
+            storyboard-result-go.json
+            storyboard-seller-go.log

--- a/adcp/addtool.go
+++ b/adcp/addtool.go
@@ -37,8 +37,9 @@ func AddTool[In any](server *mcp.Server, name, description string, handler func(
 	}, func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		var input In
 		if req.Params.Arguments != nil {
-			if err := json.Unmarshal(req.Params.Arguments, &input); err != nil {
-				return makeErrResult("INVALID_INPUT", "Failed to parse input: invalid JSON or type mismatch"), nil
+			if parseErr := json.Unmarshal(req.Params.Arguments, &input); parseErr != nil {
+				// Return an MCP tool error payload, not a transport-level error.
+				return makeErrResult("INVALID_INPUT", "Failed to parse input: invalid JSON or type mismatch"), nil //nolint:nilerr
 			}
 		}
 
@@ -148,9 +149,14 @@ func isTrueSchema(s *jsonschema.Schema) bool {
 // jsonRoundTrip marshals a value to JSON and back, ensuring struct tags
 // (like json:"name") are respected in the structured content output.
 func jsonRoundTrip(v any) any {
-	b, _ := json.Marshal(v)
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
 	var m any
-	json.Unmarshal(b, &m)
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil
+	}
 	return m
 }
 

--- a/adcp/addtool_test.go
+++ b/adcp/addtool_test.go
@@ -116,7 +116,7 @@ func TestPermissiveSchemaSerializesToJSON(t *testing.T) {
 	require.NoError(t, err, "failed to marshal schema")
 
 	var m map[string]any
-	json.Unmarshal(b, &m)
+	require.NoError(t, json.Unmarshal(b, &m))
 
 	// Should have type: "object" and properties but NO additionalProperties
 	assert.Equal(t, "object", m["type"], "expected type=object in JSON")

--- a/adcp/idempotency/postgres_test.go
+++ b/adcp/idempotency/postgres_test.go
@@ -19,7 +19,9 @@ func newPgMock(t *testing.T) (*PgBackend, sqlmock.Sqlmock, func()) {
 	b := NewPgBackend(db)
 	return b, mock, func() {
 		assert.NoError(t, mock.ExpectationsWereMet())
-		db.Close()
+		mock.ExpectClose()
+		assert.NoError(t, db.Close())
+		assert.NoError(t, mock.ExpectationsWereMet())
 	}
 }
 

--- a/adcp/idempotency/store.go
+++ b/adcp/idempotency/store.go
@@ -104,6 +104,7 @@ func (s *Store) TTL() time.Duration { return s.opts.TTL }
 // Use MergeCapability for a helper that wires it at the correct nesting.
 func (s *Store) Capability() map[string]any {
 	return map[string]any{
+		"supported":          true,
 		"replay_ttl_seconds": int64(s.opts.TTL.Seconds()),
 	}
 }

--- a/adcp/inputs.go
+++ b/adcp/inputs.go
@@ -16,10 +16,13 @@ type PackageInput struct {
 	PricingOptionID string  `json:"pricing_option_id,omitempty"`
 	Budget          float64 `json:"budget"`
 	BidPrice        float64 `json:"bid_price,omitempty"`
+	BuyerRef        string  `json:"buyer_ref,omitempty"`
 
 	// Business terms (buyer proposals, override product defaults)
-	MeasurementTerms     *MeasurementTerms    `json:"measurement_terms,omitempty"`
+	MeasurementTerms     *MeasurementTerms     `json:"measurement_terms,omitempty"`
 	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"`
+	TargetingOverlay     *Targeting            `json:"targeting_overlay,omitempty"`
+	CreativeAssignments  []any                 `json:"creative_assignments,omitempty"`
 
 	// Broadcast / scheduling
 	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"`
@@ -49,15 +52,16 @@ type GovernanceAccountInput struct {
 
 // CreativeInput is a single creative in a sync_creatives request.
 type CreativeInput struct {
-	CreativeID string            `json:"creative_id"`
-	FormatID   *FormatRef `json:"format_id,omitempty"`
-	Name       string            `json:"name,omitempty"`
-	Assets     map[string]any    `json:"assets,omitempty"`
+	CreativeID string         `json:"creative_id"`
+	FormatID   *FormatRef     `json:"format_id,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	Assets     map[string]any `json:"assets,omitempty"`
 }
 
 // CreativeFilters contains filters for list_creatives.
 type CreativeFilters struct {
-	FormatIDs []FormatRef `json:"format_ids,omitempty"`
+	CreativeIDs []string    `json:"creative_ids,omitempty"`
+	FormatIDs   []FormatRef `json:"format_ids,omitempty"`
 }
 
 // CatalogInput is a single catalog in a sync_catalogs request.

--- a/adcp/inputs.go
+++ b/adcp/inputs.go
@@ -30,6 +30,42 @@ type PackageInput struct {
 	EndTime              string `json:"end_time,omitempty"`
 }
 
+// UpdateMediaBuyRequest is the input for update_media_buy.
+type UpdateMediaBuyRequest struct {
+	AdcpMajorVersion       int              `json:"adcp_major_version,omitempty"`
+	IdempotencyKey         string           `json:"idempotency_key"`
+	Account                AccountReference `json:"account"`
+	MediaBuyID             string           `json:"media_buy_id"`
+	Revision               int              `json:"revision,omitempty"`
+	Paused                 *bool            `json:"paused,omitempty"`
+	Canceled               bool             `json:"canceled,omitempty"`
+	CancellationReason     string           `json:"cancellation_reason,omitempty"`
+	StartTime              any              `json:"start_time,omitempty"`
+	EndTime                string           `json:"end_time,omitempty"`
+	Packages               []PackageUpdate  `json:"packages,omitempty"`
+	InvoiceRecipient       any              `json:"invoice_recipient,omitempty"`
+	NewPackages            []PackageInput   `json:"new_packages,omitempty"`
+	ReportingWebhook       any              `json:"reporting_webhook,omitempty"`
+	PushNotificationConfig any              `json:"push_notification_config,omitempty"`
+	Context                any              `json:"context,omitempty"`
+	Ext                    any              `json:"ext,omitempty"`
+}
+
+// PackageUpdate identifies a package and fields to update in update_media_buy.
+type PackageUpdate struct {
+	PackageID           string     `json:"package_id"`
+	Budget              float64    `json:"budget,omitempty"`
+	BidPrice            float64    `json:"bid_price,omitempty"`
+	Impressions         float64    `json:"impressions,omitempty"`
+	StartTime           string     `json:"start_time,omitempty"`
+	EndTime             string     `json:"end_time,omitempty"`
+	Paused              *bool      `json:"paused,omitempty"`
+	Canceled            bool       `json:"canceled,omitempty"`
+	CancellationReason  string     `json:"cancellation_reason,omitempty"`
+	TargetingOverlay    *Targeting `json:"targeting_overlay,omitempty"`
+	CreativeAssignments []any      `json:"creative_assignments,omitempty"`
+}
+
 // --- Nested item types (inline objects in schemas, no $ref) ---
 
 // AccountInput is a single account in a sync_accounts request.

--- a/adcp/responses.go
+++ b/adcp/responses.go
@@ -22,12 +22,26 @@ func ProductsResponse(data *ProductsData) (*mcp.CallToolResult, any, error) {
 
 // MediaBuyResponse builds a create_media_buy response.
 func MediaBuyResponse(data *MediaBuyData) (*mcp.CallToolResult, any, error) {
-	return buildResult(fmt.Sprintf("Media buy %s created", data.MediaBuyID), data), data, nil
+	if data.Status == "submitted" {
+		out := map[string]any{"status": "submitted"}
+		if ext, ok := data.Ext.(map[string]any); ok {
+			for k, v := range ext {
+				out[k] = v
+			}
+		}
+		return buildResult("Media buy submitted", out), out, nil
+	}
+	out := flattenExt(data)
+	return buildResult(fmt.Sprintf("Media buy %s created", data.MediaBuyID), out), out, nil
 }
 
 // MediaBuysResponse builds a get_media_buys response.
 func MediaBuysResponse(mediaBuys []MediaBuyData, sandbox bool) (*mcp.CallToolResult, any, error) {
-	out := map[string]any{"media_buys": mediaBuys, "sandbox": sandbox}
+	items := make([]any, 0, len(mediaBuys))
+	for _, buy := range mediaBuys {
+		items = append(items, flattenExt(buy))
+	}
+	out := map[string]any{"media_buys": items, "sandbox": sandbox}
 	return buildResult(fmt.Sprintf("Found %d media buys", len(mediaBuys)), out), out, nil
 }
 
@@ -213,4 +227,33 @@ func buildResult(summary string, data any) *mcp.CallToolResult {
 		},
 		StructuredContent: jsonRoundTrip(data),
 	}
+}
+
+func attachContext(result *mcp.CallToolResult, context any) *mcp.CallToolResult {
+	if result == nil || context == nil {
+		return result
+	}
+	obj, ok := jsonRoundTrip(result.StructuredContent).(map[string]any)
+	if !ok {
+		return result
+	}
+	obj["context"] = context
+	result.StructuredContent = obj
+	return result
+}
+
+func flattenExt(v any) any {
+	item, ok := jsonRoundTrip(v).(map[string]any)
+	if !ok {
+		return v
+	}
+	ext, ok := item["ext"].(map[string]any)
+	if !ok {
+		return item
+	}
+	for k, val := range ext {
+		item[k] = val
+	}
+	delete(item, "ext")
+	return item
 }

--- a/adcp/seller.go
+++ b/adcp/seller.go
@@ -42,8 +42,11 @@ func Register(server *mcp.Server, cfg Config) {
 
 	// Capabilities (always registered)
 	AddTool(server, "get_adcp_capabilities", "Returns agent capabilities",
-		func(ctx context.Context, req *mcp.CallToolRequest, input EmptyInput) (*mcp.CallToolResult, any, error) {
-			return CapabilitiesResponse(caps)
+		func(ctx context.Context, req *mcp.CallToolRequest, input struct {
+			Context any `json:"context,omitempty"`
+		}) (*mcp.CallToolResult, any, error) {
+			result, out, err := CapabilitiesResponse(caps)
+			return attachContext(result, input.Context), out, err
 		})
 
 	// --- Media buy tools ---
@@ -53,9 +56,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input SyncAccountsRequest) (*mcp.CallToolResult, any, error) {
 				results, err := cfg.SyncAccounts(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return SyncAccountsResponse(results, sandbox)
+				result, out, err := SyncAccountsResponse(results, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -64,9 +69,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input SyncGovernanceRequest) (*mcp.CallToolResult, any, error) {
 				results, err := cfg.SyncGovernance(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return GovernanceResponse(results)
+				result, out, err := GovernanceResponse(results)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -79,10 +86,13 @@ func Register(server *mcp.Server, cfg Config) {
 				}
 				data, err := cfg.GetProducts(ctx, acct, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
 				data.Sandbox = sandbox
-				return ProductsResponse(data)
+				data.Context = input.Context
+				result, out, err := ProductsResponse(data)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -95,9 +105,11 @@ func Register(server *mcp.Server, cfg Config) {
 				}
 				buy, err := cfg.CreateMediaBuy(ctx, acct, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return MediaBuyResponse(buy)
+				result, out, err := MediaBuyResponse(buy)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -110,9 +122,11 @@ func Register(server *mcp.Server, cfg Config) {
 				}
 				buys, err := cfg.GetMediaBuys(ctx, acct, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return MediaBuysResponse(buys, sandbox)
+				result, out, err := MediaBuysResponse(buys, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -125,9 +139,12 @@ func Register(server *mcp.Server, cfg Config) {
 				}
 				data, err := cfg.GetDelivery(ctx, acct, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return DeliveryResponse(data)
+				data.Context = input.Context
+				result, out, err := DeliveryResponse(data)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -138,9 +155,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input ListCreativeFormatsRequest) (*mcp.CallToolResult, any, error) {
 				formats, err := cfg.ListCreativeFormats(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return CreativeFormatsResponse(formats, sandbox)
+				result, out, err := CreativeFormatsResponse(formats, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -149,9 +168,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input SyncCreativesRequest) (*mcp.CallToolResult, any, error) {
 				results, err := cfg.SyncCreatives(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return SyncCreativesResponse(results, sandbox)
+				result, out, err := SyncCreativesResponse(results, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -404,7 +425,7 @@ func buildCapabilities(cfg Config) *CapabilitiesData {
 	if existing := caps.ADCP.Idempotency.ReplayTTLSeconds; existing != 0 && existing != ttlSeconds {
 		panic(fmt.Sprintf("adcp.Register: Config.IdempotencyReplayTTL (%ds) conflicts with Capabilities.ADCP.Idempotency.ReplayTTLSeconds (%ds) — set one or the other, not both", ttlSeconds, existing))
 	}
-	caps.ADCP.Idempotency = IdempotencyCaps{ReplayTTLSeconds: ttlSeconds}
+	caps.ADCP.Idempotency = IdempotencyCaps{Supported: true, ReplayTTLSeconds: ttlSeconds}
 
 	if len(caps.SupportedProtocols) == 0 {
 		caps.SupportedProtocols = detectProtocols(cfg)

--- a/adcp/signing/client_test.go
+++ b/adcp/signing/client_test.go
@@ -71,7 +71,7 @@ func TestNewSignedHTTPClientRoundTripsAgainstVerifier(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer closeResponseBody(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -96,7 +96,7 @@ func TestNewSignedHTTPClientRejectsRedirects(t *testing.T) {
 
 	resp, err := client.Post(srv.URL+"/adcp/create_media_buy", "application/json", bytes.NewReader([]byte(`{}`)))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer closeResponseBody(t, resp)
 	// CheckRedirect returns http.ErrUseLastResponse → caller sees the 3xx
 	// directly rather than the redirect's body.
 	assert.Equal(t, http.StatusMovedPermanently, resp.StatusCode)
@@ -151,11 +151,16 @@ func TestNewSignedHTTPClientRespectsCustomInnerTransport(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	assert.NotEmpty(t, got.Header.Get("Signature"))
 	assert.NotEmpty(t, got.Header.Get("Signature-Input"))
+}
+
+func closeResponseBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	require.NoError(t, resp.Body.Close())
 }
 
 type roundTripperFunc func(r *http.Request) (*http.Response, error)
@@ -197,7 +202,7 @@ func TestCapabilityProviderSignsRequiredFor(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	assert.NotEmpty(t, got.Header.Get("Signature"), "required_for op must be signed")
@@ -232,7 +237,7 @@ func TestCapabilityProviderSkipsUnlistedOperation(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	assert.Empty(t, got.Header.Get("Signature"), "op not in any list must NOT be signed")
@@ -266,7 +271,7 @@ func TestCapabilityProviderReturningNilSkipsSigning(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	assert.Equal(t, int32(1), providerCalls.Load())
 	got := <-captured
@@ -305,7 +310,7 @@ func TestCapabilityProviderHonorsCoversContentDigestRequired(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	sigInput := got.Header.Get("Signature-Input")
@@ -346,7 +351,7 @@ func TestCapabilityProviderHonorsCoversContentDigestForbidden(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	sigInput := got.Header.Get("Signature-Input")
@@ -385,7 +390,7 @@ func TestCapabilityProviderSkipsWhenSupportedFalse(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 
 	got := <-captured
 	assert.Empty(t, got.Header.Get("Signature"), "supported=false ⇒ skip signing")
@@ -436,13 +441,13 @@ func TestMiddlewareDefaultsReplayStoreToInMemory(t *testing.T) {
 
 	// First signed request: 200.
 	resp := signAndSend()
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Each new request gets a fresh nonce, so two distinct signed requests
 	// both succeed — proves the default store accepts new (kid, nonce) pairs.
 	resp = signAndSend()
-	resp.Body.Close()
+	closeResponseBody(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
@@ -500,13 +505,13 @@ func TestMiddlewareDefaultReplayStoreRejectsActualReplay(t *testing.T) {
 	// First → 200.
 	resp1, err := srv.Client().Do(build())
 	require.NoError(t, err)
-	resp1.Body.Close()
+	closeResponseBody(t, resp1)
 	assert.Equal(t, http.StatusOK, resp1.StatusCode)
 
 	// Same (kid, nonce, body) → the default in-memory store must reject.
 	resp2, err := srv.Client().Do(build())
 	require.NoError(t, err)
-	resp2.Body.Close()
+	closeResponseBody(t, resp2)
 	assert.Equal(t, http.StatusUnauthorized, resp2.StatusCode)
 	assert.Contains(t, resp2.Header.Get("WWW-Authenticate"), `error="request_signature_replayed"`)
 }

--- a/adcp/signing/conformance_test.go
+++ b/adcp/signing/conformance_test.go
@@ -135,6 +135,7 @@ func operationFromURL(rawURL string) string {
 
 func loadVectorFile(t *testing.T, rel string) Vector {
 	t.Helper()
+	// #nosec G304 -- test reads conformance vectors discovered under testdata.
 	data, err := os.ReadFile(rel)
 	require.NoError(t, err, "open %s", rel)
 	var v Vector

--- a/adcp/signing/jwk_test.go
+++ b/adcp/signing/jwk_test.go
@@ -44,8 +44,9 @@ func TestParseSpecKeysJSON(t *testing.T) {
 	require.NoError(t, err)
 	ec, ok := pub2.(*ecdsa.PublicKey)
 	assert.True(t, ok)
-	assert.NotNil(t, ec.X)
-	assert.NotNil(t, ec.Y)
+	ecdhPub, err := ec.ECDH()
+	require.NoError(t, err)
+	assert.NotEmpty(t, ecdhPub.Bytes())
 	assert.Equal(t, "request-signing", es.AdcpUse)
 
 	gov := jwks.Find("test-gov-2026")

--- a/adcp/signing/jwks_fetcher.go
+++ b/adcp/signing/jwks_fetcher.go
@@ -187,7 +187,9 @@ func (h *HTTPJWKSResolver) refetch(ctx context.Context, jwksURL string) error {
 		}
 		return wrapError(CodeJWKSUnavailable, "fetch jwks", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode >= 400 {
 		return newError(CodeJWKSUnavailable, fmt.Sprintf("jwks fetch status %d", resp.StatusCode))
 	}

--- a/adcp/signing/keygen.go
+++ b/adcp/signing/keygen.go
@@ -79,6 +79,14 @@ func GenerateKeyForProfile(alg Algorithm, kid string, profile Profile) (*Generat
 		if err != nil {
 			return nil, err
 		}
+		ecdhPub, err := priv.PublicKey.ECDH()
+		if err != nil {
+			return nil, err
+		}
+		pubBytes := ecdhPub.Bytes()
+		if len(pubBytes) != 65 || pubBytes[0] != 4 {
+			return nil, errors.New("unexpected P-256 public key encoding")
+		}
 		pemBytes, err := encodePKCS8PEM(priv)
 		if err != nil {
 			return nil, err
@@ -93,8 +101,8 @@ func GenerateKeyForProfile(alg Algorithm, kid string, profile Profile) (*Generat
 				Use:     "sig",
 				KeyOps:  []string{"verify"},
 				AdcpUse: profile.AdcpUse,
-				X:       b64UrlEncodeRaw(leftPad(priv.PublicKey.X.Bytes(), 32)),
-				Y:       b64UrlEncodeRaw(leftPad(priv.PublicKey.Y.Bytes(), 32)),
+				X:       b64UrlEncodeRaw(pubBytes[1:33]),
+				Y:       b64UrlEncodeRaw(pubBytes[33:65]),
 			},
 		}, nil
 	}
@@ -107,15 +115,6 @@ func encodePKCS8PEM(priv any) ([]byte, error) {
 		return nil, err
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), nil
-}
-
-func leftPad(b []byte, size int) []byte {
-	if len(b) >= size {
-		return b
-	}
-	out := make([]byte, size)
-	copy(out[size-len(b):], b)
-	return out
 }
 
 // LoadPrivateKey parses a PEM-encoded PKCS#8 private key produced by

--- a/adcp/signing/middleware_test.go
+++ b/adcp/signing/middleware_test.go
@@ -62,7 +62,7 @@ func TestMiddlewareEndToEndSignAndVerify(t *testing.T) {
 
 	resp, err := srv.Client().Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer closeResponseBody(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	got := <-verified
@@ -131,9 +131,8 @@ func TestRoundTripperSignsAndBodyIsPreserved(t *testing.T) {
 	client := &http.Client{Transport: signer.RoundTripper(srv.Client().Transport, true)}
 	resp, err := client.Post(srv.URL+"/adcp/x", "application/json", bytes.NewReader([]byte(`{"a":1}`)))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer closeResponseBody(t, resp)
 
 	assert.Equal(t, `{"a":1}`, string(receivedBody))
 	assert.NotEmpty(t, receivedSig)
 }
-

--- a/adcp/signing/signatureinput.go
+++ b/adcp/signing/signatureinput.go
@@ -389,12 +389,12 @@ func isValidLabel(label string) bool {
 	// first char must be lcalpha or "*". We accept a slightly broader set since
 	// the only labels we see in practice are sig1, sig2, etc.
 	first := label[0]
-	if !((first >= 'a' && first <= 'z') || first == '*') {
+	if (first < 'a' || first > 'z') && first != '*' {
 		return false
 	}
 	for i := 1; i < len(label); i++ {
 		c := label[i]
-		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.' || c == '*') {
+		if (c < 'a' || c > 'z') && (c < '0' || c > '9') && c != '_' && c != '-' && c != '.' && c != '*' {
 			return false
 		}
 	}

--- a/adcp/skill_compile_test.go
+++ b/adcp/skill_compile_test.go
@@ -78,9 +78,12 @@ func TestSkillProductDefinitionsCompile(t *testing.T) {
 
 func extractGoBlocks(t *testing.T, path string) []string {
 	t.Helper()
+	// #nosec G304 -- test reads SKILL.md files discovered under the repository skills directory.
 	f, err := os.Open(path)
 	require.NoError(t, err, "open %s", path)
-	defer f.Close()
+	defer func() {
+		require.NoError(t, f.Close())
+	}()
 
 	var blocks []string
 	var current strings.Builder
@@ -133,7 +136,7 @@ func checkBlockCompiles(t *testing.T, block string) {
 	source := blankifyImports(block)
 
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0644)
+	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0600)
 	require.NoError(t, err, "write")
 	writeGoMod(t, dir)
 
@@ -205,7 +208,7 @@ var _ = adcp.EmptyInput{}
 `
 
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0644)
+	err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(source), 0600)
 	require.NoError(t, err, "write")
 	writeGoMod(t, dir)
 
@@ -236,12 +239,13 @@ func writeGoMod(t *testing.T, dir string) {
 		")\n\n" +
 		"replace github.com/adcontextprotocol/adcp-go/adcp => " + adcpDir + "\n"
 
-	err = os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0644)
+	err = os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0600)
 	require.NoError(t, err, "write go.mod")
 }
 
 func parseAdcpGoMod(t *testing.T, path string) (goVersion, mcpVersion string) {
 	t.Helper()
+	// #nosec G304 -- test reads the adcp module go.mod path built in this test.
 	data, err := os.ReadFile(path)
 	require.NoError(t, err, "read go.mod")
 	goVersion = "1.26.2" // fallback

--- a/adcp/testcontroller.go
+++ b/adcp/testcontroller.go
@@ -18,6 +18,8 @@ type TestControllerStore struct {
 	ForceSessionStatus  func(sessionID, status string, terminationReason string) (*StateTransition, error)
 	SimulateDelivery    func(mediaBuyID string, params SimulateDeliveryParams) (*SimulationResult, error)
 	SimulateBudgetSpend func(params SimulateBudgetParams) (*SimulationResult, error)
+	CustomScenario      func(scenario string, params map[string]any) (any, error)
+	CustomScenarios     []string
 }
 
 // StateTransition is returned by force_* scenarios.
@@ -67,8 +69,10 @@ func (e *TestControllerError) Error() string {
 }
 
 type controllerInput struct {
-	Scenario string         `json:"scenario"`
-	Params   map[string]any `json:"params,omitempty"`
+	Scenario string            `json:"scenario"`
+	Account  *AccountReference `json:"account,omitempty"`
+	Params   map[string]any    `json:"params,omitempty"`
+	Context  any               `json:"context,omitempty"`
 }
 
 type controllerErrorResponse struct {
@@ -90,7 +94,8 @@ func RegisterTestController(server *mcp.Server, store *TestControllerStore) {
 	AddTool(server, "comply_test_controller",
 		"Triggers seller-side state transitions for compliance testing. Sandbox only.",
 		func(ctx context.Context, req *mcp.CallToolRequest, input controllerInput) (*mcp.CallToolResult, any, error) {
-			return handleTestController(store, input)
+			result, out, err := handleTestController(store, input)
+			return attachContext(result, input.Context), out, err
 		})
 }
 
@@ -119,6 +124,16 @@ func handleTestController(store *TestControllerStore, input controllerInput) (*m
 	case "simulate_budget_spend":
 		return handleSimulateBudget(store, input.Params)
 	default:
+		if store.CustomScenario != nil {
+			result, err := store.CustomScenario(input.Scenario, input.Params)
+			if err != nil {
+				if tce, ok := err.(*TestControllerError); ok {
+					return controllerErr(tce.Code, tce.Message, tce.CurrentState)
+				}
+				return controllerErr("INTERNAL_ERROR", "An unexpected error occurred in the test controller store", "")
+			}
+			return controllerOK(result)
+		}
 		return controllerErr("UNKNOWN_SCENARIO", "Unrecognized scenario name", "")
 	}
 }
@@ -237,6 +252,7 @@ func listScenarios(store *TestControllerStore) []string {
 	if store.SimulateBudgetSpend != nil {
 		scenarios = append(scenarios, "simulate_budget_spend")
 	}
+	scenarios = append(scenarios, store.CustomScenarios...)
 	return scenarios
 }
 

--- a/adcp/testcontroller.go
+++ b/adcp/testcontroller.go
@@ -252,7 +252,9 @@ func listScenarios(store *TestControllerStore) []string {
 	if store.SimulateBudgetSpend != nil {
 		scenarios = append(scenarios, "simulate_budget_spend")
 	}
-	scenarios = append(scenarios, store.CustomScenarios...)
+	if store.CustomScenario != nil {
+		scenarios = append(scenarios, store.CustomScenarios...)
+	}
 	return scenarios
 }
 

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -1,6 +1,8 @@
 // Package adcp provides helpers for building AdCP MCP servers in Go.
 package adcp
 
+import "encoding/json"
+
 // CapabilitiesData is the typed get_adcp_capabilities response. Per the 3.0
 // schema, adcp (with idempotency) and supported_protocols are required; all
 // other blocks are optional and set only when the relevant protocol is
@@ -35,7 +37,8 @@ type ADCPVersion struct {
 // IdempotencyCaps declares the seller's replay window for idempotency_key.
 // Minimum 3600 (1h); recommended 86400 (24h); maximum 604800 (7d).
 type IdempotencyCaps struct {
-	ReplayTTLSeconds int `json:"replay_ttl_seconds"`
+	Supported        bool `json:"supported"`
+	ReplayTTLSeconds int  `json:"replay_ttl_seconds"`
 }
 
 // AccountCapabilities describes how accounts are established and billed.
@@ -103,17 +106,17 @@ type GeoMetrosCaps struct {
 }
 
 type GeoPostalAreasCaps struct {
-	USZip          *bool `json:"us_zip,omitempty"`
-	USZipPlusFour  *bool `json:"us_zip_plus_four,omitempty"`
-	GBOutward      *bool `json:"gb_outward,omitempty"`
-	GBFull         *bool `json:"gb_full,omitempty"`
-	CAFSA          *bool `json:"ca_fsa,omitempty"`
-	CAFull         *bool `json:"ca_full,omitempty"`
-	DEPLZ          *bool `json:"de_plz,omitempty"`
-	FRCodePostal   *bool `json:"fr_code_postal,omitempty"`
-	AUPostcode     *bool `json:"au_postcode,omitempty"`
-	CHPLZ          *bool `json:"ch_plz,omitempty"`
-	ATPLZ          *bool `json:"at_plz,omitempty"`
+	USZip         *bool `json:"us_zip,omitempty"`
+	USZipPlusFour *bool `json:"us_zip_plus_four,omitempty"`
+	GBOutward     *bool `json:"gb_outward,omitempty"`
+	GBFull        *bool `json:"gb_full,omitempty"`
+	CAFSA         *bool `json:"ca_fsa,omitempty"`
+	CAFull        *bool `json:"ca_full,omitempty"`
+	DEPLZ         *bool `json:"de_plz,omitempty"`
+	FRCodePostal  *bool `json:"fr_code_postal,omitempty"`
+	AUPostcode    *bool `json:"au_postcode,omitempty"`
+	CHPLZ         *bool `json:"ch_plz,omitempty"`
+	ATPLZ         *bool `json:"at_plz,omitempty"`
 }
 
 type GeoProximityCaps struct {
@@ -137,11 +140,11 @@ type KeywordMatchCaps struct {
 // AudienceTargetingCaps describes audience matching capabilities.
 // supported_identifier_types and minimum_audience_size are required when present.
 type AudienceTargetingCaps struct {
-	SupportedIdentifierTypes  []string              `json:"supported_identifier_types"`
-	SupportsPlatformCustomerID *bool                `json:"supports_platform_customer_id,omitempty"`
-	SupportedUIDTypes         []string              `json:"supported_uid_types,omitempty"`
-	MinimumAudienceSize       int                   `json:"minimum_audience_size"`
-	MatchingLatencyHours      *MatchingLatencyRange `json:"matching_latency_hours,omitempty"`
+	SupportedIdentifierTypes   []string              `json:"supported_identifier_types"`
+	SupportsPlatformCustomerID *bool                 `json:"supports_platform_customer_id,omitempty"`
+	SupportedUIDTypes          []string              `json:"supported_uid_types,omitempty"`
+	MinimumAudienceSize        int                   `json:"minimum_audience_size"`
+	MatchingLatencyHours       *MatchingLatencyRange `json:"matching_latency_hours,omitempty"`
 }
 
 type MatchingLatencyRange struct {
@@ -210,12 +213,12 @@ type GovernanceCapabilities struct {
 
 // GovernanceFeature describes a score/rating/certification the agent provides.
 type GovernanceFeature struct {
-	FeatureID      string           `json:"feature_id"`
-	Type           string           `json:"type"`
-	Range          *FeatureRange    `json:"range,omitempty"`
-	Categories     []string         `json:"categories,omitempty"`
-	Description    string           `json:"description,omitempty"`
-	MethodologyURL string           `json:"methodology_url,omitempty"`
+	FeatureID      string        `json:"feature_id"`
+	Type           string        `json:"type"`
+	Range          *FeatureRange `json:"range,omitempty"`
+	Categories     []string      `json:"categories,omitempty"`
+	Description    string        `json:"description,omitempty"`
+	MethodologyURL string        `json:"methodology_url,omitempty"`
 }
 
 type FeatureRange struct {
@@ -262,11 +265,11 @@ type CreativeCapabilities struct {
 
 // RequestSigningCapabilities declares RFC 9421 signing policy.
 type RequestSigningCapabilities struct {
-	Supported            bool     `json:"supported"`
-	CoversContentDigest  string   `json:"covers_content_digest,omitempty"`
-	RequiredFor          []string `json:"required_for,omitempty"`
-	WarnFor              []string `json:"warn_for,omitempty"`
-	SupportedFor         []string `json:"supported_for,omitempty"`
+	Supported           bool     `json:"supported"`
+	CoversContentDigest string   `json:"covers_content_digest,omitempty"`
+	RequiredFor         []string `json:"required_for,omitempty"`
+	WarnFor             []string `json:"warn_for,omitempty"`
+	SupportedFor        []string `json:"supported_for,omitempty"`
 }
 
 // WebhookSigningCapabilities declares RFC 9421 webhook-signature policy —
@@ -284,9 +287,9 @@ type WebhookSigningCapabilities struct {
 // compromise-response controls. All fields advisory in 3.x; receivers use
 // them to reason about blast radius and revocation latency at onboarding.
 type IdentityCapabilities struct {
-	PerPrincipalKeyIsolation bool                              `json:"per_principal_key_isolation,omitempty"`
-	KeyOrigins               *IdentityKeyOrigins               `json:"key_origins,omitempty"`
-	CompromiseNotification   *IdentityCompromiseNotification   `json:"compromise_notification,omitempty"`
+	PerPrincipalKeyIsolation bool                            `json:"per_principal_key_isolation,omitempty"`
+	KeyOrigins               *IdentityKeyOrigins             `json:"key_origins,omitempty"`
+	CompromiseNotification   *IdentityCompromiseNotification `json:"compromise_notification,omitempty"`
 }
 
 // IdentityKeyOrigins maps signing-key purpose → publishing origin so
@@ -333,9 +336,10 @@ type AccountReference struct {
 
 // PublisherPropertySelector is the flattened union of the three variants in
 // publisher-property-selector.json. SelectionType is the discriminator:
-//   "all":     set PublisherDomain only.
-//   "by_id":   set PublisherDomain + PropertyIDs.
-//   "by_tag":  set PublisherDomain + PropertyTags.
+//
+//	"all":     set PublisherDomain only.
+//	"by_id":   set PublisherDomain + PropertyIDs.
+//	"by_tag":  set PublisherDomain + PropertyTags.
 type PublisherPropertySelector struct {
 	PublisherDomain string   `json:"publisher_domain"`
 	SelectionType   string   `json:"selection_type"`
@@ -377,8 +381,10 @@ type GovernanceAgent struct {
 }
 
 type ProductsData struct {
-	Products []Product `json:"products"`
-	Sandbox  bool      `json:"sandbox,omitempty"`
+	Products          []Product        `json:"products"`
+	RefinementApplied []map[string]any `json:"refinement_applied,omitempty"`
+	Sandbox           bool             `json:"sandbox,omitempty"`
+	Context           any              `json:"context,omitempty"`
 }
 
 // PricingOption is the flattened union of all variants in pricing-option.json.
@@ -388,32 +394,33 @@ type ProductsData struct {
 // the discriminator; callers MUST only set fields that apply to their model.
 //
 // Fields by variant:
-//   cpm / vcpm / cpc / cpcv / cpv / cpp:
-//     FixedPrice (fixed) OR FloorPrice + PriceGuidance (auction); MaxBid for
-//     auction models to interpret bid_price as a ceiling.
-//   cpa:
-//     FixedPrice, EventSourceID, EventType (required); CustomEventName when
-//     EventType="custom"; EligibleAdjustments for adjustment filtering.
-//   flat_rate:
-//     FixedPrice (required).
-//   time:
-//     FixedPrice (required), Parameters for duration/unit specifics.
-//   All variants: PricingOptionID, Currency, MinSpendPerPackage, PriceBreakdown.
+//
+//	cpm / vcpm / cpc / cpcv / cpv / cpp:
+//	  FixedPrice (fixed) OR FloorPrice + PriceGuidance (auction); MaxBid for
+//	  auction models to interpret bid_price as a ceiling.
+//	cpa:
+//	  FixedPrice, EventSourceID, EventType (required); CustomEventName when
+//	  EventType="custom"; EligibleAdjustments for adjustment filtering.
+//	flat_rate:
+//	  FixedPrice (required).
+//	time:
+//	  FixedPrice (required), Parameters for duration/unit specifics.
+//	All variants: PricingOptionID, Currency, MinSpendPerPackage, PriceBreakdown.
 type PricingOption struct {
-	PricingOptionID     string  `json:"pricing_option_id"`
-	PricingModel        string  `json:"pricing_model"`
-	Currency            string  `json:"currency"`
-	FixedPrice          float64 `json:"fixed_price,omitempty"`
-	FloorPrice          float64 `json:"floor_price,omitempty"`
-	MinSpendPerPackage  float64 `json:"min_spend_per_package,omitempty"`
-	MaxBid              *bool   `json:"max_bid,omitempty"`
-	PriceGuidance       any     `json:"price_guidance,omitempty"`
-	PriceBreakdown      any     `json:"price_breakdown,omitempty"`
-	EventSourceID       string  `json:"event_source_id,omitempty"`
-	EventType           string  `json:"event_type,omitempty"`
-	CustomEventName     string  `json:"custom_event_name,omitempty"`
+	PricingOptionID     string   `json:"pricing_option_id"`
+	PricingModel        string   `json:"pricing_model"`
+	Currency            string   `json:"currency"`
+	FixedPrice          float64  `json:"fixed_price,omitempty"`
+	FloorPrice          float64  `json:"floor_price,omitempty"`
+	MinSpendPerPackage  float64  `json:"min_spend_per_package,omitempty"`
+	MaxBid              *bool    `json:"max_bid,omitempty"`
+	PriceGuidance       any      `json:"price_guidance,omitempty"`
+	PriceBreakdown      any      `json:"price_breakdown,omitempty"`
+	EventSourceID       string   `json:"event_source_id,omitempty"`
+	EventType           string   `json:"event_type,omitempty"`
+	CustomEventName     string   `json:"custom_event_name,omitempty"`
 	EligibleAdjustments []string `json:"eligible_adjustments,omitempty"`
-	Parameters          any     `json:"parameters,omitempty"`
+	Parameters          any      `json:"parameters,omitempty"`
 }
 
 type MediaBuyListItem struct {
@@ -425,7 +432,9 @@ type MediaBuyListItem struct {
 
 type DeliveryData struct {
 	ReportingPeriod    ReportingPeriod    `json:"reporting_period"`
+	Currency           string             `json:"currency"`
 	MediaBuyDeliveries []MediaBuyDelivery `json:"media_buy_deliveries"`
+	Context            any                `json:"context,omitempty"`
 }
 
 type ReportingPeriod struct {
@@ -441,8 +450,27 @@ type MediaBuyDelivery struct {
 }
 
 type PackageDelivery struct {
-	PackageID string         `json:"package_id"`
-	Totals    DeliveryTotals `json:"totals"`
+	PackageID    string         `json:"package_id"`
+	Totals       DeliveryTotals `json:"totals"`
+	Spend        float64        `json:"spend"`
+	PricingModel string         `json:"pricing_model,omitempty"`
+	Rate         float64        `json:"rate,omitempty"`
+	Currency     string         `json:"currency,omitempty"`
+}
+
+// MarshalJSON preserves the schema-required spend field even when it is zero.
+func (d DeliveryTotals) MarshalJSON() ([]byte, error) {
+	type deliveryTotals DeliveryTotals
+	b, err := json.Marshal(deliveryTotals(d))
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	out["spend"] = d.Spend
+	return json.Marshal(out)
 }
 
 // Render is a rendering variant inside a CreativeFormat. Wired into generated
@@ -518,8 +546,10 @@ type SignalPricing = VendorPricingOption
 
 // Deployment is the flattened union of deployment.json's oneOf variants.
 // Type is the discriminator:
-//   "platform": set Platform (required), AgentURL, Account, ActivationKey.
-//   "agent":    set AgentURL (required), ActivationKey.
+//
+//	"platform": set Platform (required), AgentURL, Account, ActivationKey.
+//	"agent":    set AgentURL (required), ActivationKey.
+//
 // All variants: IsLive, DeployedAt, EstimatedActivationDurationMinutes.
 // Do not mix variant-specific fields — schema validators accept it because
 // additionalProperties=true, but the result is semantically wrong.

--- a/adcp/webhook/config_test.go
+++ b/adcp/webhook/config_test.go
@@ -20,6 +20,7 @@ func TestDecodeConfigEmptyObjectReturnsNil(t *testing.T) {
 }
 
 func TestDecodeConfigHappyPath(t *testing.T) {
+	// #nosec G101 -- test fixture uses a fake validation token.
 	raw := map[string]any{
 		"url":   "https://buyer.example.com/webhooks/task-status",
 		"token": "opaque-client-validation-token-1234567890",

--- a/adcp/webhook/e2e_test.go
+++ b/adcp/webhook/e2e_test.go
@@ -61,7 +61,7 @@ func TestEndToEndDeliverToHTTPHandler(t *testing.T) {
 	ctx := context.Background()
 	res, err := Deliver(ctx, srv.URL+"/webhooks/mcp", p, signer, nil)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 	require.Equal(t, http.StatusOK, res.Response.StatusCode)
 	require.Equal(t, int32(1), received.Load())
 	require.Equal(t, res.Body, receivedBody, "handler must observe the exact signed bytes")
@@ -71,7 +71,7 @@ func TestEndToEndDeliverToHTTPHandler(t *testing.T) {
 	// idempotency_key, Deliver mints a fresh signature, dedup fires.
 	res2, err := Deliver(ctx, srv.URL+"/webhooks/mcp", p, signer, nil)
 	require.NoError(t, err)
-	res2.Response.Body.Close()
+	closeResponseBody(t, res2.Response)
 	require.Equal(t, http.StatusOK, res2.Response.StatusCode)
 	require.Equal(t, int32(1), received.Load(), "dedup must suppress handler on retry")
 	assert.Equal(t, res.Body, res2.Body, "retries MUST resend byte-identical bodies")
@@ -107,11 +107,11 @@ func TestEndToEndConflictDifferentPayloadSameKey(t *testing.T) {
 	ctx := context.Background()
 	res1, err := Deliver(ctx, srv.URL+"/webhooks/mcp", p1, signer, nil)
 	require.NoError(t, err)
-	res1.Response.Body.Close()
+	closeResponseBody(t, res1.Response)
 	require.Equal(t, http.StatusOK, res1.Response.StatusCode)
 
 	res2, err := Deliver(ctx, srv.URL+"/webhooks/mcp", p2, signer, nil)
 	require.NoError(t, err)
-	res2.Response.Body.Close()
+	closeResponseBody(t, res2.Response)
 	assert.Equal(t, http.StatusConflict, res2.Response.StatusCode, "same key + different body MUST conflict")
 }

--- a/adcp/webhook/http.go
+++ b/adcp/webhook/http.go
@@ -268,6 +268,8 @@ func Deliver(ctx context.Context, url string, p Payload, signer *signing.Signer,
 		return nil, fmt.Errorf("webhook: sign request: %w", err)
 	}
 	effective := clientNoRedirect(client)
+	// Ownership of resp.Body is returned to the caller in DeliverResult.
+	//nolint:bodyclose
 	resp, err := effective.Do(req)
 	if err != nil {
 		return nil, err

--- a/adcp/webhook/publisher_test.go
+++ b/adcp/webhook/publisher_test.go
@@ -68,6 +68,11 @@ func publisherForTest(t *testing.T) *Publisher {
 	})
 }
 
+func closeResponseBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	require.NoError(t, resp.Body.Close())
+}
+
 func TestPublisherRetriesThenSucceeds(t *testing.T) {
 	srv, attempts, _ := flappyServer(t, 2) // first 2 attempts 5xx, third 200
 	pub := publisherForTest(t)
@@ -77,7 +82,7 @@ func TestPublisherRetriesThenSucceeds(t *testing.T) {
 	}
 	res, err := pub.Emit(context.Background(), srv.URL, p)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 	assert.Equal(t, http.StatusOK, res.Response.StatusCode)
 	assert.Equal(t, 3, res.Attempts)
 	assert.Equal(t, int32(3), attempts.Load())
@@ -145,7 +150,7 @@ func TestPublisherRetriesOn408And429(t *testing.T) {
 			}
 			res, err := pub.Emit(context.Background(), srv.URL, p)
 			require.NoError(t, err)
-			res.Response.Body.Close()
+			closeResponseBody(t, res.Response)
 			assert.Equal(t, 2, res.Attempts)
 		})
 	}
@@ -185,7 +190,7 @@ func TestPublisherHonorsRetryAfter(t *testing.T) {
 	}
 	res, err := pub.Emit(context.Background(), srv.URL, p)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 	assert.Equal(t, 42*time.Second, sleptWith, "Retry-After must override computed backoff")
 }
 
@@ -276,7 +281,7 @@ func TestPublisherEachAttemptFreshSignature(t *testing.T) {
 	}
 	res, err := pub.Emit(context.Background(), srv.URL, p)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 
 	got := *sigs.Load()
 	require.Len(t, got, 2)
@@ -311,7 +316,7 @@ func TestPublisherIdempotencyKeyStableAcrossAttempts(t *testing.T) {
 	}
 	res, err := pub.Emit(context.Background(), srv.URL, p)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 
 	got := *keys.Load()
 	require.Len(t, got, 2)
@@ -364,7 +369,7 @@ func TestPublisherEndToEndWithVerifyingReceiver(t *testing.T) {
 	}
 	res, err := pub.Emit(context.Background(), srv.URL+"/webhooks/mcp", p)
 	require.NoError(t, err)
-	res.Response.Body.Close()
+	closeResponseBody(t, res.Response)
 	assert.Equal(t, http.StatusOK, res.Response.StatusCode)
 	assert.Equal(t, int32(1), delivered.Load())
 }

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -316,6 +316,270 @@ func (b *backend) listCreatives(input adcp.ListCreativesRequest) (*mcp.CallToolR
 	return result, out, err
 }
 
+func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.forced != nil {
+		forced := b.forced
+		b.forced = nil
+		return &adcp.MediaBuyData{Status: "submitted", Ext: map[string]any{"task_id": forced.TaskID, "message": forced.Message, "context": input.Context}}, nil
+	}
+	for _, p := range input.Packages {
+		if p.MeasurementTerms != nil && p.MeasurementTerms.BillingMeasurement != nil {
+			bm := p.MeasurementTerms.BillingMeasurement
+			if bm.MeasurementWindow != "c7" || bm.MaxVariancePercent < 5 {
+				return nil, adcp.NewError("TERMS_REJECTED", adcp.ErrorOptions{
+					Message:    "Measurement terms must use c7 with at least 5 percent variance.",
+					Recovery:   "revise",
+					Field:      "packages[0].measurement_terms",
+					Suggestion: "Use measurement_window c7 and max_variance_percent 10.",
+				})
+			}
+		}
+	}
+	n := b.buySeq.Add(1)
+	id := fmt.Sprintf("mb-%d", n)
+	pkgs := make([]adcp.Package, 0, len(input.Packages))
+	hasCreatives := false
+	for i, p := range input.Packages {
+		if len(p.CreativeAssignments) > 0 {
+			hasCreatives = true
+		}
+		pkgs = append(pkgs, adcp.Package{
+			PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
+			PricingOptionID: p.PricingOptionID, Budget: p.Budget,
+			StartTime: p.StartTime, EndTime: p.EndTime,
+			AgencyEstimateNumber: p.AgencyEstimateNumber,
+			MeasurementTerms:    p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
+			TargetingOverlay:    p.TargetingOverlay,
+			CreativeAssignments: p.CreativeAssignments,
+		})
+	}
+	var totalBudget float64
+	for _, p := range input.Packages {
+		totalBudget += p.Budget
+	}
+	status := "pending_creatives"
+	if hasCreatives {
+		status = "active"
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	buy := &adcp.MediaBuyData{MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs, ConfirmedAt: now, CreatedAt: now, UpdatedAt: now, Revision: 1, Ext: mediaBuyExt(status)}
+	b.mediaBuys[id] = buy
+	for _, pkg := range pkgs {
+		b.delivery[pkg.PackageID] = &deliveryState{}
+	}
+	return buy, nil
+}
+
+func (b *backend) syncCreatives(input *adcp.SyncCreativesRequest) ([]adcp.CreativeResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	results := make([]adcp.CreativeResult, 0, len(input.Creatives))
+	for _, c := range input.Creatives {
+		action := "created"
+		if _, exists := b.creatives[c.CreativeID]; exists {
+			action = "updated"
+		}
+		b.creatives[c.CreativeID] = &creativeRecord{ID: c.CreativeID, Name: c.Name, FormatID: c.FormatID, Status: "approved", Assets: c.Assets}
+		results = append(results, adcp.CreativeResult{CreativeID: c.CreativeID, Action: action, Status: "approved"})
+	}
+	for _, raw := range input.Assignments {
+		assign, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		creativeID, _ := assign["creative_id"].(string)
+		packageID, _ := assign["package_id"].(string)
+		if creativeID == "" || packageID == "" {
+			continue
+		}
+		for _, buy := range b.mediaBuys {
+			for i := range buy.Packages {
+				if buy.Packages[i].PackageID == packageID {
+					buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, map[string]any{"creative_id": creativeID})
+					if buy.Status == "pending_creatives" {
+						buy.Status = "active"
+						buy.Ext = mediaBuyExt(buy.Status)
+						buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+						buy.Revision++
+					}
+				}
+			}
+		}
+	}
+	return results, nil
+}
+
+func (b *backend) getDelivery(input *adcp.GetMediaBuyDeliveryRequest) (*adcp.DeliveryData, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	now := time.Now().UTC()
+	ids := input.MediaBuyIDs
+	if len(ids) == 0 {
+		for id := range b.mediaBuys {
+			ids = append(ids, id)
+		}
+	}
+	deliveries := make([]adcp.MediaBuyDelivery, 0, len(ids))
+	for _, mbID := range ids {
+		buy, ok := b.mediaBuys[mbID]
+		if !ok {
+			continue
+		}
+		pkgDel := make([]adcp.PackageDelivery, 0)
+		var totImps, totClicks int
+		var totSpend float64
+		for _, pkg := range buy.Packages {
+			ds := b.delivery[pkg.PackageID]
+			if ds == nil {
+				ds = &deliveryState{}
+			}
+			pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{Impressions: float64(ds.Impressions), Clicks: float64(ds.Clicks), Spend: ds.Spend}, Spend: ds.Spend, PricingModel: "cpm", Rate: 10, Currency: "USD"})
+			totImps += ds.Impressions
+			totClicks += ds.Clicks
+			totSpend += ds.Spend
+		}
+		deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{Impressions: float64(totImps), Clicks: float64(totClicks), Spend: totSpend}, ByPackage: pkgDel})
+	}
+	return &adcp.DeliveryData{ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)}, Currency: "USD", MediaBuyDeliveries: deliveries}, nil
+}
+
+func (b *backend) forceAccountStatus(accountID, status string) (*adcp.StateTransition, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	acct, ok := b.accounts[accountID]
+	if !ok {
+		return nil, fmt.Errorf("NOT_FOUND")
+	}
+	prev := acct.Status
+	acct.Status = status
+	return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+}
+
+func (b *backend) forceMediaBuyStatus(mediaBuyID, status, _ string) (*adcp.StateTransition, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	buy, ok := b.mediaBuys[mediaBuyID]
+	if !ok {
+		return nil, fmt.Errorf("NOT_FOUND")
+	}
+	prev := buy.Status
+	if prev == "completed" || prev == "rejected" || prev == "canceled" {
+		return nil, fmt.Errorf("INVALID_TRANSITION")
+	}
+	buy.Status = status
+	return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+}
+
+func (b *backend) forceCreativeStatus(creativeID, status, _ string) (*adcp.StateTransition, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	creative, ok := b.creatives[creativeID]
+	if !ok {
+		return nil, fmt.Errorf("NOT_FOUND")
+	}
+	prev := creative.Status
+	creative.Status = status
+	return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+}
+
+func (b *backend) simulateDelivery(mediaBuyID string, p adcp.SimulateDeliveryParams) (*adcp.SimulationResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	buy, ok := b.mediaBuys[mediaBuyID]
+	if !ok {
+		return nil, fmt.Errorf("NOT_FOUND")
+	}
+	var spend float64
+	if p.ReportedSpend != nil {
+		spend = p.ReportedSpend.Amount
+	}
+	for _, pkg := range buy.Packages {
+		ds := b.delivery[pkg.PackageID]
+		if ds == nil {
+			ds = &deliveryState{}
+			b.delivery[pkg.PackageID] = ds
+		}
+		ds.Impressions += p.Impressions
+		ds.Clicks += p.Clicks
+		ds.Spend += spend
+	}
+	return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
+}
+
+func (b *backend) simulateBudgetSpend(p adcp.SimulateBudgetParams) (*adcp.SimulationResult, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	buy, ok := b.mediaBuys[p.MediaBuyID]
+	if !ok {
+		return nil, fmt.Errorf("NOT_FOUND")
+	}
+	var total float64
+	for _, pkg := range buy.Packages {
+		total += pkg.Budget
+	}
+	spend := total * p.SpendPercentage
+	for _, pkg := range buy.Packages {
+		if total == 0 {
+			continue
+		}
+		ds := b.delivery[pkg.PackageID]
+		if ds == nil {
+			ds = &deliveryState{}
+			b.delivery[pkg.PackageID] = ds
+		}
+		ds.Spend += spend * (pkg.Budget / total)
+	}
+	return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"spend": spend, "percentage": p.SpendPercentage}}, nil
+}
+
+func (b *backend) handleCustomScenario(scenario string, params map[string]any) (any, error) {
+	switch scenario {
+	case "seed_product":
+		productID, _ := params["product_id"].(string)
+		if productID == "" {
+			return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_product requires params.product_id"}
+		}
+		fixture, _ := params["fixture"].(map[string]any)
+		b.seedProduct(productID, fixture)
+		return map[string]any{"success": true, "message": "seeded"}, nil
+	case "seed_pricing_option":
+		productID, _ := params["product_id"].(string)
+		pricingOptionID, _ := params["pricing_option_id"].(string)
+		if productID == "" || pricingOptionID == "" {
+			return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_pricing_option requires params.product_id and params.pricing_option_id"}
+		}
+		fixture, _ := params["fixture"].(map[string]any)
+		b.seedPricingOption(productID, pricingOptionID, fixture)
+		return map[string]any{"success": true, "message": "seeded"}, nil
+	case "force_create_media_buy_arm":
+		arm, _ := params["arm"].(string)
+		if arm != "submitted" {
+			return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Scenario not supported: force_create_media_buy_arm"}
+		}
+		taskID, _ := params["task_id"].(string)
+		message, _ := params["message"].(string)
+		if taskID == "" {
+			return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "force_create_media_buy_arm requires params.task_id"}
+		}
+		b.mu.Lock()
+		b.forced = &forceArm{TaskID: taskID, Message: message}
+		b.mu.Unlock()
+		return map[string]any{"success": true, "forced": map[string]any{"arm": arm, "task_id": taskID, "message": message}}, nil
+	default:
+		return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Unrecognized scenario name"}
+	}
+}
+
 func updateMediaBuyResult(buy *adcp.MediaBuyData, affected []adcp.Package, context any) (*mcp.CallToolResult, any, error) {
 	out := map[string]any{
 		"media_buy_id":        buy.MediaBuyID,
@@ -469,60 +733,7 @@ func main() {
 				return data, nil
 			},
 			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				if b.forced != nil {
-					forced := b.forced
-					b.forced = nil
-					return &adcp.MediaBuyData{Status: "submitted", Ext: map[string]any{"task_id": forced.TaskID, "message": forced.Message, "context": input.Context}}, nil
-				}
-				for _, p := range input.Packages {
-					if p.MeasurementTerms != nil && p.MeasurementTerms.BillingMeasurement != nil {
-						bm := p.MeasurementTerms.BillingMeasurement
-						if bm.MeasurementWindow != "c7" || bm.MaxVariancePercent < 5 {
-							return nil, adcp.NewError("TERMS_REJECTED", adcp.ErrorOptions{
-								Message:    "Measurement terms must use c7 with at least 5 percent variance.",
-								Recovery:   "revise",
-								Field:      "packages[0].measurement_terms",
-								Suggestion: "Use measurement_window c7 and max_variance_percent 10.",
-							})
-						}
-					}
-				}
-				// In production: book into your OMS / ad server
-				n := b.buySeq.Add(1)
-				id := fmt.Sprintf("mb-%d", n)
-				pkgs := make([]adcp.Package, 0, len(input.Packages))
-				hasCreatives := false
-				for i, p := range input.Packages {
-					if len(p.CreativeAssignments) > 0 {
-						hasCreatives = true
-					}
-					pkgs = append(pkgs, adcp.Package{
-						PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
-						PricingOptionID: p.PricingOptionID, Budget: p.Budget,
-						StartTime: p.StartTime, EndTime: p.EndTime,
-						AgencyEstimateNumber: p.AgencyEstimateNumber,
-						MeasurementTerms:     p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
-						TargetingOverlay:    p.TargetingOverlay,
-						CreativeAssignments: p.CreativeAssignments,
-					})
-				}
-				var totalBudget float64
-				for _, p := range input.Packages {
-					totalBudget += p.Budget
-				}
-				status := "pending_creatives"
-				if hasCreatives {
-					status = "active"
-				}
-				now := time.Now().UTC().Format(time.RFC3339)
-				buy := &adcp.MediaBuyData{MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs, ConfirmedAt: now, CreatedAt: now, UpdatedAt: now, Revision: 1, Ext: mediaBuyExt(status)}
-				b.mediaBuys[id] = buy
-				for _, pkg := range pkgs {
-					b.delivery[pkg.PackageID] = &deliveryState{}
-				}
-				return buy, nil
+				return b.createMediaBuy(input)
 			},
 			GetMediaBuys: func(_ context.Context, _ any, input *adcp.GetMediaBuysRequest) ([]adcp.MediaBuyData, error) {
 				b.mu.RLock()
@@ -560,77 +771,10 @@ func main() {
 				return formats, nil
 			},
 			SyncCreatives: func(_ context.Context, input *adcp.SyncCreativesRequest) ([]adcp.CreativeResult, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				// In production: ingest into your trafficking system
-				results := make([]adcp.CreativeResult, 0, len(input.Creatives))
-				for _, c := range input.Creatives {
-					action := "created"
-					if _, exists := b.creatives[c.CreativeID]; exists {
-						action = "updated"
-					}
-					b.creatives[c.CreativeID] = &creativeRecord{ID: c.CreativeID, Name: c.Name, FormatID: c.FormatID, Status: "approved", Assets: c.Assets}
-					results = append(results, adcp.CreativeResult{CreativeID: c.CreativeID, Action: action, Status: "approved"})
-				}
-				for _, raw := range input.Assignments {
-					assign, ok := raw.(map[string]any)
-					if !ok {
-						continue
-					}
-					creativeID, _ := assign["creative_id"].(string)
-					packageID, _ := assign["package_id"].(string)
-					if creativeID == "" || packageID == "" {
-						continue
-					}
-					for _, buy := range b.mediaBuys {
-						for i := range buy.Packages {
-							if buy.Packages[i].PackageID == packageID {
-								buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, map[string]any{"creative_id": creativeID})
-								if buy.Status == "pending_creatives" {
-									buy.Status = "active"
-									buy.Ext = mediaBuyExt(buy.Status)
-									buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-									buy.Revision++
-								}
-							}
-						}
-					}
-				}
-				return results, nil
+				return b.syncCreatives(input)
 			},
 			GetDelivery: func(_ context.Context, _ any, input *adcp.GetMediaBuyDeliveryRequest) (*adcp.DeliveryData, error) {
-				b.mu.RLock()
-				defer b.mu.RUnlock()
-				// In production: pull from your reporting system
-				now := time.Now().UTC()
-				ids := input.MediaBuyIDs
-				if len(ids) == 0 {
-					for id := range b.mediaBuys {
-						ids = append(ids, id)
-					}
-				}
-				deliveries := make([]adcp.MediaBuyDelivery, 0, len(ids))
-				for _, mbID := range ids {
-					buy, ok := b.mediaBuys[mbID]
-					if !ok {
-						continue
-					}
-					pkgDel := make([]adcp.PackageDelivery, 0)
-					var totImps, totClicks int
-					var totSpend float64
-					for _, pkg := range buy.Packages {
-						ds := b.delivery[pkg.PackageID]
-						if ds == nil {
-							ds = &deliveryState{}
-						}
-						pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{Impressions: float64(ds.Impressions), Clicks: float64(ds.Clicks), Spend: ds.Spend}, Spend: ds.Spend, PricingModel: "cpm", Rate: 10, Currency: "USD"})
-						totImps += ds.Impressions
-						totClicks += ds.Clicks
-						totSpend += ds.Spend
-					}
-					deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{Impressions: float64(totImps), Clicks: float64(totClicks), Spend: totSpend}, ByPackage: pkgDel})
-				}
-				return &adcp.DeliveryData{ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)}, Currency: "USD", MediaBuyDeliveries: deliveries}, nil
+				return b.getDelivery(input)
 			},
 		})
 
@@ -648,127 +792,12 @@ func main() {
 		if os.Getenv("ADCP_SANDBOX") != "false" {
 			adcp.RegisterTestController(server, &adcp.TestControllerStore{
 				CustomScenarios: customScenarios,
-				ForceAccountStatus: func(accountID, status string) (*adcp.StateTransition, error) {
-					b.mu.Lock()
-					defer b.mu.Unlock()
-					acct, ok := b.accounts[accountID]
-					if !ok {
-						return nil, fmt.Errorf("NOT_FOUND")
-					}
-					prev := acct.Status
-					acct.Status = status
-					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-				},
-				ForceMediaBuyStatus: func(mediaBuyID, status, reason string) (*adcp.StateTransition, error) {
-					b.mu.Lock()
-					defer b.mu.Unlock()
-					buy, ok := b.mediaBuys[mediaBuyID]
-					if !ok {
-						return nil, fmt.Errorf("NOT_FOUND")
-					}
-					prev := buy.Status
-					if prev == "completed" || prev == "rejected" || prev == "canceled" {
-						return nil, fmt.Errorf("INVALID_TRANSITION")
-					}
-					buy.Status = status
-					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-				},
-				ForceCreativeStatus: func(creativeID, status, reason string) (*adcp.StateTransition, error) {
-					b.mu.Lock()
-					defer b.mu.Unlock()
-					creative, ok := b.creatives[creativeID]
-					if !ok {
-						return nil, fmt.Errorf("NOT_FOUND")
-					}
-					prev := creative.Status
-					creative.Status = status
-					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-				},
-				SimulateDelivery: func(mediaBuyID string, p adcp.SimulateDeliveryParams) (*adcp.SimulationResult, error) {
-					b.mu.Lock()
-					defer b.mu.Unlock()
-					buy, ok := b.mediaBuys[mediaBuyID]
-					if !ok {
-						return nil, fmt.Errorf("NOT_FOUND")
-					}
-					var spend float64
-					if p.ReportedSpend != nil {
-						spend = p.ReportedSpend.Amount
-					}
-					for _, pkg := range buy.Packages {
-						ds := b.delivery[pkg.PackageID]
-						if ds == nil {
-							ds = &deliveryState{}
-							b.delivery[pkg.PackageID] = ds
-						}
-						ds.Impressions += p.Impressions
-						ds.Clicks += p.Clicks
-						ds.Spend += spend
-					}
-					return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
-				},
-				SimulateBudgetSpend: func(p adcp.SimulateBudgetParams) (*adcp.SimulationResult, error) {
-					b.mu.Lock()
-					defer b.mu.Unlock()
-					buy, ok := b.mediaBuys[p.MediaBuyID]
-					if !ok {
-						return nil, fmt.Errorf("NOT_FOUND")
-					}
-					var total float64
-					for _, pkg := range buy.Packages {
-						total += pkg.Budget
-					}
-					spend := total * p.SpendPercentage
-					for _, pkg := range buy.Packages {
-						if total == 0 {
-							continue
-						}
-						ds := b.delivery[pkg.PackageID]
-						if ds == nil {
-							ds = &deliveryState{}
-							b.delivery[pkg.PackageID] = ds
-						}
-						ds.Spend += spend * (pkg.Budget / total)
-					}
-					return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"spend": spend, "percentage": p.SpendPercentage}}, nil
-				},
-				CustomScenario: func(scenario string, params map[string]any) (any, error) {
-					switch scenario {
-					case "seed_product":
-						productID, _ := params["product_id"].(string)
-						if productID == "" {
-							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_product requires params.product_id"}
-						}
-						fixture, _ := params["fixture"].(map[string]any)
-						b.seedProduct(productID, fixture)
-						return map[string]any{"success": true, "message": "seeded"}, nil
-					case "seed_pricing_option":
-						productID, _ := params["product_id"].(string)
-						pricingOptionID, _ := params["pricing_option_id"].(string)
-						if productID == "" || pricingOptionID == "" {
-							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_pricing_option requires params.product_id and params.pricing_option_id"}
-						}
-						fixture, _ := params["fixture"].(map[string]any)
-						b.seedPricingOption(productID, pricingOptionID, fixture)
-						return map[string]any{"success": true, "message": "seeded"}, nil
-					case "force_create_media_buy_arm":
-						arm, _ := params["arm"].(string)
-						if arm != "submitted" {
-							return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Scenario not supported: force_create_media_buy_arm"}
-						}
-						taskID, _ := params["task_id"].(string)
-						message, _ := params["message"].(string)
-						if taskID == "" {
-							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "force_create_media_buy_arm requires params.task_id"}
-						}
-						b.mu.Lock()
-						b.forced = &forceArm{TaskID: taskID, Message: message}
-						b.mu.Unlock()
-						return map[string]any{"success": true, "forced": map[string]any{"arm": arm, "task_id": taskID, "message": message}}, nil
-					default:
-						return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Unrecognized scenario name"}
-					}
-				},
+				ForceAccountStatus: b.forceAccountStatus,
+				ForceMediaBuyStatus: b.forceMediaBuyStatus,
+				ForceCreativeStatus: b.forceCreativeStatus,
+				SimulateDelivery:    b.simulateDelivery,
+				SimulateBudgetSpend: b.simulateBudgetSpend,
+				CustomScenario:      b.handleCustomScenario,
 			})
 		}
 

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -128,24 +128,6 @@ type deliveryState struct {
 	Spend               float64
 }
 
-type updateMediaBuyInput struct {
-	Account            *adcp.AccountReference `json:"account,omitempty"`
-	MediaBuyID         string                 `json:"media_buy_id"`
-	Paused             *bool                  `json:"paused,omitempty"`
-	Canceled           *bool                  `json:"canceled,omitempty"`
-	CancellationReason string                 `json:"cancellation_reason,omitempty"`
-	Packages           []packageUpdate        `json:"packages,omitempty"`
-	IdempotencyKey     string                 `json:"idempotency_key,omitempty"`
-	Context            any                    `json:"context,omitempty"`
-}
-
-type packageUpdate struct {
-	PackageID           string           `json:"package_id"`
-	Paused              *bool            `json:"paused,omitempty"`
-	TargetingOverlay    *adcp.Targeting  `json:"targeting_overlay,omitempty"`
-	CreativeAssignments []map[string]any `json:"creative_assignments,omitempty"`
-}
-
 func (b *backend) seedProduct(productID string, fixture map[string]any) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -204,7 +186,7 @@ func (b *backend) seedPricingOption(productID, pricingOptionID string, fixture m
 	product.PricingOptions = append(product.PricingOptions, adcp.PricingOption{PricingOptionID: pricingOptionID, PricingModel: model, Currency: currency, FixedPrice: fixedPrice})
 }
 
-func (b *backend) updateMediaBuy(input updateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToolResult, any, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -212,7 +194,7 @@ func (b *backend) updateMediaBuy(input updateMediaBuyInput) (*mcp.CallToolResult
 	if !ok {
 		return errorResult("MEDIA_BUY_NOT_FOUND", "Media buy not found.", input.Context)
 	}
-	if input.Canceled != nil && *input.Canceled {
+	if input.Canceled {
 		if buy.Status == "canceled" {
 			return errorResult("NOT_CANCELLABLE", "Media buy is already canceled.", input.Context)
 		}
@@ -253,9 +235,7 @@ func (b *backend) updateMediaBuy(input updateMediaBuyInput) (*mcp.CallToolResult
 			buy.Packages[i].TargetingOverlay = upd.TargetingOverlay
 		}
 		if len(upd.CreativeAssignments) > 0 {
-			for _, assignment := range upd.CreativeAssignments {
-				buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, assignment)
-			}
+			buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, upd.CreativeAssignments...)
 			if buy.Status == "pending_creatives" {
 				buy.Status = "active"
 				buy.Ext = mediaBuyExt(buy.Status)
@@ -351,7 +331,7 @@ func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.Media
 			PricingOptionID: p.PricingOptionID, Budget: p.Budget,
 			StartTime: p.StartTime, EndTime: p.EndTime,
 			AgencyEstimateNumber: p.AgencyEstimateNumber,
-			MeasurementTerms:    p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
+			MeasurementTerms:     p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
 			TargetingOverlay:    p.TargetingOverlay,
 			CreativeAssignments: p.CreativeAssignments,
 		})
@@ -502,15 +482,30 @@ func (b *backend) simulateDelivery(mediaBuyID string, p adcp.SimulateDeliveryPar
 	if p.ReportedSpend != nil {
 		spend = p.ReportedSpend.Amount
 	}
-	for _, pkg := range buy.Packages {
+	count := len(buy.Packages)
+	if count == 0 {
+		return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
+	}
+	baseImps, extraImps := p.Impressions/count, p.Impressions%count
+	baseClicks, extraClicks := p.Clicks/count, p.Clicks%count
+	spendPerPackage := spend / float64(count)
+	for i, pkg := range buy.Packages {
 		ds := b.delivery[pkg.PackageID]
 		if ds == nil {
 			ds = &deliveryState{}
 			b.delivery[pkg.PackageID] = ds
 		}
-		ds.Impressions += p.Impressions
-		ds.Clicks += p.Clicks
-		ds.Spend += spend
+		imps := baseImps
+		if i < extraImps {
+			imps++
+		}
+		clicks := baseClicks
+		if i < extraClicks {
+			clicks++
+		}
+		ds.Impressions += imps
+		ds.Clicks += clicks
+		ds.Spend += spendPerPackage
 	}
 	return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
 }
@@ -626,12 +621,12 @@ func errorResult(code, message string, context any) (*mcp.CallToolResult, any, e
 		"adcp_error": map[string]any{
 			"code":     code,
 			"message":  message,
-			"recovery": "revise",
+			"recovery": "correctable",
 		},
 		"errors": []map[string]any{{
 			"code":     code,
 			"message":  message,
-			"recovery": "revise",
+			"recovery": "correctable",
 		}},
 		"context": context,
 	}
@@ -779,7 +774,7 @@ func main() {
 		})
 
 		adcp.AddTool(server, "update_media_buy", "Update a media buy",
-			func(ctx context.Context, req *mcp.CallToolRequest, input updateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+			func(ctx context.Context, req *mcp.CallToolRequest, input adcp.UpdateMediaBuyRequest) (*mcp.CallToolResult, any, error) {
 				return b.updateMediaBuy(input)
 			})
 
@@ -791,8 +786,8 @@ func main() {
 		// Test controller — sandbox only. Do not register in production.
 		if os.Getenv("ADCP_SANDBOX") != "false" {
 			adcp.RegisterTestController(server, &adcp.TestControllerStore{
-				CustomScenarios: customScenarios,
-				ForceAccountStatus: b.forceAccountStatus,
+				CustomScenarios:     customScenarios,
+				ForceAccountStatus:  b.forceAccountStatus,
 				ForceMediaBuyStatus: b.forceMediaBuyStatus,
 				ForceCreativeStatus: b.forceCreativeStatus,
 				SimulateDelivery:    b.simulateDelivery,

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,55 +16,372 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const agentURL = "http://localhost:3001/mcp"
+var agentURL = sellerAgentURL()
+
+func sellerAgentURL() string {
+	if u := os.Getenv("ADCP_AGENT_URL"); u != "" {
+		return u
+	}
+
+	port := 3001
+	if p := os.Getenv("PORT"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			port = n
+		}
+	}
+
+	return fmt.Sprintf("http://localhost:%d/mcp", port)
+}
 
 // --- Your product catalog and creative formats ---
 
-var products = []adcp.Product{
-	{
-		ProductID: "premium-display", Name: "Premium Display",
-		Description:  "High-impact display placements across our premium publisher network.",
-		Channels:     []string{"display"}, DeliveryType: "guaranteed",
-		PricingOptions: []adcp.PricingOption{{PricingOptionID: "pd-cpm-15", PricingModel: "cpm", FixedPrice: 15.00, Currency: "USD"}},
-		FormatIDs:      []adcp.FormatRef{{AgentURL: agentURL, ID: "banner-300x250"}, {AgentURL: agentURL, ID: "banner-728x90"}},
-	},
-	{
-		ProductID: "video-preroll", Name: "Video Pre-Roll",
-		Description: "15 and 30 second pre-roll video ads.",
-		Channels:    []string{"video"}, DeliveryType: "non_guaranteed",
-		PricingOptions: []adcp.PricingOption{
+func baseProducts() map[string]*adcp.Product {
+	items := []adcp.Product{
+		newProduct("premium-display", "Premium Display", "High-impact display placements across our premium publisher network.", "guaranteed", []string{"display"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "display_300x250"}}, []adcp.PricingOption{{PricingOptionID: "pd-cpm-15", PricingModel: "cpm", FixedPrice: 15.00, Currency: "USD"}}),
+		newProduct("video-preroll", "Video Pre-Roll", "15 and 30 second pre-roll video ads.", "non_guaranteed", []string{"video"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "video_30s"}, {AgentURL: agentURL, ID: "video-15s"}}, []adcp.PricingOption{
 			{PricingOptionID: "vp-cpm-25", PricingModel: "cpm", FixedPrice: 25.00, Currency: "USD"},
 			{PricingOptionID: "vp-cpcv-05", PricingModel: "cpcv", FixedPrice: 0.05, Currency: "USD"},
-		},
-		FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "video-15s"}, {AgentURL: agentURL, ID: "video-30s"}},
-	},
+		}),
+	}
+
+	out := make(map[string]*adcp.Product, len(items))
+	for i := range items {
+		product := items[i]
+		out[product.ProductID] = &product
+	}
+	return out
 }
 
 var formats = []adcp.CreativeFormat{
-	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "banner-300x250"}, Name: "Medium Rectangle", Renders: []adcp.Render{{Width: 300, Height: 250}}, Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "image", AssetType: "image", Required: true, AcceptedMediaTypes: []string{"image/png", "image/jpeg"}}}},
-	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "banner-728x90"}, Name: "Leaderboard", Renders: []adcp.Render{{Width: 728, Height: 90}}, Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "image", AssetType: "image", Required: true, AcceptedMediaTypes: []string{"image/png", "image/jpeg"}}}},
+	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "display_300x250"}, Name: "Medium Rectangle", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "image", AssetType: "image", Required: true, AcceptedMediaTypes: []string{"image/png", "image/jpeg"}}}},
+	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "banner-300x250"}, Name: "Medium Rectangle", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "image", AssetType: "image", Required: true, AcceptedMediaTypes: []string{"image/png", "image/jpeg"}}}},
+	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "banner-728x90"}, Name: "Leaderboard", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "image", AssetType: "image", Required: true, AcceptedMediaTypes: []string{"image/png", "image/jpeg"}}}},
 	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "video-15s"}, Name: "Video :15", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "video_file", AssetType: "video", Required: true, AcceptedMediaTypes: []string{"video/mp4"}}}},
+	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "video_15s"}, Name: "Video :15", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "video", AssetType: "video", Required: true, AcceptedMediaTypes: []string{"video/mp4"}}}},
 	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "video-30s"}, Name: "Video :30", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "video_file", AssetType: "video", Required: true, AcceptedMediaTypes: []string{"video/mp4"}}}},
+	{FormatID: adcp.FormatRef{AgentURL: agentURL, ID: "video_30s"}, Name: "30-second Video", Assets: []adcp.AssetSlot{{ItemType: "individual", AssetID: "video", AssetType: "video", Required: true, AcceptedMediaTypes: []string{"video/mp4"}}}},
 }
+
+var customScenarios = []string{"seed_product", "seed_pricing_option", "force_create_media_buy_arm"}
+
+func newProduct(id, name, description, deliveryType string, channels []string, formatIDs []adcp.FormatRef, pricing []adcp.PricingOption) adcp.Product {
+	return adcp.Product{
+		ProductID:                  id,
+		Name:                       name,
+		Description:                description,
+		PublisherProperties:        []adcp.PublisherPropertySelector{{PublisherDomain: "example.com", SelectionType: "all"}},
+		Channels:                   channels,
+		FormatIDs:                  formatIDs,
+		DeliveryType:               deliveryType,
+		PricingOptions:             pricing,
+		ReportingCapabilities:      reportingCapabilities(),
+		PropertyTargetingAllowed:   boolPtr(true),
+		CollectionTargetingAllowed: boolPtr(true),
+		MeasurementTerms: &adcp.MeasurementTerms{
+			BillingMeasurement: &adcp.BillingMeasurement{Vendor: &adcp.BrandReference{Domain: "videoamp.example"}, MeasurementWindow: "c7", MaxVariancePercent: 10},
+			MakegoodPolicy:     &adcp.MakegoodPolicy{AvailableRemedies: []string{"additional_delivery", "credit"}},
+		},
+	}
+}
+
+func reportingCapabilities() map[string]any {
+	return map[string]any{
+		"available_reporting_frequencies": []string{"daily"},
+		"expected_delay_minutes":          60,
+		"timezone":                        "UTC",
+		"supports_webhooks":               false,
+		"available_metrics":               []string{"impressions", "spend", "clicks"},
+		"date_range_support":              "date_range",
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
 
 // --- Your backend state (replace with your real DB / ad server client) ---
 
 type backend struct {
 	mu        sync.RWMutex
 	accounts  map[string]*adcp.AccountResult
+	products  map[string]*adcp.Product
 	mediaBuys map[string]*adcp.MediaBuyData
-	creatives map[string]string
+	creatives map[string]*creativeRecord
 	delivery  map[string]*deliveryState
 	buySeq    atomic.Int64
+	forced    *forceArm
 }
 
-type deliveryState struct{ Impressions, Clicks int; Spend float64 }
+type creativeRecord struct {
+	ID       string
+	Name     string
+	FormatID *adcp.FormatRef
+	Status   string
+	Assets   map[string]any
+}
+
+type forceArm struct {
+	TaskID  string
+	Message string
+}
+
+type deliveryState struct {
+	Impressions, Clicks int
+	Spend               float64
+}
+
+type updateMediaBuyInput struct {
+	Account            *adcp.AccountReference `json:"account,omitempty"`
+	MediaBuyID         string                 `json:"media_buy_id"`
+	Paused             *bool                  `json:"paused,omitempty"`
+	Canceled           *bool                  `json:"canceled,omitempty"`
+	CancellationReason string                 `json:"cancellation_reason,omitempty"`
+	Packages           []packageUpdate        `json:"packages,omitempty"`
+	IdempotencyKey     string                 `json:"idempotency_key,omitempty"`
+	Context            any                    `json:"context,omitempty"`
+}
+
+type packageUpdate struct {
+	PackageID           string           `json:"package_id"`
+	Paused              *bool            `json:"paused,omitempty"`
+	TargetingOverlay    *adcp.Targeting  `json:"targeting_overlay,omitempty"`
+	CreativeAssignments []map[string]any `json:"creative_assignments,omitempty"`
+}
+
+func (b *backend) seedProduct(productID string, fixture map[string]any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	channels := []string{"display"}
+	if raw, ok := fixture["channels"].([]any); ok && len(raw) > 0 {
+		channels = make([]string, 0, len(raw))
+		for _, item := range raw {
+			if s, ok := item.(string); ok {
+				channels = append(channels, s)
+			}
+		}
+	}
+	deliveryType, _ := fixture["delivery_type"].(string)
+	if deliveryType == "" {
+		deliveryType = "guaranteed"
+	}
+	formatIDs := []adcp.FormatRef{{AgentURL: agentURL, ID: "display_300x250"}}
+	if raw, ok := fixture["format_ids"].([]any); ok && len(raw) > 0 {
+		formatIDs = make([]adcp.FormatRef, 0, len(raw))
+		for _, item := range raw {
+			if m, ok := item.(map[string]any); ok {
+				id, _ := m["id"].(string)
+				if id != "" {
+					formatIDs = append(formatIDs, adcp.FormatRef{AgentURL: agentURL, ID: id})
+				}
+			}
+		}
+	}
+	product := newProduct(productID, productID, "Seeded storyboard product.", deliveryType, channels, formatIDs, []adcp.PricingOption{{PricingOptionID: "default", PricingModel: "cpm", FixedPrice: 10, Currency: "USD"}})
+	b.products[productID] = &product
+}
+
+func (b *backend) seedPricingOption(productID, pricingOptionID string, fixture map[string]any) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	product, ok := b.products[productID]
+	if !ok {
+		created := newProduct(productID, productID, "Seeded storyboard product.", "guaranteed", []string{"display"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "display_300x250"}}, nil)
+		product = &created
+		b.products[productID] = product
+	}
+	model, _ := fixture["pricing_model"].(string)
+	if model == "" {
+		model = "cpm"
+	}
+	currency, _ := fixture["currency"].(string)
+	if currency == "" {
+		currency = "USD"
+	}
+	fixedPrice := 10.0
+	if v, ok := fixture["fixed_price"].(float64); ok {
+		fixedPrice = v
+	}
+	product.PricingOptions = append(product.PricingOptions, adcp.PricingOption{PricingOptionID: pricingOptionID, PricingModel: model, Currency: currency, FixedPrice: fixedPrice})
+}
+
+func (b *backend) updateMediaBuy(input updateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	buy, ok := b.mediaBuys[input.MediaBuyID]
+	if !ok {
+		return errorResult("MEDIA_BUY_NOT_FOUND", "Media buy not found.", input.Context)
+	}
+	if input.Canceled != nil && *input.Canceled {
+		if buy.Status == "canceled" {
+			return errorResult("NOT_CANCELLABLE", "Media buy is already canceled.", input.Context)
+		}
+		buy.Status = "canceled"
+		now := time.Now().UTC().Format(time.RFC3339)
+		buy.Cancellation = map[string]any{"reason": input.CancellationReason, "canceled_by": "buyer", "canceled_at": now}
+		buy.Revision++
+		buy.UpdatedAt = now
+		buy.Ext = mediaBuyExt(buy.Status)
+		return updateMediaBuyResult(buy, buy.Packages, input.Context)
+	}
+	if input.Paused != nil {
+		if *input.Paused {
+			buy.Status = "paused"
+		} else {
+			buy.Status = "active"
+		}
+		buy.Ext = mediaBuyExt(buy.Status)
+	}
+
+	packageIndex := make(map[string]int, len(buy.Packages))
+	for i := range buy.Packages {
+		packageIndex[buy.Packages[i].PackageID] = i
+	}
+	for _, upd := range input.Packages {
+		if _, ok := packageIndex[upd.PackageID]; !ok {
+			return errorResult("PACKAGE_NOT_FOUND", "Package not found.", input.Context)
+		}
+	}
+
+	affected := make([]adcp.Package, 0, len(input.Packages))
+	for _, upd := range input.Packages {
+		i := packageIndex[upd.PackageID]
+		if upd.Paused != nil {
+			buy.Packages[i].Paused = upd.Paused
+		}
+		if upd.TargetingOverlay != nil {
+			buy.Packages[i].TargetingOverlay = upd.TargetingOverlay
+		}
+		if len(upd.CreativeAssignments) > 0 {
+			for _, assignment := range upd.CreativeAssignments {
+				buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, assignment)
+			}
+			if buy.Status == "pending_creatives" {
+				buy.Status = "active"
+				buy.Ext = mediaBuyExt(buy.Status)
+			}
+		}
+		affected = append(affected, buy.Packages[i])
+	}
+	if len(affected) == 0 {
+		affected = buy.Packages
+	}
+	buy.Revision++
+	buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	return updateMediaBuyResult(buy, affected, input.Context)
+}
+
+func (b *backend) listCreatives(input adcp.ListCreativesRequest) (*mcp.CallToolResult, any, error) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	creativeIDs := map[string]bool{}
+	formatIDs := map[string]bool{}
+	if input.Filters != nil {
+		for _, id := range input.Filters.CreativeIDs {
+			creativeIDs[id] = true
+		}
+		for _, ref := range input.Filters.FormatIDs {
+			formatIDs[ref.ID] = true
+		}
+	}
+	creatives := make([]map[string]any, 0, len(b.creatives))
+	for _, c := range b.creatives {
+		if len(creativeIDs) > 0 && !creativeIDs[c.ID] {
+			continue
+		}
+		if len(formatIDs) > 0 && (c.FormatID == nil || !formatIDs[c.FormatID.ID]) {
+			continue
+		}
+		item := map[string]any{
+			"creative_id":  c.ID,
+			"name":         c.Name,
+			"status":       c.Status,
+			"created_date": time.Now().UTC().Format(time.RFC3339),
+			"updated_date": time.Now().UTC().Format(time.RFC3339),
+		}
+		if c.FormatID != nil {
+			item["format_id"] = c.FormatID
+		}
+		if c.Assets != nil {
+			item["assets"] = c.Assets
+		}
+		creatives = append(creatives, item)
+	}
+	result, out, err := adcp.ListCreativesResponse(creatives)
+	if m, ok := out.(map[string]any); ok && input.Context != nil {
+		m["context"] = input.Context
+		result.StructuredContent = m
+	}
+	return result, out, err
+}
+
+func updateMediaBuyResult(buy *adcp.MediaBuyData, affected []adcp.Package, context any) (*mcp.CallToolResult, any, error) {
+	out := map[string]any{
+		"media_buy_id":        buy.MediaBuyID,
+		"status":              buy.Status,
+		"revision":            buy.Revision,
+		"implementation_date": time.Now().UTC().Format(time.RFC3339),
+		"affected_packages":   affected,
+		"valid_actions":       validActions(buy.Status),
+		"sandbox":             true,
+		"context":             context,
+	}
+	if buy.Cancellation != nil {
+		out["cancellation"] = buy.Cancellation
+		if cancellation, ok := buy.Cancellation.(map[string]any); ok {
+			out["canceled_by"] = cancellation["canceled_by"]
+			out["canceled_at"] = cancellation["canceled_at"]
+		}
+	}
+	return adcp.Result(out, "Media buy updated")
+}
+
+func mediaBuyExt(status string) map[string]any {
+	return map[string]any{
+		"currency":      "USD",
+		"valid_actions": validActions(status),
+	}
+}
+
+func validActions(status string) []string {
+	switch status {
+	case "canceled", "completed", "rejected", "failed":
+		return []string{}
+	case "paused":
+		return []string{"resume", "cancel", "sync_creatives", "update_packages"}
+	case "pending_creatives":
+		return []string{"cancel", "sync_creatives", "update_packages"}
+	default:
+		return []string{"pause", "cancel", "sync_creatives", "update_packages"}
+	}
+}
+
+func errorResult(code, message string, context any) (*mcp.CallToolResult, any, error) {
+	out := map[string]any{
+		"adcp_error": map[string]any{
+			"code":     code,
+			"message":  message,
+			"recovery": "revise",
+		},
+		"errors": []map[string]any{{
+			"code":     code,
+			"message":  message,
+			"recovery": "revise",
+		}},
+		"context": context,
+	}
+	result, outAny, err := adcp.Result(out, message)
+	result.IsError = true
+	return result, outAny, err
+}
 
 func main() {
 	b := &backend{
 		accounts:  make(map[string]*adcp.AccountResult),
+		products:  baseProducts(),
 		mediaBuys: make(map[string]*adcp.MediaBuyData),
-		creatives: make(map[string]string),
+		creatives: make(map[string]*creativeRecord),
 		delivery:  make(map[string]*deliveryState),
 	}
 
@@ -73,6 +391,18 @@ func main() {
 		adcp.Register(server, adcp.Config{
 			Sandbox:              true,
 			IdempotencyReplayTTL: 24 * time.Hour,
+			Capabilities: &adcp.CapabilitiesData{
+				Account: &adcp.AccountCapabilities{SupportedBilling: []string{"operator", "agent"}, Sandbox: boolPtr(true)},
+				MediaBuy: &adcp.MediaBuyCapabilities{
+					SupportedPricingModels: []string{"cpm", "cpcv"},
+					Portfolio:              &adcp.PortfolioCaps{PublisherDomains: []string{"example.com"}, PrimaryChannels: []string{"display", "olv"}},
+				},
+				Creative: &adcp.CreativeCapabilities{HasCreativeLibrary: boolPtr(true), SupportsCompliance: boolPtr(true)},
+				ComplianceTesting: &adcp.ComplianceTestingCapabilities{Scenarios: []string{
+					"force_account_status", "force_media_buy_status", "force_creative_status",
+					"simulate_delivery", "simulate_budget_spend",
+				}},
+			},
 			ResolveAccount: func(_ context.Context, ref adcp.AccountReference) (any, error) {
 				b.mu.RLock()
 				defer b.mu.RUnlock()
@@ -84,7 +414,7 @@ func main() {
 				if acct, ok := b.accounts[id]; ok {
 					return acct, nil
 				}
-				return nil, nil
+				return &adcp.AccountResult{AccountID: id, Brand: ref.Brand, Operator: ref.Operator, Action: "existing", Status: "active"}, nil
 			},
 			SyncAccounts: func(_ context.Context, input *adcp.SyncAccountsRequest) ([]adcp.AccountResult, error) {
 				b.mu.Lock()
@@ -117,31 +447,77 @@ func main() {
 				}
 				return results, nil
 			},
-			GetProducts: func(_ context.Context, _ any, _ *adcp.GetProductsRequest) (*adcp.ProductsData, error) {
-				// In production: query your inventory system
-				return &adcp.ProductsData{Products: products}, nil
+			GetProducts: func(_ context.Context, _ any, input *adcp.GetProductsRequest) (*adcp.ProductsData, error) {
+				b.mu.RLock()
+				defer b.mu.RUnlock()
+				products := make([]adcp.Product, 0, len(b.products))
+				for _, product := range b.products {
+					products = append(products, *product)
+				}
+				data := &adcp.ProductsData{Products: products}
+				if input.BuyingMode == "refine" && len(input.Refine) > 0 {
+					applied := make([]map[string]any, 0, len(input.Refine))
+					for _, ref := range input.Refine {
+						item := map[string]any{"scope": ref["scope"], "status": "applied"}
+						if productID, ok := ref["product_id"].(string); ok {
+							item["product_id"] = productID
+						}
+						applied = append(applied, item)
+					}
+					return &adcp.ProductsData{Products: products, RefinementApplied: applied}, nil
+				}
+				return data, nil
 			},
 			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
 				b.mu.Lock()
 				defer b.mu.Unlock()
+				if b.forced != nil {
+					forced := b.forced
+					b.forced = nil
+					return &adcp.MediaBuyData{Status: "submitted", Ext: map[string]any{"task_id": forced.TaskID, "message": forced.Message, "context": input.Context}}, nil
+				}
+				for _, p := range input.Packages {
+					if p.MeasurementTerms != nil && p.MeasurementTerms.BillingMeasurement != nil {
+						bm := p.MeasurementTerms.BillingMeasurement
+						if bm.MeasurementWindow != "c7" || bm.MaxVariancePercent < 5 {
+							return nil, adcp.NewError("TERMS_REJECTED", adcp.ErrorOptions{
+								Message:    "Measurement terms must use c7 with at least 5 percent variance.",
+								Recovery:   "revise",
+								Field:      "packages[0].measurement_terms",
+								Suggestion: "Use measurement_window c7 and max_variance_percent 10.",
+							})
+						}
+					}
+				}
 				// In production: book into your OMS / ad server
 				n := b.buySeq.Add(1)
 				id := fmt.Sprintf("mb-%d", n)
 				pkgs := make([]adcp.Package, 0, len(input.Packages))
+				hasCreatives := false
 				for i, p := range input.Packages {
+					if len(p.CreativeAssignments) > 0 {
+						hasCreatives = true
+					}
 					pkgs = append(pkgs, adcp.Package{
 						PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
 						PricingOptionID: p.PricingOptionID, Budget: p.Budget,
 						StartTime: p.StartTime, EndTime: p.EndTime,
 						AgencyEstimateNumber: p.AgencyEstimateNumber,
-						MeasurementTerms: p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
+						MeasurementTerms:     p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
+						TargetingOverlay:    p.TargetingOverlay,
+						CreativeAssignments: p.CreativeAssignments,
 					})
 				}
 				var totalBudget float64
 				for _, p := range input.Packages {
 					totalBudget += p.Budget
 				}
-				buy := &adcp.MediaBuyData{MediaBuyID: id, Status: "active", TotalBudget: totalBudget, Packages: pkgs}
+				status := "pending_creatives"
+				if hasCreatives {
+					status = "active"
+				}
+				now := time.Now().UTC().Format(time.RFC3339)
+				buy := &adcp.MediaBuyData{MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs, ConfirmedAt: now, CreatedAt: now, UpdatedAt: now, Revision: 1, Ext: mediaBuyExt(status)}
 				b.mediaBuys[id] = buy
 				for _, pkg := range pkgs {
 					b.delivery[pkg.PackageID] = &deliveryState{}
@@ -155,17 +531,32 @@ func main() {
 				if len(input.MediaBuyIDs) > 0 {
 					for _, id := range input.MediaBuyIDs {
 						if buy, ok := b.mediaBuys[id]; ok {
-							buys = append(buys, *buy)
+							item := *buy
+							item.Ext = mediaBuyExt(item.Status)
+							buys = append(buys, item)
 						}
 					}
 				} else {
 					for _, buy := range b.mediaBuys {
-						buys = append(buys, *buy)
+						item := *buy
+						item.Ext = mediaBuyExt(item.Status)
+						buys = append(buys, item)
 					}
 				}
 				return buys, nil
 			},
-			ListCreativeFormats: func(_ context.Context, _ *adcp.ListCreativeFormatsRequest) ([]adcp.CreativeFormat, error) {
+			ListCreativeFormats: func(_ context.Context, input *adcp.ListCreativeFormatsRequest) ([]adcp.CreativeFormat, error) {
+				if len(input.FormatIDs) > 0 {
+					filtered := make([]adcp.CreativeFormat, 0, len(input.FormatIDs))
+					for _, want := range input.FormatIDs {
+						for _, format := range formats {
+							if format.FormatID.AgentURL == want.AgentURL && format.FormatID.ID == want.ID {
+								filtered = append(filtered, format)
+							}
+						}
+					}
+					return filtered, nil
+				}
 				return formats, nil
 			},
 			SyncCreatives: func(_ context.Context, input *adcp.SyncCreativesRequest) ([]adcp.CreativeResult, error) {
@@ -178,8 +569,32 @@ func main() {
 					if _, exists := b.creatives[c.CreativeID]; exists {
 						action = "updated"
 					}
-					b.creatives[c.CreativeID] = "approved"
+					b.creatives[c.CreativeID] = &creativeRecord{ID: c.CreativeID, Name: c.Name, FormatID: c.FormatID, Status: "approved", Assets: c.Assets}
 					results = append(results, adcp.CreativeResult{CreativeID: c.CreativeID, Action: action, Status: "approved"})
+				}
+				for _, raw := range input.Assignments {
+					assign, ok := raw.(map[string]any)
+					if !ok {
+						continue
+					}
+					creativeID, _ := assign["creative_id"].(string)
+					packageID, _ := assign["package_id"].(string)
+					if creativeID == "" || packageID == "" {
+						continue
+					}
+					for _, buy := range b.mediaBuys {
+						for i := range buy.Packages {
+							if buy.Packages[i].PackageID == packageID {
+								buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, map[string]any{"creative_id": creativeID})
+								if buy.Status == "pending_creatives" {
+									buy.Status = "active"
+									buy.Ext = mediaBuyExt(buy.Status)
+									buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+									buy.Revision++
+								}
+							}
+						}
+					}
 				}
 				return results, nil
 			},
@@ -208,104 +623,153 @@ func main() {
 						if ds == nil {
 							ds = &deliveryState{}
 						}
-						pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{Impressions: float64(ds.Impressions), Clicks: float64(ds.Clicks), Spend: ds.Spend}})
+						pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{Impressions: float64(ds.Impressions), Clicks: float64(ds.Clicks), Spend: ds.Spend}, Spend: ds.Spend, PricingModel: "cpm", Rate: 10, Currency: "USD"})
 						totImps += ds.Impressions
 						totClicks += ds.Clicks
 						totSpend += ds.Spend
 					}
 					deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{Impressions: float64(totImps), Clicks: float64(totClicks), Spend: totSpend}, ByPackage: pkgDel})
 				}
-				return &adcp.DeliveryData{ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)}, MediaBuyDeliveries: deliveries}, nil
+				return &adcp.DeliveryData{ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)}, Currency: "USD", MediaBuyDeliveries: deliveries}, nil
 			},
 		})
 
+		adcp.AddTool(server, "update_media_buy", "Update a media buy",
+			func(ctx context.Context, req *mcp.CallToolRequest, input updateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+				return b.updateMediaBuy(input)
+			})
+
+		adcp.AddTool(server, "list_creatives", "List synced creatives",
+			func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativesRequest) (*mcp.CallToolResult, any, error) {
+				return b.listCreatives(input)
+			})
+
 		// Test controller — sandbox only. Do not register in production.
 		if os.Getenv("ADCP_SANDBOX") != "false" {
-		adcp.RegisterTestController(server, &adcp.TestControllerStore{
-			ForceAccountStatus: func(accountID, status string) (*adcp.StateTransition, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				acct, ok := b.accounts[accountID]
-				if !ok {
-					return nil, fmt.Errorf("NOT_FOUND")
-				}
-				prev := acct.Status
-				acct.Status = status
-				return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-			},
-			ForceMediaBuyStatus: func(mediaBuyID, status, reason string) (*adcp.StateTransition, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				buy, ok := b.mediaBuys[mediaBuyID]
-				if !ok {
-					return nil, fmt.Errorf("NOT_FOUND")
-				}
-				prev := buy.Status
-				if prev == "completed" || prev == "rejected" || prev == "canceled" {
-					return nil, fmt.Errorf("INVALID_TRANSITION")
-				}
-				buy.Status = status
-				return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-			},
-			ForceCreativeStatus: func(creativeID, status, reason string) (*adcp.StateTransition, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				prev, ok := b.creatives[creativeID]
-				if !ok {
-					return nil, fmt.Errorf("NOT_FOUND")
-				}
-				b.creatives[creativeID] = status
-				return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
-			},
-			SimulateDelivery: func(mediaBuyID string, p adcp.SimulateDeliveryParams) (*adcp.SimulationResult, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				buy, ok := b.mediaBuys[mediaBuyID]
-				if !ok {
-					return nil, fmt.Errorf("NOT_FOUND")
-				}
-				var spend float64
-				if p.ReportedSpend != nil {
-					spend = p.ReportedSpend.Amount
-				}
-				for _, pkg := range buy.Packages {
-					ds := b.delivery[pkg.PackageID]
-					if ds == nil {
-						ds = &deliveryState{}
-						b.delivery[pkg.PackageID] = ds
+			adcp.RegisterTestController(server, &adcp.TestControllerStore{
+				CustomScenarios: customScenarios,
+				ForceAccountStatus: func(accountID, status string) (*adcp.StateTransition, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
+					acct, ok := b.accounts[accountID]
+					if !ok {
+						return nil, fmt.Errorf("NOT_FOUND")
 					}
-					ds.Impressions += p.Impressions
-					ds.Clicks += p.Clicks
-					ds.Spend += spend
-				}
-				return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
-			},
-			SimulateBudgetSpend: func(p adcp.SimulateBudgetParams) (*adcp.SimulationResult, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
-				buy, ok := b.mediaBuys[p.MediaBuyID]
-				if !ok {
-					return nil, fmt.Errorf("NOT_FOUND")
-				}
-				var total float64
-				for _, pkg := range buy.Packages {
-					total += pkg.Budget
-				}
-				spend := total * p.SpendPercentage
-				for _, pkg := range buy.Packages {
-					if total == 0 {
-						continue
+					prev := acct.Status
+					acct.Status = status
+					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+				},
+				ForceMediaBuyStatus: func(mediaBuyID, status, reason string) (*adcp.StateTransition, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
+					buy, ok := b.mediaBuys[mediaBuyID]
+					if !ok {
+						return nil, fmt.Errorf("NOT_FOUND")
 					}
-					ds := b.delivery[pkg.PackageID]
-					if ds == nil {
-						ds = &deliveryState{}
-						b.delivery[pkg.PackageID] = ds
+					prev := buy.Status
+					if prev == "completed" || prev == "rejected" || prev == "canceled" {
+						return nil, fmt.Errorf("INVALID_TRANSITION")
 					}
-					ds.Spend += spend * (pkg.Budget / total)
-				}
-				return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"spend": spend, "percentage": p.SpendPercentage}}, nil
-			},
-		})
+					buy.Status = status
+					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+				},
+				ForceCreativeStatus: func(creativeID, status, reason string) (*adcp.StateTransition, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
+					creative, ok := b.creatives[creativeID]
+					if !ok {
+						return nil, fmt.Errorf("NOT_FOUND")
+					}
+					prev := creative.Status
+					creative.Status = status
+					return &adcp.StateTransition{Success: true, PreviousState: prev, CurrentState: status}, nil
+				},
+				SimulateDelivery: func(mediaBuyID string, p adcp.SimulateDeliveryParams) (*adcp.SimulationResult, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
+					buy, ok := b.mediaBuys[mediaBuyID]
+					if !ok {
+						return nil, fmt.Errorf("NOT_FOUND")
+					}
+					var spend float64
+					if p.ReportedSpend != nil {
+						spend = p.ReportedSpend.Amount
+					}
+					for _, pkg := range buy.Packages {
+						ds := b.delivery[pkg.PackageID]
+						if ds == nil {
+							ds = &deliveryState{}
+							b.delivery[pkg.PackageID] = ds
+						}
+						ds.Impressions += p.Impressions
+						ds.Clicks += p.Clicks
+						ds.Spend += spend
+					}
+					return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
+				},
+				SimulateBudgetSpend: func(p adcp.SimulateBudgetParams) (*adcp.SimulationResult, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
+					buy, ok := b.mediaBuys[p.MediaBuyID]
+					if !ok {
+						return nil, fmt.Errorf("NOT_FOUND")
+					}
+					var total float64
+					for _, pkg := range buy.Packages {
+						total += pkg.Budget
+					}
+					spend := total * p.SpendPercentage
+					for _, pkg := range buy.Packages {
+						if total == 0 {
+							continue
+						}
+						ds := b.delivery[pkg.PackageID]
+						if ds == nil {
+							ds = &deliveryState{}
+							b.delivery[pkg.PackageID] = ds
+						}
+						ds.Spend += spend * (pkg.Budget / total)
+					}
+					return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"spend": spend, "percentage": p.SpendPercentage}}, nil
+				},
+				CustomScenario: func(scenario string, params map[string]any) (any, error) {
+					switch scenario {
+					case "seed_product":
+						productID, _ := params["product_id"].(string)
+						if productID == "" {
+							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_product requires params.product_id"}
+						}
+						fixture, _ := params["fixture"].(map[string]any)
+						b.seedProduct(productID, fixture)
+						return map[string]any{"success": true, "message": "seeded"}, nil
+					case "seed_pricing_option":
+						productID, _ := params["product_id"].(string)
+						pricingOptionID, _ := params["pricing_option_id"].(string)
+						if productID == "" || pricingOptionID == "" {
+							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "seed_pricing_option requires params.product_id and params.pricing_option_id"}
+						}
+						fixture, _ := params["fixture"].(map[string]any)
+						b.seedPricingOption(productID, pricingOptionID, fixture)
+						return map[string]any{"success": true, "message": "seeded"}, nil
+					case "force_create_media_buy_arm":
+						arm, _ := params["arm"].(string)
+						if arm != "submitted" {
+							return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Scenario not supported: force_create_media_buy_arm"}
+						}
+						taskID, _ := params["task_id"].(string)
+						message, _ := params["message"].(string)
+						if taskID == "" {
+							return nil, &adcp.TestControllerError{Code: "INVALID_PARAMS", Message: "force_create_media_buy_arm requires params.task_id"}
+						}
+						b.mu.Lock()
+						b.forced = &forceArm{TaskID: taskID, Message: message}
+						b.mu.Unlock()
+						return map[string]any{"success": true, "forced": map[string]any{"arm": arm, "task_id": taskID, "message": message}}, nil
+					default:
+						return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Unrecognized scenario name"}
+					}
+				},
+			})
 		}
 
 		return server

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -105,11 +105,11 @@ func TestPendingCreativesToActive_ViaUpdateMediaBuy(t *testing.T) {
 	buy := mustCreateBuy(t, b, false)
 	pkgID := buy.Packages[0].PackageID
 
-	result, _, err := b.updateMediaBuy(updateMediaBuyInput{
+	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{
 		MediaBuyID: buy.MediaBuyID,
-		Packages: []packageUpdate{{
+		Packages: []adcp.PackageUpdate{{
 			PackageID:           pkgID,
-			CreativeAssignments: []map[string]any{{"creative_id": "cr-upd-1"}},
+			CreativeAssignments: []any{map[string]any{"creative_id": "cr-upd-1"}},
 		}},
 	})
 	if err != nil {
@@ -132,9 +132,9 @@ func TestCancellation(t *testing.T) {
 	buy := mustCreateBuy(t, b, false)
 	canceled := true
 
-	result, _, err := b.updateMediaBuy(updateMediaBuyInput{
+	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{
 		MediaBuyID:         buy.MediaBuyID,
-		Canceled:           &canceled,
+		Canceled:           canceled,
 		CancellationReason: "budget_cut",
 	})
 	if err != nil {
@@ -159,10 +159,10 @@ func TestDoubleCancellation(t *testing.T) {
 	canceled := true
 
 	// First cancel succeeds.
-	_, _, _ = b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
 
 	// Second cancel must return an error result (NOT_CANCELLABLE), not a hard error.
-	result, _, err := b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
 	if err != nil {
 		t.Fatalf("second cancel: unexpected hard error: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestForceMediaBuyStatus_TerminalStateBlocked(t *testing.T) {
 	b := newTestBackend()
 	buy := mustCreateBuy(t, b, false)
 	canceled := true
-	_, _, _ = b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
 
 	_, err := b.forceMediaBuyStatus(buy.MediaBuyID, "active", "")
 	if err == nil {

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -1,0 +1,491 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/adcontextprotocol/adcp-go/adcp"
+)
+
+func newTestBackend() *backend {
+	return &backend{
+		accounts:  make(map[string]*adcp.AccountResult),
+		products:  baseProducts(),
+		mediaBuys: make(map[string]*adcp.MediaBuyData),
+		creatives: make(map[string]*creativeRecord),
+		delivery:  make(map[string]*deliveryState),
+	}
+}
+
+func mustCreateBuy(t *testing.T, b *backend, withCreatives bool) *adcp.MediaBuyData {
+	t.Helper()
+	pkg := adcp.PackageInput{ProductID: "premium-display", PricingOptionID: "pd-cpm-15", Budget: 1000}
+	if withCreatives {
+		pkg.CreativeAssignments = []any{map[string]any{"creative_id": "cr-initial"}}
+	}
+	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+		Packages: []adcp.PackageInput{pkg},
+	})
+	if err != nil {
+		t.Fatalf("createMediaBuy: %v", err)
+	}
+	return buy
+}
+
+// --- create_media_buy ---
+
+func TestCreateMediaBuy_WithoutCreatives(t *testing.T) {
+	b := newTestBackend()
+	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+		Packages: []adcp.PackageInput{{ProductID: "premium-display", Budget: 500}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buy.Status != "pending_creatives" {
+		t.Errorf("want status pending_creatives, got %s", buy.Status)
+	}
+	if buy.MediaBuyID == "" {
+		t.Error("expected non-empty MediaBuyID")
+	}
+	if len(buy.Packages) != 1 {
+		t.Errorf("want 1 package, got %d", len(buy.Packages))
+	}
+}
+
+func TestCreateMediaBuy_WithCreatives(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, true)
+	if buy.Status != "active" {
+		t.Errorf("want status active when creatives supplied at create, got %s", buy.Status)
+	}
+}
+
+func TestCreateMediaBuy_IDsAreSequential(t *testing.T) {
+	b := newTestBackend()
+	a := mustCreateBuy(t, b, false)
+	c := mustCreateBuy(t, b, false)
+	if a.MediaBuyID == c.MediaBuyID {
+		t.Errorf("expected distinct IDs, both got %s", a.MediaBuyID)
+	}
+}
+
+// --- pending_creatives → active state transitions ---
+
+func TestPendingCreativesToActive_ViaSyncCreatives(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+	if buy.Status != "pending_creatives" {
+		t.Fatalf("pre-condition: want pending_creatives, got %s", buy.Status)
+	}
+	pkgID := buy.Packages[0].PackageID
+	revisionBefore := buy.Revision
+
+	_, err := b.syncCreatives(&adcp.SyncCreativesRequest{
+		Creatives: []adcp.CreativeInput{{CreativeID: "cr-sync-1", Name: "Banner"}},
+		Assignments: []any{map[string]any{
+			"creative_id": "cr-sync-1",
+			"package_id":  pkgID,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("syncCreatives: %v", err)
+	}
+
+	updated := b.mediaBuys[buy.MediaBuyID]
+	if updated.Status != "active" {
+		t.Errorf("want active after sync_creatives with assignment, got %s", updated.Status)
+	}
+	if updated.Revision <= revisionBefore {
+		t.Errorf("want revision to increment on status change, before=%d after=%d", revisionBefore, updated.Revision)
+	}
+}
+
+func TestPendingCreativesToActive_ViaUpdateMediaBuy(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+	pkgID := buy.Packages[0].PackageID
+
+	result, _, err := b.updateMediaBuy(updateMediaBuyInput{
+		MediaBuyID: buy.MediaBuyID,
+		Packages: []packageUpdate{{
+			PackageID:           pkgID,
+			CreativeAssignments: []map[string]any{{"creative_id": "cr-upd-1"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("updateMediaBuy: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("updateMediaBuy returned error result")
+	}
+
+	updated := b.mediaBuys[buy.MediaBuyID]
+	if updated.Status != "active" {
+		t.Errorf("want active after update_media_buy with creative assignment, got %s", updated.Status)
+	}
+}
+
+// --- cancellation ---
+
+func TestCancellation(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+	canceled := true
+
+	result, _, err := b.updateMediaBuy(updateMediaBuyInput{
+		MediaBuyID:         buy.MediaBuyID,
+		Canceled:           &canceled,
+		CancellationReason: "budget_cut",
+	})
+	if err != nil {
+		t.Fatalf("updateMediaBuy cancel: %v", err)
+	}
+	if result.IsError {
+		t.Fatal("cancel returned error result")
+	}
+
+	updated := b.mediaBuys[buy.MediaBuyID]
+	if updated.Status != "canceled" {
+		t.Errorf("want canceled, got %s", updated.Status)
+	}
+	if updated.Cancellation == nil {
+		t.Error("expected Cancellation metadata to be set")
+	}
+}
+
+func TestDoubleCancellation(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+	canceled := true
+
+	// First cancel succeeds.
+	_, _, _ = b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+
+	// Second cancel must return an error result (NOT_CANCELLABLE), not a hard error.
+	result, _, err := b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+	if err != nil {
+		t.Fatalf("second cancel: unexpected hard error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result on double-cancel")
+	}
+}
+
+// --- list_creatives filtering ---
+
+func TestListCreatives_FilterByCreativeID(t *testing.T) {
+	b := newTestBackend()
+	_, _ = b.syncCreatives(&adcp.SyncCreativesRequest{
+		Creatives: []adcp.CreativeInput{
+			{CreativeID: "cr-a", Name: "Alpha"},
+			{CreativeID: "cr-b", Name: "Beta"},
+		},
+	})
+
+	_, out, err := b.listCreatives(adcp.ListCreativesRequest{
+		Filters: &adcp.CreativeFilters{CreativeIDs: []string{"cr-a"}},
+	})
+	if err != nil {
+		t.Fatalf("listCreatives: %v", err)
+	}
+	m := out.(map[string]any)
+	items := m["creatives"].([]map[string]any)
+	if len(items) != 1 {
+		t.Fatalf("want 1 creative, got %d", len(items))
+	}
+	if items[0]["creative_id"] != "cr-a" {
+		t.Errorf("want cr-a, got %v", items[0]["creative_id"])
+	}
+}
+
+func TestListCreatives_FilterByFormatID(t *testing.T) {
+	b := newTestBackend()
+	fmtA := &adcp.FormatRef{AgentURL: "http://test", ID: "banner-300x250"}
+	fmtB := &adcp.FormatRef{AgentURL: "http://test", ID: "video-15s"}
+	_, _ = b.syncCreatives(&adcp.SyncCreativesRequest{
+		Creatives: []adcp.CreativeInput{
+			{CreativeID: "cr-fmt-a", FormatID: fmtA},
+			{CreativeID: "cr-fmt-b", FormatID: fmtB},
+		},
+	})
+
+	_, out, err := b.listCreatives(adcp.ListCreativesRequest{
+		Filters: &adcp.CreativeFilters{
+			FormatIDs: []adcp.FormatRef{{AgentURL: "http://test", ID: "banner-300x250"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("listCreatives by format: %v", err)
+	}
+	m := out.(map[string]any)
+	items := m["creatives"].([]map[string]any)
+	if len(items) != 1 {
+		t.Fatalf("want 1 creative filtered by format, got %d", len(items))
+	}
+	if items[0]["creative_id"] != "cr-fmt-a" {
+		t.Errorf("want cr-fmt-a, got %v", items[0]["creative_id"])
+	}
+}
+
+func TestListCreatives_NoFilter_ReturnsAll(t *testing.T) {
+	b := newTestBackend()
+	_, _ = b.syncCreatives(&adcp.SyncCreativesRequest{
+		Creatives: []adcp.CreativeInput{
+			{CreativeID: "cr-1"},
+			{CreativeID: "cr-2"},
+			{CreativeID: "cr-3"},
+		},
+	})
+
+	_, out, err := b.listCreatives(adcp.ListCreativesRequest{})
+	if err != nil {
+		t.Fatalf("listCreatives: %v", err)
+	}
+	m := out.(map[string]any)
+	items := m["creatives"].([]map[string]any)
+	if len(items) != 3 {
+		t.Errorf("want 3 creatives, got %d", len(items))
+	}
+}
+
+// --- delivery reporting ---
+
+func TestDeliveryReporting_SimulateDelivery(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, true)
+
+	_, err := b.simulateDelivery(buy.MediaBuyID, adcp.SimulateDeliveryParams{
+		Impressions:   1000,
+		Clicks:        50,
+		ReportedSpend: &adcp.ReportedSpend{Amount: 15.00, Currency: "USD"},
+	})
+	if err != nil {
+		t.Fatalf("simulateDelivery: %v", err)
+	}
+
+	data, err := b.getDelivery(&adcp.GetMediaBuyDeliveryRequest{
+		MediaBuyIDs: []string{buy.MediaBuyID},
+	})
+	if err != nil {
+		t.Fatalf("getDelivery: %v", err)
+	}
+	if len(data.MediaBuyDeliveries) != 1 {
+		t.Fatalf("want 1 delivery, got %d", len(data.MediaBuyDeliveries))
+	}
+	totals := data.MediaBuyDeliveries[0].Totals
+	if totals.Impressions != 1000 {
+		t.Errorf("want 1000 impressions, got %.0f", totals.Impressions)
+	}
+	if totals.Clicks != 50 {
+		t.Errorf("want 50 clicks, got %.0f", totals.Clicks)
+	}
+	if totals.Spend != 15.00 {
+		t.Errorf("want 15.00 spend, got %.2f", totals.Spend)
+	}
+}
+
+func TestDeliveryReporting_SimulateBudgetSpend(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, true)
+
+	_, err := b.simulateBudgetSpend(adcp.SimulateBudgetParams{
+		MediaBuyID:      buy.MediaBuyID,
+		SpendPercentage: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("simulateBudgetSpend: %v", err)
+	}
+
+	data, err := b.getDelivery(&adcp.GetMediaBuyDeliveryRequest{
+		MediaBuyIDs: []string{buy.MediaBuyID},
+	})
+	if err != nil {
+		t.Fatalf("getDelivery: %v", err)
+	}
+	totals := data.MediaBuyDeliveries[0].Totals
+	want := buy.TotalBudget * 0.5
+	if totals.Spend != want {
+		t.Errorf("want spend %.2f (50%% of budget %.2f), got %.2f", want, buy.TotalBudget, totals.Spend)
+	}
+}
+
+func TestDeliveryReporting_ZeroSpendInitially(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, true)
+
+	data, err := b.getDelivery(&adcp.GetMediaBuyDeliveryRequest{
+		MediaBuyIDs: []string{buy.MediaBuyID},
+	})
+	if err != nil {
+		t.Fatalf("getDelivery: %v", err)
+	}
+	totals := data.MediaBuyDeliveries[0].Totals
+	if totals.Spend != 0 || totals.Impressions != 0 {
+		t.Errorf("want zero delivery before simulation, got spend=%.2f impressions=%.0f", totals.Spend, totals.Impressions)
+	}
+}
+
+// --- comply_test_controller custom scenarios ---
+
+func TestCustomScenario_SeedProduct(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.handleCustomScenario("seed_product", map[string]any{
+		"product_id": "test-video-product",
+		"fixture": map[string]any{
+			"channels":      []any{"video"},
+			"delivery_type": "non_guaranteed",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed_product: %v", err)
+	}
+
+	b.mu.RLock()
+	p, ok := b.products["test-video-product"]
+	b.mu.RUnlock()
+	if !ok {
+		t.Fatal("expected seeded product in products map")
+	}
+	if p.DeliveryType != "non_guaranteed" {
+		t.Errorf("want delivery_type non_guaranteed, got %s", p.DeliveryType)
+	}
+}
+
+func TestCustomScenario_SeedProduct_MissingID(t *testing.T) {
+	b := newTestBackend()
+	_, err := b.handleCustomScenario("seed_product", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when product_id is missing")
+	}
+}
+
+func TestCustomScenario_SeedPricingOption(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.handleCustomScenario("seed_pricing_option", map[string]any{
+		"product_id":        "premium-display",
+		"pricing_option_id": "custom-cpm-5",
+		"fixture": map[string]any{
+			"pricing_model": "cpm",
+			"fixed_price":   5.0,
+			"currency":      "USD",
+		},
+	})
+	if err != nil {
+		t.Fatalf("seed_pricing_option: %v", err)
+	}
+
+	b.mu.RLock()
+	p := b.products["premium-display"]
+	b.mu.RUnlock()
+	found := false
+	for _, opt := range p.PricingOptions {
+		if opt.PricingOptionID == "custom-cpm-5" {
+			found = true
+			if opt.FixedPrice != 5.0 {
+				t.Errorf("want fixed_price 5.0, got %.2f", opt.FixedPrice)
+			}
+		}
+	}
+	if !found {
+		t.Error("seeded pricing option not found on product")
+	}
+}
+
+func TestCustomScenario_ForceCreateMediaBuyArm_Submitted(t *testing.T) {
+	b := newTestBackend()
+
+	_, err := b.handleCustomScenario("force_create_media_buy_arm", map[string]any{
+		"arm":     "submitted",
+		"task_id": "task-abc-123",
+		"message": "processing in async queue",
+	})
+	if err != nil {
+		t.Fatalf("force_create_media_buy_arm: %v", err)
+	}
+
+	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+		Packages: []adcp.PackageInput{{ProductID: "premium-display", Budget: 500}},
+	})
+	if err != nil {
+		t.Fatalf("createMediaBuy after forced arm: %v", err)
+	}
+	if buy.Status != "submitted" {
+		t.Errorf("want submitted status after forced arm, got %s", buy.Status)
+	}
+	ext, _ := buy.Ext.(map[string]any)
+	if ext["task_id"] != "task-abc-123" {
+		t.Errorf("want task_id task-abc-123 in Ext, got %v", ext["task_id"])
+	}
+
+	// Forced arm is consumed — next create should be normal.
+	next, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+		Packages: []adcp.PackageInput{{ProductID: "premium-display", Budget: 500}},
+	})
+	if err != nil {
+		t.Fatalf("createMediaBuy after arm consumed: %v", err)
+	}
+	if next.Status == "submitted" {
+		t.Error("forced arm should be consumed after first use")
+	}
+}
+
+func TestCustomScenario_ForceCreateMediaBuyArm_UnknownArm(t *testing.T) {
+	b := newTestBackend()
+	_, err := b.handleCustomScenario("force_create_media_buy_arm", map[string]any{
+		"arm": "rejected",
+	})
+	if err == nil {
+		t.Fatal("expected error for unsupported arm value")
+	}
+}
+
+func TestCustomScenario_Unknown(t *testing.T) {
+	b := newTestBackend()
+	_, err := b.handleCustomScenario("nonexistent_scenario", nil)
+	if err == nil {
+		t.Fatal("expected error for unknown scenario name")
+	}
+}
+
+// --- ForceMediaBuyStatus ---
+
+func TestForceMediaBuyStatus(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+
+	tr, err := b.forceMediaBuyStatus(buy.MediaBuyID, "paused", "")
+	if err != nil {
+		t.Fatalf("forceMediaBuyStatus: %v", err)
+	}
+	if !tr.Success {
+		t.Error("expected Success=true")
+	}
+	if tr.PreviousState != "pending_creatives" {
+		t.Errorf("want previous state pending_creatives, got %s", tr.PreviousState)
+	}
+	if tr.CurrentState != "paused" {
+		t.Errorf("want current state paused, got %s", tr.CurrentState)
+	}
+}
+
+func TestForceMediaBuyStatus_TerminalStateBlocked(t *testing.T) {
+	b := newTestBackend()
+	buy := mustCreateBuy(t, b, false)
+	canceled := true
+	_, _, _ = b.updateMediaBuy(updateMediaBuyInput{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
+
+	_, err := b.forceMediaBuyStatus(buy.MediaBuyID, "active", "")
+	if err == nil {
+		t.Error("expected error when forcing status on canceled buy")
+	}
+}
+
+func TestForceMediaBuyStatus_NotFound(t *testing.T) {
+	b := newTestBackend()
+	_, err := b.forceMediaBuyStatus("nonexistent-id", "active", "")
+	if err == nil {
+		t.Error("expected error for unknown media buy ID")
+	}
+}

--- a/scripts/ci/run_storyboard_reference_seller.sh
+++ b/scripts/ci/run_storyboard_reference_seller.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Run the Go reference seller through the AdCP media_buy_seller storyboard.
+#
+# Required runner input: set exactly one of these modes.
+#   ADCP_SDK_VERSION=7.11.0       Install published @adcp/sdk from npm.
+#   ADCP_SDK_TARBALL=/tmp/sdk.tgz Install a candidate @adcp/sdk tarball.
+#   ADCP_RUNNER_BIN=/path/to/adcp Use a preinstalled storyboard runner binary.
+#
+# Optional inputs:
+#   ADCP_PORT=3001
+#   STORYBOARD_RESULT_PATH=storyboard-result-go.json
+#   SELLER_LOG_PATH=/tmp/adcp-go-reference-seller.log
+#   ADCP_AGENT_URL=http://127.0.0.1:3001/mcp
+#
+# The script assumes it is running from an adcp-go checkout, boots the Go
+# reference seller, writes the storyboard JSON result, and exits non-zero unless
+# overall_status is "passing" and the test controller is detected.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+ADCP_PORT="${ADCP_PORT:-3001}"
+STORYBOARD_RESULT_PATH="${STORYBOARD_RESULT_PATH:-storyboard-result-go.json}"
+SELLER_LOG_PATH="${SELLER_LOG_PATH:-/tmp/adcp-go-reference-seller.log}"
+ADCP_AGENT_URL="${ADCP_AGENT_URL:-http://127.0.0.1:${ADCP_PORT}/mcp}"
+
+ADCP_RUNNER_BIN="${ADCP_RUNNER_BIN:-}"
+ADCP_SDK_VERSION="${ADCP_SDK_VERSION:-}"
+ADCP_SDK_TARBALL="${ADCP_SDK_TARBALL:-}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+runner_modes=0
+[[ -n "$ADCP_RUNNER_BIN" ]] && runner_modes=$((runner_modes + 1))
+[[ -n "$ADCP_SDK_TARBALL" ]] && runner_modes=$((runner_modes + 1))
+[[ -n "$ADCP_SDK_VERSION" ]] && runner_modes=$((runner_modes + 1))
+[[ "$runner_modes" -eq 1 ]] || fail "set exactly one of ADCP_RUNNER_BIN, ADCP_SDK_TARBALL, or ADCP_SDK_VERSION"
+
+install_or_select_runner() {
+  if [[ -n "$ADCP_RUNNER_BIN" ]]; then
+    command -v "$ADCP_RUNNER_BIN" >/dev/null 2>&1 || [[ -x "$ADCP_RUNNER_BIN" ]] || \
+      fail "ADCP_RUNNER_BIN is not executable or on PATH: $ADCP_RUNNER_BIN"
+    echo "Using preinstalled storyboard runner: $ADCP_RUNNER_BIN"
+  elif [[ -n "$ADCP_SDK_TARBALL" ]]; then
+    require_command npm
+    [[ -f "$ADCP_SDK_TARBALL" ]] || fail "ADCP_SDK_TARBALL not found: $ADCP_SDK_TARBALL"
+    echo "Installing candidate @adcp/sdk tarball: $ADCP_SDK_TARBALL"
+    npm install -g "$ADCP_SDK_TARBALL"
+    ADCP_RUNNER_BIN="adcp"
+  else
+    require_command npm
+    echo "Installing published @adcp/sdk@$ADCP_SDK_VERSION"
+    npm install -g "@adcp/sdk@$ADCP_SDK_VERSION"
+    ADCP_RUNNER_BIN="adcp"
+  fi
+
+  "$ADCP_RUNNER_BIN" --version
+}
+
+wait_for_seller() {
+  local pid="$1"
+  local url="http://127.0.0.1:${ADCP_PORT}/mcp"
+
+  for i in $(seq 1 60); do
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 1 "$url" 2>/dev/null) || http_code="000"
+    if [[ "$http_code" != "000" ]]; then
+      echo "Seller agent ready (HTTP ${http_code}, pid ${pid})"
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "Seller agent process died during startup"
+      tail -n 80 "$SELLER_LOG_PATH" 2>/dev/null || true
+      return 1
+    fi
+    if [[ "$i" -eq 60 ]]; then
+      echo "Seller agent failed to start within 30s"
+      tail -n 80 "$SELLER_LOG_PATH" 2>/dev/null || true
+      return 1
+    fi
+    sleep 0.5
+  done
+}
+
+assert_storyboard_passed() {
+  require_command python3
+  python3 - "$STORYBOARD_RESULT_PATH" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.exists() or path.stat().st_size == 0:
+    print(f"{path} missing or empty; runner produced no output")
+    sys.exit(1)
+
+with path.open() as f:
+    doc = json.load(f)
+
+if doc.get("overall_status") != "passing":
+    print(json.dumps(doc, indent=2))
+    sys.exit(1)
+
+if not doc.get("controller_detected"):
+    print("controller_detected was false; check reference seller test controller wiring")
+    sys.exit(1)
+
+summary = doc.get("summary") or {}
+print("Storyboard passing.")
+if summary:
+    print("summary:", json.dumps(summary, sort_keys=True))
+PY
+}
+
+cleanup() {
+  if [[ -n "${SELLER_PID:-}" ]]; then
+    kill "$SELLER_PID" 2>/dev/null || true
+    wait "$SELLER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+require_command go
+require_command curl
+install_or_select_runner
+
+mkdir -p "$(dirname "$STORYBOARD_RESULT_PATH")"
+echo "Starting Go reference seller on port $ADCP_PORT"
+(
+  cd reference/seller-agent
+  PORT="$ADCP_PORT" ADCP_AGENT_URL="$ADCP_AGENT_URL" \
+    go run ./cmd/seller-agent
+) >"$SELLER_LOG_PATH" 2>&1 &
+SELLER_PID=$!
+wait_for_seller "$SELLER_PID"
+
+echo "Running media_buy_seller storyboard"
+set +e
+"$ADCP_RUNNER_BIN" storyboard run \
+  "http://127.0.0.1:${ADCP_PORT}/mcp" media_buy_seller \
+  --json --allow-http \
+  >"$STORYBOARD_RESULT_PATH"
+RUNNER_STATUS=$?
+set -e
+
+if [[ "$RUNNER_STATUS" -ne 0 ]]; then
+  echo "Storyboard runner exited with status $RUNNER_STATUS"
+  [[ -s "$STORYBOARD_RESULT_PATH" ]] && cat "$STORYBOARD_RESULT_PATH"
+  exit "$RUNNER_STATUS"
+fi
+
+assert_storyboard_passed


### PR DESCRIPTION
## Summary

Adds a Go-owned CI harness for the reference seller storyboard and hardens the Go reference seller enough for `media_buy_seller` compliance.

Key changes:
- Add `scripts/ci/run_storyboard_reference_seller.sh`, supporting `ADCP_RUNNER_BIN`, `ADCP_SDK_TARBALL`, or pinned `ADCP_SDK_VERSION` runner modes.
- Add a blocking `Reference Seller Storyboard` CI job using `@adcp/sdk@7.11.0`, plus seller-agent test/lint coverage in CI.
- Expand the Go reference seller with storyboard fixtures, `update_media_buy`, `list_creatives`, creative assignment flows, cancellation metadata, delivery reporting, and protocol-shaped request handling.
- Fill Go SDK helper gaps needed by the seller harness, including idempotency capability metadata, context echoing, delivery zero-spend schema output, creative filters, submitted create response support, and seller-owned media-buy metadata flattening.
- Clean up the existing Go lint baseline so full repo `golangci-lint run ./...` passes.

Closes #137.

## Validation

- `golangci-lint run ./...`
- `go test ./...`
- `cd adcp && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `cd adcp/schemas && python3 lint.py --strict`
- `ADCP_RUNNER_BIN=adcp ADCP_PORT=3010 STORYBOARD_RESULT_PATH=.context/storyboard-go-ultimate.json SELLER_LOG_PATH=.context/storyboard-go-ultimate.log ./scripts/ci/run_storyboard_reference_seller.sh`

Storyboard result: `59/59` steps passing with `@adcp/sdk@7.11.0`.

## Follow-up Notes

This gets the blocking harness in place, but the exercise exposed follow-up work worth tracking separately:
- Improve typed Go SDK ergonomics for async create responses, update-media-buy responses, and seller-owned media-buy metadata instead of leaning on `Ext` flattening.
- Add focused tests for `reference/seller-agent`; today that module's `go test` is mostly a compile check and storyboard is the real behavioral test.
- Decide how custom compliance-controller scenarios should be exposed in protocol capabilities or an extension field; current schema only permits the six standard scenario enum values.
