### PR TITLE
feat(adcp)!: generate media-buy schema helpers

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,18 @@ Most wire payloads are unchanged, but several public Go structs are more typed.
   `adcp.Float64(0)` for an explicit paused creative weight; omitted weight
   still means equal rotation. Seller-specific assignment fields round-trip via
   `CreativeAssignment.Extra`.
+- `PackageInput` is now generated from `media-buy/package-request.json`. The
+  non-protocol `BuyerRef` field is gone; use `Ext` for seller-specific
+  correlation metadata. The generated type also exposes schema fields that were
+  previously missing, including `FormatIDs`, `Pacing`, `Impressions`, `Paused`,
+  `Catalogs`, `OptimizationGoals`, `Creatives`, `Context`, and `Ext`.
+- `UpdateMediaBuyRequest` is now generated from
+  `media-buy/update-media-buy-request.json`. `StartTime` is a `string` instead
+  of `any`, matching the current schema's `start-timing` alias.
+- `PackageUpdate` is now generated from `media-buy/package-update.json`. It
+  exposes schema-backed package update fields such as `Pacing`, `Catalogs`,
+  `OptimizationGoals`, keyword add/remove operations, `Creatives`, `Context`,
+  and `Ext`.
 - `SyncCreativesRequest.Assignments` is now `[]adcp.SyncCreativeAssignment`.
 - `Config.CreateMediaBuy` now returns `adcp.CreateMediaBuyResult`, which is
   implemented by the generated schema variants. Return
@@ -27,9 +39,12 @@ Most wire payloads are unchanged, but several public Go structs are more typed.
 - `MediaBuyData.Packages` is `[]adcp.PackageStatus` so `get_media_buys` can
   include creative approvals, pending formats, and delivery snapshots.
   `CreateMediaBuySuccess.Packages` remains `[]adcp.Package`.
-- `PackageDelivery` is flat. Read package-level delivery metrics directly from
-  `PackageDelivery.Impressions`, `Spend`, and `Clicks`; `Spend` remains present
-  on the wire even when zero.
+- `PackageDelivery` and `MediaBuyDelivery` are generated from the delivery
+  response inline schemas. Package-level metrics remain flat on
+  `PackageDelivery`, and `pricing_model`, `rate`, `currency`, and `spend` are
+  emitted as schema-required fields even when their Go values are zero.
+  `MediaBuyDelivery.Totals` is now `adcp.MediaBuyDeliveryTotals`, which includes
+  the schema-specific `effective_rate` field.
 
 ## v3.0.0-rc.4 (governance / policy framework)
 

--- a/adcp/inputs.go
+++ b/adcp/inputs.go
@@ -5,9 +5,9 @@ import "encoding/json"
 // Request types for AdCP tools are generated from JSON schemas in types_gen.go
 // (e.g., GetProductsRequest, CreateMediaBuyRequest, SyncAccountsRequest).
 //
-// This file contains types the generator can't produce: EmptyInput (no schema),
-// PackageInput (needs typed business terms), and nested item types that are
-// inline objects in the schemas rather than $ref targets.
+// This file contains types the generator can't produce: EmptyInput (no schema)
+// and nested item types that are inline objects in the schemas rather than $ref
+// targets.
 
 // EmptyInput is the input type for tools that accept no parameters (e.g. get_adcp_capabilities).
 type EmptyInput struct{}
@@ -110,62 +110,6 @@ func isCreativeAssignmentField(key string) bool {
 	default:
 		return false
 	}
-}
-
-// PackageInput is a single package in a create_media_buy request.
-type PackageInput struct {
-	ProductID       string  `json:"product_id"`
-	PricingOptionID string  `json:"pricing_option_id,omitempty"`
-	Budget          float64 `json:"budget"`
-	BidPrice        float64 `json:"bid_price,omitempty"`
-	BuyerRef        string  `json:"buyer_ref,omitempty"`
-
-	// Business terms (buyer proposals, override product defaults)
-	MeasurementTerms     *MeasurementTerms     `json:"measurement_terms,omitempty"`
-	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"`
-	TargetingOverlay     *Targeting            `json:"targeting_overlay,omitempty"`
-	CreativeAssignments  []CreativeAssignment  `json:"creative_assignments,omitempty"`
-
-	// Broadcast / scheduling
-	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"`
-	StartTime            string `json:"start_time,omitempty"`
-	EndTime              string `json:"end_time,omitempty"`
-}
-
-// UpdateMediaBuyRequest is the input for update_media_buy.
-type UpdateMediaBuyRequest struct {
-	AdcpMajorVersion       int              `json:"adcp_major_version,omitempty"`
-	IdempotencyKey         string           `json:"idempotency_key"`
-	Account                AccountReference `json:"account"`
-	MediaBuyID             string           `json:"media_buy_id"`
-	Revision               int              `json:"revision,omitempty"`
-	Paused                 *bool            `json:"paused,omitempty"`
-	Canceled               *bool            `json:"canceled,omitempty"`
-	CancellationReason     string           `json:"cancellation_reason,omitempty"`
-	StartTime              any              `json:"start_time,omitempty"`
-	EndTime                string           `json:"end_time,omitempty"`
-	Packages               []PackageUpdate  `json:"packages,omitempty"`
-	InvoiceRecipient       any              `json:"invoice_recipient,omitempty"`
-	NewPackages            []PackageInput   `json:"new_packages,omitempty"`
-	ReportingWebhook       any              `json:"reporting_webhook,omitempty"`
-	PushNotificationConfig any              `json:"push_notification_config,omitempty"`
-	Context                any              `json:"context,omitempty"`
-	Ext                    any              `json:"ext,omitempty"`
-}
-
-// PackageUpdate identifies a package and fields to update in update_media_buy.
-type PackageUpdate struct {
-	PackageID           string               `json:"package_id"`
-	Budget              float64              `json:"budget,omitempty"`
-	BidPrice            float64              `json:"bid_price,omitempty"`
-	Impressions         float64              `json:"impressions,omitempty"`
-	StartTime           string               `json:"start_time,omitempty"`
-	EndTime             string               `json:"end_time,omitempty"`
-	Paused              *bool                `json:"paused,omitempty"`
-	Canceled            *bool                `json:"canceled,omitempty"`
-	CancellationReason  string               `json:"cancellation_reason,omitempty"`
-	TargetingOverlay    *Targeting           `json:"targeting_overlay,omitempty"`
-	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"`
 }
 
 // --- Nested item types (inline objects in schemas, no $ref) ---

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -33,8 +33,7 @@ KNOWN_TYPES = {
     'GovernanceAgent', 'ProductsData',
     'MediaBuyListItem', 'MediaBuyData', 'MediaBuyHistoryEntry',
     'PackageStatus', 'PackageCreativeApproval', 'PackageSnapshot',
-    'DeliveryData', 'ReportingPeriod', 'MediaBuyDelivery',
-    'PackageDelivery',
+    'DeliveryData', 'ReportingPeriod',
     'Render', 'AssetSlot', 'CreativeResult', 'CreativeListItem', 'PreviewResult',
     'Preview', 'PreviewRender', 'BuildCreativeResult', 'SignalID',
     'SignalPricing', 'ActivationKey', 'CatalogResult',
@@ -43,7 +42,7 @@ KNOWN_TYPES = {
     # the union into a single struct with all variant fields.
     'PricingOption', 'Deployment', 'PublisherPropertySelector',
     # From inputs.go (hand-written types that need custom Go code)
-    'EmptyInput', 'PackageInput',
+    'EmptyInput',
     'AccountInput', 'GovernanceAccountInput',
     'CreativeInput', 'SyncCreativeAssignment',
     'CatalogInput', 'EventSourceInput', 'DestinationInput',
@@ -113,6 +112,7 @@ TOOL_SCHEMAS = [
     "media-buy/get-products-response.json",
     "media-buy/create-media-buy-request.json",
     "media-buy/create-media-buy-response.json",
+    "media-buy/update-media-buy-request.json",
     "media-buy/get-media-buys-request.json",
     "media-buy/get-media-buys-response.json",
     "media-buy/get-media-buy-delivery-request.json",
@@ -224,6 +224,73 @@ CORE_SCHEMAS = [
     "core/duration.json",
 ]
 
+# Schemas that are not standalone tool requests/responses, but are important
+# SDK input shapes referenced by tool schemas.
+SUPPORT_SCHEMAS = [
+    "media-buy/package-request.json",
+    "media-buy/package-update.json",
+]
+
+# Named types generated from inline JSON Schema pointers. This is the first step
+# toward making the Go SDK generator own composed/nested shapes instead of
+# relying on hand-written approximations.
+INLINE_SCHEMA_TYPES = OrderedDict([
+    (
+        "KeywordTargetUpdate",
+        "media-buy/package-update.json#/properties/keyword_targets_add/items",
+    ),
+    (
+        "KeywordTargetRef",
+        "media-buy/package-update.json#/properties/keyword_targets_remove/items",
+    ),
+    (
+        "DeliveryAggregatedTotals",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/aggregated_totals",
+    ),
+    (
+        "MediaBuyDeliveryTotals",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/totals",
+    ),
+    (
+        "MediaBuyDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items",
+    ),
+    (
+        "PackageDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items",
+    ),
+])
+
+# Hand-written types that should be drift-checked against a schema path or JSON
+# pointer. lint.py imports this table; keep it here so generator/lint ownership
+# lives in one place.
+HAND_WRITTEN_SCHEMA_SPECS = {
+    'Product': 'core/product.json',
+    'Package': 'core/package.json',
+    'CreativeAssignment': 'core/creative-assignment.json',
+    'Targeting': 'core/targeting.json',
+    'FormatRef': 'core/format-id.json',
+    'PricingOption': 'core/pricing-option.json',
+    'Signal': 'core/signal-definition.json',
+    'SignalPricing': 'core/signal-pricing.json',
+    'Deployment': 'core/deployment.json',
+    'CreativeFormat': 'core/format.json',
+    'VendorPricingOption': 'core/vendor-pricing-option.json',
+    'MeasurementTerms': 'core/measurement-terms.json',
+    'MeasurementWindow': 'core/measurement-window.json',
+    'PerformanceStandard': 'core/performance-standard.json',
+    'Duration': 'core/duration.json',
+    'CancellationPolicy': 'core/cancellation-policy.json',
+    'CollectionListRef': 'core/collection-list-ref.json',
+    'CreativeConsumption': 'core/creative-consumption.json',
+    'IndustryIdentifier': 'core/industry-identifier.json',
+    'ContentRating': 'core/content-rating.json',
+}
+
 # Map schema-derived Go names to the preferred Go name. Applied both when
 # resolving $ref targets and when emitting core/tool schema structs, so a
 # schema named brand-ref.json emits as `type BrandReference struct` and every
@@ -263,6 +330,15 @@ INLINE_TYPE_HINTS = {
     ('ActivateSignalRequest', 'destinations'): 'DestinationInput',
     ('GetSignalsRequest', 'filters'): 'SignalFilters',
     ('SyncPlansRequest', 'plans'): 'Plan',
+    ('PackageUpdate', 'keyword_targets_add'): 'KeywordTargetUpdate',
+    ('PackageUpdate', 'keyword_targets_remove'): 'KeywordTargetRef',
+    ('PackageUpdate', 'negative_keywords_add'): 'KeywordTargetRef',
+    ('PackageUpdate', 'negative_keywords_remove'): 'KeywordTargetRef',
+    ('MediaBuyDelivery', 'totals'): 'MediaBuyDeliveryTotals',
+    ('MediaBuyDelivery', 'by_package'): 'PackageDelivery',
+    ('GetMediaBuyDeliveryResponse', 'reporting_period'): 'ReportingPeriod',
+    ('GetMediaBuyDeliveryResponse', 'aggregated_totals'): '*DeliveryAggregatedTotals',
+    ('GetMediaBuyDeliveryResponse', 'media_buy_deliveries'): 'MediaBuyDelivery',
     # format.json: renders[] and assets[] are oneOf items. Map to hand-written
     # Render/AssetSlot so reference-agent code can keep using typed literals.
     ('CreativeFormat', 'renders'): 'Render',
@@ -283,6 +359,91 @@ def load_schema(path):
     with open(path) as f:
         # Use object_pairs_hook to preserve key order
         return json.load(f, object_pairs_hook=OrderedDict)
+
+def json_pointer_get(doc, pointer):
+    """Resolve a JSON Pointer fragment against a decoded JSON document."""
+    if pointer in ('', None):
+        return doc
+    if not pointer.startswith('/'):
+        raise ValueError(f'unsupported JSON pointer: {pointer}')
+    node = doc
+    for raw_part in pointer.split('/')[1:]:
+        part = raw_part.replace('~1', '/').replace('~0', '~')
+        if isinstance(node, list):
+            node = node[int(part)]
+        else:
+            node = node[part]
+    return node
+
+def load_schema_spec(spec):
+    """Load `path.json` or `path.json#/json/pointer` relative to schemas/."""
+    path_part, _, pointer = spec.partition('#')
+    schema = load_schema(path_part)
+    if pointer:
+        return json_pointer_get(schema, pointer)
+    return schema
+
+def resolve_ref_schema(ref):
+    """Load a schema referenced by $ref. Supports bundled refs of the form
+    /schemas/{version}/{path}.json and optional JSON Pointer fragments."""
+    if not isinstance(ref, str):
+        return None
+    m = re.match(r'^/schemas/[^/]+/(.+\.json)(#.*)?$', ref)
+    if not m:
+        return None
+    spec = m.group(1) + (m.group(2) or '')
+    path_part = spec.split('#', 1)[0]
+    path = Path(path_part).resolve()
+    root = Path.cwd().resolve()
+    if root != path and root not in path.parents:
+        return None
+    if not path.exists():
+        return None
+    try:
+        return load_schema_spec(spec)
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
+        return None
+
+def schema_properties(schema, _visited=None):
+    """Return an ordered union of properties declared directly, through $ref,
+    or through composition. allOf is flattened for generated Go structs."""
+    if _visited is None:
+        _visited = set()
+    props = OrderedDict()
+    if not isinstance(schema, dict):
+        return props
+    ref = schema.get('$ref')
+    if ref and ref not in _visited:
+        _visited.add(ref)
+        ref_schema = resolve_ref_schema(ref)
+        if ref_schema:
+            props.update(schema_properties(ref_schema, _visited))
+    for key in ('allOf', 'anyOf', 'oneOf'):
+        for branch in schema.get(key, []):
+            props.update(schema_properties(branch, _visited))
+    for json_name, prop in schema.get('properties', {}).items():
+        props[json_name] = prop
+    return props
+
+def schema_required_names(schema, _visited=None):
+    """Return fields required by the schema. For generation, allOf-required
+    fields are required; anyOf/oneOf branch requirements are intentionally not
+    merged because only one branch applies."""
+    if _visited is None:
+        _visited = set()
+    required = set()
+    if not isinstance(schema, dict):
+        return required
+    ref = schema.get('$ref')
+    if ref and ref not in _visited:
+        _visited.add(ref)
+        ref_schema = resolve_ref_schema(ref)
+        if ref_schema:
+            required.update(schema_required_names(ref_schema, _visited))
+    required.update(schema.get('required', []))
+    for branch in schema.get('allOf', []):
+        required.update(schema_required_names(branch, _visited))
+    return required
 
 def ref_to_go_name(ref):
     """Convert a $ref path to a Go type name.
@@ -338,7 +499,7 @@ def _will_generate_set():
     if _WILL_GENERATE_CACHE is not None:
         return _WILL_GENERATE_CACHE
     names = set()
-    for rel in CORE_SCHEMAS + TOOL_SCHEMAS + WEBHOOK_SCHEMAS:
+    for rel in CORE_SCHEMAS + SUPPORT_SCHEMAS + TOOL_SCHEMAS + WEBHOOK_SCHEMAS:
         if not os.path.exists(rel):
             continue
         try:
@@ -348,6 +509,13 @@ def _will_generate_set():
         if schema.get('type') == 'object' and 'properties' in schema:
             stem = Path(rel).stem
             name = REF_ALIASES.get(pascal_case(stem), pascal_case(stem))
+            names.add(name)
+    for name, spec in INLINE_SCHEMA_TYPES.items():
+        try:
+            schema = load_schema_spec(spec)
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
+            continue
+        if schema_properties(schema):
             names.add(name)
     _WILL_GENERATE_CACHE = names
     return names
@@ -364,11 +532,19 @@ def resolve_go_type(prop, required=False):
             return 'AdcpError'
         # Apply aliases for schema names that don't match Go type names
         name = REF_ALIASES.get(name, name)
+        if name in ('string', 'int', 'float64', 'bool', 'any'):
+            return name
         # Resolve if the type is hand-written (KNOWN_TYPES) or will be
         # emitted from one of the registered schema lists in this run.
         if name in KNOWN_TYPES or name in _will_generate_set():
             return name
         return 'any'  # Unknown $ref target — avoid undefined type errors
+
+    if 'allOf' in prop:
+        branches = prop.get('allOf', [])
+        if len(branches) == 1 and isinstance(branches[0], dict):
+            return resolve_go_type(branches[0], required)
+        return 'any'
 
     typ = prop.get('type', '')
 
@@ -405,8 +581,8 @@ def resolve_go_type(prop, required=False):
 
 def schema_to_struct(name, schema):
     """Convert a JSON schema to a Go struct definition string."""
-    props = schema.get('properties', {})
-    required_set = set(schema.get('required', []))
+    props = schema_properties(schema)
+    required_set = schema_required_names(schema)
 
     fields = []
     for json_name, prop in props.items():
@@ -532,6 +708,37 @@ def generate():
             continue
         generated.add(name)
         if schema.get('type') == 'object' and 'properties' in schema:
+            print(schema_to_struct(name, schema))
+
+    # Generate support/helper schema types.
+    print('// --- Support schema types ---')
+    print()
+    for path in SUPPORT_SCHEMAS:
+        if not os.path.exists(path):
+            print(f'// Skipped {path} (not found)', file=sys.stderr)
+            continue
+        schema = load_schema(path)
+        name = REF_ALIASES.get(pascal_case(Path(path).stem),
+                               pascal_case(Path(path).stem))
+        if name in generated:
+            continue
+        generated.add(name)
+        if schema_properties(schema):
+            print(schema_to_struct(name, schema))
+
+    # Generate named inline schema-pointer types.
+    print('// --- Inline schema types ---')
+    print()
+    for name, spec in INLINE_SCHEMA_TYPES.items():
+        if name in generated:
+            continue
+        generated.add(name)
+        try:
+            schema = load_schema_spec(spec)
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError) as e:
+            print(f'// Skipped {name} ({spec}: {e})', file=sys.stderr)
+            continue
+        if schema_properties(schema):
             print(schema_to_struct(name, schema))
 
     # Generate tool request/response types

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -58,7 +58,7 @@ EXEMPT = {
     'ReportedSpend', 'SimulateBudgetParams', 'SimulationResult',
     'TestControllerError',
     # inputs (agent-specific helpers, schemas are inline in request schemas)
-    'EmptyInput', 'PackageInput', 'AccountInput', 'GovernanceAccountInput',
+    'EmptyInput', 'AccountInput', 'GovernanceAccountInput',
     'CreativeInput', 'CatalogInput', 'EventSourceInput', 'DestinationInput',
     'CreativeFilters', 'SignalFilters',
     # response builders (funcs, not structs — KNOWN_TYPES collision guard)
@@ -78,8 +78,8 @@ EXEMPT = {
     'GovernanceAccount', 'GovernanceAgent', 'CreativeListItem',
     'MediaBuyListItem', 'MediaBuyData', 'MediaBuyHistoryEntry',
     'PackageStatus', 'PackageCreativeApproval', 'PackageSnapshot',
-    'SyncCreativeAssignment', 'PackageDelivery', 'DeliveryTotals', 'DeliveryData',
-    'MediaBuyDelivery', 'ReportingPeriod', 'PreviewResult', 'Preview',
+    'SyncCreativeAssignment', 'DeliveryTotals', 'DeliveryData',
+    'ReportingPeriod', 'PreviewResult', 'Preview',
     'PreviewRender', 'BuildCreativeResult', 'ProductsData',
     # capability blocks — generator doesn't own these yet
     'CapabilitiesData', 'ADCPVersion', 'IdempotencyCaps', 'AccountCapabilities',
@@ -119,28 +119,7 @@ EXEMPT = {
 # this table declares the pairing explicitly. Types with no standalone schema
 # file (nested shapes, dead code) belong in EXEMPT, not here — None entries
 # were removed because they never reach path resolution.
-EXPLICIT_SCHEMA = {
-    'Product': 'core/product.json',
-    'Package': 'core/package.json',
-    'CreativeAssignment': 'core/creative-assignment.json',
-    'Targeting': 'core/targeting.json',
-    'FormatRef': 'core/format-id.json',
-    'PricingOption': 'core/pricing-option.json',
-    'Signal': 'core/signal-definition.json',
-    'SignalPricing': 'core/signal-pricing.json',
-    'Deployment': 'core/deployment.json',
-    'CreativeFormat': 'core/format.json',
-    'VendorPricingOption': 'core/vendor-pricing-option.json',
-    'MeasurementTerms': 'core/measurement-terms.json',
-    'MeasurementWindow': 'core/measurement-window.json',
-    'PerformanceStandard': 'core/performance-standard.json',
-    'Duration': 'core/duration.json',
-    'CancellationPolicy': 'core/cancellation-policy.json',
-    'CollectionListRef': 'core/collection-list-ref.json',
-    'CreativeConsumption': 'core/creative-consumption.json',
-    'IndustryIdentifier': 'core/industry-identifier.json',
-    'ContentRating': 'core/content-rating.json',
-}
+EXPLICIT_SCHEMA = gen.HAND_WRITTEN_SCHEMA_SPECS
 
 # STRUCT_RE assumes gofmt layout (closing `}` at column 0) and top-level
 # struct declarations only. Anonymous struct fields that close at column 0
@@ -199,6 +178,31 @@ def load_schema(path):
         return json.load(f, object_pairs_hook=OrderedDict)
 
 
+def json_pointer_get(doc, pointer):
+    """Resolve a JSON Pointer fragment against a decoded JSON document."""
+    if pointer in ('', None):
+        return doc
+    if not pointer.startswith('/'):
+        raise ValueError(f'unsupported JSON pointer: {pointer}')
+    node = doc
+    for raw_part in pointer.split('/')[1:]:
+        part = raw_part.replace('~1', '/').replace('~0', '~')
+        if isinstance(node, list):
+            node = node[int(part)]
+        else:
+            node = node[part]
+    return node
+
+
+def load_schema_spec(spec):
+    """Load `path.json` or `path.json#/json/pointer` relative to schemas/."""
+    path_part, _, pointer = spec.partition('#')
+    schema = load_schema(SCRIPT_DIR / path_part)
+    if pointer:
+        return json_pointer_get(schema, pointer)
+    return schema
+
+
 def _resolve_ref(ref):
     """Load a schema referenced by $ref. Only supports local refs of the form
     /schemas/{version}/{path}.json — the only form actually used in-bundle.
@@ -206,18 +210,23 @@ def _resolve_ref(ref):
     ref could attempt."""
     if not isinstance(ref, str):
         return None
-    m = re.match(r'^/schemas/[^/]+/(.+\.json)$', ref)
+    m = re.match(r'^/schemas/[^/]+/(.+\.json)(#.*)?$', ref)
     if not m:
         return None
-    path = (SCRIPT_DIR / m.group(1)).resolve()
+    rel = m.group(1)
+    fragment = m.group(2) or ''
+    path = (SCRIPT_DIR / rel).resolve()
     root = SCRIPT_DIR.resolve()
     if root != path and root not in path.parents:
         return None
     if not path.exists():
         return None
     try:
-        return load_schema(path)
-    except (OSError, json.JSONDecodeError):
+        schema = load_schema(path)
+        if fragment:
+            return json_pointer_get(schema, fragment[1:])
+        return schema
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
         return None
 
 
@@ -229,6 +238,12 @@ def schema_property_set(schema, _visited=None):
     if _visited is None:
         _visited = set()
     props = set()
+    ref = schema.get('$ref')
+    if ref and ref not in _visited:
+        _visited.add(ref)
+        ref_schema = _resolve_ref(ref)
+        if ref_schema:
+            props.update(schema_property_set(ref_schema, _visited))
     if 'properties' in schema:
         props.update(schema['properties'].keys())
     for key in ('allOf', 'anyOf', 'oneOf'):
@@ -265,33 +280,73 @@ def schema_is_oneof_only(schema):
 
 def schema_required_set(schema):
     req = set(schema.get('required', []))
-    for key in ('allOf', 'anyOf'):
-        for branch in schema.get(key, []):
-            if isinstance(branch, dict):
-                req.update(branch.get('required', []))
+    for branch in schema.get('allOf', []):
+        if isinstance(branch, dict):
+            ref = branch.get('$ref')
+            if ref:
+                ref_schema = _resolve_ref(ref)
+                if ref_schema:
+                    req.update(schema_required_set(ref_schema))
+            req.update(branch.get('required', []))
     return req
 
 
-def resolve_schema_path(type_name):
-    """Return absolute path to the JSON schema for `type_name`, or None."""
+def validate_inline_schema_specs():
+    """Smoke-test generated inline schema pointers so pointer drift fails in CI."""
+    reports = []
+    for type_name, schema_spec in gen.INLINE_SCHEMA_TYPES.items():
+        path_part = schema_spec.split('#', 1)[0]
+        schema_path = SCRIPT_DIR / path_part
+        if not schema_path.exists():
+            reports.append({
+                'type': type_name,
+                'schema': schema_spec,
+                'error': f'schema not found: {schema_path}',
+            })
+            continue
+        try:
+            schema = load_schema_spec(schema_spec)
+        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError) as e:
+            reports.append({
+                'type': type_name,
+                'schema': schema_spec,
+                'error': f'could not resolve schema pointer: {e}',
+            })
+            continue
+        if not schema_property_set(schema):
+            reports.append({
+                'type': type_name,
+                'schema': schema_spec,
+                'error': 'schema pointer resolved but declares no properties',
+            })
+    return reports
+
+
+def resolve_schema_spec(type_name):
+    """Return schema spec for `type_name`, or None."""
     if type_name in EXPLICIT_SCHEMA:
-        return SCRIPT_DIR / EXPLICIT_SCHEMA[type_name]
+        return EXPLICIT_SCHEMA[type_name]
     # Otherwise, search the generate.py registries for a schema whose
     # filename-derived PascalCase matches.
-    candidates = gen.CORE_SCHEMAS + gen.TOOL_SCHEMAS + gen.WEBHOOK_SCHEMAS
+    candidates = (
+        gen.CORE_SCHEMAS + gen.SUPPORT_SCHEMAS +
+        gen.TOOL_SCHEMAS + gen.WEBHOOK_SCHEMAS
+    )
     for rel in candidates:
         stem = Path(rel).stem
         if gen.pascal_case(stem) == type_name:
-            return SCRIPT_DIR / rel
+            return rel
     return None
 
 
-def diff_type(type_name, go_fields, schema_path):
+def diff_type(type_name, go_fields, schema_spec):
     """Compare a hand-written Go struct against its JSON schema. Returns a dict
     describing the drift, or None if clean."""
+    path_part = schema_spec.split('#', 1)[0]
+    schema_path = SCRIPT_DIR / path_part
     if not schema_path.exists():
         return {'type': type_name, 'error': f'schema not found: {schema_path}'}
-    schema = load_schema(schema_path)
+    schema = load_schema_spec(schema_spec)
     if schema_is_oneof_only(schema):
         return None  # can't diff a pure oneOf with tag-level comparison
     schema_props = schema_property_set(schema)
@@ -312,7 +367,7 @@ def diff_type(type_name, go_fields, schema_path):
         return None
     return {
         'type': type_name,
-        'schema': str(schema_path.relative_to(SCRIPT_DIR)),
+        'schema': schema_spec,
         'missing_in_go': missing,
         'extra_in_go': extra,
         'required_with_omitempty': sorted(set(required_with_omitempty)),
@@ -379,6 +434,7 @@ def main():
     _assert_exempt_subset_known(go_structs)
     reports = []
     no_schema = []
+    inline_schema_errors = validate_inline_schema_specs()
 
     for type_name in sorted(gen.KNOWN_TYPES):
         if type_name in EXEMPT:
@@ -387,12 +443,12 @@ def main():
             # Type listed in KNOWN_TYPES but not found in hand-written sources —
             # either a stale entry or defined in a file we don't scan.
             continue
-        schema_path = resolve_schema_path(type_name)
-        if schema_path is None:
+        schema_spec = resolve_schema_spec(type_name)
+        if schema_spec is None:
             # No schema correspondent — these are candidates for deletion.
             no_schema.append(type_name)
             continue
-        drift = diff_type(type_name, go_structs[type_name], schema_path)
+        drift = diff_type(type_name, go_structs[type_name], schema_spec)
         if drift:
             reports.append(drift)
 
@@ -400,9 +456,17 @@ def main():
         out = {
             'drift': reports,
             'no_schema_correspondent': no_schema,
+            'inline_schema_errors': inline_schema_errors,
         }
         print(json.dumps(out, indent=2))
     else:
+        if inline_schema_errors:
+            print(f'Inline schema pointer errors in {len(inline_schema_errors)} type(s):')
+            for r in inline_schema_errors:
+                print()
+                print(f'  {r["type"]}  ({r.get("schema", "?")})')
+                print(f'    error: {r["error"]}')
+            print()
         if reports:
             print(f'Schema drift detected in {len(reports)} type(s):')
             for r in reports:
@@ -424,7 +488,9 @@ def main():
             for t in no_schema:
                 print(f'  - {t}')
 
-    has_problems = bool(reports) or (args.strict and bool(no_schema))
+    has_problems = bool(inline_schema_errors) or bool(reports) or (
+        args.strict and bool(no_schema)
+    )
     return 1 if (args.strict and has_problems) else 0
 
 

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -580,24 +580,6 @@ type ReportingPeriod struct {
 	End   string `json:"end"`
 }
 
-type MediaBuyDelivery struct {
-	MediaBuyID string            `json:"media_buy_id"`
-	Status     string            `json:"status"`
-	Totals     DeliveryTotals    `json:"totals"`
-	ByPackage  []PackageDelivery `json:"by_package"`
-}
-
-type PackageDelivery struct {
-	PackageID   string  `json:"package_id"`
-	Impressions float64 `json:"impressions,omitempty"`
-	// package-delivery composes delivery-metrics and requires spend at this level.
-	Spend        float64 `json:"spend"`
-	Clicks       float64 `json:"clicks,omitempty"`
-	PricingModel string  `json:"pricing_model,omitempty"`
-	Rate         float64 `json:"rate,omitempty"`
-	Currency     string  `json:"currency,omitempty"`
-}
-
 // MarshalJSON preserves the schema-required spend field even when it is zero.
 func (d DeliveryTotals) MarshalJSON() ([]byte, error) {
 	type deliveryTotals DeliveryTotals

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1936,7 +1936,7 @@ type DeliveryTotals struct {
 	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
 	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
 	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
-	ReachUnit any `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
 	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
 	QuartileData any `json:"quartile_data,omitempty"` // Audio/video quartile completion data
 	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
@@ -2074,6 +2074,188 @@ type CreativeBrief struct {
 	Compliance any `json:"compliance,omitempty"` // Regulatory and legal compliance requirements for this campaign. Campaign-specifi
 }
 
+// --- Support schema types ---
+
+// PackageInput — Package configuration for media buy creation
+type PackageInput struct {
+	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
+	ProductID string `json:"product_id"` // Product ID for this package
+	FormatIDs []FormatRef `json:"format_ids,omitempty"` // Array of format IDs that will be used for this package - must be supported by th
+	Budget float64 `json:"budget"` // Budget allocation for this package in the media buy's currency
+	Pacing string `json:"pacing,omitempty"`
+	PricingOptionID string `json:"pricing_option_id"` // ID of the selected pricing option from the product's pricing_options array
+	BidPrice float64 `json:"bid_price,omitempty"` // Bid price for auction-based pricing options. This is the exact bid/price to hono
+	Impressions float64 `json:"impressions,omitempty"` // Impression goal for this package
+	StartTime string `json:"start_time,omitempty"` // Flight start date/time for this package in ISO 8601 format. When omitted, the pa
+	EndTime string `json:"end_time,omitempty"` // Flight end date/time for this package in ISO 8601 format. When omitted, the pack
+	Paused *bool `json:"paused,omitempty"` // Whether this package should be created in a paused state. Paused packages do not
+	Catalogs []Catalog `json:"catalogs,omitempty"` // Catalogs this package promotes. Each catalog MUST have a distinct type (e.g., on
+	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
+	TargetingOverlay *Targeting `json:"targeting_overlay,omitempty"`
+	MeasurementTerms *MeasurementTerms `json:"measurement_terms,omitempty"` // Buyer's proposed billing measurement and makegood terms. Overrides product defau
+	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"` // Buyer's proposed performance standards for this package. Overrides product defau
+	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"` // Assign existing library creatives to this package with optional weights and plac
+	Creatives []CreativeAsset `json:"creatives,omitempty"` // Upload new creative assets and assign to this package (creatives will be added t
+	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"` // Agency estimate or authorization number for this package. Overrides the media bu
+	Context any `json:"context,omitempty"`
+	Ext any `json:"ext,omitempty"`
+}
+
+// PackageUpdate — Package update configuration for update_media_buy. Identifies package by package_id and specifies fi
+type PackageUpdate struct {
+	PackageID string `json:"package_id"` // Seller's ID of package to update
+	Budget float64 `json:"budget,omitempty"` // Updated budget allocation for this package in the currency specified by the pric
+	Pacing string `json:"pacing,omitempty"`
+	BidPrice float64 `json:"bid_price,omitempty"` // Updated bid price for auction-based pricing options. This is the exact bid/price
+	Impressions float64 `json:"impressions,omitempty"` // Updated impression goal for this package
+	StartTime string `json:"start_time,omitempty"` // Updated flight start date/time for this package in ISO 8601 format. Must fall wi
+	EndTime string `json:"end_time,omitempty"` // Updated flight end date/time for this package in ISO 8601 format. Must fall with
+	Paused *bool `json:"paused,omitempty"` // Pause/resume specific package (true = paused, false = active)
+	Canceled *bool `json:"canceled,omitempty"` // Cancel this specific package. Cancellation is irreversible — canceled packages s
+	CancellationReason string `json:"cancellation_reason,omitempty"` // Reason for canceling this package.
+	Catalogs []Catalog `json:"catalogs,omitempty"` // Replace the catalogs this package promotes. Uses replacement semantics — the pro
+	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Replace all optimization goals for this package. Uses replacement semantics — om
+	TargetingOverlay *Targeting `json:"targeting_overlay,omitempty"` // Targeting overlay to apply to this package. Uses replacement semantics — the ful
+	KeywordTargetsAdd []KeywordTargetUpdate `json:"keyword_targets_add,omitempty"` // Keyword targets to add or update on this package. Upserts by (keyword, match_typ
+	KeywordTargetsRemove []KeywordTargetRef `json:"keyword_targets_remove,omitempty"` // Keyword targets to remove from this package. Removes matching (keyword, match_ty
+	NegativeKeywordsAdd []KeywordTargetRef `json:"negative_keywords_add,omitempty"` // Negative keywords to add to this package. Appends to the existing negative keywo
+	NegativeKeywordsRemove []KeywordTargetRef `json:"negative_keywords_remove,omitempty"` // Negative keywords to remove from this package. Removes matching keyword+match_ty
+	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"` // Replace creative assignments for this package with optional weights and placemen
+	Creatives []CreativeAsset `json:"creatives,omitempty"` // Upload new creative assets and assign to this package (creatives will be added t
+	Context any `json:"context,omitempty"`
+	Ext any `json:"ext,omitempty"`
+}
+
+// --- Inline schema types ---
+
+type KeywordTargetUpdate struct {
+	Keyword string `json:"keyword"` // The keyword to target
+	MatchType string `json:"match_type"`
+	BidPrice float64 `json:"bid_price,omitempty"` // Per-keyword bid price. Inherits currency and max_bid interpretation from the pac
+}
+
+type KeywordTargetRef struct {
+	Keyword string `json:"keyword"` // The keyword to stop targeting
+	MatchType string `json:"match_type"`
+}
+
+// DeliveryAggregatedTotals — Combined metrics across all returned media buys. Only included in API responses (get_media_buy_deliv
+type DeliveryAggregatedTotals struct {
+	Impressions float64 `json:"impressions"` // Total impressions delivered across all media buys
+	Spend float64 `json:"spend"` // Total amount spent across all media buys
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks across all media buys (if applicable)
+	CompletedViews float64 `json:"completed_views,omitempty"` // Total audio/video completions across all media buys (if applicable)
+	Views float64 `json:"views,omitempty"` // Total views across all media buys (if applicable)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions across all media buys (if applicable)
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total conversion value across all media buys (if applicable)
+	Roas float64 `json:"roas,omitempty"` // Aggregate return on ad spend across all media buys (total conversion_value / tot
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of total conversions across all media buys from first-time brand buyers
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Aggregate cost per conversion across all media buys (total spend / total convers
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Aggregate completion rate across all media buys (weighted by impressions, not a
+	Reach float64 `json:"reach,omitempty"` // Deduplicated reach across all media buys (if the seller can deduplicate across b
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for reach. Only present when all aggregated media buys use t
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit across all media buys (impressions / reach when
+	MediaBuyCount int `json:"media_buy_count"` // Number of media buys included in the response
+}
+
+type MediaBuyDeliveryTotals struct {
+	Impressions float64 `json:"impressions,omitempty"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData any `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	EffectiveRate float64 `json:"effective_rate,omitempty"` // Effective rate paid per unit based on pricing_model (e.g., actual CPM for 'cpm',
+}
+
+type MediaBuyDelivery struct {
+	MediaBuyID string `json:"media_buy_id"` // Seller's media buy identifier
+	Status string `json:"status"` // Current media buy status. Lifecycle states use the same taxonomy as media-buy-st
+	ExpectedAvailability string `json:"expected_availability,omitempty"` // When delayed data is expected to be available (only present when status is repor
+	IsAdjusted *bool `json:"is_adjusted,omitempty"` // Indicates this delivery contains updated data for a previously reported period.
+	PricingModel string `json:"pricing_model,omitempty"` // Pricing model used for this media buy
+	Totals MediaBuyDeliveryTotals `json:"totals"`
+	ByPackage []PackageDelivery `json:"by_package"` // Metrics broken down by package
+	DailyBreakdown []any `json:"daily_breakdown,omitempty"` // Day-by-day delivery
+}
+
+type PackageDelivery struct {
+	Impressions float64 `json:"impressions,omitempty"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData any `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	PackageID string `json:"package_id"` // Seller's package identifier
+	PacingIndex float64 `json:"pacing_index,omitempty"` // Delivery pace (1.0 = on track, <1.0 = behind, >1.0 = ahead)
+	PricingModel string `json:"pricing_model"` // The pricing model used for this package (e.g., cpm, cpcv, cpp). Indicates how th
+	Rate float64 `json:"rate"` // The pricing rate for this package in the specified currency. For fixed-rate pric
+	Currency string `json:"currency"` // ISO 4217 currency code (e.g., USD, EUR, GBP) for this package's pricing. Indicat
+	DeliveryStatus string `json:"delivery_status,omitempty"` // System-reported operational state of this package. Reflects actual delivery stat
+	Paused *bool `json:"paused,omitempty"` // Whether this package is currently paused by the buyer
+	IsFinal *bool `json:"is_final,omitempty"` // Whether this delivery data is final for the reporting period. When false, the da
+	MeasurementWindow string `json:"measurement_window,omitempty"` // Which measurement window this data represents, referencing a window_id from the
+	SupersedesWindow string `json:"supersedes_window,omitempty"` // Which measurement window this data replaces. Present on window_update notificati
+	ByCatalogItem []any `json:"by_catalog_item,omitempty"` // Delivery by catalog item within this package. Available for catalog-driven packa
+	ByCreative []any `json:"by_creative,omitempty"` // Metrics broken down by creative within this package. Available when the seller s
+	ByKeyword []any `json:"by_keyword,omitempty"` // Metrics broken down by keyword within this package. One row per (keyword, match_
+	ByGeo []any `json:"by_geo,omitempty"` // Delivery by geographic area within this package. Available when the buyer reques
+	ByGeoTruncated *bool `json:"by_geo_truncated,omitempty"` // Whether by_geo was truncated due to the requested limit or a seller-imposed maxi
+	ByDeviceType []any `json:"by_device_type,omitempty"` // Delivery by device form factor within this package. Available when the buyer req
+	ByDeviceTypeTruncated *bool `json:"by_device_type_truncated,omitempty"` // Whether by_device_type was truncated. Sellers MUST return this flag whenever by_
+	ByDevicePlatform []any `json:"by_device_platform,omitempty"` // Delivery by operating system within this package. Available when the buyer reque
+	ByDevicePlatformTruncated *bool `json:"by_device_platform_truncated,omitempty"` // Whether by_device_platform was truncated. Sellers MUST return this flag whenever
+	ByAudience []any `json:"by_audience,omitempty"` // Delivery by audience segment within this package. Available when the buyer reque
+	ByAudienceTruncated *bool `json:"by_audience_truncated,omitempty"` // Whether by_audience was truncated. Sellers MUST return this flag whenever by_aud
+	ByPlacement []any `json:"by_placement,omitempty"` // Delivery by placement within this package. Available when the buyer requests pla
+	ByPlacementTruncated *bool `json:"by_placement_truncated,omitempty"` // Whether by_placement was truncated. Sellers MUST return this flag whenever by_pl
+	DailyBreakdown []any `json:"daily_breakdown,omitempty"` // Day-by-day delivery for this package. Only present when include_package_daily_br
+}
+
 // --- Tool request/response types ---
 
 // GetAdcpCapabilitiesRequest — Request payload for get_adcp_capabilities task. Protocol-level capability discovery that works acros
@@ -2178,7 +2360,7 @@ type GetProductsRequest struct {
 	Filters any `json:"filters,omitempty"`
 	PropertyList any `json:"property_list,omitempty"` // [AdCP 3.0] Reference to an externally managed property list. When provided, the
 	Fields []string `json:"fields,omitempty"` // Specific product fields to include in the response. When omitted, all fields are
-	TimeBudget any `json:"time_budget,omitempty"` // Maximum time the buyer will commit to this request. The seller returns the best
+	TimeBudget Duration `json:"time_budget,omitempty"` // Maximum time the buyer will commit to this request. The seller returns the best
 	Pagination *PaginationRequest `json:"pagination,omitempty"`
 	Context any `json:"context,omitempty"`
 	RequiredPolicies []string `json:"required_policies,omitempty"` // Registry policy IDs that the buyer requires to be enforced for products in this
@@ -2215,7 +2397,7 @@ type CreateMediaBuyRequest struct {
 	IoAcceptance any `json:"io_acceptance,omitempty"` // Acceptance of an insertion order from a committed proposal. Required when the pr
 	PoNumber string `json:"po_number,omitempty"` // Purchase order number for tracking
 	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"` // Agency estimate or authorization number. Primary financial reference for broadca
-	StartTime any `json:"start_time"`
+	StartTime string `json:"start_time"`
 	EndTime string `json:"end_time"` // Campaign end date/time in ISO 8601 format
 	PushNotificationConfig any `json:"push_notification_config,omitempty"` // Optional webhook configuration for async task status notifications. Publisher wi
 	ReportingWebhook any `json:"reporting_webhook,omitempty"` // Optional webhook configuration for automated reporting delivery
@@ -2257,6 +2439,27 @@ type CreateMediaBuySubmitted struct {
 	TaskID string `json:"task_id"` // Task handle the buyer uses with tasks/get, and that the seller references on pus
 	Message string `json:"message,omitempty"` // Optional human-readable explanation of why the task is submitted — e.g., 'Awaiti
 	Errors []AdcpError `json:"errors,omitempty"` // Optional advisory errors accompanying the submitted envelope. Use only for non-b
+	Context any `json:"context,omitempty"`
+	Ext any `json:"ext,omitempty"`
+}
+
+// UpdateMediaBuyRequest — Request parameters for updating campaign and package settings
+type UpdateMediaBuyRequest struct {
+	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
+	Account AccountReference `json:"account"` // Account that owns this media buy. Pass a natural key (brand, operator, optional
+	MediaBuyID string `json:"media_buy_id"` // Seller's ID of the media buy to update
+	Revision int `json:"revision,omitempty"` // Expected current revision for optimistic concurrency. When provided, sellers MUS
+	Paused *bool `json:"paused,omitempty"` // Pause/resume the entire media buy (true = paused, false = active)
+	Canceled *bool `json:"canceled,omitempty"` // Cancel the entire media buy. Cancellation is irreversible — canceled media buys
+	CancellationReason string `json:"cancellation_reason,omitempty"` // Reason for cancellation. Sellers SHOULD store this and return it in subsequent g
+	StartTime string `json:"start_time,omitempty"`
+	EndTime string `json:"end_time,omitempty"` // New end date/time in ISO 8601 format
+	Packages []PackageUpdate `json:"packages,omitempty"` // Package-specific updates for existing packages
+	InvoiceRecipient any `json:"invoice_recipient,omitempty"` // Update who receives the invoice for this buy. When provided, the seller invoices
+	NewPackages []PackageInput `json:"new_packages,omitempty"` // New packages to add to this media buy. Uses the same schema as create_media_buy
+	ReportingWebhook any `json:"reporting_webhook,omitempty"` // Optional webhook configuration for automated reporting delivery. Updates the rep
+	PushNotificationConfig any `json:"push_notification_config,omitempty"` // Optional webhook configuration for async update notifications. Publisher will se
+	IdempotencyKey string `json:"idempotency_key"` // Client-generated idempotency key for safe retries. If an update fails without a
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }
@@ -2306,11 +2509,11 @@ type GetMediaBuyDeliveryResponse struct {
 	UnavailableCount int `json:"unavailable_count,omitempty"` // Number of media buys with reporting_delayed or failed status (only present in we
 	SequenceNumber int `json:"sequence_number,omitempty"` // Sequential notification number (only present in webhook deliveries, starts at 1)
 	NextExpectedAt string `json:"next_expected_at,omitempty"` // ISO 8601 timestamp for next expected notification (only present in webhook deliv
-	ReportingPeriod any `json:"reporting_period"` // Date range for the report. All periods use UTC timezone.
+	ReportingPeriod ReportingPeriod `json:"reporting_period"` // Date range for the report. All periods use UTC timezone.
 	Currency string `json:"currency"` // ISO 4217 currency code
 	AttributionWindow *AttributionWindow `json:"attribution_window,omitempty"` // Attribution methodology and lookback windows used for conversion metrics in this
-	AggregatedTotals any `json:"aggregated_totals,omitempty"` // Combined metrics across all returned media buys. Only included in API responses
-	MediaBuyDeliveries []any `json:"media_buy_deliveries"` // Array of delivery data for media buys. When used in webhook notifications, may c
+	AggregatedTotals *DeliveryAggregatedTotals `json:"aggregated_totals,omitempty"` // Combined metrics across all returned media buys. Only included in API responses
+	MediaBuyDeliveries []MediaBuyDelivery `json:"media_buy_deliveries"` // Array of delivery data for media buys. When used in webhook notifications, may c
 	Errors []AdcpError `json:"errors,omitempty"` // Task-specific errors and warnings (e.g., missing delivery data, reporting platfo
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this response contains simulated data from sandbox mode.
 	Context any `json:"context,omitempty"`

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -444,7 +444,7 @@ func (b *backend) getDelivery(input *adcp.GetMediaBuyDeliveryRequest) (*adcp.Del
 			totClicks += ds.Clicks
 			totSpend += ds.Spend
 		}
-		deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{Impressions: float64(totImps), Clicks: float64(totClicks), Spend: totSpend}, ByPackage: pkgDel})
+		deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.MediaBuyDeliveryTotals{Impressions: float64(totImps), Clicks: float64(totClicks), Spend: totSpend}, ByPackage: pkgDel})
 	}
 	return &adcp.DeliveryData{ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)}, Currency: "USD", MediaBuyDeliveries: deliveries}, nil
 }

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -260,7 +260,7 @@ func main() {
                     for _, pkg := range buy.Packages {
                         pkgDel = append(pkgDel, adcp.PackageDelivery{PackageID: pkg.PackageID, Spend: 0, PricingModel: "cpm", Rate: 0, Currency: "USD"})
                     }
-                    deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.DeliveryTotals{}, ByPackage: pkgDel})
+                    deliveries = append(deliveries, adcp.MediaBuyDelivery{MediaBuyID: mbID, Status: buy.Status, Totals: adcp.MediaBuyDeliveryTotals{}, ByPackage: pkgDel})
                 }
                 return &adcp.DeliveryData{
                     ReportingPeriod: adcp.ReportingPeriod{Start: now.Add(-24 * time.Hour).Format(time.RFC3339), End: now.Format(time.RFC3339)},


### PR DESCRIPTION
## Summary

This makes the Go AdCP SDK stop hand-writing several media-buy wire structs that had drifted from the 3.0.12 schemas.

- generates `PackageInput`, `PackageUpdate`, `UpdateMediaBuyRequest`, `MediaBuyDelivery`, `PackageDelivery`, and related inline helper types from schema files / JSON pointers
- adds generator support for schema fragments, `allOf` flattening, support schemas, and inline schema-pointer types
- extends schema drift linting to resolve JSON pointers, recurse through composed refs, and smoke-test every generated inline schema pointer
- updates the reference seller and seller-building skill snippet for the new `MediaBuyDeliveryTotals` type
- documents the breaking SDK changes in `MIGRATING.md`

## Why

The previous Go types were partly invented or partial: `PackageInput` exposed `buyer_ref`, omitted real schema fields, and marked `pricing_option_id` optional; `PackageUpdate` missed several real update fields; `PackageDelivery` only covered a small subset of the composed delivery schema. That made Go materially weaker than the JS/Python adapters and let drift hide in hand-written structs.

## Impact

Breaking Go SDK changes:

- `PackageInput.BuyerRef` is removed; use `Ext` for seller-specific correlation metadata.
- `PackageInput`, `PackageUpdate`, and `UpdateMediaBuyRequest` now follow their media-buy schemas.
- `MediaBuyDelivery` and `PackageDelivery` are generated from the delivery response inline schemas.
- `MediaBuyDelivery.Totals` is now `MediaBuyDeliveryTotals`, which includes the schema-specific `effective_rate` field.

## Validation

- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 lint.py --json`
- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py`
- `git diff --check`
- `go test ./...`
- `cd adcp && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `golangci-lint run ./...`
- `cd adcp && golangci-lint run ./...`
- `cd reference/seller-agent && golangci-lint run ./...`
