### PR TITLE
test(adcp): document union constructor empty semantics

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1301,22 +1301,37 @@ def scalar_or_array_union_to_type(name, schema):
         raise ValueError(f'{name} is not a supported scalar-or-array union')
     desc = safe_comment(schema.get('description', ''), 100)
     doc = f'// {name} — {desc}\n' if desc else ''
-    reject_empty = '' if schema_accepts_empty_array(schema) else f'''\tif len(v) == 0 {{
+    accepts_empty = schema_accepts_empty_array(schema)
+    reject_empty = '' if accepts_empty else f'''\tif len(v) == 0 {{
 \t\treturn nil, fmt.Errorf("{name} must contain at least one value")
 \t}}
 '''
-    reject_empty_unmarshal = '' if schema_accepts_empty_array(schema) else f'''\tif len(many) == 0 {{
+    reject_empty_unmarshal = '' if accepts_empty else f'''\tif len(many) == 0 {{
 \t\treturn fmt.Errorf("{name} must contain at least one value")
 \t}}
 '''
-    empty_constructor = '' if schema_accepts_empty_array(schema) else f'''\tif len(values) == 0 {{
+    empty_constructor = '' if accepts_empty else f'''\tif len(values) == 0 {{
 \t\treturn nil
 \t}}
 '''
+    constructor_value = f'append({name}{{}}, values...)' if accepts_empty else f'{name}(values)'
+    if accepts_empty:
+        constructor_doc = (
+            f'// New{name} returns a pointer to a {name} containing values.\n'
+            f'// Use nil instead of New{name}() when an optional field should be omitted.\n'
+            f'// New{name}() returns a non-nil empty slice pointer that marshals as [].\n'
+        )
+    else:
+        constructor_doc = (
+            f'// New{name} returns a pointer to a {name} containing values.\n'
+            '// It returns nil when called with no values so optional fields omit instead\n'
+            '// of triggering a MarshalJSON error on a schema-invalid empty array.\n'
+        )
     return f'''{doc}type {name} []{elem_type}
 
+{constructor_doc}\
 func New{name}(values ...{elem_type}) *{name} {{
-{empty_constructor}\tv := {name}(values)
+{empty_constructor}\tv := {constructor_value}
 \treturn &v
 }}
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1,3 +1,6 @@
+import subprocess
+import tempfile
+import textwrap
 import unittest
 from collections import OrderedDict
 
@@ -116,8 +119,53 @@ class UnionHelperGenerationTest(unittest.TestCase):
         src = generate.scalar_or_array_union_to_type("TestUnion", scalar_or_array_schema())
 
         self.assertIn("func NewTestUnion(values ...string) *TestUnion", src)
+        self.assertIn("It returns nil when called with no values", src)
+        self.assertIn("triggering a MarshalJSON error on a schema-invalid empty array", src)
         self.assertIn("if len(values) == 0", src)
         self.assertIn("return nil", src)
+
+    def test_scalar_or_array_union_helper_documents_empty_accepting_constructor(self):
+        src = generate.scalar_or_array_union_to_type("TestUnion", scalar_or_array_schema(min_items=0))
+
+        self.assertIn("func NewTestUnion(values ...string) *TestUnion", src)
+        self.assertIn("Use nil instead of NewTestUnion() when an optional field should be omitted.", src)
+        self.assertIn("NewTestUnion() returns a non-nil empty slice pointer that marshals as [].", src)
+        self.assertIn("v := append(TestUnion{}, values...)", src)
+        self.assertNotIn("if len(values) == 0", src)
+
+    def test_empty_accepting_constructor_marshal_runtime(self):
+        generated = generate.scalar_or_array_union_to_type("TestUnion", scalar_or_array_schema(min_items=0))
+        source = textwrap.dedent(f"""
+            package uniontest
+
+            import (
+                "encoding/json"
+                "fmt"
+                "testing"
+            )
+
+            {generated}
+
+            func TestEmptyConstructorMarshalsArray(t *testing.T) {{
+                got := NewTestUnion()
+                if got == nil {{
+                    t.Fatal("NewTestUnion() returned nil")
+                }}
+                raw, err := json.Marshal(got)
+                if err != nil {{
+                    t.Fatalf("marshal empty test union: %v", err)
+                }}
+                if string(raw) != "[]" {{
+                    t.Fatalf("empty constructor marshaled %s, want []", raw)
+                }}
+            }}
+        """)
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(f"{tmp}/go.mod", "w") as f:
+                f.write("module uniontest\n\ngo 1.25\n")
+            with open(f"{tmp}/union_test.go", "w") as f:
+                f.write(source)
+            subprocess.run(["go", "test", "."], cwd=tmp, check=True)
 
 
 if __name__ == "__main__":

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1741,6 +1741,9 @@ const (
 // MediaBuyStatusFilter — Filter by status. Can be a single status or array of statuses
 type MediaBuyStatusFilter []MediaBuyStatus
 
+// NewMediaBuyStatusFilter returns a pointer to a MediaBuyStatusFilter containing values.
+// It returns nil when called with no values so optional fields omit instead
+// of triggering a MarshalJSON error on a schema-invalid empty array.
 func NewMediaBuyStatusFilter(values ...MediaBuyStatus) *MediaBuyStatusFilter {
 	if len(values) == 0 {
 		return nil


### PR DESCRIPTION
Closes #185.\n\n## Summary\n- emit doc comments for generated scalar-or-array union constructors\n- document the difference between omit-via-nil and explicit empty arrays for future minItems:0 schemas\n- add generator tests for both minItems:1 and minItems:0 constructor branches\n\n## Validation\n- python3 -m py_compile adcp/schemas/generate.py adcp/schemas/generate_test.py adcp/schemas/lint.py\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 45\n- generator idempotence check against adcp/types_gen.go\n- cd adcp && go test ./...\n- cd adcp && golangci-lint run ./...\n- git diff --check