### PR TITLE
fix(seller-agent): make media buy actions exhaustive

### DIFF
--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -698,18 +698,26 @@ func decorateMediaBuy(buy *adcp.MediaBuyData) {
 }
 
 func validActions(status string) []string {
-	switch status {
-	case "canceled", "completed", "rejected", "failed":
+	switch adcp.MediaBuyStatus(status) {
+	case adcp.MediaBuyStatusCanceled, adcp.MediaBuyStatusCompleted, adcp.MediaBuyStatusRejected:
 		return []string{}
-	case "paused":
-		return []string{"resume", "cancel", "sync_creatives", "update_packages"}
-	case "pending_creatives":
-		return []string{"cancel", "sync_creatives", "update_packages"}
-	case "active", "pending_start":
-		return []string{"pause", "cancel", "sync_creatives", "update_packages"}
+	case adcp.MediaBuyStatusPaused:
+		return mediaBuyActions(adcp.MediaBuyValidActionResume, adcp.MediaBuyValidActionCancel, adcp.MediaBuyValidActionSyncCreatives, adcp.MediaBuyValidActionUpdatePackages)
+	case adcp.MediaBuyStatusPendingCreatives, adcp.MediaBuyStatusPendingStart:
+		return mediaBuyActions(adcp.MediaBuyValidActionCancel, adcp.MediaBuyValidActionSyncCreatives, adcp.MediaBuyValidActionUpdatePackages)
+	case adcp.MediaBuyStatusActive:
+		return mediaBuyActions(adcp.MediaBuyValidActionPause, adcp.MediaBuyValidActionCancel, adcp.MediaBuyValidActionSyncCreatives, adcp.MediaBuyValidActionUpdatePackages)
 	default:
 		return []string{}
 	}
+}
+
+func mediaBuyActions(actions ...adcp.MediaBuyValidAction) []string {
+	out := make([]string, len(actions))
+	for i, action := range actions {
+		out[i] = string(action)
+	}
+	return out
 }
 
 func hasValidAction(status, action string) bool {

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -642,10 +642,42 @@ func TestValidActions_UnknownStatusFailsClosed(t *testing.T) {
 	}
 }
 
-func TestValidActions_PendingStartAllowsActiveBuyActions(t *testing.T) {
-	for _, action := range []string{"pause", "cancel", "sync_creatives", "update_packages"} {
-		if !hasValidAction("pending_start", action) {
-			t.Fatalf("pending_start should allow %s, got %#v", action, validActions("pending_start"))
+func TestValidActions_CoversEveryKnownMediaBuyStatus(t *testing.T) {
+	expected := map[adcp.MediaBuyStatus][]string{
+		adcp.MediaBuyStatusPendingCreatives: {"cancel", "sync_creatives", "update_packages"},
+		adcp.MediaBuyStatusPendingStart:     {"cancel", "sync_creatives", "update_packages"},
+		adcp.MediaBuyStatusActive:           {"pause", "cancel", "sync_creatives", "update_packages"},
+		adcp.MediaBuyStatusPaused:           {"resume", "cancel", "sync_creatives", "update_packages"},
+		adcp.MediaBuyStatusCompleted:        {},
+		adcp.MediaBuyStatusRejected:         {},
+		adcp.MediaBuyStatusCanceled:         {},
+	}
+
+	for _, status := range adcp.KnownMediaBuyStatusValues() {
+		want, ok := expected[status]
+		if !ok {
+			t.Fatalf("validActions missing explicit expectation for known status %q", status)
+		}
+		got := validActions(string(status))
+		if !equalStringSlices(got, want) {
+			t.Fatalf("validActions(%q) = %#v, want %#v", status, got, want)
+		}
+		for _, action := range want {
+			if !hasValidAction(string(status), action) {
+				t.Fatalf("hasValidAction(%q, %q) = false; valid actions %#v", status, action, got)
+			}
 		}
 	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

- makes the reference seller `validActions` switch use generated `MediaBuyStatus` and `MediaBuyValidAction` constants
- removes the non-schema `failed` status branch
- treats `pending_start` as explicitly editable pre-flight (`cancel`, `sync_creatives`, `update_packages`) but not pausable
- adds a table-driven test over `adcp.KnownMediaBuyStatusValues()` so new schema statuses require an explicit seller action decision

Closes #189.

## Validation

- `cd reference/seller-agent && go test ./...`
- `cd reference/seller-agent && golangci-lint run ./...`
- `cd adcp && go test ./...`
- `git diff --check`
