### PR TITLE
feat(adcp): add union helper constructors

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -226,10 +226,10 @@ Status filter migration example:
 
 ```go
 req := adcp.GetMediaBuysRequest{
-    StatusFilter: adcp.Ptr(adcp.MediaBuyStatusFilter{
+    StatusFilter: adcp.NewMediaBuyStatusFilter(
         adcp.MediaBuyStatusActive,
         adcp.MediaBuyStatusPaused,
-    }),
+    ),
 }
 ```
 

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -355,7 +355,7 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 		{
 			name: "media buy status filter scalar",
 			value: GetMediaBuysRequest{
-				StatusFilter: Ptr(MediaBuyStatusFilter{MediaBuyStatusActive}),
+				StatusFilter: NewMediaBuyStatusFilter(MediaBuyStatusActive),
 			},
 			want: []string{
 				`"status_filter":"active"`,
@@ -365,10 +365,10 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			name: "delivery status filter array",
 			value: GetMediaBuyDeliveryRequest{
 				MediaBuyIDs: []string{"mb-1"},
-				StatusFilter: Ptr(MediaBuyStatusFilter{
+				StatusFilter: NewMediaBuyStatusFilter(
 					MediaBuyStatusActive,
 					MediaBuyStatusPaused,
-				}),
+				),
 			},
 			want: []string{
 				`"status_filter":["active","paused"]`,
@@ -459,6 +459,10 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 }
 
 func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
+	if got := NewMediaBuyStatusFilter(); got != nil {
+		t.Fatalf("empty status filter constructor returned %#v, want nil", got)
+	}
+
 	var listReq GetMediaBuysRequest
 	if err := json.Unmarshal([]byte(`{"status_filter":"active"}`), &listReq); err != nil {
 		t.Fatalf("unmarshal scalar status filter: %v", err)

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1309,7 +1309,16 @@ def scalar_or_array_union_to_type(name, schema):
 \t\treturn fmt.Errorf("{name} must contain at least one value")
 \t}}
 '''
+    empty_constructor = '' if schema_accepts_empty_array(schema) else f'''\tif len(values) == 0 {{
+\t\treturn nil
+\t}}
+'''
     return f'''{doc}type {name} []{elem_type}
+
+func New{name}(values ...{elem_type}) *{name} {{
+{empty_constructor}\tv := {name}(values)
+\treturn &v
+}}
 
 func (v {name}) MarshalJSON() ([]byte, error) {{
 {reject_empty}\tif len(v) == 1 {{

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -112,6 +112,13 @@ class UnionHelperGenerationTest(unittest.TestCase):
         self.assertTrue(generate.schema_accepts_empty_array(None))
         self.assertTrue(generate.schema_accepts_empty_array([]))
 
+    def test_scalar_or_array_union_helper_includes_constructor(self):
+        src = generate.scalar_or_array_union_to_type("TestUnion", scalar_or_array_schema())
+
+        self.assertIn("func NewTestUnion(values ...string) *TestUnion", src)
+        self.assertIn("if len(values) == 0", src)
+        self.assertIn("return nil", src)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1741,6 +1741,14 @@ const (
 // MediaBuyStatusFilter — Filter by status. Can be a single status or array of statuses
 type MediaBuyStatusFilter []MediaBuyStatus
 
+func NewMediaBuyStatusFilter(values ...MediaBuyStatus) *MediaBuyStatusFilter {
+	if len(values) == 0 {
+		return nil
+	}
+	v := MediaBuyStatusFilter(values)
+	return &v
+}
+
 func (v MediaBuyStatusFilter) MarshalJSON() ([]byte, error) {
 	if len(v) == 0 {
 		return nil, fmt.Errorf("MediaBuyStatusFilter must contain at least one value")


### PR DESCRIPTION
Closes #182.\n\n## Summary\n- generate New<Type>(...) constructors for scalar-or-array union helpers\n- use NewMediaBuyStatusFilter in tests and migration docs\n- return nil for zero values when the schema disallows empty arrays, so optional fields omit instead of building invalid filters\n\n## Validation\n- python3 -m py_compile adcp/schemas/generate.py adcp/schemas/generate_test.py adcp/schemas/lint.py\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 45\n- generator idempotence check against adcp/types_gen.go\n- cd adcp && go test ./...\n- cd adcp && golangci-lint run ./...\n- git diff --check