### PR TITLE
chore(adcp): harden schema generator pointers

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -21,6 +21,14 @@ Most wire payloads are unchanged, but several public Go structs are more typed.
 - `UpdateMediaBuyRequest` is now generated from
   `media-buy/update-media-buy-request.json`. `StartTime` is a `string` instead
   of `any`, matching the current schema's `start-timing` alias.
+- `CreateMediaBuyRequest.StartTime` is also now a `string` instead of `any`.
+  The schema's `start-timing` alias resolves to string in Go; `"asap"` remains
+  valid wire data.
+- `GetProductsRequest.TimeBudget` is now `adcp.Duration` instead of `any`.
+  Use `adcp.Duration{Interval: 5, Unit: "minutes"}` or another schema-valid
+  unit.
+- `DeliveryTotals.ReachUnit` is now `string` instead of `any`, matching the
+  reach-unit enum's string wire form.
 - `PackageUpdate` is now generated from `media-buy/package-update.json`. It
   exposes schema-backed package update fields such as `Pacing`, `Catalogs`,
   `OptimizationGoals`, keyword add/remove operations, `Creatives`, `Context`,
@@ -45,6 +53,11 @@ Most wire payloads are unchanged, but several public Go structs are more typed.
   emitted as schema-required fields even when their Go values are zero.
   `MediaBuyDelivery.Totals` is now `adcp.MediaBuyDeliveryTotals`, which includes
   the schema-specific `effective_rate` field.
+- `GetMediaBuyDeliveryResponse.ReportingPeriod`,
+  `GetMediaBuyDeliveryResponse.AggregatedTotals`, and
+  `GetMediaBuyDeliveryResponse.MediaBuyDeliveries` are now typed as
+  `adcp.ReportingPeriod`, `*adcp.DeliveryAggregatedTotals`, and
+  `[]adcp.MediaBuyDelivery` instead of `any` shapes.
 
 ## v3.0.0-rc.4 (governance / policy framework)
 

--- a/adcp/delivery_types_test.go
+++ b/adcp/delivery_types_test.go
@@ -1,0 +1,106 @@
+package adcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeneratedDeliveryTypesRoundTrip(t *testing.T) {
+	paused := false
+	isFinal := true
+	resp := GetMediaBuyDeliveryResponse{
+		ReportingPeriod: ReportingPeriod{
+			Start: "2026-05-25T00:00:00Z",
+			End:   "2026-05-25T23:59:59Z",
+		},
+		Currency: "USD",
+		AggregatedTotals: &DeliveryAggregatedTotals{
+			Impressions:   1000,
+			Spend:         125,
+			ReachUnit:     "households",
+			MediaBuyCount: 1,
+		},
+		MediaBuyDeliveries: []MediaBuyDelivery{{
+			MediaBuyID:   "mb-1",
+			Status:       "active",
+			PricingModel: "cpm",
+			Totals: MediaBuyDeliveryTotals{
+				Impressions:   1000,
+				Spend:         125,
+				Clicks:        25,
+				EffectiveRate: 12.5,
+			},
+			ByPackage: []PackageDelivery{{
+				PackageID:         "pkg-1",
+				Impressions:       1000,
+				Spend:             125,
+				Clicks:            25,
+				Ctr:               0.025,
+				PricingModel:      "cpm",
+				Rate:              12.5,
+				Currency:          "USD",
+				DeliveryStatus:    "delivering",
+				Paused:            &paused,
+				IsFinal:           &isFinal,
+				MeasurementWindow: "c7",
+				DailyBreakdown: []any{
+					map[string]any{"date": "2026-05-25", "impressions": 1000, "spend": 125},
+				},
+			}},
+		}},
+	}
+
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(b, &wire))
+	assert.IsType(t, map[string]any{}, wire["reporting_period"])
+	assert.IsType(t, map[string]any{}, wire["aggregated_totals"])
+	deliveries, ok := wire["media_buy_deliveries"].([]any)
+	require.True(t, ok)
+	require.Len(t, deliveries, 1)
+	delivery, ok := deliveries[0].(map[string]any)
+	require.True(t, ok)
+	totals, ok := delivery["totals"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(12.5), totals["effective_rate"])
+	packages, ok := delivery["by_package"].([]any)
+	require.True(t, ok)
+	require.Len(t, packages, 1)
+	pkg, ok := packages[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "pkg-1", pkg["package_id"])
+	assert.Equal(t, "cpm", pkg["pricing_model"])
+	assert.Equal(t, float64(12.5), pkg["rate"])
+	assert.Equal(t, "USD", pkg["currency"])
+	assert.Equal(t, false, pkg["paused"])
+	assert.Equal(t, true, pkg["is_final"])
+
+	var decoded GetMediaBuyDeliveryResponse
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	require.Len(t, decoded.MediaBuyDeliveries, 1)
+	assert.Equal(t, "mb-1", decoded.MediaBuyDeliveries[0].MediaBuyID)
+	assert.Equal(t, 12.5, decoded.MediaBuyDeliveries[0].Totals.EffectiveRate)
+	require.Len(t, decoded.MediaBuyDeliveries[0].ByPackage, 1)
+	assert.Equal(t, "pkg-1", decoded.MediaBuyDeliveries[0].ByPackage[0].PackageID)
+	assert.Equal(t, "c7", decoded.MediaBuyDeliveries[0].ByPackage[0].MeasurementWindow)
+	require.NotNil(t, decoded.AggregatedTotals)
+	assert.Equal(t, 1, decoded.AggregatedTotals.MediaBuyCount)
+}
+
+func TestPackageDeliveryRequiredZeroValuesMarshal(t *testing.T) {
+	b, err := json.Marshal(PackageDelivery{PackageID: "pkg-zero"})
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"package_id": "pkg-zero",
+		"spend": 0,
+		"pricing_model": "",
+		"rate": 0,
+		"currency": ""
+	}`, string(b))
+}

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -10,11 +10,20 @@ with proper json tags matching the wire format.
 """
 
 import json
-import os
 import re
 import sys
 from pathlib import Path
 from collections import OrderedDict
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCHEMA_RESOLUTION_ERRORS = (
+    OSError,
+    json.JSONDecodeError,
+    KeyError,
+    ValueError,
+    IndexError,
+    TypeError,
+)
 
 # Types that exist in hand-written files or will be generated.
 # $ref targets not in this set get replaced with `any`.
@@ -314,10 +323,10 @@ REF_ALIASES = {
     'DestinationInput': 'DestinationInput',
 }
 
-# Inline array item type hints: when a schema has an array property whose items
-# are inline objects or oneOfs (no $ref to a named schema file), map
-# (struct_name, field) -> Go item type. Keeps generated structs referencing
-# hand-written or otherwise-known types instead of falling back to `any`.
+# Inline array/item type hints: when a schema has an inline object or oneOf with
+# no named $ref, map (struct_name, field) -> Go type. Non-array hints may include
+# a leading `*` for optional inline object fields; array fields wrap the hinted
+# item type as `[]{hint}`, so pointer hints on arrays produce `[]*T`.
 INLINE_TYPE_HINTS = {
     ('SyncAccountsRequest', 'accounts'): 'AccountInput',
     ('SyncGovernanceRequest', 'accounts'): 'GovernanceAccountInput',
@@ -356,9 +365,18 @@ def safe_comment(text, max_len=80):
 
 def load_schema(path):
     """Load a JSON schema file, preserving property order."""
+    path = Path(path)
+    if not path.is_absolute():
+        path = SCRIPT_DIR / path
     with open(path) as f:
         # Use object_pairs_hook to preserve key order
         return json.load(f, object_pairs_hook=OrderedDict)
+
+def schema_exists(path):
+    path = Path(path)
+    if not path.is_absolute():
+        path = SCRIPT_DIR / path
+    return path.exists()
 
 def json_pointer_get(doc, pointer):
     """Resolve a JSON Pointer fragment against a decoded JSON document."""
@@ -393,15 +411,16 @@ def resolve_ref_schema(ref):
         return None
     spec = m.group(1) + (m.group(2) or '')
     path_part = spec.split('#', 1)[0]
-    path = Path(path_part).resolve()
-    root = Path.cwd().resolve()
+    path = (SCRIPT_DIR / path_part).resolve()
+    root = SCRIPT_DIR.resolve()
     if root != path and root not in path.parents:
         return None
     if not path.exists():
         return None
     try:
         return load_schema_spec(spec)
-    except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
+    except SCHEMA_RESOLUTION_ERRORS as e:
+        print(f'// Warning: skipped ref {ref}: {e}', file=sys.stderr)
         return None
 
 def schema_properties(schema, _visited=None):
@@ -482,9 +501,9 @@ _WILL_GENERATE_CACHE = None
 
 def _reset_will_generate_cache():
     """Clear the cache so the next `_will_generate_set()` call rebuilds from
-    current CORE_SCHEMAS/TOOL_SCHEMAS/WEBHOOK_SCHEMAS + current cwd. Called at
-    the top of `generate()` to guarantee correctness when the module is used
-    across multiple runs (e.g. imported by lint.py then invoked standalone)."""
+    current CORE_SCHEMAS/TOOL_SCHEMAS/WEBHOOK_SCHEMAS. Called at the top of
+    `generate()` to guarantee correctness when the module is used across
+    multiple runs (e.g. imported by lint.py then invoked standalone)."""
     global _WILL_GENERATE_CACHE
     _WILL_GENERATE_CACHE = None
 
@@ -500,11 +519,12 @@ def _will_generate_set():
         return _WILL_GENERATE_CACHE
     names = set()
     for rel in CORE_SCHEMAS + SUPPORT_SCHEMAS + TOOL_SCHEMAS + WEBHOOK_SCHEMAS:
-        if not os.path.exists(rel):
+        if not schema_exists(rel):
             continue
         try:
             schema = load_schema(rel)
-        except (OSError, json.JSONDecodeError):
+        except SCHEMA_RESOLUTION_ERRORS as e:
+            print(f'// Warning: skipped schema {rel}: {e}', file=sys.stderr)
             continue
         if schema.get('type') == 'object' and 'properties' in schema:
             stem = Path(rel).stem
@@ -513,7 +533,8 @@ def _will_generate_set():
     for name, spec in INLINE_SCHEMA_TYPES.items():
         try:
             schema = load_schema_spec(spec)
-        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
+        except SCHEMA_RESOLUTION_ERRORS as e:
+            print(f'// Warning: skipped {name} ({spec}: {e})', file=sys.stderr)
             continue
         if schema_properties(schema):
             names.add(name)
@@ -630,7 +651,7 @@ def schema_to_struct(name, schema):
 def generate_enums():
     """Generate Go string constants for all enum schemas."""
     lines = []
-    enum_dir = Path(ENUM_DIR)
+    enum_dir = SCRIPT_DIR / ENUM_DIR
     if not enum_dir.exists():
         return ''
 
@@ -667,7 +688,7 @@ def generate():
     # Read pinned version
     version = "unknown"
     try:
-        with open('VERSION') as f:
+        with open(SCRIPT_DIR / 'VERSION') as f:
             version = f.read().strip()
     except FileNotFoundError:
         pass
@@ -698,7 +719,7 @@ def generate():
     print('// --- Core types ---')
     print()
     for path in CORE_SCHEMAS:
-        if not os.path.exists(path):
+        if not schema_exists(path):
             print(f'// Skipped {path} (not found)', file=sys.stderr)
             continue
         schema = load_schema(path)
@@ -714,7 +735,7 @@ def generate():
     print('// --- Support schema types ---')
     print()
     for path in SUPPORT_SCHEMAS:
-        if not os.path.exists(path):
+        if not schema_exists(path):
             print(f'// Skipped {path} (not found)', file=sys.stderr)
             continue
         schema = load_schema(path)
@@ -735,7 +756,7 @@ def generate():
         generated.add(name)
         try:
             schema = load_schema_spec(spec)
-        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError) as e:
+        except SCHEMA_RESOLUTION_ERRORS as e:
             print(f'// Skipped {name} ({spec}: {e})', file=sys.stderr)
             continue
         if schema_properties(schema):
@@ -745,7 +766,7 @@ def generate():
     print('// --- Tool request/response types ---')
     print()
     for path in TOOL_SCHEMAS:
-        if not os.path.exists(path):
+        if not schema_exists(path):
             print(f'// Skipped {path} (not found)', file=sys.stderr)
             continue
         schema = load_schema(path)
@@ -784,7 +805,7 @@ def generate():
     print()
     webhook_type_names = []
     for path in WEBHOOK_SCHEMAS:
-        if not os.path.exists(path):
+        if not schema_exists(path):
             print(f'// Skipped {path} (not found)', file=sys.stderr)
             continue
         schema = load_schema(path)

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -18,7 +18,6 @@ CI wiring:
 
 import argparse
 import json
-import os
 import re
 import sys
 from collections import OrderedDict
@@ -32,6 +31,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 import generate as gen  # noqa: E402
 
 ADCP_DIR = SCRIPT_DIR.parent
+SCHEMA_RESOLUTION_ERRORS = gen.SCHEMA_RESOLUTION_ERRORS
 GO_SOURCE_FILES = [
     ADCP_DIR / 'types.go',
     ADCP_DIR / 'inputs.go',
@@ -226,7 +226,7 @@ def _resolve_ref(ref):
         if fragment:
             return json_pointer_get(schema, fragment[1:])
         return schema
-    except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError):
+    except SCHEMA_RESOLUTION_ERRORS:
         return None
 
 
@@ -306,7 +306,7 @@ def validate_inline_schema_specs():
             continue
         try:
             schema = load_schema_spec(schema_spec)
-        except (OSError, json.JSONDecodeError, KeyError, ValueError, IndexError) as e:
+        except SCHEMA_RESOLUTION_ERRORS as e:
             reports.append({
                 'type': type_name,
                 'schema': schema_spec,
@@ -346,7 +346,14 @@ def diff_type(type_name, go_fields, schema_spec):
     schema_path = SCRIPT_DIR / path_part
     if not schema_path.exists():
         return {'type': type_name, 'error': f'schema not found: {schema_path}'}
-    schema = load_schema_spec(schema_spec)
+    try:
+        schema = load_schema_spec(schema_spec)
+    except SCHEMA_RESOLUTION_ERRORS as e:
+        return {
+            'type': type_name,
+            'schema': schema_spec,
+            'error': f'could not resolve schema pointer: {e}',
+        }
     if schema_is_oneof_only(schema):
         return None  # can't diff a pure oneOf with tag-level comparison
     schema_props = schema_property_set(schema)
@@ -472,6 +479,8 @@ def main():
             for r in reports:
                 print()
                 print(f'  {r["type"]}  ({r.get("schema", "?")})')
+                if r.get('error'):
+                    print(f'    error: {r["error"]}')
                 if r.get('missing_in_go'):
                     print(f'    missing in Go:       {", ".join(r["missing_in_go"])}')
                 if r.get('extra_in_go'):


### PR DESCRIPTION
## Summary

Closes #151.

- resolves generator schema paths relative to `generate.py` instead of the caller cwd
- normalizes schema pointer/ref resolution failures, including scalar-walk `TypeError`
- documents the pointer-prefixed `INLINE_TYPE_HINTS` convention
- adds a populated delivery response marshal/unmarshal round-trip test for generated delivery types
- expands `MIGRATING.md` for the extra `any` to typed narrowings introduced by PR #150

## Validation

- `cd adcp/schemas && python3 generate.py > ../types_gen.go`
- `python3 adcp/schemas/generate.py > .context/types_gen_from_root.go`
- `diff -u adcp/types_gen.go .context/types_gen_from_root.go`
- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `go test ./...`
- `cd adcp && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `golangci-lint run ./...`
- `cd adcp && golangci-lint run ./...`
- `cd reference/seller-agent && golangci-lint run ./...`
- `git diff --check`
