### PR TITLE
feat(identityagent): normalize seller_agent_url for fcap lookups

### DIFF
--- a/cmd/identity-agent/Dockerfile
+++ b/cmd/identity-agent/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /src
 COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
+COPY urlutil/ urlutil/
 COPY cmd/identity-agent/ cmd/identity-agent/
 WORKDIR /src/cmd/identity-agent
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /identity-agent .

--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -3,6 +3,7 @@ package identityagent
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"maps"
 	"sync"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
 	"github.com/adcontextprotocol/adcp-go/targeting/identityconfig"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
+	"github.com/adcontextprotocol/adcp-go/urlutil"
 )
 
 // Service composes the audience-only IdentityEngine with a frequency-cap
@@ -191,9 +193,29 @@ func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRe
 	fcapCtx, cancelFcap := context.WithTimeout(ctx, s.fcapTimeout)
 	defer cancelFcap()
 
+	// Reduce the seller URL to its registrable domain so the marker key
+	// matches what frequency-writer wrote (writer applies the same
+	// transformation via urlutil.Registrable). Any deviation makes
+	// markers unreachable and silently disables caps.
+	sellerDomain, err := urlutil.Registrable(req.SellerAgentURL)
+	if err != nil {
+		// frequency-writer skips messages whose seller URL is not
+		// registrable, so no marker exists for this URL. The symmetric
+		// reader behavior is "no caps fired" — leave cappedByPkg empty
+		// and let the audience stage decide eligibility.
+		dur := time.Since(start)
+		s.recorder.StageDuration(ctx, StageFCap, dur)
+		s.recorder.StageOutcome(ctx, StageFCap, OutcomeError)
+		slog.Warn("seller_agent_url is not a registrable domain; skipping fcap lookup",
+			"request_id", req.RequestID,
+			"seller_agent_url", req.SellerAgentURL,
+			"error", err)
+		return fcapResult{outcome: OutcomeError, duration: dur}
+	}
+
 	fields := make([]fcap.Field, len(pkgIDs))
 	for i, pkgID := range pkgIDs {
-		fields[i] = fcap.Field{SellerAgentURL: req.SellerAgentURL, PackageID: pkgID}
+		fields[i] = fcap.Field{SellerAgentURL: sellerDomain, PackageID: pkgID}
 	}
 	identities := make([]string, len(req.Identities))
 	for i, id := range req.Identities {

--- a/targeting/identityagent/service_test.go
+++ b/targeting/identityagent/service_test.go
@@ -129,18 +129,18 @@ func TestService_EmptyEffectivePackages(t *testing.T) {
 
 func TestService_NoSegmentRules_OnlyFCapGates(t *testing.T) {
 	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-1"}, TargetSegments: nil},
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-2"}, TargetSegments: nil},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-1"}, TargetSegments: nil},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-2"}, TargetSegments: nil},
 	}
 	svc := newTestService(t, testServiceOptions{
 		configEntries: entries,
 		cappedTuples: []capTuple{
-			{identity: "u1", seller: "s", pkg: "pkg-1"},
+			{identity: "u1", seller: "seller.com", pkg: "pkg-1"},
 		},
 	})
 	req := &tmproto.IdentityMatchRequest{
 		RequestID:      "r1",
-		SellerAgentURL: "s",
+		SellerAgentURL: "seller.com",
 		PackageIDs:     []string{"pkg-1", "pkg-2"},
 		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
 	}
@@ -153,18 +153,18 @@ func TestService_FCapPerIdentity(t *testing.T) {
 	// User has two identities; either being capped on a package marks
 	// that package ineligible.
 	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-1"}},
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-2"}},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-1"}},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-2"}},
 	}
 	svc := newTestService(t, testServiceOptions{
 		configEntries: entries,
 		cappedTuples: []capTuple{
-			{identity: "id5-token", seller: "s", pkg: "pkg-1"},
+			{identity: "id5-token", seller: "seller.com", pkg: "pkg-1"},
 		},
 	})
 	req := &tmproto.IdentityMatchRequest{
 		RequestID:      "r1",
-		SellerAgentURL: "s",
+		SellerAgentURL: "seller.com",
 		PackageIDs:     []string{"pkg-1", "pkg-2"},
 		Identities: []tmproto.IdentityToken{
 			{UserToken: "maid-token", UIDType: tmproto.UIDTypeMAID},
@@ -179,8 +179,8 @@ func TestService_FCapPerIdentity(t *testing.T) {
 func TestService_AudienceFiltersByRule(t *testing.T) {
 	rule := &targeting.SegmentRule{AllOf: []string{"seg-a"}}
 	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-1"}, TargetSegments: rule},
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-2"}, TargetSegments: nil}, // no rule
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-1"}, TargetSegments: rule},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-2"}, TargetSegments: nil}, // no rule
 	}
 	svc := newTestService(t, testServiceOptions{
 		configEntries: entries,
@@ -190,7 +190,7 @@ func TestService_AudienceFiltersByRule(t *testing.T) {
 	})
 	req := &tmproto.IdentityMatchRequest{
 		RequestID:      "r1",
-		SellerAgentURL: "s",
+		SellerAgentURL: "seller.com",
 		PackageIDs:     []string{"pkg-1", "pkg-2"},
 		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
 	}
@@ -208,8 +208,8 @@ func TestService_AudienceFiltersByRule(t *testing.T) {
 func TestService_AudienceUnconfigured_RulesMarkIneligible(t *testing.T) {
 	rule := &targeting.SegmentRule{AllOf: []string{"seg-a"}}
 	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-1"}, TargetSegments: rule},
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-2"}, TargetSegments: nil},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-1"}, TargetSegments: rule},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-2"}, TargetSegments: nil},
 	}
 	svc := newTestService(t, testServiceOptions{
 		configEntries:    entries,
@@ -217,7 +217,7 @@ func TestService_AudienceUnconfigured_RulesMarkIneligible(t *testing.T) {
 	})
 	req := &tmproto.IdentityMatchRequest{
 		RequestID:      "r1",
-		SellerAgentURL: "s",
+		SellerAgentURL: "seller.com",
 		PackageIDs:     []string{"pkg-1", "pkg-2"},
 		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
 	}
@@ -228,7 +228,7 @@ func TestService_AudienceUnconfigured_RulesMarkIneligible(t *testing.T) {
 
 func TestService_FCapTimeout_FailClosed(t *testing.T) {
 	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: "s", PackageID: "pkg-1"}},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-1"}},
 	}
 	// Wrap the in-memory fcap.Store in a delay shim that exceeds the
 	// 1ms FCapTimeout we set below.
@@ -245,12 +245,73 @@ func TestService_FCapTimeout_FailClosed(t *testing.T) {
 	require.NoError(t, err)
 	req := &tmproto.IdentityMatchRequest{
 		RequestID:      "r1",
-		SellerAgentURL: "s",
+		SellerAgentURL: "seller.com",
 		PackageIDs:     []string{"pkg-1"},
 		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
 	}
 	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
 	require.False(t, got["pkg-1"], "fcap timeout must fail closed")
+}
+
+// TestService_FCap_NormalizesSellerURLToRegistrableDomain ensures the fcap
+// stage reduces req.SellerAgentURL to its registrable domain (eTLD+1) before
+// looking up markers — matching the transformation frequency-writer applies
+// when it writes them. The cap is recorded under "seller.example.com" while
+// the request carries the full "https://sub.seller.example.com/agent" form;
+// the cap must still apply.
+func TestService_FCap_NormalizesSellerURLToRegistrableDomain(t *testing.T) {
+	// The full URL carries subdomain + path; its eTLD+1 is "seller.com".
+	// frequency-writer would record the marker under the eTLD+1; the
+	// fcap stage must reduce the request URL the same way for the
+	// lookup to find it.
+	fullURL := "https://api.seller.com/agent"
+	registrable := "seller.com"
+	entries := []identityconfig.Entry{
+		{Key: identityconfig.Key{SellerAgentURL: fullURL, PackageID: "pkg-1"}},
+	}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: entries,
+		cappedTuples: []capTuple{
+			{identity: "u1", seller: registrable, pkg: "pkg-1"},
+		},
+	})
+	req := &tmproto.IdentityMatchRequest{
+		RequestID:      "r1",
+		SellerAgentURL: fullURL,
+		PackageIDs:     []string{"pkg-1"},
+		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
+	}
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-1"], "cap recorded under registrable domain must apply to a request that uses a subdomain/path form")
+}
+
+// TestService_FCap_UnregistrableSellerURL_NoCapApplied verifies the symmetric
+// behavior to frequency-writer's "skip on invalid URL": if the request's
+// seller URL can't be reduced to a registrable domain, no marker exists, so
+// the fcap stage applies no caps and leaves eligibility to other stages.
+func TestService_FCap_UnregistrableSellerURL_NoCapApplied(t *testing.T) {
+	// "http://localhost" parses as a URL but localhost has no eTLD+1, so
+	// urlutil.Registrable returns ErrInvalid.
+	sellerURL := "http://localhost"
+	entries := []identityconfig.Entry{
+		{Key: identityconfig.Key{SellerAgentURL: sellerURL, PackageID: "pkg-1"}},
+	}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: entries,
+		// Seed a cap on the unreduced URL so we can prove the fcap stage
+		// never consults it.
+		cappedTuples: []capTuple{
+			{identity: "u1", seller: sellerURL, pkg: "pkg-1"},
+		},
+	})
+	req := &tmproto.IdentityMatchRequest{
+		RequestID:      "r1",
+		SellerAgentURL: sellerURL,
+		PackageIDs:     []string{"pkg-1"},
+		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
+	}
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.True(t, got["pkg-1"], "unregistrable seller URL must skip fcap and leave the package eligible")
 }
 
 // slowFCapStore is an fcap.Store wrapper that injects a fixed delay before


### PR DESCRIPTION
## Summary

- Identity-agent's fcap stage now reduces `req.SellerAgentURL` to its registrable domain via `urlutil.Registrable` before building `fcap.Field`, matching what frequency-writer applies when it writes markers. Any deviation in subdomain, scheme, or path between buyer and writer previously made markers unreachable and silently disabled caps.
- When the request URL is not reducible (raw IP, single-label host), the fcap stage skips its lookup — symmetric to frequency-writer's "skip on invalid URL" behavior — and records `StageFCap`/`error` so it's visible in metrics.
- `identityconfig.ResolveRequest` keeps the un-normalized URL because the config source keys on full URLs (e.g. `"https://seller.example.com/agent"`), so this PR scopes normalization to the marker-key path only.

## Why this is safe

- `urlutil.Registrable` is the exact helper frequency-writer uses (see `internal/processor/processor.go:139` in scope3data/frequency-writer), so both sides apply the identical transformation.
- Behavior change is limited to fcap field construction; audience and resolve stages are untouched.
- Existing tests that used the placeholder `"s"` as a seller URL have been updated to `"seller.com"` — `"s"` is not a registrable domain and would now be rejected by the new validation.

## Test plan

- [x] `go test ./targeting/identityagent/...`
- [x] `go test ./...`
- [ ] CI green
- [ ] Spot-check that a real seller URL like `https://api.adsrvr.org/path` now writes markers under `adsrvr.org` on both writer and reader sides

---

Reopened from #166 (closed due to GitHub partial outage preventing re-runs of some actions).