### PR TITLE
test(adcp): cover union helper generator guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
         working-directory: adcp/schemas
         run: ./download.sh
 
+      - name: Test schema generator
+        working-directory: adcp/schemas
+        run: python3 -m unittest discover -p '*_test.py'
+
       - name: Check adcp/types_gen.go is up to date
         run: |
           (cd adcp/schemas && python3 generate.py > ../types_gen.go)

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1,0 +1,117 @@
+import unittest
+from collections import OrderedDict
+
+import generate
+
+
+def scalar_or_array_schema(min_items=1, description="Test union"):
+    return {
+        "description": description,
+        "oneOf": [
+            {"type": "string"},
+            {
+                "type": "array",
+                "items": {"type": "string"},
+                "minItems": min_items,
+            },
+        ],
+    }
+
+
+class UnionHelperGenerationTest(unittest.TestCase):
+    def setUp(self):
+        self.original_union_schema_types = generate.UNION_SCHEMA_TYPES
+        self.original_load_schema_spec = generate.load_schema_spec
+        self.original_known_types = generate.KNOWN_TYPES
+        generate._reset_will_generate_cache()
+
+    def tearDown(self):
+        generate.UNION_SCHEMA_TYPES = self.original_union_schema_types
+        generate.load_schema_spec = self.original_load_schema_spec
+        generate.KNOWN_TYPES = self.original_known_types
+        generate._reset_will_generate_cache()
+
+    def install_union_fixture(self, specs, schemas):
+        generate.UNION_SCHEMA_TYPES = OrderedDict([("TestUnion", specs)])
+
+        def load_schema_spec(spec):
+            try:
+                return schemas[spec]
+            except KeyError as exc:
+                raise KeyError(spec) from exc
+
+        generate.load_schema_spec = load_schema_spec
+
+    def test_supported_union_schemas_resolves_equivalent_schema_specs(self):
+        self.install_union_fixture(
+            ("request-a.json#/properties/filter", "request-b.json#/properties/filter"),
+            {
+                "request-a.json#/properties/filter": scalar_or_array_schema(
+                    description="Filter by status. Defaults to active for request A."
+                ),
+                "request-b.json#/properties/filter": scalar_or_array_schema(
+                    description="Filter by status."
+                ),
+            },
+        )
+
+        schemas = generate.supported_union_schemas()
+
+        self.assertEqual(["TestUnion"], list(schemas))
+        self.assertEqual("string", generate.scalar_union_go_type(schemas["TestUnion"]))
+        self.assertEqual("Filter by status.", schemas["TestUnion"]["description"])
+
+    def test_supported_union_schemas_rejects_broken_pointer(self):
+        self.install_union_fixture(
+            "request-a.json#/properties/missing",
+            {},
+        )
+
+        with self.assertRaises(ValueError):
+            generate.supported_union_schemas()
+
+    def test_supported_union_schemas_rejects_non_equivalent_element_types(self):
+        self.install_union_fixture(
+            ("request-a.json#/properties/filter", "request-b.json#/properties/filter"),
+            {
+                "request-a.json#/properties/filter": scalar_or_array_schema(),
+                "request-b.json#/properties/filter": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "integer"}, "minItems": 1},
+                    ],
+                },
+            },
+        )
+
+        with self.assertRaises(ValueError):
+            generate.supported_union_schemas()
+
+    def test_supported_union_schemas_rejects_different_empty_array_constraints(self):
+        self.install_union_fixture(
+            ("request-a.json#/properties/filter", "request-b.json#/properties/filter"),
+            {
+                "request-a.json#/properties/filter": scalar_or_array_schema(min_items=1),
+                "request-b.json#/properties/filter": scalar_or_array_schema(min_items=0),
+            },
+        )
+
+        with self.assertRaises(ValueError):
+            generate.supported_union_schemas()
+
+    def test_coverage_mode_fails_when_configured_union_is_invalid(self):
+        self.install_union_fixture(
+            "request-a.json#/properties/missing",
+            {},
+        )
+
+        with self.assertRaises(ValueError):
+            generate.main(["--coverage-max-unreviewed-any", "999"])
+
+    def test_schema_accepts_empty_array_is_defensive_for_non_dict_schema(self):
+        self.assertTrue(generate.schema_accepts_empty_array(None))
+        self.assertTrue(generate.schema_accepts_empty_array([]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #180.\n\n## Summary\n- add stdlib unittest coverage for scalar-or-array union helper generation\n- cover broken schema pointers, non-equivalent union schemas, divergent minItems constraints, and coverage-mode fail-closed behavior\n- wire schema generator tests into CI after upstream schema download\n\n## Validation\n- python3 -m py_compile adcp/schemas/generate.py adcp/schemas/lint.py adcp/schemas/generate_test.py\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 45\n- generator idempotence check against adcp/types_gen.go\n- cd adcp && go test ./...\n- git diff --check