### PR TITLE
feat(adcp)!: type media buy status filter unions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 47
+        run: python3 generate.py --coverage-max-unreviewed-any 45
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -159,6 +159,8 @@ be populated.
 | `PackageDelivery.ByAudience` | `[]adcp.PackageAudienceDelivery` |
 | `PackageDelivery.ByPlacement` | `[]adcp.PackagePlacementDelivery` |
 | `PackageDelivery.DailyBreakdown` | `[]adcp.PackageDailyBreakdown` |
+| `GetMediaBuysRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
+| `GetMediaBuyDeliveryRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
 | `GetMediaBuyDeliveryRequest.AttributionWindow` | `*adcp.DeliveryAttributionWindow` |
 | `DeliveryAttributionWindow.PostClick` | `*adcp.Duration` |
 | `DeliveryAttributionWindow.PostView` | `*adcp.Duration` |
@@ -217,6 +219,17 @@ req := adcp.GetProductsRequest{
         ListID:   "pl-123",
     }),
     TimeBudget: adcp.Ptr(adcp.Duration{Interval: 5, Unit: "minutes"}),
+}
+```
+
+Status filter migration example:
+
+```go
+req := adcp.GetMediaBuysRequest{
+    StatusFilter: adcp.Ptr(adcp.MediaBuyStatusFilter{
+        adcp.MediaBuyStatusActive,
+        adcp.MediaBuyStatusPaused,
+    }),
 }
 ```
 

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -353,6 +353,28 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "media buy status filter scalar",
+			value: GetMediaBuysRequest{
+				StatusFilter: Ptr(MediaBuyStatusFilter{MediaBuyStatusActive}),
+			},
+			want: []string{
+				`"status_filter":"active"`,
+			},
+		},
+		{
+			name: "delivery status filter array",
+			value: GetMediaBuyDeliveryRequest{
+				MediaBuyIDs: []string{"mb-1"},
+				StatusFilter: Ptr(MediaBuyStatusFilter{
+					MediaBuyStatusActive,
+					MediaBuyStatusPaused,
+				}),
+			},
+			want: []string{
+				`"status_filter":["active","paused"]`,
+			},
+		},
+		{
 			name: "creative agent refs",
 			value: ListCreativeFormatsResponse{
 				Formats: []CreativeFormat{},
@@ -433,6 +455,38 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
+	var listReq GetMediaBuysRequest
+	if err := json.Unmarshal([]byte(`{"status_filter":"active"}`), &listReq); err != nil {
+		t.Fatalf("unmarshal scalar status filter: %v", err)
+	}
+	if listReq.StatusFilter == nil || len(*listReq.StatusFilter) != 1 || (*listReq.StatusFilter)[0] != MediaBuyStatusActive {
+		t.Fatalf("scalar status filter did not decode as one active status: %#v", listReq.StatusFilter)
+	}
+
+	var deliveryReq GetMediaBuyDeliveryRequest
+	if err := json.Unmarshal([]byte(`{"status_filter":["active","paused"]}`), &deliveryReq); err != nil {
+		t.Fatalf("unmarshal array status filter: %v", err)
+	}
+	if deliveryReq.StatusFilter == nil || len(*deliveryReq.StatusFilter) != 2 {
+		t.Fatalf("array status filter did not decode two statuses: %#v", deliveryReq.StatusFilter)
+	}
+	if (*deliveryReq.StatusFilter)[0] != MediaBuyStatusActive || (*deliveryReq.StatusFilter)[1] != MediaBuyStatusPaused {
+		t.Fatalf("array status filter decoded unexpected values: %#v", *deliveryReq.StatusFilter)
+	}
+
+	emptyFilter := MediaBuyStatusFilter{}
+	if _, err := json.Marshal(emptyFilter); err == nil {
+		t.Fatal("marshal empty status filter succeeded, want error")
+	}
+	if err := json.Unmarshal([]byte(`null`), &emptyFilter); err == nil {
+		t.Fatal("unmarshal null status filter succeeded, want error")
+	}
+	if err := json.Unmarshal([]byte(`{"status_filter":[]}`), &deliveryReq); err == nil {
+		t.Fatal("unmarshal empty status filter succeeded, want error")
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -613,6 +613,19 @@ INLINE_SCHEMA_TYPES = OrderedDict([
     ),
 ])
 
+# Named helper types generated for simple union schemas. These cover the common
+# protocol shape "single scalar or array of the same scalar" without falling
+# back to `any`.
+UNION_SCHEMA_TYPES = OrderedDict([
+    (
+        "MediaBuyStatusFilter",
+        (
+            "media-buy/get-media-buys-request.json#/properties/status_filter",
+            "media-buy/get-media-buy-delivery-request.json#/properties/status_filter",
+        ),
+    ),
+])
+
 # Hand-written types that should be drift-checked against a schema path or JSON
 # pointer. lint.py imports this table; keep it here so generator/lint ownership
 # lives in one place.
@@ -764,6 +777,8 @@ INLINE_TYPE_HINTS = {
     ('DeliveryReportingGeoDimension', 'system'): 'string',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
+    ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',
+    ('GetMediaBuyDeliveryRequest', 'status_filter'): '*MediaBuyStatusFilter',
     ('GetCollectionListRequest', 'pagination'): '*CollectionRequestPagination',
     ('CollectionListChangedWebhook', 'change_summary'): '*CollectionChangeSummary',
     ('PropertyListChangedWebhook', 'change_summary'): '*PropertyChangeSummary',
@@ -946,6 +961,52 @@ def resolve_ref_schema(ref):
         print(f'// Warning: skipped ref {ref}: {e}', file=sys.stderr)
         return None
 
+def scalar_union_go_type(schema):
+    """Return the element Go type for `scalar or []scalar` unions.
+
+    This intentionally covers only the narrow wire shape used by status_filter:
+    one branch is a string/enum scalar and the other is an array of that same
+    scalar. More complex oneOf schemas need a discriminator-aware strategy.
+    """
+    if not isinstance(schema, dict):
+        return None
+    branches = schema.get('oneOf') or schema.get('anyOf') or []
+    if len(branches) != 2:
+        return None
+
+    def branch_scalar_type(branch):
+        if not isinstance(branch, dict):
+            return None
+        if '$ref' in branch and is_enum_ref(branch['$ref']):
+            return ref_to_go_name(branch['$ref'])
+        if branch.get('type') == 'string':
+            return 'string'
+        return None
+
+    scalar_type = None
+    array_item_type = None
+    for branch in branches:
+        current = branch_scalar_type(branch)
+        if current:
+            scalar_type = current
+            continue
+        if isinstance(branch, dict) and branch.get('type') == 'array':
+            array_item_type = branch_scalar_type(branch.get('items', {}))
+
+    if scalar_type and array_item_type and scalar_type == array_item_type:
+        return scalar_type
+    return None
+
+def schema_accepts_empty_array(schema):
+    """Report whether a scalar-or-array union permits an empty array branch."""
+    if not isinstance(schema, dict):
+        return True
+    branches = schema.get('oneOf') or schema.get('anyOf') or []
+    for branch in branches:
+        if isinstance(branch, dict) and branch.get('type') == 'array':
+            return int(branch.get('minItems', 0)) == 0
+    return True
+
 def schema_properties(schema, _visited=None):
     """Return an ordered union of properties declared directly, through $ref,
     or through composition. allOf is flattened for generated Go structs."""
@@ -1082,6 +1143,8 @@ def _will_generate_set():
             continue
         if schema_properties(schema):
             names.add(name)
+    for name in supported_union_schemas(skip_names=KNOWN_TYPES):
+        names.add(name)
     _WILL_GENERATE_CACHE = names
     return names
 
@@ -1230,6 +1293,77 @@ def schema_to_struct(name, schema):
     desc = safe_comment(schema.get('description', ''), 100)
     doc = f'// {name} — {desc}\n' if desc else ''
     return f'{doc}type {name} struct {{\n' + '\n'.join(fields) + '\n}\n'
+
+def scalar_or_array_union_to_type(name, schema):
+    """Generate a Go helper for a `scalar or []scalar` JSON union."""
+    elem_type = scalar_union_go_type(schema)
+    if not elem_type:
+        raise ValueError(f'{name} is not a supported scalar-or-array union')
+    desc = safe_comment(schema.get('description', ''), 100)
+    doc = f'// {name} — {desc}\n' if desc else ''
+    reject_empty = '' if schema_accepts_empty_array(schema) else f'''\tif len(v) == 0 {{
+\t\treturn nil, fmt.Errorf("{name} must contain at least one value")
+\t}}
+'''
+    reject_empty_unmarshal = '' if schema_accepts_empty_array(schema) else f'''\tif len(many) == 0 {{
+\t\treturn fmt.Errorf("{name} must contain at least one value")
+\t}}
+'''
+    return f'''{doc}type {name} []{elem_type}
+
+func (v {name}) MarshalJSON() ([]byte, error) {{
+{reject_empty}\tif len(v) == 1 {{
+\t\treturn json.Marshal(v[0])
+\t}}
+\treturn json.Marshal([]{elem_type}(v))
+}}
+
+func (v *{name}) UnmarshalJSON(data []byte) error {{
+\tif string(data) == "null" {{
+\t\treturn fmt.Errorf("{name} cannot be null")
+\t}}
+\tvar single {elem_type}
+\tif err := json.Unmarshal(data, &single); err == nil {{
+\t\t*v = {name}{{single}}
+\t\treturn nil
+\t}}
+\tvar many []{elem_type}
+\tif err := json.Unmarshal(data, &many); err != nil {{
+\t\treturn err
+\t}}
+\t{reject_empty_unmarshal.strip()}
+\t*v = {name}(many)
+\treturn nil
+}}
+'''
+
+def supported_union_schemas(skip_names=None):
+    """Return configured union helper schemas that this generator can emit."""
+    skip_names = set(skip_names or ())
+    schemas = OrderedDict()
+    for name, specs in UNION_SCHEMA_TYPES.items():
+        if name in skip_names:
+            continue
+        if isinstance(specs, str):
+            specs = (specs,)
+        primary_schema = None
+        try:
+            loaded = [(spec, load_schema_spec(spec)) for spec in specs]
+        except SCHEMA_RESOLUTION_ERRORS as e:
+            raise ValueError(f'{name} has an invalid union schema pointer: {e}') from e
+        elem_types = {scalar_union_go_type(schema) for _, schema in loaded}
+        if len(elem_types) != 1 or None in elem_types:
+            raise ValueError(f'{name} union schemas are not equivalent scalar-or-array unions')
+        if len({schema_accepts_empty_array(schema) for _, schema in loaded}) != 1:
+            raise ValueError(f'{name} union array constraints differ')
+        for spec, schema in loaded:
+            description = schema.get('description', '')
+            # Prefer the shortest shared helper doc when one field description
+            # includes request-specific defaults that do not apply everywhere.
+            if primary_schema is None or len(description) < len(primary_schema.get('description', '')):
+                primary_schema = schema
+        schemas[name] = primary_schema
+    return schemas
 
 def generate_enums():
     """Generate Go string constants for all enum schemas."""
@@ -1471,6 +1605,13 @@ def generate():
     print()
     print('package adcp')
     print()
+    union_schemas = supported_union_schemas(skip_names=KNOWN_TYPES)
+    if union_schemas:
+        print('import (')
+        print('\t"encoding/json"')
+        print('\t"fmt"')
+        print(')')
+        print()
 
     # Type aliases for $ref targets not in our core generation list
     print('// Type aliases for $ref targets from schemas not directly generated.')
@@ -1486,6 +1627,15 @@ def generate():
 
     # Use KNOWN_TYPES as the skip set — single source of truth
     generated = set(KNOWN_TYPES)
+
+    # Generate narrow union helper types.
+    print('// --- Union helper types ---')
+    print()
+    for name, schema in union_schemas.items():
+        if name in generated:
+            continue
+        generated.add(name)
+        print(scalar_or_array_union_to_type(name, schema))
 
     # Generate core types
     print('// --- Core types ---')
@@ -1631,6 +1781,7 @@ def main(argv=None):
         args.coverage_max_unreviewed_any is not None
     ):
         _reset_will_generate_cache()
+        supported_union_schemas(skip_names=KNOWN_TYPES)
         report = any_coverage_report()
         if args.coverage_json:
             print(json.dumps(report, indent=2))

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -309,6 +309,52 @@ def validate_inline_schema_specs():
     return reports
 
 
+def validate_union_schema_specs():
+    """Smoke-test generated union schema pointers and shared-helper equivalence."""
+    reports = []
+    for type_name, schema_specs in gen.UNION_SCHEMA_TYPES.items():
+        if isinstance(schema_specs, str):
+            schema_specs = (schema_specs,)
+        loaded = []
+        error_count = len(reports)
+        for schema_spec in schema_specs:
+            path_part = schema_spec.split('#', 1)[0]
+            schema_path = SCRIPT_DIR / path_part
+            if not schema_path.exists():
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'schema not found: {schema_path}',
+                })
+                continue
+            try:
+                loaded.append((schema_spec, load_schema_spec(schema_spec)))
+            except SCHEMA_RESOLUTION_ERRORS as e:
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'could not resolve schema pointer: {e}',
+                })
+        if len(reports) != error_count or len(loaded) != len(schema_specs):
+            continue
+        elem_types = {gen.scalar_union_go_type(schema) for _, schema in loaded}
+        if len(elem_types) != 1 or None in elem_types:
+            reports.append({
+                'type': type_name,
+                'schema': ', '.join(schema_specs),
+                'error': 'schemas are not equivalent scalar-or-array unions',
+            })
+            continue
+        empty_constraints = {gen.schema_accepts_empty_array(schema) for _, schema in loaded}
+        if len(empty_constraints) != 1:
+            reports.append({
+                'type': type_name,
+                'schema': ', '.join(schema_specs),
+                'error': 'array minItems constraints differ',
+            })
+    return reports
+
+
 def resolve_schema_spec(type_name):
     """Return schema spec for `type_name`, or None."""
     if type_name in EXPLICIT_SCHEMA:
@@ -429,6 +475,7 @@ def main():
     reports = []
     no_schema = []
     inline_schema_errors = validate_inline_schema_specs()
+    union_schema_errors = validate_union_schema_specs()
 
     for type_name in sorted(gen.KNOWN_TYPES):
         if type_name in EXEMPT:
@@ -451,12 +498,20 @@ def main():
             'drift': reports,
             'no_schema_correspondent': no_schema,
             'inline_schema_errors': inline_schema_errors,
+            'union_schema_errors': union_schema_errors,
         }
         print(json.dumps(out, indent=2))
     else:
         if inline_schema_errors:
             print(f'Inline schema pointer errors in {len(inline_schema_errors)} type(s):')
             for r in inline_schema_errors:
+                print()
+                print(f'  {r["type"]}  ({r.get("schema", "?")})')
+                print(f'    error: {r["error"]}')
+            print()
+        if union_schema_errors:
+            print(f'Union schema pointer errors in {len(union_schema_errors)} type(s):')
+            for r in union_schema_errors:
                 print()
                 print(f'  {r["type"]}  ({r.get("schema", "?")})')
                 print(f'    error: {r["error"]}')
@@ -484,7 +539,7 @@ def main():
             for t in no_schema:
                 print(f'  - {t}')
 
-    has_problems = bool(inline_schema_errors) or bool(reports) or (
+    has_problems = bool(inline_schema_errors) or bool(union_schema_errors) or bool(reports) or (
         args.strict and bool(no_schema)
     )
     return 1 if (args.strict and has_problems) else 0

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -4,6 +4,11 @@
 
 package adcp
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Type aliases for $ref targets from schemas not directly generated.
 type AdcpError = map[string]any
 
@@ -1730,6 +1735,41 @@ const (
 	WebhookSecurityMethodAPIKey WebhookSecurityMethod = "api_key"
 	WebhookSecurityMethodNone WebhookSecurityMethod = "none"
 )
+
+// --- Union helper types ---
+
+// MediaBuyStatusFilter — Filter by status. Can be a single status or array of statuses
+type MediaBuyStatusFilter []MediaBuyStatus
+
+func (v MediaBuyStatusFilter) MarshalJSON() ([]byte, error) {
+	if len(v) == 0 {
+		return nil, fmt.Errorf("MediaBuyStatusFilter must contain at least one value")
+	}
+	if len(v) == 1 {
+		return json.Marshal(v[0])
+	}
+	return json.Marshal([]MediaBuyStatus(v))
+}
+
+func (v *MediaBuyStatusFilter) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return fmt.Errorf("MediaBuyStatusFilter cannot be null")
+	}
+	var single MediaBuyStatus
+	if err := json.Unmarshal(data, &single); err == nil {
+		*v = MediaBuyStatusFilter{single}
+		return nil
+	}
+	var many []MediaBuyStatus
+	if err := json.Unmarshal(data, &many); err != nil {
+		return err
+	}
+	if len(many) == 0 {
+		return fmt.Errorf("MediaBuyStatusFilter must contain at least one value")
+	}
+	*v = MediaBuyStatusFilter(many)
+	return nil
+}
 
 // --- Core types ---
 
@@ -3567,7 +3607,7 @@ type GetMediaBuysRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	Account *AccountReference `json:"account,omitempty"` // Account to retrieve media buys for. When omitted, returns data across all access
 	MediaBuyIDs []string `json:"media_buy_ids,omitempty"` // Array of media buy IDs to retrieve. When omitted, returns a paginated set of acc
-	StatusFilter any `json:"status_filter,omitempty"` // Filter by status. Can be a single status or array of statuses. Defaults to ["act
+	StatusFilter *MediaBuyStatusFilter `json:"status_filter,omitempty"` // Filter by status. Can be a single status or array of statuses. Defaults to ["act
 	IncludeSnapshot *bool `json:"include_snapshot,omitempty"` // When true, include a near-real-time delivery snapshot for each package. Snapshot
 	IncludeHistory int `json:"include_history,omitempty"` // When present, include the last N revision history entries for each media buy (re
 	Pagination *PaginationRequest `json:"pagination,omitempty"` // Cursor-based pagination controls. Strongly recommended when querying broad scope
@@ -3590,7 +3630,7 @@ type GetMediaBuyDeliveryRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	Account *AccountReference `json:"account,omitempty"` // Filter delivery data to a specific account. When omitted, returns data across al
 	MediaBuyIDs []string `json:"media_buy_ids,omitempty"` // Array of media buy IDs to get delivery data for
-	StatusFilter any `json:"status_filter,omitempty"` // Filter by status. Can be a single status or array of statuses
+	StatusFilter *MediaBuyStatusFilter `json:"status_filter,omitempty"` // Filter by status. Can be a single status or array of statuses
 	StartDate string `json:"start_date,omitempty"` // Start date for reporting period (YYYY-MM-DD). When omitted along with end_date,
 	EndDate string `json:"end_date,omitempty"` // End date for reporting period (YYYY-MM-DD). When omitted along with start_date,
 	IncludePackageDailyBreakdown *bool `json:"include_package_daily_breakdown,omitempty"` // When true, include daily_breakdown arrays within each package in by_package. Use


### PR DESCRIPTION
## Summary
- generate a narrow scalar-or-array union helper for media buy status filters
- type GetMediaBuysRequest.StatusFilter and GetMediaBuyDeliveryRequest.StatusFilter as *MediaBuyStatusFilter
- fail closed when configured union helper schemas drift, and lint union helper pointers/equivalence
- reject empty/null direct status filters and document the typed migration pattern
- lower generated-any coverage budget from 47 to 45

## Validation
- python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 45
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 44 (expected failure)
- generator idempotence check against adcp/types_gen.go
- deliberate broken UNION_SCHEMA_TYPES pointer raises ValueError during coverage
- cd adcp && go test ./...
- cd adcp && golangci-lint run ./...
- go test ./...
- cd reference/seller-agent && go test ./...
- cd reference/context-agent && go test ./...
- cd e2e && go test ./...
- cd bench && go test ./...
- cd adcp && go test -race -count=1 ./...
- git diff --check

## Expert review
- Protocol/DX/code reviewers flagged empty filter validation and union pointer false-green risk; both are fixed here.
- Remaining DX follow-up: consider generated convenience constructors for pointer-heavy union helpers.