### PR TITLE
feat(adcp)!: type media-buy seller follow-ups

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,36 @@
 # Migrating adcp-go
 
+## Next: typed seller media-buy helpers
+
+This release tightens the Go seller SDK around AdCP 3.0.12 media-buy shapes.
+Most wire payloads are unchanged, but several public Go structs are more typed.
+
+- `UpdateMediaBuyRequest.Canceled` and `PackageUpdate.Canceled` are `*bool`.
+  Use nil when the field is absent and `adcp.Bool(true)` when requesting
+  cancellation. The AdCP schema constrains `canceled` to true; do not send
+  `adcp.Bool(false)` to mean resume. Use `Paused: adcp.Bool(false)` for resume.
+- `CreativeAssignments` is now `[]adcp.CreativeAssignment`. Use
+  `adcp.Float64(0)` for an explicit paused creative weight; omitted weight
+  still means equal rotation. Seller-specific assignment fields round-trip via
+  `CreativeAssignment.Extra`.
+- `SyncCreativesRequest.Assignments` is now `[]adcp.SyncCreativeAssignment`.
+- `Config.CreateMediaBuy` now returns `adcp.CreateMediaBuyResult`, which is
+  implemented by the generated schema variants. Return
+  `*adcp.CreateMediaBuySuccess` for synchronous success,
+  `*adcp.CreateMediaBuySubmitted` for async submission, or
+  `*adcp.CreateMediaBuyError` when building the schema error branch directly.
+- `CreateMediaBuySubmitted` carries async `task_id` / `message` fields:
+  `return &adcp.CreateMediaBuySubmitted{Status: "submitted", TaskID: taskID, Message: msg}, nil`.
+- `MediaBuyData` is now scoped to `get_media_buys` items. It carries fields such
+  as `currency`, `total_budget`, `start_time`, `end_time`, `history`, and
+  `valid_actions`, but not create-task fields like `task_id` / `message`.
+- `MediaBuyData.Packages` is `[]adcp.PackageStatus` so `get_media_buys` can
+  include creative approvals, pending formats, and delivery snapshots.
+  `CreateMediaBuySuccess.Packages` remains `[]adcp.Package`.
+- `PackageDelivery` is flat. Read package-level delivery metrics directly from
+  `PackageDelivery.Impressions`, `Spend`, and `Clicks`; `Spend` remains present
+  on the wire even when zero.
+
 ## v3.0.0-rc.4 (governance / policy framework)
 
 rc.4 lands the AdCP governance plan schema with breaking changes. If you

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ adcp.AddTool(server, "tool_name", "Description",
 |---------|------|
 | `adcp.CapabilitiesResponse(data)` | `get_adcp_capabilities` |
 | `adcp.ProductsResponse(data)` | `get_products` |
-| `adcp.MediaBuyResponse(data)` | `create_media_buy` |
+| `adcp.MediaBuyResponse(*CreateMediaBuySuccess\|*CreateMediaBuyError\|*CreateMediaBuySubmitted)` | `create_media_buy` |
+| `adcp.CreateMediaBuySuccessResponse(data)` | synchronous `create_media_buy` |
+| `adcp.CreateMediaBuyErrorResponse(data)` | schema error branch for `create_media_buy` |
+| `adcp.CreateMediaBuySubmittedResponse(taskID, message)` | async `create_media_buy` |
 | `adcp.MediaBuysResponse(buys, sandbox)` | `get_media_buys` |
+| `adcp.MediaBuysDataResponse(data)` | `get_media_buys` with pagination/errors |
 | `adcp.DeliveryResponse(data)` | `get_media_buy_delivery` |
 | `adcp.SyncAccountsResponse(accounts, sandbox)` | `sync_accounts` |
 | `adcp.GovernanceResponse(accounts)` | `sync_governance` |
@@ -106,6 +110,15 @@ adcp.AddTool(server, "tool_name", "Description",
 - [`adcp/types_gen.go`](adcp/types_gen.go) — types generated from [AdCP schemas](https://github.com/adcontextprotocol/adcp) v3.0.0-rc.4 (latest dev snapshot)
 - [`adcp/governance_types.go`](adcp/governance_types.go) — hand-written `Plan` and related governance types (inline in sync_plans)
 - [`adcp/plan_validate.go`](adcp/plan_validate.go) — client-side enforcement of the budget `oneOf` and Annex III `if/then` invariants
+
+Media-buy seller helpers use the schema variants directly:
+`*CreateMediaBuySuccess`, `*CreateMediaBuyError`, or `*CreateMediaBuySubmitted`
+for `create_media_buy`, and `MediaBuyData` for items returned by
+`get_media_buys`. `MediaBuyData.Packages` is `[]PackageStatus`; create success
+packages remain `[]Package`.
+Use `adcp.Bool(true)` for optional boolean updates and `adcp.Float64(0)` when a
+creative assignment weight of zero is intentional. `CreativeAssignment.Extra`
+preserves seller-specific assignment fields allowed by the schema.
 
 ## Request signing (AdCP 3.0 optional, 4.0 required)
 

--- a/adcp/addtool.go
+++ b/adcp/addtool.go
@@ -18,14 +18,14 @@ import (
 //
 // Usage:
 //
-//	type GetProductsInput struct {
+//	type GetProductsRequest struct {
 //	    Brief   string `json:"brief,omitempty"`
 //	    Account any    `json:"account,omitempty"`
 //	}
 //
 //	adcp.AddTool(server, "get_products", "Returns available products",
-//	    func(ctx context.Context, req *mcp.CallToolRequest, input GetProductsInput) (*mcp.CallToolResult, any, error) {
-//	        return adcp.ProductsResult(&adcp.ProductsData{Products: products, Sandbox: true})
+//	    func(ctx context.Context, req *mcp.CallToolRequest, input GetProductsRequest) (*mcp.CallToolResult, any, error) {
+//	        return adcp.ProductsResponse(&adcp.ProductsData{Products: products, Sandbox: true})
 //	    })
 func AddTool[In any](server *mcp.Server, name, description string, handler func(ctx context.Context, req *mcp.CallToolRequest, input In) (*mcp.CallToolResult, any, error)) {
 	schema := permissiveSchemaFor[In]()

--- a/adcp/inputs.go
+++ b/adcp/inputs.go
@@ -1,5 +1,7 @@
 package adcp
 
+import "encoding/json"
+
 // Request types for AdCP tools are generated from JSON schemas in types_gen.go
 // (e.g., GetProductsRequest, CreateMediaBuyRequest, SyncAccountsRequest).
 //
@@ -9,6 +11,106 @@ package adcp
 
 // EmptyInput is the input type for tools that accept no parameters (e.g. get_adcp_capabilities).
 type EmptyInput struct{}
+
+// Bool returns a pointer to v for optional boolean request fields.
+func Bool(v bool) *bool {
+	return &v
+}
+
+// Float64 returns a pointer to v for optional numeric fields where zero is meaningful.
+func Float64(v float64) *float64 {
+	return &v
+}
+
+// CreativeAssignment assigns an existing creative to a package.
+type CreativeAssignment struct {
+	CreativeID   string         `json:"creative_id"`
+	Weight       *float64       `json:"weight,omitempty"`
+	PlacementIDs []string       `json:"placement_ids,omitempty"`
+	Extra        map[string]any `json:"-"`
+}
+
+// SyncCreativeAssignment assigns a synced creative to an existing package.
+type SyncCreativeAssignment struct {
+	CreativeID   string   `json:"creative_id"`
+	PackageID    string   `json:"package_id"`
+	Weight       *float64 `json:"weight,omitempty"`
+	PlacementIDs []string `json:"placement_ids,omitempty"`
+}
+
+// MarshalJSON preserves schema-allowed vendor fields while keeping typed fields
+// authoritative when keys collide.
+func (a CreativeAssignment) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(a.Extra)+3)
+	for k, v := range a.Extra {
+		if isCreativeAssignmentField(k) {
+			continue
+		}
+		out[k] = v
+	}
+	out["creative_id"] = a.CreativeID
+	if a.Weight != nil {
+		out["weight"] = *a.Weight
+	}
+	if len(a.PlacementIDs) > 0 {
+		out["placement_ids"] = a.PlacementIDs
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON captures schema-allowed vendor fields so agents can round-trip
+// platform-specific assignment metadata.
+func (a *CreativeAssignment) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw == nil {
+		return nil
+	}
+	if v, ok := raw["creative_id"]; ok {
+		if err := json.Unmarshal(v, &a.CreativeID); err != nil {
+			return err
+		}
+		delete(raw, "creative_id")
+	}
+	if v, ok := raw["weight"]; ok {
+		var weight float64
+		if err := json.Unmarshal(v, &weight); err != nil {
+			return err
+		}
+		a.Weight = &weight
+		delete(raw, "weight")
+	}
+	if v, ok := raw["placement_ids"]; ok {
+		if err := json.Unmarshal(v, &a.PlacementIDs); err != nil {
+			return err
+		}
+		delete(raw, "placement_ids")
+	}
+	if len(raw) == 0 {
+		a.Extra = nil
+		return nil
+	}
+	a.Extra = make(map[string]any, len(raw))
+	for k, v := range raw {
+		var value any
+		if err := json.Unmarshal(v, &value); err != nil {
+			return err
+		}
+		a.Extra[k] = value
+	}
+	return nil
+}
+
+func isCreativeAssignmentField(key string) bool {
+	switch key {
+	case "creative_id", "weight", "placement_ids":
+		return true
+	default:
+		return false
+	}
+}
 
 // PackageInput is a single package in a create_media_buy request.
 type PackageInput struct {
@@ -22,7 +124,7 @@ type PackageInput struct {
 	MeasurementTerms     *MeasurementTerms     `json:"measurement_terms,omitempty"`
 	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"`
 	TargetingOverlay     *Targeting            `json:"targeting_overlay,omitempty"`
-	CreativeAssignments  []any                 `json:"creative_assignments,omitempty"`
+	CreativeAssignments  []CreativeAssignment  `json:"creative_assignments,omitempty"`
 
 	// Broadcast / scheduling
 	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"`
@@ -38,7 +140,7 @@ type UpdateMediaBuyRequest struct {
 	MediaBuyID             string           `json:"media_buy_id"`
 	Revision               int              `json:"revision,omitempty"`
 	Paused                 *bool            `json:"paused,omitempty"`
-	Canceled               bool             `json:"canceled,omitempty"`
+	Canceled               *bool            `json:"canceled,omitempty"`
 	CancellationReason     string           `json:"cancellation_reason,omitempty"`
 	StartTime              any              `json:"start_time,omitempty"`
 	EndTime                string           `json:"end_time,omitempty"`
@@ -53,17 +155,17 @@ type UpdateMediaBuyRequest struct {
 
 // PackageUpdate identifies a package and fields to update in update_media_buy.
 type PackageUpdate struct {
-	PackageID           string     `json:"package_id"`
-	Budget              float64    `json:"budget,omitempty"`
-	BidPrice            float64    `json:"bid_price,omitempty"`
-	Impressions         float64    `json:"impressions,omitempty"`
-	StartTime           string     `json:"start_time,omitempty"`
-	EndTime             string     `json:"end_time,omitempty"`
-	Paused              *bool      `json:"paused,omitempty"`
-	Canceled            bool       `json:"canceled,omitempty"`
-	CancellationReason  string     `json:"cancellation_reason,omitempty"`
-	TargetingOverlay    *Targeting `json:"targeting_overlay,omitempty"`
-	CreativeAssignments []any      `json:"creative_assignments,omitempty"`
+	PackageID           string               `json:"package_id"`
+	Budget              float64              `json:"budget,omitempty"`
+	BidPrice            float64              `json:"bid_price,omitempty"`
+	Impressions         float64              `json:"impressions,omitempty"`
+	StartTime           string               `json:"start_time,omitempty"`
+	EndTime             string               `json:"end_time,omitempty"`
+	Paused              *bool                `json:"paused,omitempty"`
+	Canceled            *bool                `json:"canceled,omitempty"`
+	CancellationReason  string               `json:"cancellation_reason,omitempty"`
+	TargetingOverlay    *Targeting           `json:"targeting_overlay,omitempty"`
+	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"`
 }
 
 // --- Nested item types (inline objects in schemas, no $ref) ---

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -1,0 +1,49 @@
+package adcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreativeAssignmentWeightZeroAndExtraRoundTrip(t *testing.T) {
+	in := []byte(`{"creative_id":"cr-1","weight":0,"placement_ids":["hero"],"vendor_hint":"x"}`)
+
+	var assignment CreativeAssignment
+	require.NoError(t, json.Unmarshal(in, &assignment))
+	require.NotNil(t, assignment.Weight)
+	assert.Equal(t, float64(0), *assignment.Weight)
+	assert.Equal(t, map[string]any{"vendor_hint": "x"}, assignment.Extra)
+
+	out, err := json.Marshal(assignment)
+	require.NoError(t, err)
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, "cr-1", wire["creative_id"])
+	assert.Equal(t, float64(0), wire["weight"])
+	assert.Equal(t, []any{"hero"}, wire["placement_ids"])
+	assert.Equal(t, "x", wire["vendor_hint"])
+}
+
+func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {
+	out, err := json.Marshal(CreativeAssignment{
+		CreativeID: "cr-typed",
+		Weight:     Float64(0),
+		Extra: map[string]any{
+			"creative_id":   "cr-extra",
+			"weight":        99,
+			"placement_ids": []string{"extra"},
+			"vendor_hint":   "x",
+		},
+	})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, "cr-typed", wire["creative_id"])
+	assert.Equal(t, float64(0), wire["weight"])
+	assert.NotContains(t, wire, "placement_ids")
+	assert.Equal(t, "x", wire["vendor_hint"])
+}

--- a/adcp/responses.go
+++ b/adcp/responses.go
@@ -20,29 +20,107 @@ func ProductsResponse(data *ProductsData) (*mcp.CallToolResult, any, error) {
 	return buildResult(fmt.Sprintf("Found %d products", len(data.Products)), data), data, nil
 }
 
+// CreateMediaBuyResult is implemented by generated create_media_buy response variants.
+type CreateMediaBuyResult interface {
+	createMediaBuyResult()
+}
+
+func (*CreateMediaBuySuccess) createMediaBuyResult()   {}
+func (*CreateMediaBuyError) createMediaBuyResult()     {}
+func (*CreateMediaBuySubmitted) createMediaBuyResult() {}
+
 // MediaBuyResponse builds a create_media_buy response.
-func MediaBuyResponse(data *MediaBuyData) (*mcp.CallToolResult, any, error) {
-	if data.Status == "submitted" {
-		out := map[string]any{"status": "submitted"}
-		if ext, ok := data.Ext.(map[string]any); ok {
-			for k, v := range ext {
-				out[k] = v
-			}
-		}
-		return buildResult("Media buy submitted", out), out, nil
+func MediaBuyResponse(data CreateMediaBuyResult) (*mcp.CallToolResult, any, error) {
+	if data == nil {
+		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "media buy response is required"})
 	}
-	out := flattenExt(data)
-	return buildResult(fmt.Sprintf("Media buy %s created", data.MediaBuyID), out), out, nil
+
+	switch v := data.(type) {
+	case *CreateMediaBuySuccess:
+		return createMediaBuySuccessResponse(v)
+	case *CreateMediaBuyError:
+		return createMediaBuyErrorResponse(v)
+	case *CreateMediaBuySubmitted:
+		return createMediaBuySubmittedResponse(v)
+	default:
+		return Errorf("INVALID_REQUEST", ErrorOptions{
+			Message:    "create_media_buy response must be a generated create_media_buy response variant",
+			Suggestion: "Return adcp.CreateMediaBuySuccess, adcp.CreateMediaBuyError, or adcp.CreateMediaBuySubmitted from Config.CreateMediaBuy.",
+		})
+	}
+}
+
+func createMediaBuySuccessResponse(data *CreateMediaBuySuccess) (*mcp.CallToolResult, any, error) {
+	if data == nil {
+		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "create media buy success response is required"})
+	}
+	return buildResult(fmt.Sprintf("Media buy %s created", data.MediaBuyID), data), data, nil
+}
+
+func createMediaBuyErrorResponse(data *CreateMediaBuyError) (*mcp.CallToolResult, any, error) {
+	if data == nil {
+		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "create media buy error response is required"})
+	}
+	result := buildResult("Media buy creation failed", data)
+	result.IsError = true
+	return result, data, nil
+}
+
+func createMediaBuySubmittedResponse(data *CreateMediaBuySubmitted) (*mcp.CallToolResult, any, error) {
+	if data == nil {
+		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "create media buy submitted response is required"})
+	}
+	if data.Status == "" {
+		data.Status = "submitted"
+	}
+	if data.Status != "submitted" {
+		return Errorf("INVALID_FIELD", ErrorOptions{
+			Message: "submitted media buy response status must be submitted",
+			Field:   "status",
+		})
+	}
+	if data.TaskID == "" {
+		return Errorf("MISSING_FIELD", ErrorOptions{
+			Message:    "submitted media buy response requires task_id",
+			Field:      "task_id",
+			Suggestion: "Set CreateMediaBuySubmitted.TaskID or use CreateMediaBuySubmittedResponse.",
+		})
+	}
+	return buildResult("Media buy submitted", data), data, nil
+}
+
+// CreateMediaBuySuccessResponse builds a synchronous create_media_buy success response.
+func CreateMediaBuySuccessResponse(data *CreateMediaBuySuccess) (*mcp.CallToolResult, any, error) {
+	return MediaBuyResponse(data)
+}
+
+// CreateMediaBuyErrorResponse builds a create_media_buy schema error-branch response.
+func CreateMediaBuyErrorResponse(data *CreateMediaBuyError) (*mcp.CallToolResult, any, error) {
+	return MediaBuyResponse(data)
+}
+
+// CreateMediaBuySubmittedResponse builds an async create_media_buy submitted response.
+func CreateMediaBuySubmittedResponse(taskID, message string) (*mcp.CallToolResult, any, error) {
+	return MediaBuyResponse(&CreateMediaBuySubmitted{Status: "submitted", TaskID: taskID, Message: message})
 }
 
 // MediaBuysResponse builds a get_media_buys response.
 func MediaBuysResponse(mediaBuys []MediaBuyData, sandbox bool) (*mcp.CallToolResult, any, error) {
-	items := make([]any, 0, len(mediaBuys))
-	for _, buy := range mediaBuys {
-		items = append(items, flattenExt(buy))
+	if mediaBuys == nil {
+		mediaBuys = []MediaBuyData{}
 	}
-	out := map[string]any{"media_buys": items, "sandbox": sandbox}
-	return buildResult(fmt.Sprintf("Found %d media buys", len(mediaBuys)), out), out, nil
+	return MediaBuysDataResponse(&GetMediaBuysResponse{MediaBuys: mediaBuys, Sandbox: Bool(sandbox)})
+}
+
+// MediaBuysDataResponse builds a get_media_buys response with the full envelope.
+func MediaBuysDataResponse(data *GetMediaBuysResponse) (*mcp.CallToolResult, any, error) {
+	if data == nil {
+		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "media buys response is required"})
+	}
+	if data.MediaBuys == nil {
+		data.MediaBuys = []MediaBuyData{}
+	}
+	return buildResult(fmt.Sprintf("Found %d media buys", len(data.MediaBuys)), data), data, nil
 }
 
 // DeliveryResponse builds a get_media_buy_delivery response.
@@ -240,20 +318,4 @@ func attachContext(result *mcp.CallToolResult, context any) *mcp.CallToolResult 
 	obj["context"] = context
 	result.StructuredContent = obj
 	return result
-}
-
-func flattenExt(v any) any {
-	item, ok := jsonRoundTrip(v).(map[string]any)
-	if !ok {
-		return v
-	}
-	ext, ok := item["ext"].(map[string]any)
-	if !ok {
-		return item
-	}
-	for k, val := range ext {
-		item[k] = val
-	}
-	delete(item, "ext")
-	return item
 }

--- a/adcp/responses_test.go
+++ b/adcp/responses_test.go
@@ -1,0 +1,143 @@
+package adcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMediaBuyResponseUsesCreateSuccessFields(t *testing.T) {
+	result, out, err := MediaBuyResponse(&CreateMediaBuySuccess{
+		MediaBuyID:      "mb-1",
+		Status:          "active",
+		Packages:        []Package{{PackageID: "pkg-1"}},
+		ValidActions:    []string{"pause", "cancel"},
+		PlannedDelivery: map[string]any{"impressions": 1000},
+		Ext:             map[string]any{"status": "wrong"},
+	})
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "active", wire["status"])
+	assert.Equal(t, []any{"pause", "cancel"}, wire["valid_actions"])
+	assert.Equal(t, map[string]any{"impressions": float64(1000)}, wire["planned_delivery"])
+	assert.Equal(t, map[string]any{"status": "wrong"}, wire["ext"])
+	assert.IsType(t, &CreateMediaBuySuccess{}, out)
+}
+
+func TestMediaBuyResponseSubmittedUsesTypedTaskFields(t *testing.T) {
+	result, out, err := MediaBuyResponse(&CreateMediaBuySubmitted{
+		Status:  "submitted",
+		TaskID:  "task-1",
+		Message: "queued",
+	})
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "submitted", wire["status"])
+	assert.Equal(t, "task-1", wire["task_id"])
+	assert.Equal(t, "queued", wire["message"])
+	assert.NotContains(t, wire, "media_buy_id")
+	assert.IsType(t, &CreateMediaBuySubmitted{}, out)
+}
+
+func TestMediaBuyResponseSubmittedRequiresTaskID(t *testing.T) {
+	result, out, err := MediaBuyResponse(&CreateMediaBuySubmitted{Status: "submitted"})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Nil(t, out)
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	errObj, ok := wire["adcp_error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "MISSING_FIELD", errObj["code"])
+	assert.Equal(t, "task_id", errObj["field"])
+}
+
+func TestMediaBuyResponsePreservesEmptyValidActions(t *testing.T) {
+	result, _, err := MediaBuysDataResponse(&GetMediaBuysResponse{
+		MediaBuys: []MediaBuyData{{
+			MediaBuyID:   "mb-1",
+			Status:       "canceled",
+			Currency:     "USD",
+			TotalBudget:  100,
+			Packages:     []PackageStatus{{Package: Package{PackageID: "pkg-1"}}},
+			ValidActions: []string{},
+		}},
+	})
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	buys, ok := wire["media_buys"].([]any)
+	require.True(t, ok)
+	require.Len(t, buys, 1)
+	buy, ok := buys[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{}, buy["valid_actions"])
+}
+
+func TestMediaBuysResponseNilListEmitsEmptyArray(t *testing.T) {
+	result, _, err := MediaBuysResponse(nil, true)
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	buys, ok := wire["media_buys"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, buys)
+	assert.Equal(t, true, wire["sandbox"])
+}
+
+func TestMediaBuysDataResponseIncludesPackageStatusFields(t *testing.T) {
+	result, _, err := MediaBuysDataResponse(&GetMediaBuysResponse{
+		MediaBuys: []MediaBuyData{{
+			MediaBuyID:  "mb-1",
+			Status:      "active",
+			Currency:    "USD",
+			TotalBudget: 100,
+			Packages: []PackageStatus{{
+				Package: Package{
+					PackageID:           "pkg-1",
+					PricingOptionID:     "po-1",
+					CreativeAssignments: []CreativeAssignment{{CreativeID: "cr-hidden"}},
+				},
+				CreativeApprovals: []PackageCreativeApproval{{
+					CreativeID:     "cr-1",
+					ApprovalStatus: "approved",
+				}},
+				FormatIDsPending: []FormatRef{{AgentURL: "https://seller.example", ID: "display"}},
+				Snapshot: &PackageSnapshot{
+					AsOf:             "2026-05-25T12:00:00Z",
+					StalenessSeconds: 30,
+					Impressions:      1000,
+					Spend:            12.5,
+					Currency:         "USD",
+				},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	buys, ok := wire["media_buys"].([]any)
+	require.True(t, ok)
+	require.Len(t, buys, 1)
+	buy, ok := buys[0].(map[string]any)
+	require.True(t, ok)
+	packages, ok := buy["packages"].([]any)
+	require.True(t, ok)
+	require.Len(t, packages, 1)
+	pkg, ok := packages[0].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, pkg, "creative_approvals")
+	assert.Contains(t, pkg, "format_ids_pending")
+	assert.Contains(t, pkg, "snapshot")
+	assert.NotContains(t, pkg, "pricing_option_id")
+	assert.NotContains(t, pkg, "creative_assignments")
+}

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -31,7 +31,9 @@ KNOWN_TYPES = {
     'CapabilitiesData', 'ADCPVersion', 'BrandReference', 'AccountReference',
     'AccountResult', 'AccountSetup', 'GovernanceResult', 'GovernanceAccount',
     'GovernanceAgent', 'ProductsData',
-    'MediaBuyListItem', 'DeliveryData', 'ReportingPeriod', 'MediaBuyDelivery',
+    'MediaBuyListItem', 'MediaBuyData', 'MediaBuyHistoryEntry',
+    'PackageStatus', 'PackageCreativeApproval', 'PackageSnapshot',
+    'DeliveryData', 'ReportingPeriod', 'MediaBuyDelivery',
     'PackageDelivery',
     'Render', 'AssetSlot', 'CreativeResult', 'CreativeListItem', 'PreviewResult',
     'Preview', 'PreviewRender', 'BuildCreativeResult', 'SignalID',
@@ -43,7 +45,8 @@ KNOWN_TYPES = {
     # From inputs.go (hand-written types that need custom Go code)
     'EmptyInput', 'PackageInput',
     'AccountInput', 'GovernanceAccountInput',
-    'CreativeInput', 'CatalogInput', 'EventSourceInput', 'DestinationInput',
+    'CreativeInput', 'SyncCreativeAssignment',
+    'CatalogInput', 'EventSourceInput', 'DestinationInput',
     'CreativeFilters', 'SignalFilters',
     # From errors.go
     'Error', 'ErrorOptions',
@@ -67,7 +70,7 @@ KNOWN_TYPES = {
     'ListCollectionListsResponse',
     # New core types (from types.go)
     'Duration', 'CancellationPolicy', 'CancellationFee',
-    'CollectionListRef', 'CreativeConsumption', 'IndustryIdentifier',
+    'CollectionListRef', 'CreativeAssignment', 'CreativeConsumption', 'IndustryIdentifier',
     'MeasurementTerms', 'BillingMeasurement', 'MakegoodPolicy',
     'MeasurementWindow', 'PerformanceStandard', 'VendorPricingOption',
     # Hand-written in types.go; listed here so $ref resolution uses the typed name.
@@ -252,6 +255,7 @@ INLINE_TYPE_HINTS = {
     ('SyncAccountsRequest', 'accounts'): 'AccountInput',
     ('SyncGovernanceRequest', 'accounts'): 'GovernanceAccountInput',
     ('SyncCreativesRequest', 'creatives'): 'CreativeInput',
+    ('SyncCreativesRequest', 'assignments'): 'SyncCreativeAssignment',
     ('ListCreativesRequest', 'filters'): 'CreativeFilters',
     ('SyncCatalogsRequest', 'catalogs'): 'CatalogInput',
     ('SyncEventSourcesRequest', 'event_sources'): 'EventSourceInput',
@@ -263,6 +267,7 @@ INLINE_TYPE_HINTS = {
     # Render/AssetSlot so reference-agent code can keep using typed literals.
     ('CreativeFormat', 'renders'): 'Render',
     ('CreativeFormat', 'assets'): 'AssetSlot',
+    ('GetMediaBuysResponse', 'media_buys'): 'MediaBuyData',
 }
 
 # Enum schemas
@@ -271,7 +276,7 @@ ENUM_DIR = "enums"
 def safe_comment(text, max_len=80):
     """Sanitize text for embedding in a Go // comment. Strips newlines to
     prevent code injection via schema descriptions."""
-    return text.replace('\n', ' ').replace('\r', '')[:max_len] if text else ''
+    return text.replace('\n', ' ').replace('\r', '')[:max_len].rstrip() if text else ''
 
 def load_schema(path):
     """Load a JSON schema file, preserving property order."""

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -76,7 +76,9 @@ EXEMPT = {
     'AccountResult', 'AccountSetup', 'CreativeResult', 'CatalogResult',
     'EventSourceResult', 'LogEventResult', 'GovernanceResult',
     'GovernanceAccount', 'GovernanceAgent', 'CreativeListItem',
-    'MediaBuyListItem', 'PackageDelivery', 'DeliveryTotals', 'DeliveryData',
+    'MediaBuyListItem', 'MediaBuyData', 'MediaBuyHistoryEntry',
+    'PackageStatus', 'PackageCreativeApproval', 'PackageSnapshot',
+    'SyncCreativeAssignment', 'PackageDelivery', 'DeliveryTotals', 'DeliveryData',
     'MediaBuyDelivery', 'ReportingPeriod', 'PreviewResult', 'Preview',
     'PreviewRender', 'BuildCreativeResult', 'ProductsData',
     # capability blocks — generator doesn't own these yet
@@ -120,7 +122,7 @@ EXEMPT = {
 EXPLICIT_SCHEMA = {
     'Product': 'core/product.json',
     'Package': 'core/package.json',
-    'MediaBuyData': 'core/media-buy.json',
+    'CreativeAssignment': 'core/creative-assignment.json',
     'Targeting': 'core/targeting.json',
     'FormatRef': 'core/format-id.json',
     'PricingOption': 'core/pricing-option.json',
@@ -180,6 +182,8 @@ def parse_go_structs():
             body = m.group(2)
             fields = []
             for fm in FIELD_LINE_RE.finditer(body):
+                if fm.group(3) == '-':
+                    continue
                 fields.append((
                     fm.group(1),
                     fm.group(2).strip(),

--- a/adcp/seller.go
+++ b/adcp/seller.go
@@ -32,7 +32,7 @@ import (
 //	    GetProducts: func(ctx context.Context, acct any, req *adcp.GetProductsRequest) (*adcp.ProductsData, error) {
 //	        return &adcp.ProductsData{Products: catalog.Query(req.Brief)}, nil
 //	    },
-//	    CreateMediaBuy: func(ctx context.Context, acct any, req *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
+//	    CreateMediaBuy: func(ctx context.Context, acct any, req *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
 //	        return oms.BookCampaign(req)
 //	    },
 //	})
@@ -120,12 +120,20 @@ func Register(server *mcp.Server, cfg Config) {
 				if result != nil {
 					return result, nil, nil
 				}
-				buys, err := cfg.GetMediaBuys(ctx, acct, &input)
+				data, err := cfg.GetMediaBuys(ctx, acct, &input)
 				if err != nil {
 					result, out, e := errorToResult(err)
 					return attachContext(result, input.Context), out, e
 				}
-				result, out, err := MediaBuysResponse(buys, sandbox)
+				if data == nil {
+					result, out, e := errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					return attachContext(result, input.Context), out, e
+				}
+				if data.Sandbox == nil {
+					data.Sandbox = Bool(sandbox)
+				}
+				data.Context = input.Context
+				result, out, err := MediaBuysDataResponse(data)
 				return attachContext(result, input.Context), out, err
 			})
 	}
@@ -183,9 +191,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input GetSignalsRequest) (*mcp.CallToolResult, any, error) {
 				signals, err := cfg.GetSignals(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return SignalsResponse(signals, sandbox)
+				result, out, err := SignalsResponse(signals, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -194,9 +204,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input ActivateSignalRequest) (*mcp.CallToolResult, any, error) {
 				deployments, err := cfg.ActivateSignal(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return ActivateSignalResponse(deployments, sandbox)
+				result, out, err := ActivateSignalResponse(deployments, sandbox)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -207,12 +219,15 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input CreateCollectionListRequest) (*mcp.CallToolResult, any, error) {
 				result, err := cfg.CreateCollectionList(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
 				if result == nil || result.List == nil {
-					return errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					result, out, e := errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					return attachContext(result, input.Context), out, e
 				}
-				return CreateCollectionListResponse(result.List, result.AuthToken)
+				callResult, out, err := CreateCollectionListResponse(result.List, result.AuthToken)
+				return attachContext(callResult, input.Context), out, err
 			})
 	}
 
@@ -221,12 +236,15 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input GetCollectionListRequest) (*mcp.CallToolResult, any, error) {
 				result, err := cfg.GetCollectionList(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
 				if result == nil || result.List == nil {
-					return errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					result, out, e := errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					return attachContext(result, input.Context), out, e
 				}
-				return GetCollectionListResponse(result.List, result.Collections, result.Pagination)
+				callResult, out, err := GetCollectionListResponse(result.List, result.Collections, result.Pagination)
+				return attachContext(callResult, input.Context), out, err
 			})
 	}
 
@@ -235,12 +253,15 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input UpdateCollectionListRequest) (*mcp.CallToolResult, any, error) {
 				list, err := cfg.UpdateCollectionList(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
 				if list == nil {
-					return errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					result, out, e := errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					return attachContext(result, input.Context), out, e
 				}
-				return UpdateCollectionListResponse(list)
+				result, out, err := UpdateCollectionListResponse(list)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -249,9 +270,11 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input DeleteCollectionListRequest) (*mcp.CallToolResult, any, error) {
 				err := cfg.DeleteCollectionList(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
-				return DeleteCollectionListResponse(input.ListID)
+				result, out, err := DeleteCollectionListResponse(input.ListID)
+				return attachContext(result, input.Context), out, err
 			})
 	}
 
@@ -260,12 +283,15 @@ func Register(server *mcp.Server, cfg Config) {
 			func(ctx context.Context, req *mcp.CallToolRequest, input ListCollectionListsRequest) (*mcp.CallToolResult, any, error) {
 				result, err := cfg.ListCollectionLists(ctx, &input)
 				if err != nil {
-					return errorToResult(err)
+					result, out, e := errorToResult(err)
+					return attachContext(result, input.Context), out, e
 				}
 				if result == nil {
-					return errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					result, out, e := errorToResult(NewError("INTERNAL_ERROR", ErrorOptions{Message: "handler returned nil result"}))
+					return attachContext(result, input.Context), out, e
 				}
-				return ListCollectionListsResponse(result.Lists, result.Pagination)
+				callResult, out, err := ListCollectionListsResponse(result.Lists, result.Pagination)
+				return attachContext(callResult, input.Context), out, err
 			})
 	}
 }
@@ -301,8 +327,8 @@ type Config struct {
 	SyncAccounts   func(ctx context.Context, req *SyncAccountsRequest) ([]AccountResult, error)
 	SyncGovernance func(ctx context.Context, req *SyncGovernanceRequest) ([]GovernanceResult, error)
 	GetProducts    func(ctx context.Context, acct any, req *GetProductsRequest) (*ProductsData, error)
-	CreateMediaBuy func(ctx context.Context, acct any, req *CreateMediaBuyRequest) (*MediaBuyData, error)
-	GetMediaBuys   func(ctx context.Context, acct any, req *GetMediaBuysRequest) ([]MediaBuyData, error)
+	CreateMediaBuy func(ctx context.Context, acct any, req *CreateMediaBuyRequest) (CreateMediaBuyResult, error)
+	GetMediaBuys   func(ctx context.Context, acct any, req *GetMediaBuysRequest) (*GetMediaBuysResponse, error)
 	GetDelivery    func(ctx context.Context, acct any, req *GetMediaBuyDeliveryRequest) (*DeliveryData, error)
 
 	// --- Creative ---

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -430,6 +430,144 @@ type MediaBuyListItem struct {
 	Packages   []Package `json:"packages"`
 }
 
+// MediaBuyData is one item in a get_media_buys response.
+type MediaBuyData struct {
+	MediaBuyID       string                 `json:"media_buy_id"`
+	Account          *Account               `json:"account,omitempty"`
+	Status           string                 `json:"status"`
+	Currency         string                 `json:"currency"`
+	TotalBudget      float64                `json:"total_budget"`
+	StartTime        string                 `json:"start_time,omitempty"`
+	EndTime          string                 `json:"end_time,omitempty"`
+	InvoiceRecipient any                    `json:"invoice_recipient,omitempty"`
+	ConfirmedAt      string                 `json:"confirmed_at,omitempty"`
+	Cancellation     any                    `json:"cancellation,omitempty"`
+	CreativeDeadline string                 `json:"creative_deadline,omitempty"`
+	Revision         int                    `json:"revision,omitempty"`
+	CreatedAt        string                 `json:"created_at,omitempty"`
+	UpdatedAt        string                 `json:"updated_at,omitempty"`
+	ValidActions     []string               `json:"valid_actions,omitempty"`
+	History          []MediaBuyHistoryEntry `json:"history,omitempty"`
+	Packages         []PackageStatus        `json:"packages"`
+	Ext              any                    `json:"ext,omitempty"`
+}
+
+// MarshalJSON preserves an explicitly empty valid_actions array. In the protocol,
+// [] means no actions are available; omission means the seller did not say.
+func (d MediaBuyData) MarshalJSON() ([]byte, error) {
+	type mediaBuyData MediaBuyData
+	b, err := json.Marshal(mediaBuyData(d))
+	if err != nil {
+		return nil, err
+	}
+	if d.ValidActions == nil {
+		return b, nil
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	out["valid_actions"] = d.ValidActions
+	return json.Marshal(out)
+}
+
+// MediaBuyHistoryEntry is a get_media_buys revision history entry.
+type MediaBuyHistoryEntry struct {
+	Revision  int    `json:"revision"`
+	Timestamp string `json:"timestamp"`
+	Actor     string `json:"actor,omitempty"`
+	Action    string `json:"action"`
+	Summary   string `json:"summary,omitempty"`
+	PackageID string `json:"package_id,omitempty"`
+	Ext       any    `json:"ext,omitempty"`
+}
+
+// PackageStatus is a package row in get_media_buys. It embeds Package for
+// ergonomic construction from create/update state, but marshals only the fields
+// modeled by the get_media_buys response schema.
+type PackageStatus struct {
+	Package
+	Currency                  string                    `json:"currency,omitempty"`
+	CreativeApprovals         []PackageCreativeApproval `json:"creative_approvals,omitempty"`
+	FormatIDsPending          []FormatRef               `json:"format_ids_pending,omitempty"`
+	SnapshotUnavailableReason string                    `json:"snapshot_unavailable_reason,omitempty"`
+	Snapshot                  *PackageSnapshot          `json:"snapshot,omitempty"`
+}
+
+func (p PackageStatus) MarshalJSON() ([]byte, error) {
+	out := map[string]any{"package_id": p.PackageID}
+	if p.ProductID != "" {
+		out["product_id"] = p.ProductID
+	}
+	if p.Budget != 0 {
+		out["budget"] = p.Budget
+	}
+	if p.BidPrice != 0 {
+		out["bid_price"] = p.BidPrice
+	}
+	if p.Impressions != 0 {
+		out["impressions"] = p.Impressions
+	}
+	if p.Currency != "" {
+		out["currency"] = p.Currency
+	}
+	if p.StartTime != "" {
+		out["start_time"] = p.StartTime
+	}
+	if p.EndTime != "" {
+		out["end_time"] = p.EndTime
+	}
+	if p.Paused != nil {
+		out["paused"] = p.Paused
+	}
+	if p.Canceled != nil {
+		out["canceled"] = p.Canceled
+	}
+	if p.Cancellation != nil {
+		out["cancellation"] = p.Cancellation
+	}
+	if p.CreativeDeadline != "" {
+		out["creative_deadline"] = p.CreativeDeadline
+	}
+	if p.TargetingOverlay != nil {
+		out["targeting_overlay"] = p.TargetingOverlay
+	}
+	if p.Ext != nil {
+		out["ext"] = p.Ext
+	}
+	if len(p.CreativeApprovals) > 0 {
+		out["creative_approvals"] = p.CreativeApprovals
+	}
+	if len(p.FormatIDsPending) > 0 {
+		out["format_ids_pending"] = p.FormatIDsPending
+	}
+	if p.SnapshotUnavailableReason != "" {
+		out["snapshot_unavailable_reason"] = p.SnapshotUnavailableReason
+	}
+	if p.Snapshot != nil {
+		out["snapshot"] = p.Snapshot
+	}
+	return json.Marshal(out)
+}
+
+type PackageCreativeApproval struct {
+	CreativeID      string `json:"creative_id"`
+	ApprovalStatus  string `json:"approval_status"`
+	RejectionReason string `json:"rejection_reason,omitempty"`
+}
+
+type PackageSnapshot struct {
+	AsOf             string  `json:"as_of"`
+	StalenessSeconds int     `json:"staleness_seconds"`
+	Impressions      float64 `json:"impressions"`
+	Spend            float64 `json:"spend"`
+	Currency         string  `json:"currency,omitempty"`
+	Clicks           float64 `json:"clicks,omitempty"`
+	PacingIndex      float64 `json:"pacing_index,omitempty"`
+	DeliveryStatus   string  `json:"delivery_status,omitempty"`
+	Ext              any     `json:"ext,omitempty"`
+}
+
 type DeliveryData struct {
 	ReportingPeriod    ReportingPeriod    `json:"reporting_period"`
 	Currency           string             `json:"currency"`
@@ -450,12 +588,14 @@ type MediaBuyDelivery struct {
 }
 
 type PackageDelivery struct {
-	PackageID    string         `json:"package_id"`
-	Totals       DeliveryTotals `json:"totals"`
-	Spend        float64        `json:"spend"`
-	PricingModel string         `json:"pricing_model,omitempty"`
-	Rate         float64        `json:"rate,omitempty"`
-	Currency     string         `json:"currency,omitempty"`
+	PackageID   string  `json:"package_id"`
+	Impressions float64 `json:"impressions,omitempty"`
+	// package-delivery composes delivery-metrics and requires spend at this level.
+	Spend        float64 `json:"spend"`
+	Clicks       float64 `json:"clicks,omitempty"`
+	PricingModel string  `json:"pricing_model,omitempty"`
+	Rate         float64 `json:"rate,omitempty"`
+	Currency     string  `json:"currency,omitempty"`
 }
 
 // MarshalJSON preserves the schema-required spend field even when it is zero.

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -225,7 +225,7 @@ const (
 	AudioChannelLayout71 AudioChannelLayout = "7.1"
 )
 
-// AuthScheme — Legacy authentication schemes for the webhook auth block. Bearer: token sent in 
+// AuthScheme — Legacy authentication schemes for the webhook auth block. Bearer: token sent in
 type AuthScheme = string
 const (
 	AuthSchemeBearer AuthScheme = "Bearer"
@@ -304,7 +304,7 @@ const (
 	CatalogActionDeleted CatalogAction = "deleted"
 )
 
-// CatalogItemStatus — Approval status of an individual item within a synced catalog. Platforms review 
+// CatalogItemStatus — Approval status of an individual item within a synced catalog. Platforms review
 type CatalogItemStatus = string
 const (
 	CatalogItemStatusApproved CatalogItemStatus = "approved"
@@ -392,7 +392,7 @@ const (
 	CollectionKindRotation CollectionKind = "rotation"
 )
 
-// CollectionRelationship — How two collections are related. References are scoped to the same get_products 
+// CollectionRelationship — How two collections are related. References are scoped to the same get_products
 type CollectionRelationship = string
 const (
 	CollectionRelationshipSpinoff CollectionRelationship = "spinoff"
@@ -411,7 +411,7 @@ const (
 	CollectionStatusUpcoming CollectionStatus = "upcoming"
 )
 
-// ConsentBasis — Common GDPR lawful bases relevant to advertising. Covers the Article 6(1) bases 
+// ConsentBasis — Common GDPR lawful bases relevant to advertising. Covers the Article 6(1) bases
 type ConsentBasis = string
 const (
 	ConsentBasisConsent ConsentBasis = "consent"
@@ -481,7 +481,7 @@ const (
 	CreativeApprovalStatusRejected CreativeApprovalStatus = "rejected"
 )
 
-// CreativeIdentifierType — Industry-standard identifier types for advertising creatives. These identifiers 
+// CreativeIdentifierType — Industry-standard identifier types for advertising creatives. These identifiers
 type CreativeIdentifierType = string
 const (
 	CreativeIdentifierTypeAdID CreativeIdentifierType = "ad_id"
@@ -806,7 +806,7 @@ const (
 	ExclusivityExclusive Exclusivity = "exclusive"
 )
 
-// FeatureCheckStatus — Per-feature evaluation outcome in content standards checks. For the two-outcome 
+// FeatureCheckStatus — Per-feature evaluation outcome in content standards checks. For the two-outcome
 type FeatureCheckStatus = string
 const (
 	FeatureCheckStatusPassed FeatureCheckStatus = "passed"
@@ -815,7 +815,7 @@ const (
 	FeatureCheckStatusUnevaluated FeatureCheckStatus = "unevaluated"
 )
 
-// FeedFormat — Catalog feed formats. Determines how the platform parses items from an external 
+// FeedFormat — Catalog feed formats. Determines how the platform parses items from an external
 type FeedFormat = string
 const (
 	FeedFormatGoogleMerchantCenter FeedFormat = "google_merchant_center"
@@ -876,7 +876,7 @@ const (
 	ForecastableMetricPlays ForecastableMetric = "plays"
 )
 
-// FormatIDParameter — Types of parameters that template formats accept in format_id objects to create 
+// FormatIDParameter — Types of parameters that template formats accept in format_id objects to create
 type FormatIDParameter = string
 const (
 	FormatIDParameterDimensions FormatIDParameter = "dimensions"
@@ -1225,7 +1225,7 @@ const (
 	ProductionQualityUgc ProductionQuality = "ugc"
 )
 
-// PropertyType — Types of addressable advertising properties with verifiable ownership. Property 
+// PropertyType — Types of addressable advertising properties with verifiable ownership. Property
 type PropertyType = string
 const (
 	PropertyTypeWebsite PropertyType = "website"
@@ -1266,7 +1266,7 @@ const (
 	PurchaseTypeCreativeServices PurchaseType = "creative_services"
 )
 
-// ReachUnit — Unit of measurement for reach and audience size metrics. Different channels and 
+// ReachUnit — Unit of measurement for reach and audience size metrics. Different channels and
 type ReachUnit = string
 const (
 	ReachUnitIndividuals ReachUnit = "individuals"
@@ -1285,7 +1285,7 @@ const (
 	ReportingFrequencyMonthly ReportingFrequency = "monthly"
 )
 
-// ResponseType — What the publisher wants back from a TMP context match. Determines the richness 
+// ResponseType — What the publisher wants back from a TMP context match. Determines the richness
 type ResponseType = string
 const (
 	ResponseTypeActivation ResponseType = "activation"
@@ -1294,7 +1294,7 @@ const (
 	ResponseTypeDeal ResponseType = "deal"
 )
 
-// RestrictedAttribute — Personal data categories that may be restricted from use in audience targeting. 
+// RestrictedAttribute — Personal data categories that may be restricted from use in audience targeting.
 type RestrictedAttribute = string
 const (
 	RestrictedAttributeRacialEthnicOrigin RestrictedAttribute = "racial_ethnic_origin"
@@ -1371,7 +1371,7 @@ const (
 	SignalCatalogTypeOwned SignalCatalogType = "owned"
 )
 
-// SignalSource — Source type for signal identifiers. Determines how the signal is referenced and 
+// SignalSource — Source type for signal identifiers. Determines how the signal is referenced and
 type SignalSource = string
 const (
 	SignalSourceCatalog SignalSource = "catalog"
@@ -1539,7 +1539,7 @@ const (
 	TravelTimeUnitHr TravelTimeUnit = "hr"
 )
 
-// UIDType — Type of user identifier. Used in audience sync, event logging, and TMP identity 
+// UIDType — Type of user identifier. Used in audience sync, event logging, and TMP identity
 type UIDType = string
 const (
 	UIDTypeRampid UIDType = "rampid"
@@ -1737,8 +1737,8 @@ const (
 type PolicyEntry struct {
 	PolicyID string `json:"policy_id"` // Unique identifier for this policy. Registry-published ids are canonical (e.g., "
 	Source string `json:"source,omitempty"` // Origin of this policy. 'registry' = published to the shared AdCP policy registry
-	Version string `json:"version,omitempty"` // Semver version string (e.g., "1.0.0"). Incremented when policy content changes. 
-	Name string `json:"name,omitempty"` // Human-readable name (e.g., "UK HFSS Restrictions"). Optional for inline bespoke 
+	Version string `json:"version,omitempty"` // Semver version string (e.g., "1.0.0"). Incremented when policy content changes.
+	Name string `json:"name,omitempty"` // Human-readable name (e.g., "UK HFSS Restrictions"). Optional for inline bespoke
 	Description string `json:"description,omitempty"` // Brief summary of what this policy covers.
 	Category string `json:"category,omitempty"` // The nature of the obligation: regulation (legal requirement) or standard (best p
 	Enforcement string `json:"enforcement"` // How governance agents treat violations. Regulations are typically "must"; standa
@@ -1749,7 +1749,7 @@ type PolicyEntry struct {
 	Channels []string `json:"channels,omitempty"` // Advertising channels this policy applies to. If omitted or null, the policy appl
 	GovernanceDomains []string `json:"governance_domains,omitempty"` // Governance sub-domains this policy applies to. Determines which types of governa
 	EffectiveDate string `json:"effective_date,omitempty"` // ISO 8601 date when the regulation or standard takes effect. Before this date, go
-	SunsetDate string `json:"sunset_date,omitempty"` // ISO 8601 date when the regulation or standard is no longer enforced. After this 
+	SunsetDate string `json:"sunset_date,omitempty"` // ISO 8601 date when the regulation or standard is no longer enforced. After this
 	SourceURL string `json:"source_url,omitempty"` // Link to the source regulation, standard, or legislation.
 	SourceName string `json:"source_name,omitempty"` // Name of the issuing body (e.g., "UK Food Standards Agency", "US Federal Trade Co
 	Policy string `json:"policy"` // Natural language policy text describing what is required, prohibited, or recomme
@@ -1758,23 +1758,23 @@ type PolicyEntry struct {
 	Ext any `json:"ext,omitempty"`
 }
 
-// PolicyCategoryDefinition — Definition of a policy category in the registry. Policy categories group related regulatory regimes 
+// PolicyCategoryDefinition — Definition of a policy category in the registry. Policy categories group related regulatory regimes
 type PolicyCategoryDefinition struct {
 	CategoryID string `json:"category_id"` // Unique identifier for this category. Used in plan.policy_categories, signal-defi
 	Name string `json:"name"` // Human-readable name (e.g., 'Children-Directed Content').
 	Description string `json:"description"` // What this category covers. Defines the boundary — what campaigns or data fall un
 	RegulatoryFrameworks []any `json:"regulatory_frameworks,omitempty"` // Key regulations and standards grouped under this category. Governance agents use
 	RestrictedAttributes []string `json:"restricted_attributes,omitempty"` // Restricted attribute categories that regulations in this category prohibit for t
-	RequiresHumanReview *bool `json:"requires_human_review,omitempty"` // When true, any plan declaring this category MUST set plan.human_review_required 
+	RequiresHumanReview *bool `json:"requires_human_review,omitempty"` // When true, any plan declaring this category MUST set plan.human_review_required
 	Industries []string `json:"industries,omitempty"` // Industries where this category commonly applies (e.g., 'pharmaceutical' for age_
 	Guidance string `json:"guidance,omitempty"` // Implementation notes for governance agents. Edge cases, disambiguation, and comm
 	RelatedCategories []string `json:"related_categories,omitempty"` // Categories that frequently co-occur (e.g., 'children_directed' often appears wit
 }
 
-// AudienceConstraints — Buyer-defined audience targeting constraints for a campaign plan. Specifies who the campaign should 
+// AudienceConstraints — Buyer-defined audience targeting constraints for a campaign plan. Specifies who the campaign should
 type AudienceConstraints struct {
-	Include []any `json:"include,omitempty"` // Desired audience criteria. The seller's targeting should align with these. Each 
-	Exclude []any `json:"exclude,omitempty"` // Excluded audience criteria. The seller's targeting must not overlap with these. 
+	Include []any `json:"include,omitempty"` // Desired audience criteria. The seller's targeting should align with these. Each
+	Exclude []any `json:"exclude,omitempty"` // Excluded audience criteria. The seller's targeting must not overlap with these.
 }
 
 // Product — Represents available advertising inventory
@@ -1798,7 +1798,7 @@ type Product struct {
 	ReportingCapabilities any `json:"reporting_capabilities"`
 	CreativePolicy any `json:"creative_policy,omitempty"`
 	IsCustom *bool `json:"is_custom,omitempty"` // Whether this is a custom product
-	PropertyTargetingAllowed *bool `json:"property_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its publisher_properties. 
+	PropertyTargetingAllowed *bool `json:"property_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its publisher_properties.
 	DataProviderSignals []any `json:"data_provider_signals,omitempty"` // Data provider signals available for this product. Buyers fetch signal definition
 	SignalTargetingAllowed *bool `json:"signal_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its data_provider_signals.
 	CatalogTypes []string `json:"catalog_types,omitempty"` // Catalog types this product supports for catalog-driven campaigns. A sponsored pr
@@ -1813,9 +1813,9 @@ type Product struct {
 	ProductCardDetailed any `json:"product_card_detailed,omitempty"` // Optional detailed card with carousel and full specifications. Provides rich prod
 	Collections []any `json:"collections,omitempty"` // Collections available in this product. Each entry references collections declare
 	CollectionTargetingAllowed *bool `json:"collection_targeting_allowed,omitempty"` // Whether buyers can target a subset of this product's collections. When false (de
-	Installments []any `json:"installments,omitempty"` // Specific installments included in this product. Each installment references its 
+	Installments []any `json:"installments,omitempty"` // Specific installments included in this product. Each installment references its
 	EnforcedPolicies []string `json:"enforced_policies,omitempty"` // Registry policy IDs the seller enforces for this product. Enforcement level come
-	TrustedMatch any `json:"trusted_match,omitempty"` // Trusted Match Protocol capabilities for this product. When present, the product 
+	TrustedMatch any `json:"trusted_match,omitempty"` // Trusted Match Protocol capabilities for this product. When present, the product
 	MaterialSubmission any `json:"material_submission,omitempty"` // Instructions for submitting physical creative materials (print, static OOH, cine
 	Ext any `json:"ext,omitempty"`
 }
@@ -1835,7 +1835,7 @@ type Package struct {
 	TargetingOverlay *Targeting `json:"targeting_overlay,omitempty"`
 	MeasurementTerms *MeasurementTerms `json:"measurement_terms,omitempty"` // Agreed billing measurement and makegood terms for this package. Reflects what wa
 	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"` // Agreed performance standards for this package. When any entry specifies a vendor
-	CreativeAssignments []any `json:"creative_assignments,omitempty"` // Creative assets assigned to this package
+	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"` // Creative assets assigned to this package
 	FormatIDsToProvide []FormatRef `json:"format_ids_to_provide,omitempty"` // Format IDs that creative assets will be provided for this package
 	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
 	StartTime string `json:"start_time,omitempty"` // Flight start date/time for this package in ISO 8601 format. When omitted, the pa
@@ -1849,24 +1849,6 @@ type Package struct {
 	Ext any `json:"ext,omitempty"`
 }
 
-// MediaBuyData — Represents a purchased advertising campaign
-type MediaBuyData struct {
-	MediaBuyID string `json:"media_buy_id"` // Seller's unique identifier for the media buy
-	Account *Account `json:"account,omitempty"` // Account billed for this media buy
-	Status string `json:"status"`
-	RejectionReason string `json:"rejection_reason,omitempty"` // Reason provided by the seller when status is 'rejected'. Present only when statu
-	ConfirmedAt string `json:"confirmed_at,omitempty"` // ISO 8601 timestamp when the seller confirmed this media buy. A successful create
-	Cancellation any `json:"cancellation,omitempty"` // Cancellation metadata. Present only when status is 'canceled'.
-	TotalBudget float64 `json:"total_budget"` // Total budget amount
-	Packages []Package `json:"packages"` // Array of packages within this media buy
-	InvoiceRecipient any `json:"invoice_recipient,omitempty"` // Per-buy override for who receives the invoice. When provided, the seller invoice
-	CreativeDeadline string `json:"creative_deadline,omitempty"` // ISO 8601 timestamp for creative upload deadline
-	Revision int `json:"revision,omitempty"` // Monotonically increasing revision number. Incremented on every state change or u
-	CreatedAt string `json:"created_at,omitempty"` // Creation timestamp
-	UpdatedAt string `json:"updated_at,omitempty"` // Last update timestamp
-	Ext any `json:"ext,omitempty"`
-}
-
 // CreativeFormat — Represents a creative format with its requirements
 type CreativeFormat struct {
 	FormatID FormatRef `json:"format_id"` // This format's own identifier — a structured object {agent_url, id}, not a string
@@ -1874,7 +1856,7 @@ type CreativeFormat struct {
 	Description string `json:"description,omitempty"` // Plain text explanation of what this format does and what assets it requires
 	ExampleURL string `json:"example_url,omitempty"` // Optional URL to showcase page with examples and interactive demos of this format
 	AcceptsParameters []string `json:"accepts_parameters,omitempty"` // List of parameters this format accepts in format_id. Template formats define whi
-	Renders []Render `json:"renders,omitempty"` // Specification of rendered pieces for this format. Most formats produce a single 
+	Renders []Render `json:"renders,omitempty"` // Specification of rendered pieces for this format. Most formats produce a single
 	Assets []AssetSlot `json:"assets,omitempty"` // Array of all assets supported for this format. Each asset is identified by its a
 	Delivery map[string]any `json:"delivery,omitempty"` // Delivery method specifications (e.g., hosted, VAST, third-party tags)
 	SupportedMacros []any `json:"supported_macros,omitempty"` // List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUST
@@ -1889,13 +1871,13 @@ type CreativeFormat struct {
 	PricingOptions []VendorPricingOption `json:"pricing_options,omitempty"` // Pricing options for this format. Used by transformation and generation agents th
 }
 
-// FormatRef — A JSON object — never a plain string — that identifies a creative format by its declaring agent and 
+// FormatRef — A JSON object — never a plain string — that identifies a creative format by its declaring agent and
 type FormatRef struct {
 	AgentURL string `json:"agent_url"` // URL of the agent that defines this format (e.g., 'https://creative.adcontextprot
 	ID string `json:"id"` // Format identifier within the agent's namespace (e.g., 'display_static', 'video_h
 	Width int `json:"width,omitempty"` // Width in pixels for visual formats. When specified, height must also be specifie
 	Height int `json:"height,omitempty"` // Height in pixels for visual formats. When specified, width must also be specifie
-	DurationMs float64 `json:"duration_ms,omitempty"` // Duration in milliseconds for time-based formats (video, audio). When specified, 
+	DurationMs float64 `json:"duration_ms,omitempty"` // Duration in milliseconds for time-based formats (video, audio). When specified,
 }
 
 // CreativeAsset — Creative asset for upload to library - supports static assets, generative formats, and third-party s
@@ -1910,14 +1892,14 @@ type CreativeAsset struct {
 	Weight float64 `json:"weight,omitempty"` // Optional delivery weight for creative rotation when uploading via create_media_b
 	PlacementIDs []string `json:"placement_ids,omitempty"` // Optional array of placement IDs where this creative should run when uploading vi
 	IndustryIdentifiers []IndustryIdentifier `json:"industry_identifiers,omitempty"` // Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast cl
-	Provenance any `json:"provenance,omitempty"` // Provenance metadata for this creative. Serves as the default provenance for all 
+	Provenance any `json:"provenance,omitempty"` // Provenance metadata for this creative. Serves as the default provenance for all
 }
 
 // CreativeManifest — Complete specification of a creative: format_id + assets. Everything the creative needs — images, te
 type CreativeManifest struct {
 	FormatID FormatRef `json:"format_id"` // Always a structured object {agent_url, id} — never a plain string. Format identi
 	Assets map[string]any `json:"assets"` // Map of asset IDs to actual asset content. Each key MUST match an asset_id from t
-	Rights []any `json:"rights,omitempty"` // Rights constraints attached to this creative. Each entry represents constraints 
+	Rights []any `json:"rights,omitempty"` // Rights constraints attached to this creative. Each entry represents constraints
 	IndustryIdentifiers []IndustryIdentifier `json:"industry_identifiers,omitempty"` // Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Cle
 	Provenance any `json:"provenance,omitempty"` // Provenance metadata for this creative manifest. Serves as the default provenance
 	Ext any `json:"ext,omitempty"`
@@ -1951,21 +1933,21 @@ type DeliveryTotals struct {
 	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
 	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
 	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
-	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA) 
+	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
 	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
 	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
-	ReachUnit any `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on 
+	ReachUnit any `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
 	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
 	QuartileData any `json:"quartile_data,omitempty"` // Audio/video quartile completion data
 	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
-	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions 
+	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
 	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
-	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this 
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
 	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
 	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
 	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
 	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
-	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.). 
+	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
 }
 
 // Account — A billing account representing the relationship between a buyer and seller. The account determines r
@@ -1974,7 +1956,7 @@ type Account struct {
 	Name string `json:"name"` // Human-readable account name (e.g., 'Acme', 'Acme c/o Pinnacle')
 	Advertiser string `json:"advertiser,omitempty"` // The advertiser whose rates apply to this account
 	BillingProxy string `json:"billing_proxy,omitempty"` // Optional intermediary who receives invoices on behalf of the advertiser (e.g., a
-	Status string `json:"status"` // Account lifecycle status. See the Accounts Protocol overview for the operations 
+	Status string `json:"status"` // Account lifecycle status. See the Accounts Protocol overview for the operations
 	Brand *BrandReference `json:"brand,omitempty"` // Brand reference identifying the advertiser
 	Operator string `json:"operator,omitempty"` // Domain of the entity operating this account. When the brand operates directly, t
 	Billing string `json:"billing,omitempty"` // Who is invoiced on this account. See billing_entity for the invoiced party's bus
@@ -1985,7 +1967,7 @@ type Account struct {
 	Setup any `json:"setup,omitempty"` // Present when status is 'pending_approval'. Contains next steps for completing ac
 	AccountScope string `json:"account_scope,omitempty"`
 	GovernanceAgents []any `json:"governance_agents,omitempty"` // Governance agent endpoints registered on this account. Authentication credential
-	ReportingBucket any `json:"reporting_bucket,omitempty"` // Cloud storage bucket where the seller delivers offline reporting files for this 
+	ReportingBucket any `json:"reporting_bucket,omitempty"` // Cloud storage bucket where the seller delivers offline reporting files for this
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this is a sandbox account — no real platform calls, no real spend. Fo
 	Ext any `json:"ext,omitempty"`
 }
@@ -1993,7 +1975,7 @@ type Account struct {
 // Targeting — Optional restriction overlays for media buys. Most targeting should be expressed in the brief and ha
 type Targeting struct {
 	GeoCountries []string `json:"geo_countries,omitempty"` // Restrict delivery to specific countries. ISO 3166-1 alpha-2 codes (e.g., 'US', '
-	GeoCountriesExclude []string `json:"geo_countries_exclude,omitempty"` // Exclude specific countries from delivery. ISO 3166-1 alpha-2 codes (e.g., 'US', 
+	GeoCountriesExclude []string `json:"geo_countries_exclude,omitempty"` // Exclude specific countries from delivery. ISO 3166-1 alpha-2 codes (e.g., 'US',
 	GeoRegions []string `json:"geo_regions,omitempty"` // Restrict delivery to specific regions/states. ISO 3166-2 subdivision codes (e.g.
 	GeoRegionsExclude []string `json:"geo_regions_exclude,omitempty"` // Exclude specific regions/states from delivery. ISO 3166-2 subdivision codes (e.g
 	GeoMetros []any `json:"geo_metros,omitempty"` // Restrict delivery to specific metro areas. Each entry specifies the classificati
@@ -2009,8 +1991,8 @@ type Targeting struct {
 	PropertyList any `json:"property_list,omitempty"` // Reference to a property list for targeting specific properties within this produ
 	CollectionList *CollectionListRef `json:"collection_list,omitempty"` // Reference to a collection list for including specific collections (programs, sho
 	CollectionListExclude *CollectionListRef `json:"collection_list_exclude,omitempty"` // Reference to a collection list for excluding specific collections (programs, sho
-	AgeRestriction any `json:"age_restriction,omitempty"` // Age restriction for compliance. Use for legal requirements (alcohol, gambling), 
-	DevicePlatform []string `json:"device_platform,omitempty"` // Restrict to specific platforms. Use for technical compatibility (app only works 
+	AgeRestriction any `json:"age_restriction,omitempty"` // Age restriction for compliance. Use for legal requirements (alcohol, gambling),
+	DevicePlatform []string `json:"device_platform,omitempty"` // Restrict to specific platforms. Use for technical compatibility (app only works
 	DeviceType []string `json:"device_type,omitempty"` // Restrict to specific device form factors. Use for campaigns targeting hardware c
 	DeviceTypeExclude []string `json:"device_type_exclude,omitempty"` // Exclude specific device form factors from delivery (e.g., exclude CTV for app-in
 	StoreCatchments []any `json:"store_catchments,omitempty"` // Target users within store catchment areas from a synced store catalog. Each entr
@@ -2024,7 +2006,7 @@ type Targeting struct {
 type PaginationResponse struct {
 	HasMore bool `json:"has_more"` // Whether more results are available beyond this page
 	Cursor string `json:"cursor,omitempty"` // Opaque cursor to pass in the next request to fetch the next page. Only present w
-	TotalCount int `json:"total_count,omitempty"` // Total number of items matching the query across all pages. Optional because not 
+	TotalCount int `json:"total_count,omitempty"` // Total number of items matching the query across all pages. Optional because not
 }
 
 // PaginationRequest — Standard cursor-based pagination parameters for list operations
@@ -2039,7 +2021,7 @@ type Catalog struct {
 	Name string `json:"name,omitempty"` // Human-readable name for this catalog (e.g., 'Summer Products 2025', 'Amsterdam S
 	Type string `json:"type"` // Catalog type. Structural types: 'offering' (AdCP Offering objects), 'product' (e
 	URL string `json:"url,omitempty"` // URL to an external catalog feed. The platform fetches and resolves items from th
-	FeedFormat string `json:"feed_format,omitempty"` // Format of the external feed at url. Required when url points to a non-AdCP feed 
+	FeedFormat string `json:"feed_format,omitempty"` // Format of the external feed at url. Required when url points to a non-AdCP feed
 	UpdateFrequency string `json:"update_frequency,omitempty"` // How often the platform should re-fetch the feed from url. Only applicable when u
 	Items []map[string]any `json:"items,omitempty"` // Inline catalog data. The item schema depends on the catalog type: Offering objec
 	IDs []string `json:"ids,omitempty"` // Filter catalog to specific item IDs. For offering-type catalogs, these are offer
@@ -2047,7 +2029,7 @@ type Catalog struct {
 	Tags []string `json:"tags,omitempty"` // Filter catalog to items with these tags. Tags are matched using OR logic — items
 	Category string `json:"category,omitempty"` // Filter catalog to items in this category (e.g., 'beverages/soft-drinks', 'chef-p
 	Query string `json:"query,omitempty"` // Natural language filter for catalog items (e.g., 'all pasta sauces under $5', 'a
-	ConversionEvents []string `json:"conversion_events,omitempty"` // Event types that represent conversions for items in this catalog. Declares what 
+	ConversionEvents []string `json:"conversion_events,omitempty"` // Event types that represent conversions for items in this catalog. Declares what
 	ContentIDType string `json:"content_id_type,omitempty"` // Identifier type that the event's content_ids field should be matched against for
 	FeedFieldMappings []any `json:"feed_field_mappings,omitempty"` // Declarative normalization rules for external feeds. Maps non-standard feed field
 }
@@ -2194,38 +2176,38 @@ type GetProductsRequest struct {
 	Account *AccountReference `json:"account,omitempty"` // Account for product lookup. Returns products with pricing specific to this accou
 	PreferredDeliveryTypes []string `json:"preferred_delivery_types,omitempty"` // Delivery types the buyer prefers, in priority order. Unlike filters.delivery_typ
 	Filters any `json:"filters,omitempty"`
-	PropertyList any `json:"property_list,omitempty"` // [AdCP 3.0] Reference to an externally managed property list. When provided, the 
+	PropertyList any `json:"property_list,omitempty"` // [AdCP 3.0] Reference to an externally managed property list. When provided, the
 	Fields []string `json:"fields,omitempty"` // Specific product fields to include in the response. When omitted, all fields are
-	TimeBudget any `json:"time_budget,omitempty"` // Maximum time the buyer will commit to this request. The seller returns the best 
+	TimeBudget any `json:"time_budget,omitempty"` // Maximum time the buyer will commit to this request. The seller returns the best
 	Pagination *PaginationRequest `json:"pagination,omitempty"`
 	Context any `json:"context,omitempty"`
-	RequiredPolicies []string `json:"required_policies,omitempty"` // Registry policy IDs that the buyer requires to be enforced for products in this 
+	RequiredPolicies []string `json:"required_policies,omitempty"` // Registry policy IDs that the buyer requires to be enforced for products in this
 	Ext any `json:"ext,omitempty"`
 }
 
 // GetProductsResponse — Response payload for get_products task
 type GetProductsResponse struct {
 	Products []Product `json:"products"` // Array of matching products
-	Proposals []any `json:"proposals,omitempty"` // Optional array of proposed media plans with budget allocations across products. 
+	Proposals []any `json:"proposals,omitempty"` // Optional array of proposed media plans with budget allocations across products.
 	Errors []AdcpError `json:"errors,omitempty"` // Task-specific errors and warnings (e.g., product filtering issues)
 	PropertyListApplied *bool `json:"property_list_applied,omitempty"` // [AdCP 3.0] Indicates whether property_list filtering was applied. True if the ag
 	CatalogApplied *bool `json:"catalog_applied,omitempty"` // Whether the seller filtered results based on the provided catalog. True if the s
 	RefinementApplied []map[string]any `json:"refinement_applied,omitempty"` // Seller's response to each change request in the refine array, matched by positio
-	Incomplete []any `json:"incomplete,omitempty"` // Declares what the seller could not finish within the buyer's time_budget or due 
+	Incomplete []any `json:"incomplete,omitempty"` // Declares what the seller could not finish within the buyer's time_budget or due
 	Pagination *PaginationResponse `json:"pagination,omitempty"`
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this response contains simulated data from sandbox mode.
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }
 
-// CreateMediaBuyRequest — Request parameters for creating a media buy. Supports two modes: (1) Manual mode - provide packages 
+// CreateMediaBuyRequest — Request parameters for creating a media buy. Supports two modes: (1) Manual mode - provide packages
 type CreateMediaBuyRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for this request. If a request with the same idempot
 	PlanID string `json:"plan_id,omitempty"` // Campaign governance plan identifier. Required when the account has governance_ag
 	Account AccountReference `json:"account"` // Account to bill for this media buy. Pass a natural key (brand, operator, optiona
-	ProposalID string `json:"proposal_id,omitempty"` // ID of a proposal from get_products to execute. When provided with total_budget, 
-	TotalBudget any `json:"total_budget,omitempty"` // Total budget for the media buy when executing a proposal. The publisher applies 
+	ProposalID string `json:"proposal_id,omitempty"` // ID of a proposal from get_products to execute. When provided with total_budget,
+	TotalBudget any `json:"total_budget,omitempty"` // Total budget for the media buy when executing a proposal. The publisher applies
 	Packages []PackageInput `json:"packages,omitempty"` // Array of package configurations. Required when not using proposal_id. When execu
 	Brand BrandReference `json:"brand"` // Brand reference for this media buy. Resolved to full brand identity at execution
 	AdvertiserIndustry string `json:"advertiser_industry,omitempty"` // Industry classification for this specific campaign. A brand may operate across m
@@ -2248,7 +2230,7 @@ type CreateMediaBuyResponse = any
 // CreateMediaBuySuccess — Success response - media buy created successfully
 type CreateMediaBuySuccess struct {
 	MediaBuyID string `json:"media_buy_id"` // Seller's unique identifier for the created media buy
-	Account *Account `json:"account,omitempty"` // Account billed for this media buy. Includes advertiser, billing proxy (if any), 
+	Account *Account `json:"account,omitempty"` // Account billed for this media buy. Includes advertiser, billing proxy (if any),
 	InvoiceRecipient any `json:"invoice_recipient,omitempty"` // Per-buy invoice recipient, echoed from the request when provided. Confirms the s
 	Status string `json:"status,omitempty"` // Initial media buy status. Either 'pending_creatives' (awaiting creative assets),
 	ConfirmedAt string `json:"confirmed_at,omitempty"` // ISO 8601 timestamp when this media buy was confirmed by the seller. A successful
@@ -2292,9 +2274,9 @@ type GetMediaBuysRequest struct {
 	Ext any `json:"ext,omitempty"`
 }
 
-// GetMediaBuysResponse — Response payload for get_media_buys task. Returns media buy configuration, creative approval state, 
+// GetMediaBuysResponse — Response payload for get_media_buys task. Returns media buy configuration, creative approval state,
 type GetMediaBuysResponse struct {
-	MediaBuys []any `json:"media_buys"` // Array of media buys with status, creative approval state, and optional delivery 
+	MediaBuys []MediaBuyData `json:"media_buys"` // Array of media buys with status, creative approval state, and optional delivery
 	Errors []AdcpError `json:"errors,omitempty"` // Task-specific errors (e.g., media buy not found)
 	Pagination *PaginationResponse `json:"pagination,omitempty"` // Pagination metadata for the media_buys array.
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this response contains simulated data from sandbox mode.
@@ -2308,8 +2290,8 @@ type GetMediaBuyDeliveryRequest struct {
 	Account *AccountReference `json:"account,omitempty"` // Filter delivery data to a specific account. When omitted, returns data across al
 	MediaBuyIDs []string `json:"media_buy_ids,omitempty"` // Array of media buy IDs to get delivery data for
 	StatusFilter any `json:"status_filter,omitempty"` // Filter by status. Can be a single status or array of statuses
-	StartDate string `json:"start_date,omitempty"` // Start date for reporting period (YYYY-MM-DD). When omitted along with end_date, 
-	EndDate string `json:"end_date,omitempty"` // End date for reporting period (YYYY-MM-DD). When omitted along with start_date, 
+	StartDate string `json:"start_date,omitempty"` // Start date for reporting period (YYYY-MM-DD). When omitted along with end_date,
+	EndDate string `json:"end_date,omitempty"` // End date for reporting period (YYYY-MM-DD). When omitted along with start_date,
 	IncludePackageDailyBreakdown *bool `json:"include_package_daily_breakdown,omitempty"` // When true, include daily_breakdown arrays within each package in by_package. Use
 	AttributionWindow any `json:"attribution_window,omitempty"` // Attribution window to apply for conversion metrics. When provided, the seller re
 	ReportingDimensions any `json:"reporting_dimensions,omitempty"` // Request dimensional breakdowns in delivery reporting. Each key enables a specifi
@@ -2327,7 +2309,7 @@ type GetMediaBuyDeliveryResponse struct {
 	ReportingPeriod any `json:"reporting_period"` // Date range for the report. All periods use UTC timezone.
 	Currency string `json:"currency"` // ISO 4217 currency code
 	AttributionWindow *AttributionWindow `json:"attribution_window,omitempty"` // Attribution methodology and lookback windows used for conversion metrics in this
-	AggregatedTotals any `json:"aggregated_totals,omitempty"` // Combined metrics across all returned media buys. Only included in API responses 
+	AggregatedTotals any `json:"aggregated_totals,omitempty"` // Combined metrics across all returned media buys. Only included in API responses
 	MediaBuyDeliveries []any `json:"media_buy_deliveries"` // Array of delivery data for media buys. When used in webhook notifications, may c
 	Errors []AdcpError `json:"errors,omitempty"` // Task-specific errors and warnings (e.g., missing delivery data, reporting platfo
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this response contains simulated data from sandbox mode.
@@ -2340,14 +2322,14 @@ type ListCreativeFormatsRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	FormatIDs []FormatRef `json:"format_ids,omitempty"` // Return only these specific format IDs (e.g., from get_products response)
 	AssetTypes []string `json:"asset_types,omitempty"` // Filter to formats that include these asset types. For third-party tags, search f
-	MaxWidth int `json:"max_width,omitempty"` // Maximum width in pixels (inclusive). Returns formats where ANY render has width 
+	MaxWidth int `json:"max_width,omitempty"` // Maximum width in pixels (inclusive). Returns formats where ANY render has width
 	MaxHeight int `json:"max_height,omitempty"` // Maximum height in pixels (inclusive). Returns formats where ANY render has heigh
-	MinWidth int `json:"min_width,omitempty"` // Minimum width in pixels (inclusive). Returns formats where ANY render has width 
+	MinWidth int `json:"min_width,omitempty"` // Minimum width in pixels (inclusive). Returns formats where ANY render has width
 	MinHeight int `json:"min_height,omitempty"` // Minimum height in pixels (inclusive). Returns formats where ANY render has heigh
 	IsResponsive *bool `json:"is_responsive,omitempty"` // Filter for responsive formats that adapt to container size. When true, returns f
 	NameSearch string `json:"name_search,omitempty"` // Search for formats by name (case-insensitive partial match)
 	WcagLevel string `json:"wcag_level,omitempty"` // Filter to formats that meet at least this WCAG conformance level (A < AA < AAA)
-	DisclosurePositions []string `json:"disclosure_positions,omitempty"` // Filter to formats that support all of these disclosure positions. When a format 
+	DisclosurePositions []string `json:"disclosure_positions,omitempty"` // Filter to formats that support all of these disclosure positions. When a format
 	DisclosurePersistence []string `json:"disclosure_persistence,omitempty"` // Filter to formats where each requested persistence mode is supported by at least
 	OutputFormatIDs []FormatRef `json:"output_format_ids,omitempty"` // Filter to formats whose output_format_ids includes any of these format IDs. Retu
 	InputFormatIDs []FormatRef `json:"input_format_ids,omitempty"` // Filter to formats whose input_format_ids includes any of these format IDs. Retur
@@ -2367,14 +2349,14 @@ type ListCreativeFormatsResponse struct {
 	Ext any `json:"ext,omitempty"`
 }
 
-// SyncCatalogsRequest — Request parameters for syncing catalog feeds with upsert semantics. Supports bulk operations across 
+// SyncCatalogsRequest — Request parameters for syncing catalog feeds with upsert semantics. Supports bulk operations across
 type SyncCatalogsRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for at-most-once execution. `catalog_id` gives resou
 	Account AccountReference `json:"account"` // Account that owns these catalogs.
 	Catalogs []CatalogInput `json:"catalogs,omitempty"` // Array of catalog feeds to sync (create or update). When omitted, the call is dis
 	CatalogIDs []string `json:"catalog_ids,omitempty"` // Optional filter to limit sync scope to specific catalog IDs. When provided, only
-	DeleteMissing *bool `json:"delete_missing,omitempty"` // When true, buyer-managed catalogs on the account not included in this sync will 
+	DeleteMissing *bool `json:"delete_missing,omitempty"` // When true, buyer-managed catalogs on the account not included in this sync will
 	DryRun *bool `json:"dry_run,omitempty"` // When true, preview changes without applying them. Returns what would be created/
 	ValidationMode string `json:"validation_mode,omitempty"` // Validation strictness. 'strict' fails entire sync on any validation error. 'leni
 	PushNotificationConfig any `json:"push_notification_config,omitempty"` // Optional webhook configuration for async sync notifications. Publisher will send
@@ -2385,7 +2367,7 @@ type SyncCatalogsRequest struct {
 // SyncEventSourcesRequest — Request parameters for configuring event sources on an account with upsert semantics. Existing event
 type SyncEventSourcesRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
-	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for at-most-once execution. `event_source_id` gives 
+	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for at-most-once execution. `event_source_id` gives
 	Account AccountReference `json:"account"` // Account to configure event sources for.
 	EventSources []EventSourceInput `json:"event_sources,omitempty"` // Event sources to sync (create or update). When omitted, the call is discovery-on
 	DeleteMissing *bool `json:"delete_missing,omitempty"` // When true, event sources not included in this sync will be removed
@@ -2432,7 +2414,7 @@ type ProvidePerformanceFeedbackSuccess struct {
 
 // ProvidePerformanceFeedbackError — Error response - feedback rejected or could not be processed
 type ProvidePerformanceFeedbackError struct {
-	Errors []AdcpError `json:"errors"` // Array of errors explaining why feedback was rejected (e.g., invalid measurement 
+	Errors []AdcpError `json:"errors"` // Array of errors explaining why feedback was rejected (e.g., invalid measurement
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }
@@ -2468,7 +2450,7 @@ type SyncCreativesRequest struct {
 	Account AccountReference `json:"account"` // Account that owns these creatives.
 	Creatives []CreativeInput `json:"creatives"` // Array of creative assets to sync (create or update)
 	CreativeIDs []string `json:"creative_ids,omitempty"` // Optional filter to limit sync scope to specific creative IDs. When provided, onl
-	Assignments []any `json:"assignments,omitempty"` // Optional bulk assignment of creatives to packages. Each entry maps one creative 
+	Assignments []SyncCreativeAssignment `json:"assignments,omitempty"` // Optional bulk assignment of creatives to packages. Each entry maps one creative
 	IdempotencyKey string `json:"idempotency_key"` // Client-generated idempotency key for safe retries. If a sync fails without a res
 	DeleteMissing *bool `json:"delete_missing,omitempty"` // When true, creatives not included in this sync will be archived. Use with cautio
 	DryRun *bool `json:"dry_run,omitempty"` // When true, preview changes without applying them. Returns what would be created/
@@ -2488,7 +2470,7 @@ type ListCreativesRequest struct {
 	IncludeSnapshot *bool `json:"include_snapshot,omitempty"` // Include a lightweight delivery snapshot per creative (lifetime impressions and l
 	IncludeItems *bool `json:"include_items,omitempty"` // Include items for multi-asset formats like carousels and native ads
 	IncludeVariables *bool `json:"include_variables,omitempty"` // Include dynamic content variable definitions (DCO slots) for each creative
-	IncludePricing *bool `json:"include_pricing,omitempty"` // Include pricing_options on each creative. Requires account to be provided. When 
+	IncludePricing *bool `json:"include_pricing,omitempty"` // Include pricing_options on each creative. Requires account to be provided. When
 	Account *AccountReference `json:"account,omitempty"` // Account reference for pricing and access. When provided with include_pricing, th
 	Fields []string `json:"fields,omitempty"` // Specific fields to include in response (omit for all fields). The 'concept' valu
 	Context any `json:"context,omitempty"`
@@ -2518,8 +2500,8 @@ type GetSignalsRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	Account *AccountReference `json:"account,omitempty"` // Account for this request. When provided, the signals agent returns per-account p
 	SignalSpec string `json:"signal_spec,omitempty"` // Natural language description of the desired signals. When used alone, enables se
-	SignalIDs []SignalID `json:"signal_ids,omitempty"` // Specific signals to look up by data provider and ID. Returns exact matches from 
-	Destinations []any `json:"destinations,omitempty"` // Filter signals to those activatable on specific agents/platforms. When omitted, 
+	SignalIDs []SignalID `json:"signal_ids,omitempty"` // Specific signals to look up by data provider and ID. Returns exact matches from
+	Destinations []any `json:"destinations,omitempty"` // Filter signals to those activatable on specific agents/platforms. When omitted,
 	Countries []string `json:"countries,omitempty"` // Countries where signals will be used (ISO 3166-1 alpha-2 codes). When omitted, n
 	Filters *SignalFilters `json:"filters,omitempty"`
 	MaxResults int `json:"max_results,omitempty"` // DEPRECATED: Use pagination.max_results instead. When both fields are present, ag
@@ -2546,7 +2528,7 @@ type ActivateSignalRequest struct {
 	Destinations []DestinationInput `json:"destinations"` // Target destination(s) for activation. If the authenticated caller matches one of
 	PricingOptionID string `json:"pricing_option_id,omitempty"` // The pricing option selected from the signal's pricing_options in the get_signals
 	Account *AccountReference `json:"account,omitempty"` // Account for this activation. Associates with a commercial relationship establish
-	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for this request. Prevents duplicate activations on 
+	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for this request. Prevents duplicate activations on
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }
@@ -2659,7 +2641,7 @@ type CheckGovernanceResponse struct {
 	PlanID string `json:"plan_id"` // Echoed from request.
 	Explanation string `json:"explanation"` // Human-readable explanation of the governance decision.
 	Findings []any `json:"findings,omitempty"` // Specific issues found during the governance check. Present when status is 'denie
-	Conditions []any `json:"conditions,omitempty"` // Present when status is 'conditions'. Specific adjustments the caller must make. 
+	Conditions []any `json:"conditions,omitempty"` // Present when status is 'conditions'. Specific adjustments the caller must make.
 	ExpiresAt string `json:"expires_at,omitempty"` // When this approval expires. Present when status is 'approved' or 'conditions'. T
 	NextCheck string `json:"next_check,omitempty"` // When the seller should next call check_governance with delivery metrics. Present
 	CategoriesEvaluated []string `json:"categories_evaluated,omitempty"` // Governance categories evaluated during this check.
@@ -2735,7 +2717,7 @@ type CreateCollectionListRequest struct {
 type GetCollectionListRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	ListID string `json:"list_id"` // ID of the collection list to retrieve
-	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to 
+	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to
 	Resolve *bool `json:"resolve,omitempty"` // Whether to apply filters and return resolved collections (default: true)
 	Pagination any `json:"pagination,omitempty"` // Pagination parameters. Uses higher limits than standard pagination because colle
 	Context any `json:"context,omitempty"`
@@ -2746,10 +2728,10 @@ type GetCollectionListRequest struct {
 type UpdateCollectionListRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	ListID string `json:"list_id"` // ID of the collection list to update
-	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to 
+	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to
 	Name string `json:"name,omitempty"` // New name for the list
 	Description string `json:"description,omitempty"` // New description
-	BaseCollections []BaseCollectionSource `json:"base_collections,omitempty"` // Complete replacement for the base collections list (not a patch). Each entry is 
+	BaseCollections []BaseCollectionSource `json:"base_collections,omitempty"` // Complete replacement for the base collections list (not a patch). Each entry is
 	Filters *CollectionListFilters `json:"filters,omitempty"` // Complete replacement for the filters (not a patch)
 	Brand *BrandReference `json:"brand,omitempty"` // Update brand reference. Resolved to full brand identity at execution time.
 	WebhookURL string `json:"webhook_url,omitempty"` // Update the webhook URL for list change notifications (set to empty string to rem
@@ -2762,7 +2744,7 @@ type UpdateCollectionListRequest struct {
 type DeleteCollectionListRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	ListID string `json:"list_id"` // ID of the collection list to delete
-	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to 
+	Account *AccountReference `json:"account,omitempty"` // Account that owns the list. Required when the authenticated agent has access to
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 	IdempotencyKey string `json:"idempotency_key"` // Client-generated unique key for at-most-once execution. If a request with the sa
@@ -2780,13 +2762,13 @@ type ListCollectionListsRequest struct {
 
 // --- Webhook payload types ---
 
-// MCPWebhookPayload — Standard envelope for HTTP-based push notifications (MCP). This defines the wire format sent to the 
+// MCPWebhookPayload — Standard envelope for HTTP-based push notifications (MCP). This defines the wire format sent to the
 type MCPWebhookPayload struct {
 	IdempotencyKey string `json:"idempotency_key"` // Sender-generated key stable across retries of the same webhook event. Publishers
 	OperationID string `json:"operation_id,omitempty"` // Client-generated identifier that was embedded in the webhook URL by the buyer. P
 	TaskID string `json:"task_id"` // Unique identifier for this task. Use this to correlate webhook notifications wit
-	TaskType string `json:"task_type"` // Type of AdCP operation that triggered this webhook. Enables webhook handlers to 
-	Protocol string `json:"protocol,omitempty"` // AdCP protocol this task belongs to. Helps classify the operation type at a high 
+	TaskType string `json:"task_type"` // Type of AdCP operation that triggered this webhook. Enables webhook handlers to
+	Protocol string `json:"protocol,omitempty"` // AdCP protocol this task belongs to. Helps classify the operation type at a high
 	Status string `json:"status"` // Current task status. Webhooks are triggered for status changes after initial sub
 	Timestamp string `json:"timestamp"` // ISO 8601 timestamp when this webhook was generated.
 	Message string `json:"message,omitempty"` // Human-readable summary of the current task state. Provides context about what ha
@@ -2803,7 +2785,7 @@ type CollectionListChangedWebhook struct {
 	ChangeSummary any `json:"change_summary,omitempty"` // Summary of changes to the resolved list
 	ResolvedAt string `json:"resolved_at"` // When the list was re-resolved
 	CacheValidUntil string `json:"cache_valid_until,omitempty"` // When the consumer should refresh from the governance agent
-	Signature string `json:"signature"` // HMAC-SHA256 webhook signature over {unix_timestamp}.{raw_http_body_bytes} using 
+	Signature string `json:"signature"` // HMAC-SHA256 webhook signature over {unix_timestamp}.{raw_http_body_bytes} using
 	Ext any `json:"ext,omitempty"`
 }
 
@@ -2816,7 +2798,7 @@ type PropertyListChangedWebhook struct {
 	ChangeSummary any `json:"change_summary,omitempty"` // Summary of changes to the resolved list
 	ResolvedAt string `json:"resolved_at"` // When the list was re-resolved
 	CacheValidUntil string `json:"cache_valid_until,omitempty"` // When the consumer should refresh from the governance agent
-	Signature string `json:"signature"` // Cryptographic signature of the webhook payload, signed with the agent's private 
+	Signature string `json:"signature"` // Cryptographic signature of the webhook payload, signed with the agent's private
 	Ext any `json:"ext,omitempty"`
 }
 
@@ -2833,11 +2815,11 @@ type ArtifactWebhookPayload struct {
 
 // RevocationNotification — Payload sent by a rights holder to a buyer's revocation_webhook when rights are revoked. The buyer m
 type RevocationNotification struct {
-	IdempotencyKey string `json:"idempotency_key"` // Sender-generated key stable across retries of the same revocation notification. 
+	IdempotencyKey string `json:"idempotency_key"` // Sender-generated key stable across retries of the same revocation notification.
 	RightsID string `json:"rights_id"` // The revoked rights grant identifier
 	BrandID string `json:"brand_id"` // Brand identifier of the rights subject
 	Reason string `json:"reason"` // Human-readable reason for revocation
-	EffectiveAt string `json:"effective_at"` // When the revocation takes effect. Immediate revocations use current time. Grace 
+	EffectiveAt string `json:"effective_at"` // When the revocation takes effect. Immediate revocations use current time. Grace
 	RevokedUses []string `json:"revoked_uses,omitempty"` // If present, only these uses are revoked (partial revocation). If absent, all use
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -194,7 +194,7 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 	if !ok {
 		return errorResult("MEDIA_BUY_NOT_FOUND", "Media buy not found.", input.Context)
 	}
-	if input.Canceled {
+	if input.Canceled != nil && *input.Canceled {
 		if buy.Status == "canceled" {
 			return errorResult("NOT_CANCELLABLE", "Media buy is already canceled.", input.Context)
 		}
@@ -203,8 +203,8 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 		buy.Cancellation = map[string]any{"reason": input.CancellationReason, "canceled_by": "buyer", "canceled_at": now}
 		buy.Revision++
 		buy.UpdatedAt = now
-		buy.Ext = mediaBuyExt(buy.Status)
-		return updateMediaBuyResult(buy, buy.Packages, input.Context)
+		decorateMediaBuy(buy)
+		return updateMediaBuyResult(buy, packagesForCreateSuccess(buy.Packages), input.Context)
 	}
 	if input.Paused != nil {
 		if *input.Paused {
@@ -212,7 +212,7 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 		} else {
 			buy.Status = "active"
 		}
-		buy.Ext = mediaBuyExt(buy.Status)
+		decorateMediaBuy(buy)
 	}
 
 	packageIndex := make(map[string]int, len(buy.Packages))
@@ -235,16 +235,16 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 			buy.Packages[i].TargetingOverlay = upd.TargetingOverlay
 		}
 		if len(upd.CreativeAssignments) > 0 {
-			buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, upd.CreativeAssignments...)
+			buy.Packages[i].CreativeAssignments = upd.CreativeAssignments
 			if buy.Status == "pending_creatives" {
 				buy.Status = "active"
-				buy.Ext = mediaBuyExt(buy.Status)
+				decorateMediaBuy(buy)
 			}
 		}
-		affected = append(affected, buy.Packages[i])
+		affected = append(affected, buy.Packages[i].Package)
 	}
 	if len(affected) == 0 {
-		affected = buy.Packages
+		affected = packagesForCreateSuccess(buy.Packages)
 	}
 	buy.Revision++
 	buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -256,13 +256,13 @@ func (b *backend) listCreatives(input adcp.ListCreativesRequest) (*mcp.CallToolR
 	defer b.mu.RUnlock()
 
 	creativeIDs := map[string]bool{}
-	formatIDs := map[string]bool{}
+	formatIDs := map[adcp.FormatRef]bool{}
 	if input.Filters != nil {
 		for _, id := range input.Filters.CreativeIDs {
 			creativeIDs[id] = true
 		}
 		for _, ref := range input.Filters.FormatIDs {
-			formatIDs[ref.ID] = true
+			formatIDs[ref] = true
 		}
 	}
 	creatives := make([]map[string]any, 0, len(b.creatives))
@@ -270,7 +270,7 @@ func (b *backend) listCreatives(input adcp.ListCreativesRequest) (*mcp.CallToolR
 		if len(creativeIDs) > 0 && !creativeIDs[c.ID] {
 			continue
 		}
-		if len(formatIDs) > 0 && (c.FormatID == nil || !formatIDs[c.FormatID.ID]) {
+		if len(formatIDs) > 0 && (c.FormatID == nil || !formatIDs[*c.FormatID]) {
 			continue
 		}
 		item := map[string]any{
@@ -300,11 +300,6 @@ func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.Media
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.forced != nil {
-		forced := b.forced
-		b.forced = nil
-		return &adcp.MediaBuyData{Status: "submitted", Ext: map[string]any{"task_id": forced.TaskID, "message": forced.Message, "context": input.Context}}, nil
-	}
 	for _, p := range input.Packages {
 		if p.MeasurementTerms != nil && p.MeasurementTerms.BillingMeasurement != nil {
 			bm := p.MeasurementTerms.BillingMeasurement
@@ -320,20 +315,22 @@ func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.Media
 	}
 	n := b.buySeq.Add(1)
 	id := fmt.Sprintf("mb-%d", n)
-	pkgs := make([]adcp.Package, 0, len(input.Packages))
+	pkgs := make([]adcp.PackageStatus, 0, len(input.Packages))
 	hasCreatives := false
 	for i, p := range input.Packages {
 		if len(p.CreativeAssignments) > 0 {
 			hasCreatives = true
 		}
-		pkgs = append(pkgs, adcp.Package{
-			PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
-			PricingOptionID: p.PricingOptionID, Budget: p.Budget,
-			StartTime: p.StartTime, EndTime: p.EndTime,
-			AgencyEstimateNumber: p.AgencyEstimateNumber,
-			MeasurementTerms:     p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
-			TargetingOverlay:    p.TargetingOverlay,
-			CreativeAssignments: p.CreativeAssignments,
+		pkgs = append(pkgs, adcp.PackageStatus{
+			Package: adcp.Package{
+				PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
+				PricingOptionID: p.PricingOptionID, Budget: p.Budget,
+				StartTime: p.StartTime, EndTime: p.EndTime,
+				AgencyEstimateNumber: p.AgencyEstimateNumber,
+				MeasurementTerms:     p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
+				TargetingOverlay:    p.TargetingOverlay,
+				CreativeAssignments: p.CreativeAssignments,
+			},
 		})
 	}
 	var totalBudget float64
@@ -345,12 +342,30 @@ func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.Media
 		status = "active"
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
-	buy := &adcp.MediaBuyData{MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs, ConfirmedAt: now, CreatedAt: now, UpdatedAt: now, Revision: 1, Ext: mediaBuyExt(status)}
+	buy := &adcp.MediaBuyData{MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs, ConfirmedAt: now, CreatedAt: now, UpdatedAt: now, Revision: 1}
+	decorateMediaBuy(buy)
 	b.mediaBuys[id] = buy
 	for _, pkg := range pkgs {
 		b.delivery[pkg.PackageID] = &deliveryState{}
 	}
 	return buy, nil
+}
+
+func (b *backend) createMediaBuyResponse(input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
+	b.mu.Lock()
+	if b.forced != nil {
+		forced := b.forced
+		b.forced = nil
+		b.mu.Unlock()
+		return &adcp.CreateMediaBuySubmitted{Status: "submitted", TaskID: forced.TaskID, Message: forced.Message}, nil
+	}
+	b.mu.Unlock()
+
+	buy, err := b.createMediaBuy(input)
+	if err != nil {
+		return nil, err
+	}
+	return mediaBuyCreateSuccess(buy), nil
 }
 
 func (b *backend) syncCreatives(input *adcp.SyncCreativesRequest) ([]adcp.CreativeResult, error) {
@@ -366,23 +381,21 @@ func (b *backend) syncCreatives(input *adcp.SyncCreativesRequest) ([]adcp.Creati
 		b.creatives[c.CreativeID] = &creativeRecord{ID: c.CreativeID, Name: c.Name, FormatID: c.FormatID, Status: "approved", Assets: c.Assets}
 		results = append(results, adcp.CreativeResult{CreativeID: c.CreativeID, Action: action, Status: "approved"})
 	}
-	for _, raw := range input.Assignments {
-		assign, ok := raw.(map[string]any)
-		if !ok {
-			continue
-		}
-		creativeID, _ := assign["creative_id"].(string)
-		packageID, _ := assign["package_id"].(string)
-		if creativeID == "" || packageID == "" {
+	for _, assign := range input.Assignments {
+		if assign.CreativeID == "" || assign.PackageID == "" {
 			continue
 		}
 		for _, buy := range b.mediaBuys {
 			for i := range buy.Packages {
-				if buy.Packages[i].PackageID == packageID {
-					buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, map[string]any{"creative_id": creativeID})
+				if buy.Packages[i].PackageID == assign.PackageID {
+					buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, adcp.CreativeAssignment{
+						CreativeID:   assign.CreativeID,
+						Weight:       assign.Weight,
+						PlacementIDs: assign.PlacementIDs,
+					})
 					if buy.Status == "pending_creatives" {
 						buy.Status = "active"
-						buy.Ext = mediaBuyExt(buy.Status)
+						decorateMediaBuy(buy)
 						buy.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 						buy.Revision++
 					}
@@ -418,7 +431,15 @@ func (b *backend) getDelivery(input *adcp.GetMediaBuyDeliveryRequest) (*adcp.Del
 			if ds == nil {
 				ds = &deliveryState{}
 			}
-			pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{Impressions: float64(ds.Impressions), Clicks: float64(ds.Clicks), Spend: ds.Spend}, Spend: ds.Spend, PricingModel: "cpm", Rate: 10, Currency: "USD"})
+			pkgDel = append(pkgDel, adcp.PackageDelivery{
+				PackageID:    pkg.PackageID,
+				Impressions:  float64(ds.Impressions),
+				Clicks:       float64(ds.Clicks),
+				Spend:        ds.Spend,
+				PricingModel: "cpm",
+				Rate:         10,
+				Currency:     "USD",
+			})
 			totImps += ds.Impressions
 			totClicks += ds.Clicks
 			totSpend += ds.Spend
@@ -488,7 +509,7 @@ func (b *backend) simulateDelivery(mediaBuyID string, p adcp.SimulateDeliveryPar
 	}
 	baseImps, extraImps := p.Impressions/count, p.Impressions%count
 	baseClicks, extraClicks := p.Clicks/count, p.Clicks%count
-	spendPerPackage := spend / float64(count)
+	totalBudget := mediaBuyBudget(buy)
 	for i, pkg := range buy.Packages {
 		ds := b.delivery[pkg.PackageID]
 		if ds == nil {
@@ -505,7 +526,7 @@ func (b *backend) simulateDelivery(mediaBuyID string, p adcp.SimulateDeliveryPar
 		}
 		ds.Impressions += imps
 		ds.Clicks += clicks
-		ds.Spend += spendPerPackage
+		ds.Spend += weightedSpend(spend, pkg.Budget, totalBudget, count)
 	}
 	return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"impressions": p.Impressions, "clicks": p.Clicks, "spend": spend}}, nil
 }
@@ -518,10 +539,7 @@ func (b *backend) simulateBudgetSpend(p adcp.SimulateBudgetParams) (*adcp.Simula
 	if !ok {
 		return nil, fmt.Errorf("NOT_FOUND")
 	}
-	var total float64
-	for _, pkg := range buy.Packages {
-		total += pkg.Budget
-	}
+	total := mediaBuyBudget(buy)
 	spend := total * p.SpendPercentage
 	for _, pkg := range buy.Packages {
 		if total == 0 {
@@ -532,9 +550,27 @@ func (b *backend) simulateBudgetSpend(p adcp.SimulateBudgetParams) (*adcp.Simula
 			ds = &deliveryState{}
 			b.delivery[pkg.PackageID] = ds
 		}
-		ds.Spend += spend * (pkg.Budget / total)
+		ds.Spend += weightedSpend(spend, pkg.Budget, total, len(buy.Packages))
 	}
 	return &adcp.SimulationResult{Success: true, Simulated: map[string]any{"spend": spend, "percentage": p.SpendPercentage}}, nil
+}
+
+func mediaBuyBudget(buy *adcp.MediaBuyData) float64 {
+	var total float64
+	for _, pkg := range buy.Packages {
+		total += pkg.Budget
+	}
+	return total
+}
+
+func weightedSpend(spend, packageBudget, totalBudget float64, packageCount int) float64 {
+	if spend == 0 || packageCount == 0 {
+		return 0
+	}
+	if totalBudget == 0 {
+		return spend / float64(packageCount)
+	}
+	return spend * (packageBudget / totalBudget)
 }
 
 func (b *backend) handleCustomScenario(scenario string, params map[string]any) (any, error) {
@@ -588,19 +624,39 @@ func updateMediaBuyResult(buy *adcp.MediaBuyData, affected []adcp.Package, conte
 	}
 	if buy.Cancellation != nil {
 		out["cancellation"] = buy.Cancellation
-		if cancellation, ok := buy.Cancellation.(map[string]any); ok {
-			out["canceled_by"] = cancellation["canceled_by"]
-			out["canceled_at"] = cancellation["canceled_at"]
-		}
 	}
 	return adcp.Result(out, "Media buy updated")
 }
 
-func mediaBuyExt(status string) map[string]any {
-	return map[string]any{
-		"currency":      "USD",
-		"valid_actions": validActions(status),
+func mediaBuyCreateSuccess(buy *adcp.MediaBuyData) *adcp.CreateMediaBuySuccess {
+	return &adcp.CreateMediaBuySuccess{
+		MediaBuyID:       buy.MediaBuyID,
+		Account:          buy.Account,
+		InvoiceRecipient: buy.InvoiceRecipient,
+		Status:           buy.Status,
+		ConfirmedAt:      buy.ConfirmedAt,
+		CreativeDeadline: buy.CreativeDeadline,
+		Revision:         buy.Revision,
+		ValidActions:     buy.ValidActions,
+		Packages:         packagesForCreateSuccess(buy.Packages),
+		Sandbox:          adcp.Bool(true),
+		Ext:              buy.Ext,
 	}
+}
+
+func packagesForCreateSuccess(statuses []adcp.PackageStatus) []adcp.Package {
+	pkgs := make([]adcp.Package, 0, len(statuses))
+	for _, status := range statuses {
+		pkgs = append(pkgs, status.Package)
+	}
+	return pkgs
+}
+
+func decorateMediaBuy(buy *adcp.MediaBuyData) {
+	buy.Currency = "USD"
+	buy.ValidActions = validActions(buy.Status)
+	// Response envelope fields are typed; do not smuggle them through ext.
+	buy.Ext = nil
 }
 
 func validActions(status string) []string {
@@ -727,10 +783,10 @@ func main() {
 				}
 				return data, nil
 			},
-			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
-				return b.createMediaBuy(input)
+			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
+				return b.createMediaBuyResponse(input)
 			},
-			GetMediaBuys: func(_ context.Context, _ any, input *adcp.GetMediaBuysRequest) ([]adcp.MediaBuyData, error) {
+			GetMediaBuys: func(_ context.Context, _ any, input *adcp.GetMediaBuysRequest) (*adcp.GetMediaBuysResponse, error) {
 				b.mu.RLock()
 				defer b.mu.RUnlock()
 				buys := make([]adcp.MediaBuyData, 0)
@@ -738,18 +794,18 @@ func main() {
 					for _, id := range input.MediaBuyIDs {
 						if buy, ok := b.mediaBuys[id]; ok {
 							item := *buy
-							item.Ext = mediaBuyExt(item.Status)
+							decorateMediaBuy(&item)
 							buys = append(buys, item)
 						}
 					}
 				} else {
 					for _, buy := range b.mediaBuys {
 						item := *buy
-						item.Ext = mediaBuyExt(item.Status)
+						decorateMediaBuy(&item)
 						buys = append(buys, item)
 					}
 				}
-				return buys, nil
+				return &adcp.GetMediaBuysResponse{MediaBuys: buys}, nil
 			},
 			ListCreativeFormats: func(_ context.Context, input *adcp.ListCreativeFormatsRequest) ([]adcp.CreativeFormat, error) {
 				if len(input.FormatIDs) > 0 {

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/adcontextprotocol/adcp-go/adcp"
@@ -20,7 +21,7 @@ func mustCreateBuy(t *testing.T, b *backend, withCreatives bool) *adcp.MediaBuyD
 	t.Helper()
 	pkg := adcp.PackageInput{ProductID: "premium-display", PricingOptionID: "pd-cpm-15", Budget: 1000}
 	if withCreatives {
-		pkg.CreativeAssignments = []any{map[string]any{"creative_id": "cr-initial"}}
+		pkg.CreativeAssignments = []adcp.CreativeAssignment{{CreativeID: "cr-initial"}}
 	}
 	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
 		Packages: []adcp.PackageInput{pkg},
@@ -81,11 +82,8 @@ func TestPendingCreativesToActive_ViaSyncCreatives(t *testing.T) {
 	revisionBefore := buy.Revision
 
 	_, err := b.syncCreatives(&adcp.SyncCreativesRequest{
-		Creatives: []adcp.CreativeInput{{CreativeID: "cr-sync-1", Name: "Banner"}},
-		Assignments: []any{map[string]any{
-			"creative_id": "cr-sync-1",
-			"package_id":  pkgID,
-		}},
+		Creatives:   []adcp.CreativeInput{{CreativeID: "cr-sync-1", Name: "Banner"}},
+		Assignments: []adcp.SyncCreativeAssignment{{CreativeID: "cr-sync-1", PackageID: pkgID}},
 	})
 	if err != nil {
 		t.Fatalf("syncCreatives: %v", err)
@@ -109,7 +107,7 @@ func TestPendingCreativesToActive_ViaUpdateMediaBuy(t *testing.T) {
 		MediaBuyID: buy.MediaBuyID,
 		Packages: []adcp.PackageUpdate{{
 			PackageID:           pkgID,
-			CreativeAssignments: []any{map[string]any{"creative_id": "cr-upd-1"}},
+			CreativeAssignments: []adcp.CreativeAssignment{{CreativeID: "cr-upd-1"}},
 		}},
 	})
 	if err != nil {
@@ -134,7 +132,7 @@ func TestCancellation(t *testing.T) {
 
 	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{
 		MediaBuyID:         buy.MediaBuyID,
-		Canceled:           canceled,
+		Canceled:           &canceled,
 		CancellationReason: "budget_cut",
 	})
 	if err != nil {
@@ -159,10 +157,10 @@ func TestDoubleCancellation(t *testing.T) {
 	canceled := true
 
 	// First cancel succeeds.
-	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
+	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
 
 	// Second cancel must return an error result (NOT_CANCELLABLE), not a hard error.
-	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
+	result, _, err := b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
 	if err != nil {
 		t.Fatalf("second cancel: unexpected hard error: %v", err)
 	}
@@ -202,10 +200,12 @@ func TestListCreatives_FilterByFormatID(t *testing.T) {
 	b := newTestBackend()
 	fmtA := &adcp.FormatRef{AgentURL: "http://test", ID: "banner-300x250"}
 	fmtB := &adcp.FormatRef{AgentURL: "http://test", ID: "video-15s"}
+	fmtOtherAgent := &adcp.FormatRef{AgentURL: "http://other-agent", ID: "banner-300x250"}
 	_, _ = b.syncCreatives(&adcp.SyncCreativesRequest{
 		Creatives: []adcp.CreativeInput{
 			{CreativeID: "cr-fmt-a", FormatID: fmtA},
 			{CreativeID: "cr-fmt-b", FormatID: fmtB},
+			{CreativeID: "cr-fmt-other-agent", FormatID: fmtOtherAgent},
 		},
 	})
 
@@ -282,6 +282,21 @@ func TestDeliveryReporting_SimulateDelivery(t *testing.T) {
 	if totals.Spend != 15.00 {
 		t.Errorf("want 15.00 spend, got %.2f", totals.Spend)
 	}
+	pkg := data.MediaBuyDeliveries[0].ByPackage[0]
+	if pkg.Impressions != 1000 || pkg.Clicks != 50 || pkg.Spend != 15.00 {
+		t.Errorf("want flat package metrics, got impressions=%.0f clicks=%.0f spend=%.2f", pkg.Impressions, pkg.Clicks, pkg.Spend)
+	}
+	wire, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal package delivery: %v", err)
+	}
+	var row map[string]any
+	if err := json.Unmarshal(wire, &row); err != nil {
+		t.Fatalf("unmarshal package delivery: %v", err)
+	}
+	if _, ok := row["totals"]; ok {
+		t.Error("package delivery row should use flat delivery metrics, not nested totals")
+	}
 }
 
 func TestDeliveryReporting_SimulateBudgetSpend(t *testing.T) {
@@ -306,6 +321,40 @@ func TestDeliveryReporting_SimulateBudgetSpend(t *testing.T) {
 	want := buy.TotalBudget * 0.5
 	if totals.Spend != want {
 		t.Errorf("want spend %.2f (50%% of budget %.2f), got %.2f", want, buy.TotalBudget, totals.Spend)
+	}
+}
+
+func TestDeliveryReporting_SimulateDeliveryWeightsSpendByBudget(t *testing.T) {
+	b := newTestBackend()
+	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+		Packages: []adcp.PackageInput{
+			{ProductID: "premium-display", PricingOptionID: "pd-cpm-15", Budget: 100, CreativeAssignments: []adcp.CreativeAssignment{{CreativeID: "cr-a"}}},
+			{ProductID: "premium-display", PricingOptionID: "pd-cpm-15", Budget: 300, CreativeAssignments: []adcp.CreativeAssignment{{CreativeID: "cr-b"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createMediaBuy: %v", err)
+	}
+
+	_, err = b.simulateDelivery(buy.MediaBuyID, adcp.SimulateDeliveryParams{
+		Impressions:   100,
+		Clicks:        10,
+		ReportedSpend: &adcp.ReportedSpend{Amount: 40, Currency: "USD"},
+	})
+	if err != nil {
+		t.Fatalf("simulateDelivery: %v", err)
+	}
+
+	data, err := b.getDelivery(&adcp.GetMediaBuyDeliveryRequest{MediaBuyIDs: []string{buy.MediaBuyID}})
+	if err != nil {
+		t.Fatalf("getDelivery: %v", err)
+	}
+	packages := data.MediaBuyDeliveries[0].ByPackage
+	if len(packages) != 2 {
+		t.Fatalf("want 2 package rows, got %d", len(packages))
+	}
+	if packages[0].Spend != 10 || packages[1].Spend != 30 {
+		t.Errorf("want spend weighted by 100/300 budget split, got %.2f/%.2f", packages[0].Spend, packages[1].Spend)
 	}
 }
 
@@ -405,18 +454,24 @@ func TestCustomScenario_ForceCreateMediaBuyArm_Submitted(t *testing.T) {
 		t.Fatalf("force_create_media_buy_arm: %v", err)
 	}
 
-	buy, err := b.createMediaBuy(&adcp.CreateMediaBuyRequest{
+	resp, err := b.createMediaBuyResponse(&adcp.CreateMediaBuyRequest{
 		Packages: []adcp.PackageInput{{ProductID: "premium-display", Budget: 500}},
 	})
 	if err != nil {
 		t.Fatalf("createMediaBuy after forced arm: %v", err)
 	}
-	if buy.Status != "submitted" {
-		t.Errorf("want submitted status after forced arm, got %s", buy.Status)
+	submitted, ok := resp.(*adcp.CreateMediaBuySubmitted)
+	if !ok {
+		t.Fatalf("want submitted response after forced arm, got %T", resp)
 	}
-	ext, _ := buy.Ext.(map[string]any)
-	if ext["task_id"] != "task-abc-123" {
-		t.Errorf("want task_id task-abc-123 in Ext, got %v", ext["task_id"])
+	if submitted.Status != "submitted" {
+		t.Errorf("want submitted status after forced arm, got %s", submitted.Status)
+	}
+	if submitted.TaskID != "task-abc-123" {
+		t.Errorf("want task_id task-abc-123, got %v", submitted.TaskID)
+	}
+	if submitted.Message != "processing in async queue" {
+		t.Errorf("want async message, got %q", submitted.Message)
 	}
 
 	// Forced arm is consumed — next create should be normal.
@@ -474,7 +529,7 @@ func TestForceMediaBuyStatus_TerminalStateBlocked(t *testing.T) {
 	b := newTestBackend()
 	buy := mustCreateBuy(t, b, false)
 	canceled := true
-	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: canceled})
+	_, _, _ = b.updateMediaBuy(adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: &canceled})
 
 	_, err := b.forceMediaBuyStatus(buy.MediaBuyID, "active", "")
 	if err == nil {

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -45,7 +45,7 @@ Asset `item_type` must be `"individual"`.
 
 ```go
 adcp.AddTool(server, "list_creative_formats", "Available creative formats",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsRequest) (*mcp.CallToolResult, any, error) {
         return adcp.CreativeFormatsResponse(formats, true)
     })
 ```
@@ -58,7 +58,7 @@ Input has `creatives[]` with `creative_id`, `format_id`, `name`, `assets`. Store
 
 ```go
 adcp.AddTool(server, "sync_creatives", "Accept and store creatives",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesRequest) (*mcp.CallToolResult, any, error) {
         s.mu.Lock()
         defer s.mu.Unlock()
 
@@ -106,7 +106,7 @@ Each creative must include `created_date` and `updated_date` (ISO 8601).
 
 ```go
 adcp.AddTool(server, "list_creatives", "List creative library",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativesInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativesRequest) (*mcp.CallToolResult, any, error) {
         s.mu.RLock()
         defer s.mu.RUnlock()
 
@@ -145,7 +145,7 @@ The request can come as `creative_id` (lookup) or `creative_manifest` (render di
 
 ```go
 adcp.AddTool(server, "preview_creative", "Render a preview",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.PreviewCreativeInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.PreviewCreativeRequest) (*mcp.CallToolResult, any, error) {
         var creativeID, name string
         var w, h int
 
@@ -185,7 +185,7 @@ Handle both `creative_manifest` (direct build) and `creative_id` (store lookup).
 
 ```go
 adcp.AddTool(server, "build_creative", "Build serving tag",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.BuildCreativeInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.BuildCreativeRequest) (*mcp.CallToolResult, any, error) {
         var manifest map[string]any
 
         if input.CreativeManifest != nil {
@@ -308,6 +308,6 @@ npx @adcp/client storyboard run http://localhost:3001/mcp creative_lifecycle --j
 | `adcp.Result(data, summary)` | Generic response |
 | `adcp.Errorf(code, opts)` | Error response |
 
-Input types: `adcp.EmptyInput`, `adcp.ListCreativeFormatsInput`, `adcp.SyncCreativesInput`, `adcp.ListCreativesInput`, `adcp.PreviewCreativeInput`, `adcp.BuildCreativeInput`
+Input types: `adcp.EmptyInput`, `adcp.ListCreativeFormatsRequest`, `adcp.SyncCreativesRequest`, `adcp.ListCreativesRequest`, `adcp.PreviewCreativeRequest`, `adcp.BuildCreativeRequest`
 
 The skill contains everything you need.

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -51,7 +51,7 @@ Echo brand/operator back, assign an account_id.
 
 ```go
 adcp.AddTool(server, "sync_accounts", "Register accounts",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncAccountsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncAccountsRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.AccountResult
         for i, acct := range input.Accounts {
             id := fmt.Sprintf("acct-%s-%d", acct.Brand.Domain, i+1)
@@ -71,7 +71,7 @@ Input has `accounts[]` with nested `account.brand`, `account.operator`, and `gov
 
 ```go
 adcp.AddTool(server, "sync_governance", "Register governance agents",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncGovernanceInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncGovernanceRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.GovernanceResult
         for _, acct := range input.Accounts {
             govAcct := acct.Account
@@ -107,7 +107,7 @@ var products = []adcp.Product{
 }
 
 adcp.AddTool(server, "get_products", "Available products",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetProductsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetProductsRequest) (*mcp.CallToolResult, any, error) {
         return adcp.ProductsResponse(&adcp.ProductsData{Products: products, Sandbox: true})
     })
 ```
@@ -116,17 +116,19 @@ adcp.AddTool(server, "get_products", "Available products",
 
 ```go
 adcp.AddTool(server, "create_media_buy", "Create media buy",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.CreateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.CreateMediaBuyRequest) (*mcp.CallToolResult, any, error) {
         id := fmt.Sprintf("mb-%d", counter)
         var pkgs []adcp.Package
         for i, p := range input.Packages {
             pkgs = append(pkgs, adcp.Package{
                 PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1),
                 ProductID: p.ProductID, PricingOptionID: p.PricingOptionID, Budget: p.Budget,
+                CreativeAssignments: p.CreativeAssignments,
             })
         }
-        return adcp.MediaBuyResponse(&adcp.MediaBuyData{
-            MediaBuyID: id, Status: "active", Currency: "USD", Packages: pkgs,
+        return adcp.MediaBuyResponse(&adcp.CreateMediaBuySuccess{
+            MediaBuyID: id, Status: "active", Packages: pkgs,
+            ValidActions: []string{"pause", "cancel", "sync_creatives", "update_packages"},
         })
     })
 ```
@@ -135,9 +137,12 @@ adcp.AddTool(server, "create_media_buy", "Create media buy",
 
 ```go
 adcp.AddTool(server, "get_media_buys", "List media buys",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuysInput) (*mcp.CallToolResult, any, error) {
-        buys := make([]adcp.MediaBuyData, 0) // make, not var — ensures JSON [] not null
-        // ... populate from store
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuysRequest) (*mcp.CallToolResult, any, error) {
+        buys := []adcp.MediaBuyData{{
+            MediaBuyID: "mb-1", Status: "active", Currency: "USD", TotalBudget: 1000,
+            ValidActions: []string{"pause", "cancel", "sync_creatives", "update_packages"},
+            Packages: []adcp.PackageStatus{{Package: adcp.Package{PackageID: "mb-1-pkg-1", ProductID: "display", Budget: 1000}}},
+        }}
         return adcp.MediaBuysResponse(buys, true)
     })
 ```
@@ -165,7 +170,7 @@ var creativeFormats = []adcp.CreativeFormat{
 }
 
 adcp.AddTool(server, "list_creative_formats", "Available formats",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsRequest) (*mcp.CallToolResult, any, error) {
         return adcp.CreativeFormatsResponse(creativeFormats, true)
     })
 ```
@@ -176,7 +181,7 @@ Check format to decide status: generative → `"pending_review"`, standard → `
 
 ```go
 adcp.AddTool(server, "sync_creatives", "Submit creatives",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.CreativeResult
         for _, c := range input.Creatives {
             status := "approved"
@@ -199,7 +204,7 @@ Use `make([]T, 0)` for empty slices to ensure JSON `[]` not `null`.
 
 ```go
 adcp.AddTool(server, "get_media_buy_delivery", "Delivery metrics",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuyDeliveryInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuyDeliveryRequest) (*mcp.CallToolResult, any, error) {
         deliveries := make([]adcp.MediaBuyDelivery, 0)
         // ... populate from store
         return adcp.DeliveryResponse(&adcp.DeliveryData{
@@ -312,7 +317,10 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_s
 | `adcp.RegisterTestController(server, store)` | Test controller |
 | `adcp.CapabilitiesResponse(data)` | Capabilities |
 | `adcp.ProductsResponse(data)` | Products |
-| `adcp.MediaBuyResponse(data)` | Create media buy |
+| `adcp.MediaBuyResponse(*CreateMediaBuySuccess\|*CreateMediaBuyError\|*CreateMediaBuySubmitted)` | Create media buy |
+| `adcp.CreateMediaBuySuccessResponse(data)` | Sync create media buy |
+| `adcp.CreateMediaBuyErrorResponse(data)` | Create media buy error branch |
+| `adcp.CreateMediaBuySubmittedResponse(taskID, message)` | Async create media buy |
 | `adcp.MediaBuysResponse(buys, sandbox)` | List media buys |
 | `adcp.DeliveryResponse(data)` | Delivery metrics |
 | `adcp.SyncAccountsResponse(accounts, sandbox)` | Sync accounts |
@@ -322,6 +330,6 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_s
 | `adcp.Result(data, summary)` | Generic response |
 | `adcp.Errorf(code, opts)` | Error response |
 
-Input types: `adcp.EmptyInput`, `adcp.SyncAccountsInput`, `adcp.SyncGovernanceInput`, `adcp.GetProductsInput`, `adcp.CreateMediaBuyInput`, `adcp.GetMediaBuysInput`, `adcp.ListCreativeFormatsInput`, `adcp.SyncCreativesInput`, `adcp.GetMediaBuyDeliveryInput`
+Input types: `adcp.EmptyInput`, `adcp.SyncAccountsRequest`, `adcp.SyncGovernanceRequest`, `adcp.GetProductsRequest`, `adcp.CreateMediaBuyRequest`, `adcp.GetMediaBuysRequest`, `adcp.ListCreativeFormatsRequest`, `adcp.SyncCreativesRequest`, `adcp.GetMediaBuyDeliveryRequest`
 
 The skill contains everything you need.

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -40,7 +40,7 @@ adcp.AddTool(server, "get_adcp_capabilities", "Agent capabilities",
 
 ```go
 adcp.AddTool(server, "sync_accounts", "Register accounts",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncAccountsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncAccountsRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.AccountResult
         for i, acct := range input.Accounts {
             id := fmt.Sprintf("acct-%s-%d", acct.Brand.Domain, i+1)
@@ -57,7 +57,7 @@ adcp.AddTool(server, "sync_accounts", "Register accounts",
 
 ```go
 adcp.AddTool(server, "sync_governance", "Register governance agents",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncGovernanceInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncGovernanceRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.GovernanceResult
         for _, acct := range input.Accounts {
             govAcct := acct.Account
@@ -88,7 +88,7 @@ var products = []adcp.Product{
 }
 
 adcp.AddTool(server, "get_products", "Available products",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetProductsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetProductsRequest) (*mcp.CallToolResult, any, error) {
         return adcp.ProductsResponse(&adcp.ProductsData{Products: products, Sandbox: true})
     })
 ```
@@ -97,17 +97,19 @@ adcp.AddTool(server, "get_products", "Available products",
 
 ```go
 adcp.AddTool(server, "create_media_buy", "Create media buy",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.CreateMediaBuyInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.CreateMediaBuyRequest) (*mcp.CallToolResult, any, error) {
         id := fmt.Sprintf("mb-%d", counter)
         var pkgs []adcp.Package
         for i, p := range input.Packages {
             pkgs = append(pkgs, adcp.Package{
                 PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1),
                 ProductID: p.ProductID, PricingOptionID: p.PricingOptionID, Budget: p.Budget,
+                CreativeAssignments: p.CreativeAssignments,
             })
         }
-        return adcp.MediaBuyResponse(&adcp.MediaBuyData{
-            MediaBuyID: id, Status: "active", Currency: "USD", Packages: pkgs,
+        return adcp.MediaBuyResponse(&adcp.CreateMediaBuySuccess{
+            MediaBuyID: id, Status: "active", Packages: pkgs,
+            ValidActions: []string{"pause", "cancel", "sync_creatives", "update_packages"},
         })
     })
 ```
@@ -116,9 +118,12 @@ adcp.AddTool(server, "create_media_buy", "Create media buy",
 
 ```go
 adcp.AddTool(server, "get_media_buys", "List media buys",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuysInput) (*mcp.CallToolResult, any, error) {
-        buys := make([]adcp.MediaBuyData, 0)
-        // populate from store
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuysRequest) (*mcp.CallToolResult, any, error) {
+        buys := []adcp.MediaBuyData{{
+            MediaBuyID: "mb-1", Status: "active", Currency: "USD", TotalBudget: 1000,
+            ValidActions: []string{"pause", "cancel", "sync_creatives", "update_packages"},
+            Packages: []adcp.PackageStatus{{Package: adcp.Package{PackageID: "mb-1-pkg-1", ProductID: "sponsored-products", Budget: 1000}}},
+        }}
         return adcp.MediaBuysResponse(buys, true)
     })
 ```
@@ -127,7 +132,7 @@ adcp.AddTool(server, "get_media_buys", "List media buys",
 
 ```go
 adcp.AddTool(server, "list_creative_formats", "Available formats",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ListCreativeFormatsRequest) (*mcp.CallToolResult, any, error) {
         return adcp.CreativeFormatsResponse(creativeFormats, true)
     })
 ```
@@ -136,7 +141,7 @@ adcp.AddTool(server, "list_creative_formats", "Available formats",
 
 ```go
 adcp.AddTool(server, "sync_creatives", "Submit creatives",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCreativesRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.CreativeResult
         for _, c := range input.Creatives {
             results = append(results, adcp.CreativeResult{
@@ -151,7 +156,7 @@ adcp.AddTool(server, "sync_creatives", "Submit creatives",
 
 ```go
 adcp.AddTool(server, "get_media_buy_delivery", "Delivery metrics",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuyDeliveryInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.GetMediaBuyDeliveryRequest) (*mcp.CallToolResult, any, error) {
         deliveries := make([]adcp.MediaBuyDelivery, 0)
         // populate from store
         return adcp.DeliveryResponse(&adcp.DeliveryData{
@@ -165,7 +170,7 @@ adcp.AddTool(server, "get_media_buy_delivery", "Delivery metrics",
 
 ```go
 adcp.AddTool(server, "sync_catalogs", "Accept product catalog feeds",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCatalogsInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncCatalogsRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.CatalogResult
         for _, c := range input.Catalogs {
             count := len(c.Items)
@@ -182,7 +187,7 @@ adcp.AddTool(server, "sync_catalogs", "Accept product catalog feeds",
 
 ```go
 adcp.AddTool(server, "sync_event_sources", "Register event tracking",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncEventSourcesInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.SyncEventSourcesRequest) (*mcp.CallToolResult, any, error) {
         var results []adcp.EventSourceResult
         for _, es := range input.EventSources {
             results = append(results, adcp.EventSourceResult{
@@ -201,7 +206,7 @@ adcp.AddTool(server, "sync_event_sources", "Register event tracking",
 
 ```go
 adcp.AddTool(server, "log_event", "Accept conversion events",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.LogEventInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.LogEventRequest) (*mcp.CallToolResult, any, error) {
         return adcp.LogEventResponse(len(input.Events), len(input.Events), 0.85, true)
     })
 ```
@@ -210,7 +215,7 @@ adcp.AddTool(server, "log_event", "Accept conversion events",
 
 ```go
 adcp.AddTool(server, "provide_performance_feedback", "Accept performance metrics",
-    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.PerformanceFeedbackInput) (*mcp.CallToolResult, any, error) {
+    func(ctx context.Context, req *mcp.CallToolRequest, input adcp.ProvidePerformanceFeedbackRequest) (*mcp.CallToolResult, any, error) {
         return adcp.PerformanceFeedbackResponse(true)
     })
 ```
@@ -310,7 +315,10 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_crea
 | `adcp.RegisterTestController(server, store)` | Test controller |
 | `adcp.CapabilitiesResponse(data)` | Capabilities |
 | `adcp.ProductsResponse(data)` | Products |
-| `adcp.MediaBuyResponse(data)` | Create media buy |
+| `adcp.MediaBuyResponse(*CreateMediaBuySuccess\|*CreateMediaBuyError\|*CreateMediaBuySubmitted)` | Create media buy |
+| `adcp.CreateMediaBuySuccessResponse(data)` | Sync create media buy |
+| `adcp.CreateMediaBuyErrorResponse(data)` | Create media buy error branch |
+| `adcp.CreateMediaBuySubmittedResponse(taskID, message)` | Async create media buy |
 | `adcp.MediaBuysResponse(buys, sandbox)` | List media buys |
 | `adcp.DeliveryResponse(data)` | Delivery metrics |
 | `adcp.SyncAccountsResponse(accounts, sandbox)` | Sync accounts |
@@ -324,6 +332,6 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_crea
 | `adcp.Result(data, summary)` | Generic response |
 | `adcp.Errorf(code, opts)` | Error response |
 
-Input types: `adcp.EmptyInput`, `adcp.SyncAccountsInput`, `adcp.SyncGovernanceInput`, `adcp.GetProductsInput`, `adcp.CreateMediaBuyInput`, `adcp.GetMediaBuysInput`, `adcp.ListCreativeFormatsInput`, `adcp.SyncCreativesInput`, `adcp.GetMediaBuyDeliveryInput`, `adcp.SyncCatalogsInput`, `adcp.SyncEventSourcesInput`, `adcp.LogEventInput`, `adcp.PerformanceFeedbackInput`
+Input types: `adcp.EmptyInput`, `adcp.SyncAccountsRequest`, `adcp.SyncGovernanceRequest`, `adcp.GetProductsRequest`, `adcp.CreateMediaBuyRequest`, `adcp.GetMediaBuysRequest`, `adcp.ListCreativeFormatsRequest`, `adcp.SyncCreativesRequest`, `adcp.GetMediaBuyDeliveryRequest`, `adcp.SyncCatalogsRequest`, `adcp.SyncEventSourcesRequest`, `adcp.LogEventRequest`, `adcp.ProvidePerformanceFeedbackRequest`
 
 The skill contains everything you need.

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -23,7 +23,7 @@ Ask the user — don't guess.
 1. **What kind of seller?** Premium publisher (guaranteed, fixed pricing) / SSP (non-guaranteed, auction) / Retail media (both)
 2. **Guaranteed or non-guaranteed?** `delivery_type: "guaranteed"` vs `"non_guaranteed"`. Many sellers support both.
 3. **Products and pricing.** Each product needs: product_id, name, description, channels (array of channel enums), delivery_type, pricing_options, format_ids. publisher_properties is optional; if present, it's a list of `PublisherPropertySelector` entries each pointing at a publisher_domain.
-4. **Approval workflow.** Instant (`status: "active"`) or async (`status: "pending_approval"`). Async can surface via buyer polling `get_media_buys` OR via signed webhooks to `push_notification_config.url` — see `skills/build-webhook-publisher/` for the emission pattern. Webhooks are baseline in AdCP 3.0; polling is the legacy fallback.
+4. **Approval workflow.** Instant create returns a media buy such as `status: "active"` or `status: "pending_creatives"`. Async create returns the submitted task envelope (`status: "submitted"`, `task_id`, optional `message`) and later exposes the confirmed buy via `get_media_buys` or signed webhooks to `push_notification_config.url` — see `skills/build-webhook-publisher/` for the emission pattern.
 5. **Creative management.** Standard (`list_creative_formats` + `sync_creatives`) or none.
 
 ## Complete Skeleton
@@ -149,31 +149,50 @@ func main() {
                 return &adcp.ProductsData{Products: products}, nil
             },
 
-            CreateMediaBuy: func(_ context.Context, _ any, req *adcp.CreateMediaBuyRequest) (*adcp.MediaBuyData, error) {
+            CreateMediaBuy: func(_ context.Context, _ any, req *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
                 b.mu.Lock()
                 defer b.mu.Unlock()
                 // In production: book into your OMS / ad server
                 n := b.buySeq.Add(1)
                 id := fmt.Sprintf("mb-%d", n)
-                pkgs := make([]adcp.Package, 0, len(req.Packages))
+                pkgs := make([]adcp.PackageStatus, 0, len(req.Packages))
+                createPkgs := make([]adcp.Package, 0, len(req.Packages))
+                hasCreatives := false
                 for i, p := range req.Packages {
-                    pkgs = append(pkgs, adcp.Package{
+                    if len(p.CreativeAssignments) > 0 { hasCreatives = true }
+                    pkg := adcp.Package{
                         PackageID: fmt.Sprintf("%s-pkg-%d", id, i+1), ProductID: p.ProductID,
                         PricingOptionID: p.PricingOptionID, Budget: p.Budget,
                         StartTime: p.StartTime, EndTime: p.EndTime,
                         AgencyEstimateNumber: p.AgencyEstimateNumber,
                         MeasurementTerms: p.MeasurementTerms, PerformanceStandards: p.PerformanceStandards,
-                    })
+                        CreativeAssignments: p.CreativeAssignments,
+                    }
+                    pkgs = append(pkgs, adcp.PackageStatus{Package: pkg})
+                    createPkgs = append(createPkgs, pkg)
                 }
                 var totalBudget float64
                 for _, p := range req.Packages { totalBudget += p.Budget }
-                buy := &adcp.MediaBuyData{MediaBuyID: id, Status: "active", TotalBudget: totalBudget, Packages: pkgs}
+                status := "active"
+                if !hasCreatives { status = "pending_creatives" }
+                validActions := []string{"pause", "cancel", "sync_creatives", "update_packages"}
+                if status == "pending_creatives" { validActions = []string{"cancel", "sync_creatives", "update_packages"} }
+                buy := &adcp.MediaBuyData{
+                    MediaBuyID: id, Status: status, TotalBudget: totalBudget, Packages: pkgs,
+                    Currency: "USD", ValidActions: validActions,
+                }
                 b.mediaBuys[id] = buy
                 for _, pkg := range pkgs { b.delivery[pkg.PackageID] = &struct{ Impressions, Clicks int; Spend float64 }{} }
-                return buy, nil
+                return &adcp.CreateMediaBuySuccess{
+                    MediaBuyID: id, Status: status, Packages: createPkgs,
+                    ValidActions: buy.ValidActions, Sandbox: adcp.Bool(true),
+                }, nil
             },
 
-            GetMediaBuys: func(_ context.Context, _ any, req *adcp.GetMediaBuysRequest) ([]adcp.MediaBuyData, error) {
+            // Async sellers can return:
+            // return &adcp.CreateMediaBuySubmitted{Status: "submitted", TaskID: taskID, Message: "Awaiting IO signature"}, nil
+
+            GetMediaBuys: func(_ context.Context, _ any, req *adcp.GetMediaBuysRequest) (*adcp.GetMediaBuysResponse, error) {
                 b.mu.RLock()
                 defer b.mu.RUnlock()
                 buys := make([]adcp.MediaBuyData, 0)
@@ -184,7 +203,7 @@ func main() {
                 } else {
                     for _, buy := range b.mediaBuys { buys = append(buys, *buy) }
                 }
-                return buys, nil
+                return &adcp.GetMediaBuysResponse{MediaBuys: buys}, nil
             },
 
             ListCreativeFormats: func(_ context.Context, _ *adcp.ListCreativeFormatsRequest) ([]adcp.CreativeFormat, error) {
@@ -202,6 +221,19 @@ func main() {
                     b.creatives[c.CreativeID] = "approved"
                     results = append(results, adcp.CreativeResult{CreativeID: c.CreativeID, Action: action, Status: "approved"})
                 }
+                for _, assign := range req.Assignments {
+                    for _, buy := range b.mediaBuys {
+                        for i := range buy.Packages {
+                            if buy.Packages[i].PackageID == assign.PackageID {
+                                buy.Packages[i].CreativeAssignments = append(buy.Packages[i].CreativeAssignments, adcp.CreativeAssignment{
+                                    CreativeID: assign.CreativeID, Weight: assign.Weight, PlacementIDs: assign.PlacementIDs,
+                                })
+                                buy.Status = "active"
+                                buy.ValidActions = []string{"pause", "cancel", "sync_creatives", "update_packages"}
+                            }
+                        }
+                    }
+                }
                 return results, nil
             },
 
@@ -218,7 +250,7 @@ func main() {
                     if !ok { continue }
                     pkgDel := make([]adcp.PackageDelivery, 0)
                     for _, pkg := range buy.Packages {
-                        pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Totals: adcp.DeliveryTotals{}})
+                        pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Spend: 0, PricingModel: "cpm", Rate: 0, Currency: "USD"})
                     }
                     deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{}, ByPackage: pkgDel})
                 }


### PR DESCRIPTION
## Summary

Addresses the concrete Argus follow-ups from the Go reference seller harness merge, plus protocol/code/DX expert passes on the SDK surface:

- replaces the generated `CreateMediaBuyResponse = any` callback surface with a real `CreateMediaBuyResult` interface implemented by the three generated schema variants
- scopes `MediaBuyData` to the `get_media_buys.media_buys[]` item shape instead of using it as a create/task catchall
- routes `Config.GetMediaBuys` through the generated `GetMediaBuysResponse` envelope so pagination/errors/context are reachable from normal `adcp.Register` handlers
- types `GetMediaBuysResponse.MediaBuys` as `[]MediaBuyData` and adds `PackageStatus` for get-media-buys package rows, including creative approvals, pending formats, and delivery snapshots
- ensures `get_media_buys` emits `media_buys: []` instead of `null` for empty/nil lists
- adds typed response helpers for create media buy success/error/submitted variants
- makes creative assignments typed without losing schema expressiveness: `weight: 0` is preserved and vendor-specific assignment fields round-trip via `CreativeAssignment.Extra`
- types `SyncCreativesRequest.Assignments` as `[]SyncCreativeAssignment`
- changes `UpdateMediaBuyRequest.canceled` and package updates to pointer booleans; docs now call out that `canceled` is nil-or-true while resume uses `paused:false`
- normalizes package delivery rows to the flat schema shape instead of emitting nested package `totals`, with a comment for schema-required package spend
- applies context echo consistently to signals and collection tools
- makes `list_creatives` format filtering match the full format ref, not just `id`
- weights simulated reported spend consistently by package budget
- updates README, migration notes, and SDK-local build skills for the current typed request/response names and seller patterns

## Notes

The protocol-managed `skills/adcp-media-buy` bundle still has stale buyer-facing examples for creative assignments/update wrappers/async status. I did not hand-edit that managed skill; it should be fixed upstream or refreshed through the bundle sync. Tracked in #143.

First-class `Config.UpdateMediaBuy` and `Config.ListCreatives` hooks are still an additive SDK follow-up. Tracked in #144.

The compliance scenario enum concern appears resolved in the current 3.0.12 schemas in this repo: `seed_product`, `seed_pricing_option`, and `force_create_media_buy_arm` are already present in the request/response scenario enums. I left that as an issue-tracking/spec-sync item rather than changing runtime behavior here.

## Validation

- `go test ./...`
- `cd adcp && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `cd bench && go test ./...`
- `cd adcp/schemas && python3 lint.py --strict`
- `git diff --check`
- `golangci-lint run ./...`
- `cd adcp && golangci-lint run ./...`
- `cd reference/seller-agent && golangci-lint run ./...`
- `cd reference/context-agent && golangci-lint run ./...`
- `ADCP_RUNNER_BIN=adcp ADCP_PORT=3015 STORYBOARD_RESULT_PATH=.context/storyboard-final-dx.json SELLER_LOG_PATH=.context/storyboard-final-dx.log ./scripts/ci/run_storyboard_reference_seller.sh` (`59/59`)
