### PR TITLE
fix(adcp): keep enum handling forward compatible

### DIFF
--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -482,6 +482,14 @@ func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
 		t.Fatalf("array status filter decoded unexpected values: %#v", *deliveryReq.StatusFilter)
 	}
 
+	var forwardReq GetMediaBuysRequest
+	if err := json.Unmarshal([]byte(`{"status_filter":"future_status"}`), &forwardReq); err != nil {
+		t.Fatalf("unmarshal forward-compatible status filter: %v", err)
+	}
+	if forwardReq.StatusFilter == nil || len(*forwardReq.StatusFilter) != 1 || (*forwardReq.StatusFilter)[0] != MediaBuyStatus("future_status") {
+		t.Fatalf("forward-compatible status filter did not preserve unknown value: %#v", forwardReq.StatusFilter)
+	}
+
 	emptyFilter := MediaBuyStatusFilter{}
 	if _, err := json.Marshal(emptyFilter); err == nil {
 		t.Fatal("marshal empty status filter succeeded, want error")

--- a/adcp/schemas/download.sh
+++ b/adcp/schemas/download.sh
@@ -49,6 +49,7 @@ PROTECTED=(
   download.sh
   check-freshness.sh
   generate.py
+  generate_test.py
   lint.py
 )
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1301,6 +1301,10 @@ def scalar_or_array_union_to_type(name, schema):
         raise ValueError(f'{name} is not a supported scalar-or-array union')
     desc = safe_comment(schema.get('description', ''), 100)
     doc = f'// {name} — {desc}\n' if desc else ''
+    doc += (
+        f'// {name} preserves unknown values for forward compatibility.\n'
+        '// It validates only scalar-or-array shape and array cardinality.\n'
+    )
     accepts_empty = schema_accepts_empty_array(schema)
     reject_empty = '' if accepts_empty else f'''\tif len(v) == 0 {{
 \t\treturn nil, fmt.Errorf("{name} must contain at least one value")
@@ -1314,6 +1318,7 @@ def scalar_or_array_union_to_type(name, schema):
 \t\treturn nil
 \t}}
 '''
+    # append to a zero-length literal keeps the no-arg constructor non-nil.
     constructor_value = f'append({name}{{}}, values...)' if accepts_empty else f'{name}(values)'
     if accepts_empty:
         constructor_doc = (

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1,4 +1,5 @@
 import subprocess
+import shutil
 import tempfile
 import textwrap
 import unittest
@@ -133,6 +134,7 @@ class UnionHelperGenerationTest(unittest.TestCase):
         self.assertIn("v := append(TestUnion{}, values...)", src)
         self.assertNotIn("if len(values) == 0", src)
 
+    @unittest.skipUnless(shutil.which("go"), "go command not found")
     def test_empty_accepting_constructor_marshal_runtime(self):
         generated = generate.scalar_or_array_union_to_type("TestUnion", scalar_or_array_schema(min_items=0))
         source = textwrap.dedent(f"""
@@ -162,7 +164,7 @@ class UnionHelperGenerationTest(unittest.TestCase):
         """)
         with tempfile.TemporaryDirectory() as tmp:
             with open(f"{tmp}/go.mod", "w") as f:
-                f.write("module uniontest\n\ngo 1.25\n")
+                f.write("module uniontest\n\ngo 1.22\n")
             with open(f"{tmp}/union_test.go", "w") as f:
                 f.write(source)
             subprocess.run(["go", "test", "."], cwd=tmp, check=True)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -1739,6 +1739,8 @@ const (
 // --- Union helper types ---
 
 // MediaBuyStatusFilter — Filter by status. Can be a single status or array of statuses
+// MediaBuyStatusFilter preserves unknown values for forward compatibility.
+// It validates only scalar-or-array shape and array cardinality.
 type MediaBuyStatusFilter []MediaBuyStatus
 
 // NewMediaBuyStatusFilter returns a pointer to a MediaBuyStatusFilter containing values.

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -209,6 +209,9 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 		if buy.Status == "canceled" {
 			return errorResult("NOT_CANCELLABLE", "Media buy is already canceled.", input.Context)
 		}
+		if !hasValidAction(buy.Status, "cancel") {
+			return errorResult("INVALID_TRANSITION", "Media buy cannot be changed from its current status.", input.Context)
+		}
 		buy.Status = "canceled"
 		now := time.Now().UTC().Format(time.RFC3339)
 		buy.Cancellation = map[string]any{"reason": input.CancellationReason, "canceled_by": "buyer", "canceled_at": now}
@@ -218,6 +221,13 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 		return updateMediaBuyResult(buy, packagesForCreateSuccess(buy.Packages), input.Context)
 	}
 	if input.Paused != nil {
+		action := "resume"
+		if *input.Paused {
+			action = "pause"
+		}
+		if !hasValidAction(buy.Status, action) {
+			return errorResult("INVALID_TRANSITION", "Media buy cannot be changed from its current status.", input.Context)
+		}
 		if *input.Paused {
 			buy.Status = "paused"
 		} else {
@@ -227,6 +237,9 @@ func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToo
 	}
 	if input.InvoiceRecipient != nil {
 		buy.InvoiceRecipient = responseBusinessEntity(input.InvoiceRecipient)
+	}
+	if len(input.Packages) > 0 && !hasValidAction(buy.Status, "update_packages") {
+		return errorResult("INVALID_TRANSITION", "Media buy cannot be changed from its current status.", input.Context)
 	}
 
 	packageIndex := make(map[string]int, len(buy.Packages))
@@ -692,9 +705,20 @@ func validActions(status string) []string {
 		return []string{"resume", "cancel", "sync_creatives", "update_packages"}
 	case "pending_creatives":
 		return []string{"cancel", "sync_creatives", "update_packages"}
-	default:
+	case "active", "pending_start":
 		return []string{"pause", "cancel", "sync_creatives", "update_packages"}
+	default:
+		return []string{}
 	}
+}
+
+func hasValidAction(status, action string) bool {
+	for _, valid := range validActions(status) {
+		if valid == action {
+			return true
+		}
+	}
+	return false
 }
 
 func errorResult(code, message string, context any) (*mcp.CallToolResult, any, error) {

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -206,6 +206,60 @@ func TestDoubleCancellation(t *testing.T) {
 	}
 }
 
+func TestUpdateMediaBuy_UnknownStatusRejectsStateChanges(t *testing.T) {
+	cases := []struct {
+		name  string
+		input func(buy *adcp.MediaBuyData) adcp.UpdateMediaBuyRequest
+	}{
+		{
+			name: "cancel",
+			input: func(buy *adcp.MediaBuyData) adcp.UpdateMediaBuyRequest {
+				canceled := true
+				return adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Canceled: &canceled}
+			},
+		},
+		{
+			name: "pause",
+			input: func(buy *adcp.MediaBuyData) adcp.UpdateMediaBuyRequest {
+				paused := true
+				return adcp.UpdateMediaBuyRequest{MediaBuyID: buy.MediaBuyID, Paused: &paused}
+			},
+		},
+		{
+			name: "package update",
+			input: func(buy *adcp.MediaBuyData) adcp.UpdateMediaBuyRequest {
+				paused := true
+				return adcp.UpdateMediaBuyRequest{
+					MediaBuyID: buy.MediaBuyID,
+					Packages: []adcp.PackageUpdate{{
+						PackageID: buy.Packages[0].PackageID,
+						Paused:    &paused,
+					}},
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBackend()
+			buy := mustCreateBuy(t, b, true)
+			buy.Status = "future_status"
+
+			result, _, err := b.updateMediaBuy(tc.input(buy))
+			if err != nil {
+				t.Fatalf("updateMediaBuy: %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("expected error result for unknown status transition")
+			}
+			if buy.Status != "future_status" {
+				t.Fatalf("unknown status transition changed status to %s", buy.Status)
+			}
+		})
+	}
+}
+
 // --- list_creatives filtering ---
 
 func TestListCreatives_FilterByCreativeID(t *testing.T) {
@@ -579,5 +633,19 @@ func TestForceMediaBuyStatus_NotFound(t *testing.T) {
 	_, err := b.forceMediaBuyStatus("nonexistent-id", "active", "")
 	if err == nil {
 		t.Error("expected error for unknown media buy ID")
+	}
+}
+
+func TestValidActions_UnknownStatusFailsClosed(t *testing.T) {
+	if got := validActions("future_status"); len(got) != 0 {
+		t.Fatalf("unknown media buy status should expose no valid actions, got %#v", got)
+	}
+}
+
+func TestValidActions_PendingStartAllowsActiveBuyActions(t *testing.T) {
+	for _, action := range []string{"pause", "cancel", "sync_creatives", "update_packages"} {
+		if !hasValidAction("pending_start", action) {
+			t.Fatalf("pending_start should allow %s, got %#v", action, validActions("pending_start"))
+		}
 	}
 }

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -149,7 +149,7 @@ func ValidateIdentityRequest(req *IdentityMatchRequest) error {
 			return fmt.Errorf("identities[%d].uid_type is required", i)
 		}
 		if _, ok := validUIDTypes[id.UIDType]; !ok {
-			return fmt.Errorf("identities[%d].uid_type %q is not a recognized TMP identity type", i, id.UIDType)
+			return fmt.Errorf("identities[%d].uid_type is not a recognized TMP identity type", i)
 		}
 	}
 	if req.Country != "" {

--- a/tmproto/validate_test.go
+++ b/tmproto/validate_test.go
@@ -22,6 +22,7 @@ func TestValidateIdentityRequest(t *testing.T) {
 		name    string
 		mutate  func(*IdentityMatchRequest)
 		wantErr string
+		wantNot string
 	}{
 		{name: "ok", mutate: func(*IdentityMatchRequest) {}},
 		{
@@ -66,7 +67,8 @@ func TestValidateIdentityRequest(t *testing.T) {
 			mutate: func(r *IdentityMatchRequest) {
 				r.Identities = []IdentityToken{{UserToken: "tok", UIDType: UIDType("made_up")}}
 			},
-			wantErr: "uid_type \"made_up\" is not a recognized TMP identity type",
+			wantErr: "uid_type is not a recognized TMP identity type",
+			wantNot: "made_up",
 		},
 		{
 			name: "every spec uid_type accepted",
@@ -89,6 +91,9 @@ func TestValidateIdentityRequest(t *testing.T) {
 			}
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
+			if tc.wantNot != "" {
+				assert.NotContains(t, err.Error(), tc.wantNot)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- documents generated scalar-or-array union helpers as forward-compatible for unknown enum values
- adds a regression test that `MediaBuyStatusFilter` preserves unknown statuses while still validating shape/cardinality
- makes the reference seller fail closed for unknown media buy statuses instead of exposing active-buy actions
- removes the attacker-controlled `uid_type` value from TMP validation error text

Closes #181.

## Why

Experts agreed that global strict enum decoding would make additive protocol enum values breaking for older Go SDKs. The safer Go SDK policy is tolerant decoding plus explicit validation where application logic depends on an enum. This PR codifies that policy for the generated union helper and fixes the two concrete local safety gaps that made strict global validation tempting.

A larger future DX improvement remains possible: generated defined enum types plus opt-in `IsValid`/`Parse` helpers, without strict JSON unmarshal by default.

## Validation

- `python3 -m py_compile adcp/schemas/generate.py adcp/schemas/generate_test.py adcp/schemas/lint.py`
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`
- `cd adcp/schemas && python3 lint.py --strict && python3 generate.py --coverage-max-unreviewed-any 45 && tmp=$(mktemp) && python3 generate.py > "$tmp" && cmp -s "$tmp" ../types_gen.go`
- `cd adcp && go test ./...`
- `go test ./tmproto && cd reference/seller-agent && go test ./...`
- `go test ./...`
- `cd adcp && golangci-lint run ./... && cd ../reference/seller-agent && golangci-lint run ./...`
- `git diff --check`
