### PR TITLE
docs(skills): fix typed SDK examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ adcp.AddTool(server, "tool_name", "Description",
 | `adcp.ActivateSignalResponse(deployments, sandbox)` | `activate_signal` |
 | `adcp.SyncCatalogsResponse(catalogs, sandbox)` | `sync_catalogs` |
 | `adcp.SyncEventSourcesResponse(sources, sandbox)` | `sync_event_sources` |
-| `adcp.LogEventResponse(received, processed, sandbox)` | `log_event` |
+| `adcp.LogEventResponse(received, processed, matchQuality, sandbox)` | `log_event` |
 | `adcp.PerformanceFeedbackResponse(sandbox)` | `provide_performance_feedback` |
 | `adcp.Result(data, summary)` | Any tool (generic) |
 | `adcp.Errorf(code, opts)` | Error response |

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -151,12 +151,7 @@ adcp.AddTool(server, "preview_creative", "Render a preview",
 
         if input.CreativeManifest != nil {
             // Render from manifest directly
-            if fid, ok := input.CreativeManifest["format_id"].(map[string]any); ok {
-                if id, ok := fid["id"].(string); ok {
-                    w, h = formatDimensions(id)
-                }
-            }
-            name, _ = input.CreativeManifest["name"].(string)
+            w, h = formatDimensions(input.CreativeManifest.FormatID.ID)
             creativeID = "preview-manifest"
         } else if input.CreativeID != "" {
             // Lookup from store
@@ -181,7 +176,7 @@ adcp.AddTool(server, "preview_creative", "Render a preview",
 
 ### 6. `build_creative`
 
-Handle both `creative_manifest` (direct build) and `creative_id` (store lookup). If neither is provided but `format_id` is, build a default manifest from the format.
+Handle both `creative_manifest` (direct build) and `creative_id` (store lookup). If neither is provided but `target_format_id` is, build a default manifest from the format.
 
 ```go
 adcp.AddTool(server, "build_creative", "Build serving tag",
@@ -189,7 +184,10 @@ adcp.AddTool(server, "build_creative", "Build serving tag",
         var manifest map[string]any
 
         if input.CreativeManifest != nil {
-            manifest = input.CreativeManifest
+            manifest = map[string]any{
+                "format_id": input.CreativeManifest.FormatID,
+                "assets": input.CreativeManifest.Assets,
+            }
         } else if input.CreativeID != "" {
             s.mu.RLock()
             c, ok := s.creatives[input.CreativeID]
@@ -200,12 +198,12 @@ adcp.AddTool(server, "build_creative", "Build serving tag",
                 })
             }
             manifest = map[string]any{"format_id": c.FormatID, "name": c.Name, "assets": c.Assets}
-        } else if input.FormatID != nil {
+        } else if input.TargetFormatID != nil {
             // Build default manifest from format
-            manifest = map[string]any{"format_id": input.FormatID, "name": "Built Creative"}
+            manifest = map[string]any{"format_id": input.TargetFormatID, "assets": map[string]any{}}
         } else {
             return adcp.Errorf("INVALID_INPUT", adcp.ErrorOptions{
-                Message: "creative_id, creative_manifest, or format_id required",
+                Message: "creative_id, creative_manifest, or target_format_id required",
             })
         }
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -5,7 +5,7 @@ description: Use when building an AdCP generative seller in Go — an AI ad netw
 
 # Build a Generative Seller Agent (Go)
 
-> **Status: Not yet validated against storyboard runner.** If validation fails, check the common mistakes table first, then file an issue.
+> **Status: Validated against storyboard runner.** If validation fails, check the common mistakes table first, then file an issue.
 
 ## Overview
 
@@ -16,7 +16,7 @@ A generative seller does everything a standard seller does (products, media buys
 Ask the user — don't guess.
 
 1. **What kind of platform?** AI ad network, generative DSP, retail media with creative generation.
-2. **Products and pricing.** Each product needs: product_id, name, description (required), channel, delivery_type, pricing_options, publisher_properties (empty array OK), format_ids. Use lowercase pricing models.
+2. **Products and pricing.** Each product needs: product_id, name, description (required), channel, delivery_type, pricing_options, publisher_properties, format_ids, and reporting_capabilities. Use lowercase pricing models.
 3. **Generative formats.** What does the platform generate? Each generative format needs a `brief` asset slot. Standard formats need traditional asset slots (image, video).
 4. **Approval workflow.** Instant (`status: "active"`) or async (`status: "submitted"`). Async transitions SHOULD emit signed webhooks to `push_notification_config.url` — see `skills/build-webhook-publisher/`. Buyer polling is the legacy fallback only.
 
@@ -88,7 +88,7 @@ adcp.AddTool(server, "sync_governance", "Register governance agents",
 
 ### 4. `get_products`
 
-Products MUST include `description`, `publisher_properties`, and `format_ids`:
+Products MUST include `description`, `publisher_properties`, `format_ids`, and `reporting_capabilities`:
 
 ```go
 var products = []adcp.Product{
@@ -96,12 +96,20 @@ var products = []adcp.Product{
         ProductID: "ai-display", Name: "AI-Generated Display",
         Description: "AI-generated display ads from creative briefs",
         Channels: []string{"display"}, DeliveryType: "non_guaranteed",
+        PublisherProperties: []adcp.PublisherPropertySelector{
+            {PublisherDomain: "example.com", SelectionType: "all"},
+        },
         PricingOptions: []adcp.PricingOption{
             {PricingOptionID: "ai-display-floor", PricingModel: "cpm", FloorPrice: 8.00, Currency: "USD"},
         },
         FormatIDs: []adcp.FormatRef{
             {AgentURL: agentURL, ID: "display_300x250_generative"},
             {AgentURL: agentURL, ID: "display_300x250"},
+        },
+        ReportingCapabilities: map[string]any{
+            "available_metrics": []string{"impressions", "spend", "clicks"},
+            "available_reporting_frequencies": []string{"daily"},
+            "timezone": "UTC",
         },
     },
 }
@@ -301,7 +309,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_s
 | Only generative formats | Must also accept standard IAB formats |
 | Same status for brief and standard | Generative → `"pending_review"`, standard → `"approved"` |
 | Products missing `description` | Required field |
-| Missing `publisher_properties`/`format_ids` | Required fields |
+| Missing `publisher_properties`, `format_ids`, or `reporting_capabilities` | Required fields |
 | `sync_governance` response key `results` | Must be `accounts` |
 | `get_delivery` returns `null` for empty arrays | Use `make([]T, 0)` |
 | `get_delivery` returns `null` for empty deliveries | Use `adcp.DeliveryResponse` |

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -5,7 +5,7 @@ description: Use when building an AdCP retail media network agent in Go — sell
 
 # Build a Retail Media Agent (Go)
 
-> **Status: Not yet validated against storyboard runner.** If validation fails, check the common mistakes table first, then file an issue.
+> **Status: Validated against storyboard runner.** If validation fails, check the common mistakes table first, then file an issue.
 
 ## Overview
 
@@ -13,7 +13,7 @@ A retail media agent sells advertising on a retailer's properties. It extends th
 
 ## Before Writing Code
 
-1. **Products.** Each needs: product_id, name, description (required), channel, delivery_type, pricing_options, publisher_properties, format_ids. Use lowercase pricing models.
+1. **Products.** Each needs: product_id, name, description (required), channel, delivery_type, pricing_options, publisher_properties, format_ids, and reporting_capabilities. Use lowercase pricing models.
 2. **Catalogs.** What product feeds? How connected to ad rendering?
 3. **Events.** What conversion events? Purchase, add_to_cart, page_view?
 4. **Approval workflow.** Instant or async. Async SHOULD emit signed webhooks when the buyer supplies `push_notification_config` — see `skills/build-webhook-publisher/` for the emission pattern.
@@ -80,10 +80,18 @@ var products = []adcp.Product{
         ProductID: "sponsored-product", Name: "Sponsored Product",
         Description: "Promoted product listings in search results",
         Channels: []string{"retail_media"}, DeliveryType: "non_guaranteed",
+        PublisherProperties: []adcp.PublisherPropertySelector{
+            {PublisherDomain: "shop.example", SelectionType: "all"},
+        },
         PricingOptions: []adcp.PricingOption{
             {PricingOptionID: "sp-cpc", PricingModel: "cpc", FixedPrice: 0.50, Currency: "USD"},
         },
         FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "product-card"}},
+        ReportingCapabilities: map[string]any{
+            "available_metrics": []string{"impressions", "spend", "clicks", "conversions"},
+            "available_reporting_frequencies": []string{"daily"},
+            "timezone": "UTC",
+        },
     },
 }
 
@@ -295,7 +303,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_crea
 | Using `mcp.AddTool` directly | Use `adcp.AddTool` |
 | Missing `conversion_tracking` in supported_protocols | Storyboard rejects catalog/event tools without it |
 | Products missing `description` | Required field |
-| Missing `publisher_properties`/`format_ids` | Required fields |
+| Missing `publisher_properties`, `format_ids`, or `reporting_capabilities` | Required fields |
 | `sync_catalogs` missing `item_count` | Required field |
 | `log_event` missing `events_received` | Required counter |
 | `log_event` missing `match_quality` | Include match quality score (0.0-1.0) via `adcp.LogEventResponse` |
@@ -327,7 +335,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_crea
 | `adcp.SyncCreativesResponse(creatives, sandbox)` | Sync creatives |
 | `adcp.SyncCatalogsResponse(catalogs, sandbox)` | Sync catalogs |
 | `adcp.SyncEventSourcesResponse(sources, sandbox)` | Event sources |
-| `adcp.LogEventResponse(received, processed, sandbox)` | Log events |
+| `adcp.LogEventResponse(received, processed, matchQuality, sandbox)` | Log events |
 | `adcp.PerformanceFeedbackResponse(sandbox)` | Performance feedback |
 | `adcp.Result(data, summary)` | Generic response |
 | `adcp.Errorf(code, opts)` | Error response |

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -22,7 +22,7 @@ Ask the user — don't guess.
 
 1. **What kind of seller?** Premium publisher (guaranteed, fixed pricing) / SSP (non-guaranteed, auction) / Retail media (both)
 2. **Guaranteed or non-guaranteed?** `delivery_type: "guaranteed"` vs `"non_guaranteed"`. Many sellers support both.
-3. **Products and pricing.** Each product needs: product_id, name, description, channels (array of channel enums), delivery_type, pricing_options, format_ids. publisher_properties is optional; if present, it's a list of `PublisherPropertySelector` entries each pointing at a publisher_domain.
+3. **Products and pricing.** Each product needs: product_id, name, description, publisher_properties, channels (array of channel enums), delivery_type, pricing_options, format_ids, and reporting_capabilities. Use `PublisherPropertySelector` entries pointing at publisher_domain values.
 4. **Approval workflow.** Instant create returns a media buy such as `status: "active"` or `status: "pending_creatives"`. Async create returns the submitted task envelope (`status: "submitted"`, `task_id`, optional `message`) and later exposes the confirmed buy via `get_media_buys` or signed webhooks to `push_notification_config.url` — see `skills/build-webhook-publisher/` for the emission pattern.
 5. **Creative management.** Standard (`list_creative_formats` + `sync_creatives`) or none.
 
@@ -65,10 +65,18 @@ var products = []adcp.Product{
         ProductID: "premium-display", Name: "Premium Display",
         Description: "High-impact display placements.",
         Channels: []string{"display"}, DeliveryType: "guaranteed",
+        PublisherProperties: []adcp.PublisherPropertySelector{
+            {PublisherDomain: "example.com", SelectionType: "all"},
+        },
         PricingOptions: []adcp.PricingOption{
             {PricingOptionID: "pd-cpm", PricingModel: "cpm", FixedPrice: 15.00, Currency: "USD"},
         },
         FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "banner-300x250"}},
+        ReportingCapabilities: map[string]any{
+            "available_metrics": []string{"impressions", "spend", "clicks"},
+            "available_reporting_frequencies": []string{"daily"},
+            "timezone": "UTC",
+        },
     },
 }
 
@@ -407,7 +415,7 @@ Use lowercase pricing models: `"cpm"`, `"cpc"`, `"cpcv"`, not `"CPM"`.
 |---------|-----|
 | Missing `IdempotencyReplayTTL` on `adcp.Config` | Required — set to `24*time.Hour`. Panics at startup if unset or outside 1h–7d. |
 | Missing `Description` on products | Required by schema validation |
-| Missing `format_ids` on products | Required field — use an empty `[]adcp.FormatRef{}` if none. `publisher_properties` is optional; omit it rather than sending an empty array. |
+| Missing `publisher_properties`, `format_ids`, or `reporting_capabilities` on products | Required fields. Use at least one publisher selector, supported format, and reporting capability block. |
 | `sync_governance` response key `results` | Must be `accounts` |
 | `sync_creatives` status `"accepted"` | Use `"approved"` — valid: processing, pending_review, approved, rejected, archived |
 | Empty slices serialize as `null` | Use `make([]T, 0)` not `var x []T` |


### PR DESCRIPTION
## Summary

Follow-up from the expert pass after #142:

- fixes seller/generative/retail product examples to include required `publisher_properties` and `reporting_capabilities`
- updates creative-agent snippets to use typed `CreativeManifest` and `BuildCreativeRequest.TargetFormatID`
- fixes `LogEventResponse` docs to include `matchQuality`
- aligns generative/retail skill validation status with README

## Validation

- `git diff --check`
- source/docs inspection only; markdown/example-only changes

## Related

Generator replacement/evaluation tracked in #145.
