### PR TITLE
chore(adcp): enforce generated any coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: adcp/schemas
         run: python3 lint.py --strict
 
+      - name: Check generated any coverage
+        working-directory: adcp/schemas
+        run: python3 generate.py --coverage-max-unreviewed-any 144
+
       - name: Check generated code is up to date
         run: |
           go generate ./tmproto/...

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1104,15 +1104,36 @@ def main(argv=None):
         action='store_true',
         help='emit human-readable report of generated any fallbacks instead of Go code',
     )
+    parser.add_argument(
+        '--coverage-max-unreviewed-any',
+        type=int,
+        metavar='N',
+        help='fail if generated unreviewed any fallbacks exceed N',
+    )
     args = parser.parse_args(argv)
 
-    if args.coverage_json or args.coverage_summary:
+    if (
+        args.coverage_json or
+        args.coverage_summary or
+        args.coverage_max_unreviewed_any is not None
+    ):
         _reset_will_generate_cache()
         report = any_coverage_report()
         if args.coverage_json:
             print(json.dumps(report, indent=2))
         else:
             print_any_coverage_summary(report)
+        if (
+            args.coverage_max_unreviewed_any is not None and
+            report['unreviewed_any'] > args.coverage_max_unreviewed_any
+        ):
+            print(
+                'Generated unreviewed any fallbacks exceed baseline: '
+                f'{report["unreviewed_any"]} > '
+                f'{args.coverage_max_unreviewed_any}',
+                file=sys.stderr,
+            )
+            return 1
         return 0
 
     generate()


### PR DESCRIPTION
## Summary

- add `generate.py --coverage-max-unreviewed-any N`
- fail nonzero when generated unreviewed `any` fallbacks exceed the configured baseline
- wire CI to the current post-#156 baseline of `144` unreviewed generated `any` sites

## Why

The generator coverage report is now useful as a guardrail, not just a diagnostic. Future generator work can reduce the baseline, but accidental regressions will fail CI.

## Validation

- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 144`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 143` exits `1` with the expected baseline error
- `cd adcp/schemas && python3 generate.py > ../types_gen.go && git diff --exit-code -- adcp/types_gen.go`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`
