### PR TITLE
feat(adcp)!: generate flattened core oneof refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 124
+        run: python3 generate.py --coverage-max-unreviewed-any 119
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -84,9 +84,14 @@ be populated.
 | `Product.MeasurementReadiness` | `*adcp.MeasurementReadiness` |
 | `MeasurementReadiness.Issues` | `[]adcp.DiagnosticIssue` |
 | `Product.Collections` | `[]adcp.CollectionSelector` |
+| `Product.DataProviderSignals` | `[]adcp.DataProviderSignalSelector` |
 | `Package.PriceBreakdown` | `*adcp.PriceBreakdown` |
 | `CreativeBrief.ReferenceAssets` | `[]adcp.ReferenceAsset` |
 | `CreativeManifest.Rights` | `[]adcp.RightsConstraint` |
+| `AudienceConstraints.Include` | `[]adcp.AudienceSelector` |
+| `AudienceConstraints.Exclude` | `[]adcp.AudienceSelector` |
+| `PlannedDelivery.AudienceTargeting` | `[]adcp.AudienceSelector` |
+| `GetSignalsRequest.Destinations` | `[]adcp.Destination` |
 
 Buyer request migration example:
 

--- a/adcp/generated_product_refs_test.go
+++ b/adcp/generated_product_refs_test.go
@@ -56,6 +56,11 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 				Message:  "purchase events are active",
 			}},
 		},
+		DataProviderSignals: []DataProviderSignalSelector{{
+			DataProviderDomain: "signals.example",
+			SelectionType:      "signal_ids",
+			SignalIDs:          []string{"auto_intenders"},
+		}},
 		Collections: []CollectionSelector{{
 			PublisherDomain: "example.com",
 			CollectionIDs:   []string{"sports"},
@@ -74,11 +79,44 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 		`"reporting_capabilities":{"available_reporting_frequencies":["daily"],"expected_delay_minutes":60`,
 		`"creative_policy":{"co_branding":"optional","landing_page":"required","templates_available":true}`,
 		`"measurement_readiness":{"status":"ready","required_event_types":["purchase"],"issues":[{"severity":"info","message":"purchase events are active"}]}`,
+		`"data_provider_signals":[{"data_provider_domain":"signals.example","selection_type":"signal_ids","signal_ids":["auto_intenders"]}]`,
 		`"collections":[{"publisher_domain":"example.com","collection_ids":["sports"]}]`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("marshaled product missing %s:\n%s", want, body)
 		}
+	}
+}
+
+func TestGeneratedOneOfRefsMarshalFlattenedFields(t *testing.T) {
+	req := GetSignalsRequest{
+		SignalSpec: "auto intenders",
+		Destinations: []Destination{{
+			Type:     "platform",
+			Platform: "the-trade-desk",
+		}},
+	}
+	plan := PlannedDelivery{
+		AudienceTargeting: []AudienceSelector{{
+			Type:        "description",
+			Description: "likely auto intenders",
+		}},
+	}
+
+	rawReq, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal get signals request: %v", err)
+	}
+	if !strings.Contains(string(rawReq), `"destinations":[{"type":"platform","platform":"the-trade-desk"}]`) {
+		t.Fatalf("destinations did not marshal as typed field: %s", rawReq)
+	}
+
+	rawPlan, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal planned delivery: %v", err)
+	}
+	if !strings.Contains(string(rawPlan), `"audience_targeting":[{"type":"description","description":"likely auto intenders"}]`) {
+		t.Fatalf("audience targeting did not marshal as typed field: %s", rawPlan)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -195,7 +195,9 @@ CORE_SCHEMAS = [
     "governance/policy-entry.json",
     "governance/policy-category-definition.json",
     "governance/audience-constraints.json",
+    "core/audience-selector.json",
     "core/product.json",
+    "core/data-provider-signal-selector.json",
     "core/placement.json",
     "core/delivery-forecast.json",
     "core/forecast-point.json",
@@ -216,6 +218,7 @@ CORE_SCHEMAS = [
     "core/creative-asset.json",
     "core/creative-manifest.json",
     "core/deployment.json",
+    "core/destination.json",
     "core/activation-key.json",
     "core/signal-definition.json",
     "core/signal-id.json",
@@ -557,6 +560,13 @@ def schema_required_names(schema, _visited=None):
         required.update(schema_required_names(branch, _visited))
     return required
 
+def has_struct_fields(schema):
+    """True when a schema can emit a Go struct. This includes top-level oneOf
+    schemas whose branches declare object properties; Go represents those as a
+    flattened struct with the union of variant fields, matching the hand-written
+    oneOf pattern used elsewhere in this package."""
+    return bool(schema_properties(schema))
+
 def ref_to_go_name(ref):
     """Convert a $ref path to a Go type name.
     /schemas/core/product.json -> Product
@@ -605,13 +615,27 @@ def _will_generate_set():
     """Names (after REF_ALIASES) that this generator run will emit as structs.
     Used so `resolve_go_type` can typed-reference a schema-derived type even
     though it hasn't been emitted yet at the moment of the first reference.
-    Excludes schemas that will not produce a struct (no `properties`, oneOf-
-    only, etc.) because a ref to such a name resolves to `any`."""
+    Excludes schemas that will not produce a struct. Core/support oneOf schemas
+    with object branches are included because generation flattens their variant
+    fields into one struct; top-level tool oneOf schemas still emit `type X =
+    any` and are not treated as typed refs."""
     global _WILL_GENERATE_CACHE
     if _WILL_GENERATE_CACHE is not None:
         return _WILL_GENERATE_CACHE
     names = set()
-    for rel in CORE_SCHEMAS + SUPPORT_SCHEMAS + TOOL_SCHEMAS + WEBHOOK_SCHEMAS:
+    for rel in CORE_SCHEMAS + SUPPORT_SCHEMAS:
+        if not schema_exists(rel):
+            continue
+        try:
+            schema = load_schema(rel)
+        except SCHEMA_RESOLUTION_ERRORS as e:
+            print(f'// Warning: skipped schema {rel}: {e}', file=sys.stderr)
+            continue
+        if has_struct_fields(schema):
+            stem = Path(rel).stem
+            name = REF_ALIASES.get(pascal_case(stem), pascal_case(stem))
+            names.add(name)
+    for rel in TOOL_SCHEMAS + WEBHOOK_SCHEMAS:
         if not schema_exists(rel):
             continue
         try:
@@ -832,7 +856,7 @@ def generated_schema_entries():
             if name in generated:
                 continue
             generated.add(name)
-            if schema_properties(schema):
+            if has_struct_fields(schema):
                 yield {
                     'section': section,
                     'name': name,
@@ -849,7 +873,7 @@ def generated_schema_entries():
             schema = load_schema_spec(spec)
         except SCHEMA_RESOLUTION_ERRORS:
             continue
-        if schema_properties(schema):
+        if has_struct_fields(schema):
             yield {
                 'section': 'inline',
                 'name': name,
@@ -1049,7 +1073,7 @@ def generate():
         if name in generated:
             continue
         generated.add(name)
-        if schema.get('type') == 'object' and 'properties' in schema:
+        if has_struct_fields(schema):
             print(schema_to_struct(name, schema))
 
     # Generate support/helper schema types.
@@ -1065,7 +1089,7 @@ def generate():
         if name in generated:
             continue
         generated.add(name)
-        if schema_properties(schema):
+        if has_struct_fields(schema):
             print(schema_to_struct(name, schema))
 
     # Generate named inline schema-pointer types.

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1773,8 +1773,21 @@ type PolicyCategoryDefinition struct {
 
 // AudienceConstraints — Buyer-defined audience targeting constraints for a campaign plan. Specifies who the campaign should
 type AudienceConstraints struct {
-	Include []any `json:"include,omitempty"` // Desired audience criteria. The seller's targeting should align with these. Each
-	Exclude []any `json:"exclude,omitempty"` // Excluded audience criteria. The seller's targeting must not overlap with these.
+	Include []AudienceSelector `json:"include,omitempty"` // Desired audience criteria. The seller's targeting should align with these. Each
+	Exclude []AudienceSelector `json:"exclude,omitempty"` // Excluded audience criteria. The seller's targeting must not overlap with these.
+}
+
+// AudienceSelector — Selects an audience by signal reference or natural language description. Uses 'type' as the primary
+type AudienceSelector struct {
+	Type string `json:"type,omitempty"` // Discriminator for description-based selectors
+	SignalID *SignalID `json:"signal_id,omitempty"` // The signal to target
+	ValueType string `json:"value_type,omitempty"` // Discriminator for numeric signals
+	Value *bool `json:"value,omitempty"` // Whether to include (true) or exclude (false) users matching this signal
+	Values []string `json:"values,omitempty"` // Values to target. Users with any of these values will be included.
+	MinValue float64 `json:"min_value,omitempty"` // Minimum value (inclusive). Omit for no minimum. Must be <= max_value when both a
+	MaxValue float64 `json:"max_value,omitempty"` // Maximum value (inclusive). Omit for no maximum. Must be >= min_value when both a
+	Description string `json:"description,omitempty"` // Natural language description of the audience (e.g., 'likely EV buyers', 'high ne
+	Category string `json:"category,omitempty"` // Optional grouping hint for the governance agent (e.g., 'demographic', 'behaviora
 }
 
 // Product — Represents available advertising inventory
@@ -1799,7 +1812,7 @@ type Product struct {
 	CreativePolicy *CreativePolicy `json:"creative_policy,omitempty"`
 	IsCustom *bool `json:"is_custom,omitempty"` // Whether this is a custom product
 	PropertyTargetingAllowed *bool `json:"property_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its publisher_properties.
-	DataProviderSignals []any `json:"data_provider_signals,omitempty"` // Data provider signals available for this product. Buyers fetch signal definition
+	DataProviderSignals []DataProviderSignalSelector `json:"data_provider_signals,omitempty"` // Data provider signals available for this product. Buyers fetch signal definition
 	SignalTargetingAllowed *bool `json:"signal_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its data_provider_signals.
 	CatalogTypes []string `json:"catalog_types,omitempty"` // Catalog types this product supports for catalog-driven campaigns. A sponsored pr
 	MetricOptimization any `json:"metric_optimization,omitempty"` // Metric optimization capabilities for this product. Presence indicates the produc
@@ -1818,6 +1831,14 @@ type Product struct {
 	TrustedMatch any `json:"trusted_match,omitempty"` // Trusted Match Protocol capabilities for this product. When present, the product
 	MaterialSubmission any `json:"material_submission,omitempty"` // Instructions for submitting physical creative materials (print, static OOH, cine
 	Ext any `json:"ext,omitempty"`
+}
+
+// DataProviderSignalSelector — Selects signals from a data provider's adagents.json catalog. Used for product definitions and agent
+type DataProviderSignalSelector struct {
+	DataProviderDomain string `json:"data_provider_domain,omitempty"` // Domain where data provider's adagents.json is hosted (e.g., 'polk.com')
+	SelectionType string `json:"selection_type,omitempty"` // Discriminator indicating selection by signal tags
+	SignalIDs []string `json:"signal_ids,omitempty"` // Specific signal IDs from the data provider's catalog
+	SignalTags []string `json:"signal_tags,omitempty"` // Signal tags from the data provider's catalog. Selector covers all signals with t
 }
 
 // Placement — Represents a specific ad placement within a product's inventory. When the publisher declares a place
@@ -2010,6 +2031,14 @@ type CreativeManifest struct {
 	IndustryIdentifiers []IndustryIdentifier `json:"industry_identifiers,omitempty"` // Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Cle
 	Provenance any `json:"provenance,omitempty"` // Provenance metadata for this creative manifest. Serves as the default provenance
 	Ext any `json:"ext,omitempty"`
+}
+
+// Destination — A deployment target where signals can be activated (DSP, sales agent, etc.)
+type Destination struct {
+	Type string `json:"type,omitempty"` // Discriminator indicating this is an agent URL-based deployment
+	Platform string `json:"platform,omitempty"` // Platform identifier for DSPs (e.g., 'the-trade-desk', 'amazon-dsp')
+	Account string `json:"account,omitempty"` // Optional account identifier on the agent
+	AgentURL string `json:"agent_url,omitempty"` // URL identifying the deployment agent (for sales agents, etc.)
 }
 
 // Signal — Definition of a signal in a data provider's catalog, published via adagents.json
@@ -2261,7 +2290,7 @@ type PlannedDelivery struct {
 	EndTime string `json:"end_time,omitempty"` // Actual flight end the seller will use.
 	FrequencyCap *FrequencyCap `json:"frequency_cap,omitempty"` // Frequency cap the seller will apply.
 	AudienceSummary string `json:"audience_summary,omitempty"` // Human-readable summary of the audience the seller will target.
-	AudienceTargeting []any `json:"audience_targeting,omitempty"` // Structured audience targeting the seller will activate. Each entry is either a s
+	AudienceTargeting []AudienceSelector `json:"audience_targeting,omitempty"` // Structured audience targeting the seller will activate. Each entry is either a s
 	TotalBudget float64 `json:"total_budget,omitempty"` // Total budget the seller will deliver against.
 	Currency string `json:"currency,omitempty"` // ISO 4217 currency code for the budget.
 	EnforcedPolicies []string `json:"enforced_policies,omitempty"` // Registry policy IDs the seller will enforce for this delivery.
@@ -2949,7 +2978,7 @@ type GetSignalsRequest struct {
 	Account *AccountReference `json:"account,omitempty"` // Account for this request. When provided, the signals agent returns per-account p
 	SignalSpec string `json:"signal_spec,omitempty"` // Natural language description of the desired signals. When used alone, enables se
 	SignalIDs []SignalID `json:"signal_ids,omitempty"` // Specific signals to look up by data provider and ID. Returns exact matches from
-	Destinations []any `json:"destinations,omitempty"` // Filter signals to those activatable on specific agents/platforms. When omitted,
+	Destinations []Destination `json:"destinations,omitempty"` // Filter signals to those activatable on specific agents/platforms. When omitted,
 	Countries []string `json:"countries,omitempty"` // Countries where signals will be used (ISO 3166-1 alpha-2 codes). When omitted, n
 	Filters *SignalFilters `json:"filters,omitempty"`
 	MaxResults int `json:"max_results,omitempty"` // DEPRECATED: Use pagination.max_results instead. When both fields are present, ag


### PR DESCRIPTION
## Summary
- teach the generator to emit flattened structs for core/support `oneOf` schemas whose variants declare object properties
- generate typed `AudienceSelector`, `DataProviderSignalSelector`, and `Destination` from bundled 3.0.12 schemas
- replace generated `any` refs for audience constraints, planned delivery audience targeting, product data-provider signals, and `get_signals` destinations
- lower generated unreviewed `any` coverage gate from 124 to 119

## Notes
- This follows the SDK's existing hand-written oneOf flattening style: Go gets one struct with the union of schema variant fields.
- Top-level tool-response oneOf schemas still emit `type X = any` plus variant structs; this PR intentionally does not change response union ergonomics.
- No protocol fields were invented; field names come from the existing schema variant properties.
- GitHub Actions is currently under an active Actions outage affecting action downloads, so remote checks may fail before running code.

## Local validation
- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 119`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 118` fails as expected
- generator idempotence check for `adcp/types_gen.go`
- `cd adcp && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `go test ./...`
- `cd adcp && golangci-lint run ./...`
- `git diff --check`
