### PR TITLE
feat(adcp)!: type delivery and product inline refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 91
+        run: python3 generate.py --coverage-max-unreviewed-any 61
 
       - name: Check generated code is up to date
         run: |
@@ -53,6 +53,10 @@ jobs:
           git diff --exit-code tmproto/types_gen.go
 
       - name: Test root module
+        run: go test -race -count=1 ./...
+
+      - name: Test adcp module
+        working-directory: adcp
         run: go test -race -count=1 ./...
 
       - name: Test context agent

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -91,13 +91,46 @@ be populated.
 | `Product.CreativePolicy` | `*adcp.CreativePolicy` |
 | `Product.MeasurementReadiness` | `*adcp.MeasurementReadiness` |
 | `MeasurementReadiness.Issues` | `[]adcp.DiagnosticIssue` |
+| `Product.MetricOptimization` | `*adcp.ProductMetricOptimization` |
+| `Product.ConversionTracking` | `*adcp.ProductConversionTracking` |
+| `Product.TrustedMatch` | `*adcp.ProductTrustedMatch` |
+| `ProductTrustedMatch.Providers` | `[]adcp.ProductTrustedMatchProvider` |
+| `Product.MaterialSubmission` | `*adcp.ProductMaterialSubmission` |
 | `Product.Collections` | `[]adcp.CollectionSelector` |
 | `Product.DataProviderSignals` | `[]adcp.DataProviderSignalSelector` |
 | `Package.PriceBreakdown` | `*adcp.PriceBreakdown` |
+| `PriceBreakdown.Adjustments` | `[]adcp.PriceAdjustment` |
 | `Package.Cancellation` | `*adcp.PackageCancellation` |
 | `CreativeFormat.Accessibility` | `*adcp.CreativeFormatAccessibility` |
+| `CreativeFormat.DisclosureCapabilities` | `[]adcp.CreativeFormatDisclosureCapability` |
+| `CreativeAsset.Inputs` | `[]adcp.CreativeAssetInput` |
 | `Signal.Range` | `*adcp.SignalRange` |
+| `Targeting.StoreCatchments` | `[]adcp.TargetingStoreCatchment` |
+| `DeliveryTotals.ByEventType` | `[]adcp.DeliveryEventTypeMetrics` |
 | `DeliveryTotals.QuartileData` | `*adcp.DeliveryQuartileData` |
+| `DeliveryTotals.DoohMetrics` | `*adcp.DeliveryDOOHMetrics` |
+| `DeliveryTotals.Viewability` | `*adcp.DeliveryViewability` |
+| `DeliveryTotals.ByActionSource` | `[]adcp.DeliveryActionSourceMetrics` |
+| `MediaBuyDeliveryTotals.ByEventType` | `[]adcp.DeliveryEventTypeMetrics` |
+| `MediaBuyDeliveryTotals.QuartileData` | `*adcp.DeliveryQuartileData` |
+| `MediaBuyDeliveryTotals.DoohMetrics` | `*adcp.DeliveryDOOHMetrics` |
+| `MediaBuyDeliveryTotals.Viewability` | `*adcp.DeliveryViewability` |
+| `MediaBuyDeliveryTotals.ByActionSource` | `[]adcp.DeliveryActionSourceMetrics` |
+| `PackageDelivery.ByEventType` | `[]adcp.DeliveryEventTypeMetrics` |
+| `PackageDelivery.QuartileData` | `*adcp.DeliveryQuartileData` |
+| `PackageDelivery.DoohMetrics` | `*adcp.DeliveryDOOHMetrics` |
+| `PackageDelivery.Viewability` | `*adcp.DeliveryViewability` |
+| `PackageDelivery.ByActionSource` | `[]adcp.DeliveryActionSourceMetrics` |
+| `MediaBuyDelivery.DailyBreakdown` | `[]adcp.MediaBuyDailyBreakdown` |
+| `PackageDelivery.ByCatalogItem` | `[]adcp.PackageCatalogItemDelivery` |
+| `PackageDelivery.ByCreative` | `[]adcp.PackageCreativeDelivery` |
+| `PackageDelivery.ByKeyword` | `[]adcp.PackageKeywordDelivery` |
+| `PackageDelivery.ByGeo` | `[]adcp.PackageGeoDelivery` |
+| `PackageDelivery.ByDeviceType` | `[]adcp.PackageDeviceTypeDelivery` |
+| `PackageDelivery.ByDevicePlatform` | `[]adcp.PackageDevicePlatformDelivery` |
+| `PackageDelivery.ByAudience` | `[]adcp.PackageAudienceDelivery` |
+| `PackageDelivery.ByPlacement` | `[]adcp.PackagePlacementDelivery` |
+| `PackageDelivery.DailyBreakdown` | `[]adcp.PackageDailyBreakdown` |
 | `CreativeBrief.ReferenceAssets` | `[]adcp.ReferenceAsset` |
 | `CreativeManifest.Rights` | `[]adcp.RightsConstraint` |
 | `RightsConstraint.RightsAgent` | `adcp.RightsAgentRef` |
@@ -148,6 +181,19 @@ req := adcp.GetProductsRequest{
 }
 ```
 
+Price adjustment migration example:
+
+```go
+breakdown := adcp.PriceBreakdown{
+    ListPrice: 20,
+    Adjustments: []adcp.PriceAdjustment{{
+        Kind:   "discount",
+        Name:   "volume",
+        Amount: 5,
+    }},
+}
+```
+
 Seller response and governance migration example:
 
 ```go
@@ -194,6 +240,11 @@ feedback := adcp.ProvidePerformanceFeedbackRequest{
   emitted as schema-required fields even when their Go values are zero.
   `MediaBuyDelivery.Totals` is now `adcp.MediaBuyDeliveryTotals`, which includes
   the schema-specific `effective_rate` field.
+- Delivery metric breakdowns use the same generated metric helper types across
+  `DeliveryTotals`, `MediaBuyDeliveryTotals`, package rows, and package
+  breakdown rows: `DeliveryEventTypeMetrics`, `DeliveryQuartileData`,
+  `DeliveryDOOHMetrics`, `DeliveryViewability`, and
+  `DeliveryActionSourceMetrics`.
 - `GetMediaBuyDeliveryResponse.ReportingPeriod`,
   `GetMediaBuyDeliveryResponse.AggregatedTotals`, and
   `GetMediaBuyDeliveryResponse.MediaBuyDeliveries` are now typed as

--- a/adcp/delivery_types_test.go
+++ b/adcp/delivery_types_test.go
@@ -46,9 +46,7 @@ func TestGeneratedDeliveryTypesRoundTrip(t *testing.T) {
 				Paused:            &paused,
 				IsFinal:           &isFinal,
 				MeasurementWindow: "c7",
-				DailyBreakdown: []any{
-					map[string]any{"date": "2026-05-25", "impressions": 1000, "spend": 125},
-				},
+				DailyBreakdown:    []PackageDailyBreakdown{{Date: "2026-05-25", Impressions: 1000, Spend: 125}},
 			}},
 		}},
 	}

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -92,6 +92,11 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				FrequencyCap:   Ptr(FrequencyCap{MaxImpressions: 3, Per: "user", Window: Ptr(Duration{Interval: 7, Unit: "days"})}),
 				PropertyList:   Ptr(PropertyListRef{AgentURL: "https://lists.example/mcp", ListID: "pl-456"}),
 				GeoMetros:      []GeoMetroTarget{{System: "nielsen_dma", Values: []string{"501"}}},
+				StoreCatchments: []TargetingStoreCatchment{{
+					CatalogID:    "stores",
+					StoreIDs:     []string{"store-1"},
+					CatchmentIDs: []string{"drive"},
+				}},
 				AgeRestriction: Ptr(AgeRestriction{Min: 21}),
 				KeywordTargets: []KeywordTarget{{Keyword: "running shoes", MatchType: "phrase"}},
 			},
@@ -100,6 +105,7 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				`"frequency_cap":{"max_impressions":3,"per":"user","window":{"interval":7,"unit":"days"}}`,
 				`"property_list":{"agent_url":"https://lists.example/mcp","list_id":"pl-456"}`,
 				`"geo_metros":[{"system":"nielsen_dma","values":["501"]}]`,
+				`"store_catchments":[{"catalog_id":"stores","store_ids":["store-1"],"catchment_ids":["drive"]}]`,
 				`"age_restriction":{"min":21}`,
 				`"keyword_targets":[{"keyword":"running shoes","match_type":"phrase"}]`,
 			},
@@ -144,12 +150,20 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
-			name: "delivery quartiles",
+			name: "delivery metrics",
 			value: DeliveryTotals{
-				QuartileData: Ptr(DeliveryQuartileData{Q1Views: 10, Q4Views: 4}),
+				QuartileData:   Ptr(DeliveryQuartileData{Q1Views: 10, Q4Views: 4}),
+				ByEventType:    []DeliveryEventTypeMetrics{{EventType: "purchase", Count: 2, Value: 42}},
+				ByActionSource: []DeliveryActionSourceMetrics{{ActionSource: "website", Count: 2}},
+				DoohMetrics:    Ptr(DeliveryDOOHMetrics{LoopPlays: 5, VenueBreakdown: []DeliveryDOOHVenueBreakdown{{VenueID: "venue-1", Impressions: 100}}}),
+				Viewability:    Ptr(DeliveryViewability{MeasurableImpressions: 100, ViewableImpressions: 80, ViewableRate: 0.8, Standard: "mrc"}),
 			},
 			want: []string{
 				`"quartile_data":{"q1_views":10,"q4_views":4}`,
+				`"by_event_type":[{"count":2,"event_type":"purchase","value":42}]`,
+				`"dooh_metrics":{"loop_plays":5,"venue_breakdown":[{"impressions":100,"venue_id":"venue-1"}]}`,
+				`"viewability":{"measurable_impressions":100,"standard":"mrc","viewable_impressions":80,"viewable_rate":0.8}`,
+				`"by_action_source":[{"action_source":"website","count":2}]`,
 			},
 		},
 		{
@@ -163,6 +177,76 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 			want: []string{
 				`"total_budget":{"amount":10000,"currency":"USD"}`,
+			},
+		},
+		{
+			name: "creative format disclosures",
+			value: CreativeFormat{
+				FormatID: FormatRef{AgentURL: "https://seller.example/mcp", ID: "display_300x250"},
+				Name:     "Display",
+				DisclosureCapabilities: []CreativeFormatDisclosureCapability{{
+					Position:    "overlay_top_left",
+					Persistence: []string{"initial", "persistent"},
+				}},
+			},
+			want: []string{
+				`"disclosure_capabilities":[{"position":"overlay_top_left","persistence":["initial","persistent"]}]`,
+			},
+		},
+		{
+			name: "creative asset inputs",
+			value: CreativeAsset{
+				CreativeID: "creative-1",
+				Name:       "Creative",
+				FormatID:   FormatRef{AgentURL: "https://seller.example/mcp", ID: "gen_display"},
+				Assets:     map[string]any{"headline": "Sale"},
+				Inputs: []CreativeAssetInput{{
+					Name:               "default",
+					Macros:             map[string]string{"CITY": "Honolulu"},
+					ContextDescription: "Warm-weather retail offer",
+				}},
+			},
+			want: []string{
+				`"inputs":[{"name":"default","macros":{"CITY":"Honolulu"},"context_description":"Warm-weather retail offer"}]`,
+			},
+		},
+		{
+			name: "delivery package breakdowns",
+			value: PackageDelivery{
+				PackageID:    "pkg-1",
+				Spend:        10,
+				PricingModel: "cpm",
+				Rate:         5,
+				Currency:     "USD",
+				ByCatalogItem: []PackageCatalogItemDelivery{{
+					ContentID:     "sku-1",
+					ContentIDType: "sku",
+					Impressions:   100,
+					Spend:         10,
+				}},
+				ByCreative: []PackageCreativeDelivery{{
+					CreativeID:   "creative-1",
+					Impressions:  100,
+					Spend:        10,
+					QuartileData: Ptr(DeliveryQuartileData{Q4Views: 9}),
+				}},
+				DailyBreakdown: []PackageDailyBreakdown{{Date: "2026-06-01", Impressions: 100, Spend: 10}},
+			},
+			want: []string{
+				`"by_catalog_item":[{"impressions":100,"spend":10,"content_id":"sku-1","content_id_type":"sku"}]`,
+				`"by_creative":[{"impressions":100,"spend":10,"quartile_data":{"q4_views":9},"creative_id":"creative-1"}]`,
+				`"daily_breakdown":[{"date":"2026-06-01","impressions":100,"spend":10}]`,
+			},
+		},
+		{
+			name: "media buy daily breakdown",
+			value: MediaBuyDelivery{
+				MediaBuyID:     "mb-1",
+				Totals:         MediaBuyDeliveryTotals{Impressions: 100, Spend: 10},
+				DailyBreakdown: []MediaBuyDailyBreakdown{{Date: "2026-06-01", Impressions: 100, Spend: 10}},
+			},
+			want: []string{
+				`"daily_breakdown":[{"date":"2026-06-01","impressions":100,"spend":10}]`,
 			},
 		},
 		{

--- a/adcp/generated_product_refs_test.go
+++ b/adcp/generated_product_refs_test.go
@@ -60,10 +60,31 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 				Message:  "purchase events are active",
 			}},
 		},
+		MetricOptimization: &ProductMetricOptimization{
+			SupportedMetrics: []string{"clicks", "reach"},
+			SupportedTargets: []string{"cost_per"},
+		},
+		ConversionTracking: &ProductConversionTracking{
+			ActionSources:    []string{"website"},
+			SupportedTargets: []string{"cost_per"},
+			PlatformManaged:  Ptr(true),
+		},
 		CatalogMatch: &ProductCatalogMatch{
 			MatchedIDs:     []string{"sku-1"},
 			MatchedCount:   1,
 			SubmittedCount: 10,
+		},
+		TrustedMatch: &ProductTrustedMatch{
+			ContextMatch:  true,
+			ResponseTypes: []string{"activation"},
+			Providers: []ProductTrustedMatchProvider{{
+				AgentURL:     "https://tmp.example/mcp",
+				ContextMatch: Ptr(true),
+			}},
+		},
+		MaterialSubmission: &ProductMaterialSubmission{
+			URL:          "https://seller.example/materials",
+			Instructions: "Upload print-ready PDF.",
 		},
 		DataProviderSignals: []DataProviderSignalSelector{{
 			DataProviderDomain: "signals.example",
@@ -89,7 +110,11 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 		`"reporting_capabilities":{"available_reporting_frequencies":["daily"],"expected_delay_minutes":60`,
 		`"creative_policy":{"co_branding":"optional","landing_page":"required","templates_available":true}`,
 		`"measurement_readiness":{"status":"ready","required_event_types":["purchase"],"issues":[{"severity":"info","message":"purchase events are active"}]}`,
+		`"metric_optimization":{"supported_metrics":["clicks","reach"],"supported_targets":["cost_per"]}`,
+		`"conversion_tracking":{"action_sources":["website"],"supported_targets":["cost_per"],"platform_managed":true}`,
 		`"catalog_match":{"matched_ids":["sku-1"],"matched_count":1,"submitted_count":10}`,
+		`"trusted_match":{"context_match":true,"response_types":["activation"],"providers":[{"agent_url":"https://tmp.example/mcp","context_match":true}]}`,
+		`"material_submission":{"url":"https://seller.example/materials","instructions":"Upload print-ready PDF."}`,
 		`"data_provider_signals":[{"data_provider_domain":"signals.example","selection_type":"signal_ids","signal_ids":["auto_intenders"]}]`,
 		`"collections":[{"publisher_domain":"example.com","collection_ids":["sports"]}]`,
 	} {
@@ -137,7 +162,7 @@ func TestGeneratedPackagePriceBreakdown(t *testing.T) {
 		PackageID: "pkg-1",
 		PriceBreakdown: &PriceBreakdown{
 			ListPrice:   20,
-			Adjustments: []any{map[string]any{"type": "discount", "amount": 5}},
+			Adjustments: []PriceAdjustment{{Kind: "discount", Name: "volume", Amount: 5}},
 		},
 		Canceled: Ptr(canceled),
 		Cancellation: &PackageCancellation{
@@ -151,7 +176,7 @@ func TestGeneratedPackagePriceBreakdown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal package: %v", err)
 	}
-	if !strings.Contains(string(raw), `"price_breakdown":{"list_price":20,"adjustments":[{"amount":5,"type":"discount"}]}`) {
+	if !strings.Contains(string(raw), `"price_breakdown":{"list_price":20,"adjustments":[{"kind":"discount","name":"volume","amount":5}]}`) {
 		t.Fatalf("price breakdown did not marshal as typed field: %s", raw)
 	}
 	if !strings.Contains(string(raw), `"cancellation":{"canceled_at":"2026-06-01T00:00:00Z","canceled_by":"buyer","reason":"budget_cut"}`) {

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -393,6 +393,121 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "RightsAgentRef",
         "core/rights-constraint.json#/properties/rights_agent",
     ),
+    (
+        "ProductMetricOptimization",
+        "core/product.json#/properties/metric_optimization",
+    ),
+    (
+        "ProductConversionTracking",
+        "core/product.json#/properties/conversion_tracking",
+    ),
+    (
+        "ProductTrustedMatch",
+        "core/product.json#/properties/trusted_match",
+    ),
+    (
+        "ProductTrustedMatchProvider",
+        "core/product.json#/properties/trusted_match/properties/providers/items",
+    ),
+    (
+        "ProductMaterialSubmission",
+        "core/product.json#/properties/material_submission",
+    ),
+    (
+        "PriceAdjustment",
+        "pricing-options/price-breakdown.json#/properties/adjustments/items",
+    ),
+    (
+        "CreativeFormatDisclosureCapability",
+        "core/format.json#/properties/disclosure_capabilities/items",
+    ),
+    (
+        "CreativeAssetInput",
+        "core/creative-asset.json#/properties/inputs/items",
+    ),
+    (
+        "TargetingStoreCatchment",
+        "core/targeting.json#/properties/store_catchments/items",
+    ),
+    (
+        "DeliveryEventTypeMetrics",
+        "core/delivery-metrics.json#/properties/by_event_type/items",
+    ),
+    (
+        "DeliveryDOOHMetrics",
+        "core/delivery-metrics.json#/properties/dooh_metrics",
+    ),
+    (
+        "DeliveryDOOHVenueBreakdown",
+        "core/delivery-metrics.json#/properties/dooh_metrics/properties/venue_breakdown/items",
+    ),
+    (
+        "DeliveryViewability",
+        "core/delivery-metrics.json#/properties/viewability",
+    ),
+    (
+        "DeliveryActionSourceMetrics",
+        "core/delivery-metrics.json#/properties/by_action_source/items",
+    ),
+    (
+        "MediaBuyDailyBreakdown",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/daily_breakdown/items",
+    ),
+    (
+        "PackageCatalogItemDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_catalog_item/items",
+    ),
+    (
+        "PackageCreativeDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_creative/items",
+    ),
+    (
+        "PackageKeywordDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_keyword/items",
+    ),
+    (
+        "PackageGeoDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_geo/items",
+    ),
+    (
+        "PackageDeviceTypeDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_device_type/items",
+    ),
+    (
+        "PackageDevicePlatformDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_device_platform/items",
+    ),
+    (
+        "PackageAudienceDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_audience/items",
+    ),
+    (
+        "PackagePlacementDelivery",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/by_placement/items",
+    ),
+    (
+        "PackageDailyBreakdown",
+        "media-buy/get-media-buy-delivery-response.json"
+        "#/properties/media_buy_deliveries/items/properties/by_package/items"
+        "/allOf/1/properties/daily_breakdown/items",
+    ),
 ])
 
 # Hand-written types that should be drift-checked against a schema path or JSON
@@ -533,6 +648,38 @@ INLINE_TYPE_HINTS = {
     ('CollectionListChangedWebhook', 'change_summary'): '*CollectionChangeSummary',
     ('PropertyListChangedWebhook', 'change_summary'): '*PropertyChangeSummary',
     ('RightsConstraint', 'rights_agent'): 'RightsAgentRef',
+    ('Product', 'metric_optimization'): '*ProductMetricOptimization',
+    ('Product', 'conversion_tracking'): '*ProductConversionTracking',
+    ('Product', 'trusted_match'): '*ProductTrustedMatch',
+    ('Product', 'material_submission'): '*ProductMaterialSubmission',
+    ('ProductTrustedMatch', 'providers'): 'ProductTrustedMatchProvider',
+    ('PriceBreakdown', 'adjustments'): 'PriceAdjustment',
+    ('CreativeFormat', 'disclosure_capabilities'): 'CreativeFormatDisclosureCapability',
+    ('CreativeAsset', 'inputs'): 'CreativeAssetInput',
+    ('Targeting', 'store_catchments'): 'TargetingStoreCatchment',
+    ('DeliveryTotals', 'by_event_type'): 'DeliveryEventTypeMetrics',
+    ('DeliveryTotals', 'dooh_metrics'): '*DeliveryDOOHMetrics',
+    ('DeliveryTotals', 'viewability'): '*DeliveryViewability',
+    ('DeliveryTotals', 'by_action_source'): 'DeliveryActionSourceMetrics',
+    ('DeliveryDOOHMetrics', 'venue_breakdown'): 'DeliveryDOOHVenueBreakdown',
+    ('MediaBuyDeliveryTotals', 'by_event_type'): 'DeliveryEventTypeMetrics',
+    ('MediaBuyDeliveryTotals', 'dooh_metrics'): '*DeliveryDOOHMetrics',
+    ('MediaBuyDeliveryTotals', 'viewability'): '*DeliveryViewability',
+    ('MediaBuyDeliveryTotals', 'by_action_source'): 'DeliveryActionSourceMetrics',
+    ('MediaBuyDelivery', 'daily_breakdown'): 'MediaBuyDailyBreakdown',
+    ('PackageDelivery', 'by_event_type'): 'DeliveryEventTypeMetrics',
+    ('PackageDelivery', 'dooh_metrics'): '*DeliveryDOOHMetrics',
+    ('PackageDelivery', 'viewability'): '*DeliveryViewability',
+    ('PackageDelivery', 'by_action_source'): 'DeliveryActionSourceMetrics',
+    ('PackageDelivery', 'by_catalog_item'): 'PackageCatalogItemDelivery',
+    ('PackageDelivery', 'by_creative'): 'PackageCreativeDelivery',
+    ('PackageDelivery', 'by_keyword'): 'PackageKeywordDelivery',
+    ('PackageDelivery', 'by_geo'): 'PackageGeoDelivery',
+    ('PackageDelivery', 'by_device_type'): 'PackageDeviceTypeDelivery',
+    ('PackageDelivery', 'by_device_platform'): 'PackageDevicePlatformDelivery',
+    ('PackageDelivery', 'by_audience'): 'PackageAudienceDelivery',
+    ('PackageDelivery', 'by_placement'): 'PackagePlacementDelivery',
+    ('PackageDelivery', 'daily_breakdown'): 'PackageDailyBreakdown',
     ('GetAdcpCapabilitiesResponse', 'adcp'): 'ADCPVersion',
     ('GetAdcpCapabilitiesResponse', 'account'): 'AccountCapabilities',
     ('GetAdcpCapabilitiesResponse', 'media_buy'): 'MediaBuyCapabilities',
@@ -551,6 +698,24 @@ INLINE_TYPE_HINTS = {
     ('CreativeFormat', 'assets'): 'AssetSlot',
     ('GetMediaBuysResponse', 'media_buys'): 'MediaBuyData',
 }
+
+for _delivery_metric_type in (
+    'PackageCatalogItemDelivery',
+    'PackageCreativeDelivery',
+    'PackageKeywordDelivery',
+    'PackageGeoDelivery',
+    'PackageDeviceTypeDelivery',
+    'PackageDevicePlatformDelivery',
+    'PackageAudienceDelivery',
+    'PackagePlacementDelivery',
+):
+    INLINE_TYPE_HINTS.update({
+        (_delivery_metric_type, 'by_event_type'): 'DeliveryEventTypeMetrics',
+        (_delivery_metric_type, 'quartile_data'): '*DeliveryQuartileData',
+        (_delivery_metric_type, 'dooh_metrics'): '*DeliveryDOOHMetrics',
+        (_delivery_metric_type, 'viewability'): '*DeliveryViewability',
+        (_delivery_metric_type, 'by_action_source'): 'DeliveryActionSourceMetrics',
+    })
 
 # Initial allowlist for generated `any` fallbacks that are intentional protocol
 # escape hatches rather than generator gaps. The coverage report still includes

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1815,10 +1815,10 @@ type Product struct {
 	DataProviderSignals []DataProviderSignalSelector `json:"data_provider_signals,omitempty"` // Data provider signals available for this product. Buyers fetch signal definition
 	SignalTargetingAllowed *bool `json:"signal_targeting_allowed,omitempty"` // Whether buyers can filter this product to a subset of its data_provider_signals.
 	CatalogTypes []string `json:"catalog_types,omitempty"` // Catalog types this product supports for catalog-driven campaigns. A sponsored pr
-	MetricOptimization any `json:"metric_optimization,omitempty"` // Metric optimization capabilities for this product. Presence indicates the produc
+	MetricOptimization *ProductMetricOptimization `json:"metric_optimization,omitempty"` // Metric optimization capabilities for this product. Presence indicates the produc
 	MaxOptimizationGoals int `json:"max_optimization_goals,omitempty"` // Maximum number of optimization_goals this product accepts on a package. When abs
 	MeasurementReadiness *MeasurementReadiness `json:"measurement_readiness,omitempty"` // Assessment of whether the buyer's event source setup is sufficient for this prod
-	ConversionTracking any `json:"conversion_tracking,omitempty"` // Conversion event tracking for this product. Presence indicates the product suppo
+	ConversionTracking *ProductConversionTracking `json:"conversion_tracking,omitempty"` // Conversion event tracking for this product. Presence indicates the product suppo
 	CatalogMatch *ProductCatalogMatch `json:"catalog_match,omitempty"` // When the buyer provides a catalog on get_products, indicates which catalog items
 	BriefRelevance string `json:"brief_relevance,omitempty"` // Explanation of why this product matches the brief (only included when brief is p
 	ExpiresAt string `json:"expires_at,omitempty"` // Expiration timestamp. After this time, the product may no longer be available fo
@@ -1828,8 +1828,8 @@ type Product struct {
 	CollectionTargetingAllowed *bool `json:"collection_targeting_allowed,omitempty"` // Whether buyers can target a subset of this product's collections. When false (de
 	Installments []any `json:"installments,omitempty"` // Specific installments included in this product. Each installment references its
 	EnforcedPolicies []string `json:"enforced_policies,omitempty"` // Registry policy IDs the seller enforces for this product. Enforcement level come
-	TrustedMatch any `json:"trusted_match,omitempty"` // Trusted Match Protocol capabilities for this product. When present, the product
-	MaterialSubmission any `json:"material_submission,omitempty"` // Instructions for submitting physical creative materials (print, static OOH, cine
+	TrustedMatch *ProductTrustedMatch `json:"trusted_match,omitempty"` // Trusted Match Protocol capabilities for this product. When present, the product
+	MaterialSubmission *ProductMaterialSubmission `json:"material_submission,omitempty"` // Instructions for submitting physical creative materials (print, static OOH, cine
 	Ext any `json:"ext,omitempty"`
 }
 
@@ -1974,7 +1974,7 @@ type Package struct {
 // PriceBreakdown — Breaks down the composition of fixed_price from a list (rate card) price through adjustments. Adjust
 type PriceBreakdown struct {
 	ListPrice float64 `json:"list_price"` // Rate card or base price before any adjustments. The starting point from which fi
-	Adjustments []any `json:"adjustments"` // Ordered list of price adjustments. Fee and discount adjustments walk list_price
+	Adjustments []PriceAdjustment `json:"adjustments"` // Ordered list of price adjustments. Fee and discount adjustments walk list_price
 }
 
 // CreativeFormat — Represents a creative format with its requirements
@@ -1993,7 +1993,7 @@ type CreativeFormat struct {
 	FormatCard any `json:"format_card,omitempty"` // Optional standard visual card (300x400px) for displaying this format in user int
 	Accessibility *CreativeFormatAccessibility `json:"accessibility,omitempty"` // Accessibility posture of this format. Declares the WCAG conformance level that c
 	SupportedDisclosurePositions []string `json:"supported_disclosure_positions,omitempty"` // Disclosure positions this format can render. Buyers use this to determine whethe
-	DisclosureCapabilities []any `json:"disclosure_capabilities,omitempty"` // Structured disclosure capabilities per position with persistence modes. Declares
+	DisclosureCapabilities []CreativeFormatDisclosureCapability `json:"disclosure_capabilities,omitempty"` // Structured disclosure capabilities per position with persistence modes. Declares
 	FormatCardDetailed any `json:"format_card_detailed,omitempty"` // Optional detailed card with carousel and full specifications. Provides rich form
 	ReportedMetrics []string `json:"reported_metrics,omitempty"` // Metrics this format can produce in delivery reporting. Buyers receive the inters
 	PricingOptions []VendorPricingOption `json:"pricing_options,omitempty"` // Pricing options for this format. Used by transformation and generation agents th
@@ -2014,7 +2014,7 @@ type CreativeAsset struct {
 	Name string `json:"name"` // Human-readable creative name
 	FormatID FormatRef `json:"format_id"` // Always a structured object {agent_url, id} — never a plain string. Format identi
 	Assets map[string]any `json:"assets"` // Assets required by the format, keyed by asset_id. Each asset value carries an `a
-	Inputs []any `json:"inputs,omitempty"` // Preview contexts for generative formats - defines what scenarios to generate pre
+	Inputs []CreativeAssetInput `json:"inputs,omitempty"` // Preview contexts for generative formats - defines what scenarios to generate pre
 	Tags []string `json:"tags,omitempty"` // User-defined tags for organization and searchability
 	Status string `json:"status,omitempty"` // For generative creatives: set to 'approved' to finalize, 'rejected' to request r
 	Weight float64 `json:"weight,omitempty"` // Optional delivery weight for creative rotation when uploading via create_media_b
@@ -2069,21 +2069,21 @@ type DeliveryTotals struct {
 	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
 	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
 	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
-	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
 	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
 	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
 	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
 	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
 	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
-	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
-	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
 	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
 	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
 	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
 	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
 	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
 	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
-	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
 }
 
 // Account — A billing account representing the relationship between a buyer and seller. The account determines r
@@ -2131,7 +2131,7 @@ type Targeting struct {
 	DevicePlatform []string `json:"device_platform,omitempty"` // Restrict to specific platforms. Use for technical compatibility (app only works
 	DeviceType []string `json:"device_type,omitempty"` // Restrict to specific device form factors. Use for campaigns targeting hardware c
 	DeviceTypeExclude []string `json:"device_type_exclude,omitempty"` // Exclude specific device form factors from delivery (e.g., exclude CTV for app-in
-	StoreCatchments []any `json:"store_catchments,omitempty"` // Target users within store catchment areas from a synced store catalog. Each entr
+	StoreCatchments []TargetingStoreCatchment `json:"store_catchments,omitempty"` // Target users within store catchment areas from a synced store catalog. Each entr
 	GeoProximity []any `json:"geo_proximity,omitempty"` // Target users within travel time, distance, or a custom boundary around arbitrary
 	Language []string `json:"language,omitempty"` // Restrict to users with specific language preferences. ISO 639-1 codes (e.g., 'en
 	KeywordTargets []KeywordTarget `json:"keyword_targets,omitempty"` // Keyword targeting for search and retail media platforms. Restricts delivery to q
@@ -2446,21 +2446,21 @@ type MediaBuyDeliveryTotals struct {
 	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
 	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
 	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
-	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
 	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
 	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
 	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
 	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
 	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
-	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
-	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
 	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
 	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
 	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
 	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
 	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
 	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
-	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
 	EffectiveRate float64 `json:"effective_rate,omitempty"` // Effective rate paid per unit based on pricing_model (e.g., actual CPM for 'cpm',
 }
 
@@ -2472,7 +2472,7 @@ type MediaBuyDelivery struct {
 	PricingModel string `json:"pricing_model,omitempty"` // Pricing model used for this media buy
 	Totals MediaBuyDeliveryTotals `json:"totals"`
 	ByPackage []PackageDelivery `json:"by_package"` // Metrics broken down by package
-	DailyBreakdown []any `json:"daily_breakdown,omitempty"` // Day-by-day delivery
+	DailyBreakdown []MediaBuyDailyBreakdown `json:"daily_breakdown,omitempty"` // Day-by-day delivery
 }
 
 type PackageDelivery struct {
@@ -2489,21 +2489,21 @@ type PackageDelivery struct {
 	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
 	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
 	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
-	ByEventType []any `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
 	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
 	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
 	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
 	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
 	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
-	DoohMetrics any `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
-	Viewability any `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
 	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
 	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
 	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
 	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
 	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
 	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
-	ByActionSource []any `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
 	PackageID string `json:"package_id"` // Seller's package identifier
 	PacingIndex float64 `json:"pacing_index,omitempty"` // Delivery pace (1.0 = on track, <1.0 = behind, >1.0 = ahead)
 	PricingModel string `json:"pricing_model"` // The pricing model used for this package (e.g., cpm, cpcv, cpp). Indicates how th
@@ -2514,20 +2514,20 @@ type PackageDelivery struct {
 	IsFinal *bool `json:"is_final,omitempty"` // Whether this delivery data is final for the reporting period. When false, the da
 	MeasurementWindow string `json:"measurement_window,omitempty"` // Which measurement window this data represents, referencing a window_id from the
 	SupersedesWindow string `json:"supersedes_window,omitempty"` // Which measurement window this data replaces. Present on window_update notificati
-	ByCatalogItem []any `json:"by_catalog_item,omitempty"` // Delivery by catalog item within this package. Available for catalog-driven packa
-	ByCreative []any `json:"by_creative,omitempty"` // Metrics broken down by creative within this package. Available when the seller s
-	ByKeyword []any `json:"by_keyword,omitempty"` // Metrics broken down by keyword within this package. One row per (keyword, match_
-	ByGeo []any `json:"by_geo,omitempty"` // Delivery by geographic area within this package. Available when the buyer reques
+	ByCatalogItem []PackageCatalogItemDelivery `json:"by_catalog_item,omitempty"` // Delivery by catalog item within this package. Available for catalog-driven packa
+	ByCreative []PackageCreativeDelivery `json:"by_creative,omitempty"` // Metrics broken down by creative within this package. Available when the seller s
+	ByKeyword []PackageKeywordDelivery `json:"by_keyword,omitempty"` // Metrics broken down by keyword within this package. One row per (keyword, match_
+	ByGeo []PackageGeoDelivery `json:"by_geo,omitempty"` // Delivery by geographic area within this package. Available when the buyer reques
 	ByGeoTruncated *bool `json:"by_geo_truncated,omitempty"` // Whether by_geo was truncated due to the requested limit or a seller-imposed maxi
-	ByDeviceType []any `json:"by_device_type,omitempty"` // Delivery by device form factor within this package. Available when the buyer req
+	ByDeviceType []PackageDeviceTypeDelivery `json:"by_device_type,omitempty"` // Delivery by device form factor within this package. Available when the buyer req
 	ByDeviceTypeTruncated *bool `json:"by_device_type_truncated,omitempty"` // Whether by_device_type was truncated. Sellers MUST return this flag whenever by_
-	ByDevicePlatform []any `json:"by_device_platform,omitempty"` // Delivery by operating system within this package. Available when the buyer reque
+	ByDevicePlatform []PackageDevicePlatformDelivery `json:"by_device_platform,omitempty"` // Delivery by operating system within this package. Available when the buyer reque
 	ByDevicePlatformTruncated *bool `json:"by_device_platform_truncated,omitempty"` // Whether by_device_platform was truncated. Sellers MUST return this flag whenever
-	ByAudience []any `json:"by_audience,omitempty"` // Delivery by audience segment within this package. Available when the buyer reque
+	ByAudience []PackageAudienceDelivery `json:"by_audience,omitempty"` // Delivery by audience segment within this package. Available when the buyer reque
 	ByAudienceTruncated *bool `json:"by_audience_truncated,omitempty"` // Whether by_audience was truncated. Sellers MUST return this flag whenever by_aud
-	ByPlacement []any `json:"by_placement,omitempty"` // Delivery by placement within this package. Available when the buyer requests pla
+	ByPlacement []PackagePlacementDelivery `json:"by_placement,omitempty"` // Delivery by placement within this package. Available when the buyer requests pla
 	ByPlacementTruncated *bool `json:"by_placement_truncated,omitempty"` // Whether by_placement was truncated. Sellers MUST return this flag whenever by_pl
-	DailyBreakdown []any `json:"daily_breakdown,omitempty"` // Day-by-day delivery for this package. Only present when include_package_daily_br
+	DailyBreakdown []PackageDailyBreakdown `json:"daily_breakdown,omitempty"` // Day-by-day delivery for this package. Only present when include_package_daily_br
 }
 
 // ProductDeliveryMeasurement — Measurement provider and methodology for delivery metrics. The buyer accepts the declared provider a
@@ -2685,6 +2685,398 @@ type PropertyChangeSummary struct {
 type RightsAgentRef struct {
 	URL string `json:"url"` // MCP endpoint URL of the rights agent
 	ID string `json:"id"` // Agent identifier
+}
+
+// ProductMetricOptimization — Metric optimization capabilities for this product. Presence indicates the product supports optimizat
+type ProductMetricOptimization struct {
+	SupportedMetrics []string `json:"supported_metrics"` // Metric kinds this product can optimize for. Buyers should only request metric go
+	SupportedReachUnits []string `json:"supported_reach_units,omitempty"` // Reach units this product can optimize for. Required when supported_metrics inclu
+	SupportedViewDurations []float64 `json:"supported_view_durations,omitempty"` // Video view duration thresholds (in seconds) this product supports for completed_
+	SupportedTargets []string `json:"supported_targets,omitempty"` // Target kinds available for metric goals on this product. Values match target.kin
+}
+
+// ProductConversionTracking — Conversion event tracking for this product. Presence indicates the product supports optimization_goa
+type ProductConversionTracking struct {
+	ActionSources []string `json:"action_sources,omitempty"` // Action sources relevant to this product (e.g. a retail media product might have
+	SupportedTargets []string `json:"supported_targets,omitempty"` // Target kinds available for event goals on this product. Values match target.kind
+	PlatformManaged *bool `json:"platform_managed,omitempty"` // Whether the seller provides its own always-on measurement (e.g. Amazon sales att
+}
+
+// ProductTrustedMatch — Trusted Match Protocol capabilities for this product. When present, the product supports real-time c
+type ProductTrustedMatch struct {
+	ContextMatch bool `json:"context_match"` // Whether this product supports Context Match requests. When true, the publisher's
+	IdentityMatch *bool `json:"identity_match,omitempty"` // Whether this product supports Identity Match requests. When true, the publisher'
+	ResponseTypes []string `json:"response_types,omitempty"` // What the publisher can accept back from context match.
+	DynamicBrands *bool `json:"dynamic_brands,omitempty"` // Whether the buyer can select a brand at match time. When false (default), the br
+	Providers []ProductTrustedMatchProvider `json:"providers,omitempty"` // TMP providers integrated with this product's inventory. Each entry identifies a
+}
+
+type ProductTrustedMatchProvider struct {
+	AgentURL string `json:"agent_url"` // Provider's agent URL from the registry. Canonical identifier for this TMP provid
+	ContextMatch *bool `json:"context_match,omitempty"` // Whether this provider handles context match for this product.
+	IdentityMatch *bool `json:"identity_match,omitempty"` // Whether this provider handles identity match for this product.
+	Countries []string `json:"countries,omitempty"` // ISO 3166-1 alpha-2 country codes this provider serves for identity match. The ro
+	UIDTypes []string `json:"uid_types,omitempty"` // Identity types this regional provider can resolve. The router filters providers
+}
+
+// ProductMaterialSubmission — Instructions for submitting physical creative materials (print, static OOH, cinema). Present only fo
+type ProductMaterialSubmission struct {
+	URL string `json:"url,omitempty"` // HTTPS URL for uploading or submitting physical creative materials
+	Email string `json:"email,omitempty"` // Email address for creative material submission
+	Instructions string `json:"instructions,omitempty"` // Human-readable instructions for material submission (file naming conventions, sh
+	Ext any `json:"ext,omitempty"`
+}
+
+type PriceAdjustment struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"` // Specific adjustment name. Use well-known values where applicable for interoperab
+	Rate float64 `json:"rate,omitempty"` // Adjustment as a decimal proportion (e.g., 0.15 for 15%). Always positive — kind
+	Amount float64 `json:"amount,omitempty"` // Adjustment as a fixed monetary amount in the pricing option's currency. Always p
+	Description string `json:"description,omitempty"` // Human-readable description of this adjustment (e.g., 'Malstaffel 12x', '2% Skont
+	Beneficiary string `json:"beneficiary,omitempty"` // Identifies who receives this adjustment's value. For commissions, the intermedia
+}
+
+type CreativeFormatDisclosureCapability struct {
+	Position string `json:"position"` // The disclosure position
+	Persistence []string `json:"persistence"` // Persistence modes this position supports
+}
+
+type CreativeAssetInput struct {
+	Name string `json:"name"` // Human-readable name for this preview variant
+	Macros map[string]string `json:"macros,omitempty"` // Macro values to apply for this preview
+	ContextDescription string `json:"context_description,omitempty"` // Natural language description of the context for AI-generated content
+}
+
+type TargetingStoreCatchment struct {
+	CatalogID string `json:"catalog_id"` // Synced store-type catalog ID from sync_catalogs.
+	StoreIDs []string `json:"store_ids,omitempty"` // Filter to specific stores within the catalog. Omit to target all stores.
+	CatchmentIDs []string `json:"catchment_ids,omitempty"` // Catchment zone IDs to target (e.g., 'walk', 'drive'). Omit to target all catchme
+}
+
+type DeliveryEventTypeMetrics struct {
+	EventType string `json:"event_type"` // The event type
+	EventSourceID string `json:"event_source_id,omitempty"` // Event source that produced these conversions (for disambiguation when multiple e
+	Count float64 `json:"count"` // Number of events of this type
+	Value float64 `json:"value,omitempty"` // Total monetary value of events of this type
+}
+
+// DeliveryDOOHMetrics — DOOH-specific metrics (only included for DOOH campaigns)
+type DeliveryDOOHMetrics struct {
+	LoopPlays int `json:"loop_plays,omitempty"` // Number of times ad played in rotation
+	ScreensUsed int `json:"screens_used,omitempty"` // Number of unique screens displaying the ad
+	ScreenTimeSeconds int `json:"screen_time_seconds,omitempty"` // Total display time in seconds
+	SovAchieved float64 `json:"sov_achieved,omitempty"` // Actual share of voice delivered (0.0 to 1.0)
+	CalculationNotes string `json:"calculation_notes,omitempty"` // Explanation of how DOOH impressions were calculated
+	VenueBreakdown []DeliveryDOOHVenueBreakdown `json:"venue_breakdown,omitempty"` // Per-venue performance breakdown
+}
+
+type DeliveryDOOHVenueBreakdown struct {
+	VenueID string `json:"venue_id"` // Venue identifier
+	VenueName string `json:"venue_name,omitempty"` // Human-readable venue name
+	VenueType string `json:"venue_type,omitempty"` // Venue type (e.g., 'airport', 'transit', 'retail', 'billboard')
+	Impressions int `json:"impressions"` // Impressions delivered at this venue
+	LoopPlays int `json:"loop_plays,omitempty"` // Loop plays at this venue
+	ScreensUsed int `json:"screens_used,omitempty"` // Number of screens used at this venue
+}
+
+// DeliveryViewability — Viewability metrics. Viewable rate should be calculated as viewable_impressions / measurable_impress
+type DeliveryViewability struct {
+	MeasurableImpressions float64 `json:"measurable_impressions,omitempty"` // Impressions where viewability could be measured. Excludes environments without m
+	ViewableImpressions float64 `json:"viewable_impressions,omitempty"` // Impressions that met the viewability threshold defined by the measurement standa
+	ViewableRate float64 `json:"viewable_rate,omitempty"` // Viewable impression rate (viewable_impressions / measurable_impressions). Range
+	Standard string `json:"standard,omitempty"` // Viewability measurement standard applied to these metrics.
+}
+
+type DeliveryActionSourceMetrics struct {
+	ActionSource string `json:"action_source"` // Where the conversion occurred
+	EventSourceID string `json:"event_source_id,omitempty"` // Event source that produced these conversions (for disambiguation when multiple e
+	Count float64 `json:"count"` // Number of conversions from this action source
+	Value float64 `json:"value,omitempty"` // Total monetary value of conversions from this action source
+}
+
+type MediaBuyDailyBreakdown struct {
+	Date string `json:"date"` // Date (YYYY-MM-DD)
+	Impressions float64 `json:"impressions"` // Daily impressions
+	Spend float64 `json:"spend"` // Daily spend
+	Conversions float64 `json:"conversions,omitempty"` // Daily conversions
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Daily conversion value
+	Roas float64 `json:"roas,omitempty"` // Daily return on ad spend (conversion_value / spend)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+}
+
+type PackageCatalogItemDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	ContentID string `json:"content_id"` // Catalog item identifier (e.g., SKU, GTIN, job_id, offering_id)
+	ContentIDType string `json:"content_id_type,omitempty"` // Identifier type for this content_id
+}
+
+type PackageCreativeDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	CreativeID string `json:"creative_id"` // Creative identifier matching the creative assignment
+	Weight float64 `json:"weight,omitempty"` // Observed delivery share for this creative within the package during the reportin
+}
+
+type PackageKeywordDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	Keyword string `json:"keyword"` // The targeted keyword
+	MatchType string `json:"match_type"`
+}
+
+type PackageGeoDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	GeoLevel string `json:"geo_level"` // Geographic level of this entry (country, region, metro, postal_area)
+	System string `json:"system,omitempty"` // Classification system for metro or postal_area levels (e.g., 'nielsen_dma', 'us_
+	GeoCode string `json:"geo_code"` // Geographic code within the level and system. Country: ISO 3166-1 alpha-2 ('US').
+	GeoName string `json:"geo_name,omitempty"` // Human-readable geographic name (e.g., 'United States', 'California', 'New York D
+}
+
+type PackageDeviceTypeDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	DeviceType string `json:"device_type"` // Device form factor (desktop, mobile, tablet, ctv, dooh, unknown)
+}
+
+type PackageDevicePlatformDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	DevicePlatform string `json:"device_platform"` // Operating system platform
+}
+
+type PackageAudienceDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	AudienceID string `json:"audience_id"` // Audience segment identifier. For 'synced' source, matches audience_id from sync_
+	AudienceSource string `json:"audience_source"` // Origin of the audience segment (synced, platform, third_party, lookalike, retarg
+	AudienceName string `json:"audience_name,omitempty"` // Human-readable audience segment name
+}
+
+type PackagePlacementDelivery struct {
+	Impressions float64 `json:"impressions"` // Impressions delivered
+	Spend float64 `json:"spend"` // Amount spent
+	Clicks float64 `json:"clicks,omitempty"` // Total clicks
+	Ctr float64 `json:"ctr,omitempty"` // Click-through rate (clicks/impressions)
+	Views float64 `json:"views,omitempty"` // Content engagements counted toward the billable view threshold. For video this i
+	CompletedViews float64 `json:"completed_views,omitempty"` // Video/audio completions. When the package has a completed_views optimization goa
+	CompletionRate float64 `json:"completion_rate,omitempty"` // Completion rate (completed_views/impressions)
+	Conversions float64 `json:"conversions,omitempty"` // Total conversions attributed to this delivery. When by_event_type is present, th
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Total monetary value of attributed conversions (in the reporting currency)
+	Roas float64 `json:"roas,omitempty"` // Return on ad spend (conversion_value / spend)
+	CostPerAcquisition float64 `json:"cost_per_acquisition,omitempty"` // Cost per conversion (spend / conversions)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+	Leads float64 `json:"leads,omitempty"` // Leads generated (convenience alias for by_event_type where event_type='lead')
+	ByEventType []DeliveryEventTypeMetrics `json:"by_event_type,omitempty"` // Conversion metrics broken down by event type. Spend-derived metrics (ROAS, CPA)
+	Grps float64 `json:"grps,omitempty"` // Gross Rating Points delivered (for CPP)
+	Reach float64 `json:"reach,omitempty"` // Unique reach in the units specified by reach_unit. When reach_unit is omitted, u
+	ReachUnit string `json:"reach_unit,omitempty"` // Unit of measurement for the reach field. Aligns with the reach_unit declared on
+	Frequency float64 `json:"frequency,omitempty"` // Average frequency per reach unit (typically measured over campaign duration, but
+	QuartileData *DeliveryQuartileData `json:"quartile_data,omitempty"` // Audio/video quartile completion data
+	DoohMetrics *DeliveryDOOHMetrics `json:"dooh_metrics,omitempty"` // DOOH-specific metrics (only included for DOOH campaigns)
+	Viewability *DeliveryViewability `json:"viewability,omitempty"` // Viewability metrics. Viewable rate should be calculated as viewable_impressions
+	Engagements float64 `json:"engagements,omitempty"` // Total engagements — direct interactions with the ad beyond viewing. Includes soc
+	Follows float64 `json:"follows,omitempty"` // New followers, page likes, artist/podcast/channel subscribes attributed to this
+	Saves float64 `json:"saves,omitempty"` // Saves, bookmarks, playlist adds, pins attributed to this delivery.
+	ProfileVisits float64 `json:"profile_visits,omitempty"` // Visits to the brand's in-platform page (profile, artist page, channel, or storef
+	EngagementRate float64 `json:"engagement_rate,omitempty"` // Platform-specific engagement rate (0.0 to 1.0). Typically engagements/impression
+	CostPerClick float64 `json:"cost_per_click,omitempty"` // Cost per click (spend / clicks)
+	ByActionSource []DeliveryActionSourceMetrics `json:"by_action_source,omitempty"` // Conversion metrics broken down by action source (website, app, in_store, etc.).
+	PlacementID string `json:"placement_id"` // Placement identifier from the product's placements array
+	PlacementName string `json:"placement_name,omitempty"` // Human-readable placement name
+}
+
+type PackageDailyBreakdown struct {
+	Date string `json:"date"` // Date (YYYY-MM-DD)
+	Impressions float64 `json:"impressions"` // Daily impressions for this package
+	Spend float64 `json:"spend"` // Daily spend for this package
+	Conversions float64 `json:"conversions,omitempty"` // Daily conversions for this package
+	ConversionValue float64 `json:"conversion_value,omitempty"` // Daily conversion value for this package
+	Roas float64 `json:"roas,omitempty"` // Daily return on ad spend (conversion_value / spend)
+	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
 }
 
 // --- Tool request/response types ---


### PR DESCRIPTION
## Summary
- generate schema-backed inline types for product optimization/conversion/TMP metadata, material submission, price adjustments, creative disclosure/input helpers, targeting store catchments, delivery metric breakdowns, and package/media-buy daily delivery rows
- lower generated unreviewed `any` coverage from 91 to 61 and enforce it in CI
- add `adcp` module tests to CI so generated SDK type assertions run remotely
- update migration notes with the new public Go types and a concrete `PriceAdjustment` example

## Validation
- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 61`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 60` fails as expected
- generator idempotence check for `adcp/types_gen.go`
- `cd adcp && go test ./...`
- `cd adcp && go test -race -count=1 ./...`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `cd bench && go test ./...`
- `cd adcp && golangci-lint run ./...`
- `git diff --check`

## Expert review
- DX review requested clearer migration docs for delivery breakdowns and `PriceAdjustment`; addressed in `MIGRATING.md`.
- Code review requested running `adcp` module tests in CI; added `Test adcp module`.
