### PR TITLE
feat(adcp)!: type media buy acceptance webhooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 53
+        run: python3 generate.py --coverage-max-unreviewed-any 51
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -67,6 +67,9 @@ be populated.
 | `PushNotificationConfig.Authentication` | `*adcp.LegacyWebhookAuthentication` |
 | `ReportingWebhook.Authentication` | `adcp.LegacyWebhookAuthentication` |
 | `CreateMediaBuyRequest.TotalBudget` | `*adcp.MediaBuyBudget` |
+| `CreateMediaBuyRequest.IoAcceptance` | `*adcp.IOAcceptance` |
+| `CreateMediaBuyRequest.ArtifactWebhook` | `*adcp.ArtifactWebhookConfig` |
+| `ArtifactWebhookConfig.Authentication` | `adcp.LegacyWebhookAuthentication` |
 | `GetAdcpCapabilitiesResponse.Adcp` | `adcp.ADCPVersion` |
 | `GetAdcpCapabilitiesResponse.Account` | `*adcp.AccountCapabilities` |
 | `GetAdcpCapabilitiesResponse.MediaBuy` | `*adcp.MediaBuyCapabilities` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -34,6 +34,19 @@ func TestGeneratedCoreRefsMarshalTypedFields(t *testing.T) {
 			Authentication:     LegacyWebhookAuthentication{Schemes: []string{"Bearer"}, Credentials: "fedcba9876543210fedcba9876543210"},
 			ReportingFrequency: "daily",
 		},
+		IoAcceptance: &IOAcceptance{
+			IoID:        "io-1",
+			AcceptedAt:  "2026-05-26T15:00:00Z",
+			Signatory:   "agent:buyer.example",
+			SignatureID: "sig-1",
+		},
+		ArtifactWebhook: &ArtifactWebhookConfig{
+			URL:            "https://buyer.example/webhooks/artifacts",
+			Authentication: LegacyWebhookAuthentication{Schemes: []string{"HMAC-SHA256"}, Credentials: "abcdef0123456789abcdef0123456789"},
+			DeliveryMode:   "batched",
+			BatchFrequency: "hourly",
+			SamplingRate:   Ptr(0.0),
+		},
 	}
 
 	raw, err := json.Marshal(req)
@@ -47,6 +60,8 @@ func TestGeneratedCoreRefsMarshalTypedFields(t *testing.T) {
 		`"bank":{"account_holder":"Acme Corporation","account_number":"1234"}`,
 		`"push_notification_config":{"url":"https://buyer.example/webhooks/tasks","authentication":{"schemes":["Bearer"],"credentials":"0123456789abcdef0123456789abcdef"}}`,
 		`"reporting_webhook":{"url":"https://buyer.example/webhooks/reporting"`,
+		`"io_acceptance":{"io_id":"io-1","accepted_at":"2026-05-26T15:00:00Z","signatory":"agent:buyer.example","signature_id":"sig-1"}`,
+		`"artifact_webhook":{"url":"https://buyer.example/webhooks/artifacts","authentication":{"schemes":["HMAC-SHA256"],"credentials":"abcdef0123456789abcdef0123456789"},"delivery_mode":"batched","batch_frequency":"hourly","sampling_rate":0}`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("marshaled request missing %s:\n%s", want, body)
@@ -65,6 +80,12 @@ func TestGeneratedCoreRefsMarshalTypedFields(t *testing.T) {
 	}
 	if decoded.ReportingWebhook == nil || decoded.ReportingWebhook.ReportingFrequency != "daily" {
 		t.Fatalf("reporting webhook did not round-trip: %#v", decoded.ReportingWebhook)
+	}
+	if decoded.IoAcceptance == nil || decoded.IoAcceptance.IoID != "io-1" {
+		t.Fatalf("io acceptance did not round-trip: %#v", decoded.IoAcceptance)
+	}
+	if decoded.ArtifactWebhook == nil || decoded.ArtifactWebhook.DeliveryMode != "batched" {
+		t.Fatalf("artifact webhook did not round-trip: %#v", decoded.ArtifactWebhook)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -388,6 +388,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "media-buy/create-media-buy-request.json#/properties/total_budget",
     ),
     (
+        "IOAcceptance",
+        "media-buy/create-media-buy-request.json#/properties/io_acceptance",
+    ),
+    (
+        "ArtifactWebhookConfig",
+        "media-buy/create-media-buy-request.json#/properties/artifact_webhook",
+    ),
+    (
         "CollectionRequestPagination",
         "collection/get-collection-list-request.json#/properties/pagination",
     ),
@@ -716,6 +724,10 @@ INLINE_TYPE_HINTS = {
     ('MediaBuyDeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PackageDelivery', 'quartile_data'): '*DeliveryQuartileData',
     ('CreateMediaBuyRequest', 'total_budget'): '*MediaBuyBudget',
+    ('CreateMediaBuyRequest', 'io_acceptance'): '*IOAcceptance',
+    ('CreateMediaBuyRequest', 'artifact_webhook'): '*ArtifactWebhookConfig',
+    ('ArtifactWebhookConfig', 'authentication'): 'LegacyWebhookAuthentication',
+    ('ArtifactWebhookConfig', 'sampling_rate'): '*float64',
     ('GetCollectionListRequest', 'pagination'): '*CollectionRequestPagination',
     ('CollectionListChangedWebhook', 'change_summary'): '*CollectionChangeSummary',
     ('PropertyListChangedWebhook', 'change_summary'): '*PropertyChangeSummary',

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -2774,6 +2774,24 @@ type MediaBuyBudget struct {
 	Currency string `json:"currency"` // ISO 4217 currency code
 }
 
+// IOAcceptance — Acceptance of an insertion order from a committed proposal. Required when the proposal's insertion_o
+type IOAcceptance struct {
+	IoID string `json:"io_id"` // The io_id from the proposal's insertion_order being accepted
+	AcceptedAt string `json:"accepted_at"` // ISO 8601 timestamp when the IO was accepted
+	Signatory string `json:"signatory"` // Who accepted the IO — agent identifier or human name
+	SignatureID string `json:"signature_id,omitempty"` // Reference to the electronic signature from the signing service, when signing_url
+}
+
+// ArtifactWebhookConfig — Optional webhook configuration for content artifact delivery. Used by governance agents to validate
+type ArtifactWebhookConfig struct {
+	URL string `json:"url"` // Webhook endpoint URL for artifact delivery
+	Token string `json:"token,omitempty"` // Optional client-provided token for webhook validation. Echoed back in webhook pa
+	Authentication LegacyWebhookAuthentication `json:"authentication"` // Legacy authentication configuration for webhook delivery (A2A-compatible). Opts
+	DeliveryMode string `json:"delivery_mode"` // How artifacts are delivered. 'realtime' pushes artifacts as impressions occur. '
+	BatchFrequency string `json:"batch_frequency,omitempty"` // For batched delivery, how often to push artifacts. Required when delivery_mode i
+	SamplingRate *float64 `json:"sampling_rate,omitempty"` // Fraction of impressions to include (0-1). 1.0 = all impressions, 0.1 = 10% sampl
+}
+
 // CollectionRequestPagination — Pagination parameters. Uses higher limits than standard pagination because collection lists can cont
 type CollectionRequestPagination struct {
 	MaxResults int `json:"max_results,omitempty"` // Maximum number of collections to return per page
@@ -3432,14 +3450,14 @@ type CreateMediaBuyRequest struct {
 	Brand BrandReference `json:"brand"` // Brand reference for this media buy. Resolved to full brand identity at execution
 	AdvertiserIndustry string `json:"advertiser_industry,omitempty"` // Industry classification for this specific campaign. A brand may operate across m
 	InvoiceRecipient *BusinessEntity `json:"invoice_recipient,omitempty"` // Override the account's default billing entity for this specific buy. When provid
-	IoAcceptance any `json:"io_acceptance,omitempty"` // Acceptance of an insertion order from a committed proposal. Required when the pr
+	IoAcceptance *IOAcceptance `json:"io_acceptance,omitempty"` // Acceptance of an insertion order from a committed proposal. Required when the pr
 	PoNumber string `json:"po_number,omitempty"` // Purchase order number for tracking
 	AgencyEstimateNumber string `json:"agency_estimate_number,omitempty"` // Agency estimate or authorization number. Primary financial reference for broadca
 	StartTime string `json:"start_time"`
 	EndTime string `json:"end_time"` // Campaign end date/time in ISO 8601 format
 	PushNotificationConfig *PushNotificationConfig `json:"push_notification_config,omitempty"` // Optional webhook configuration for async task status notifications. Publisher wi
 	ReportingWebhook *ReportingWebhook `json:"reporting_webhook,omitempty"` // Optional webhook configuration for automated reporting delivery
-	ArtifactWebhook any `json:"artifact_webhook,omitempty"` // Optional webhook configuration for content artifact delivery. Used by governance
+	ArtifactWebhook *ArtifactWebhookConfig `json:"artifact_webhook,omitempty"` // Optional webhook configuration for content artifact delivery. Used by governance
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }


### PR DESCRIPTION
## Summary
- generate typed IOAcceptance and ArtifactWebhookConfig from create_media_buy_request inline schemas
- wire CreateMediaBuyRequest.io_acceptance and artifact_webhook to those generated types
- reuse LegacyWebhookAuthentication for artifact webhook auth and lower generated-any coverage to 51

## Validation
- python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 51
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 50 (expected failure)
- generator idempotence check for adcp/types_gen.go
- cd adcp && go test ./...
- go test ./...
- cd reference/seller-agent && go test ./...
- cd adcp && golangci-lint run ./...
- cd reference/context-agent && go test ./...
- cd e2e && go test ./...
- cd bench && go test ./...
- cd adcp && go test -race -count=1 ./...
- git diff --check