### PR TITLE
fix(tmproto): avoid echoing validator inputs

### DIFF
--- a/tmproto/artifact.go
+++ b/tmproto/artifact.go
@@ -280,7 +280,7 @@ func (a AssetAccess) MarshalJSON() ([]byte, error) {
 	case AssetAccessMethodSignedURL:
 		// No extra fields: credentials embedded in URL.
 	default:
-		return nil, fmt.Errorf("AssetAccess: unknown method %q", a.Method)
+		return nil, fmt.Errorf("AssetAccess: unknown method")
 	}
 	return json.Marshal(m)
 }
@@ -307,7 +307,7 @@ func (a *AssetAccess) UnmarshalJSON(data []byte) error {
 	case "":
 		return fmt.Errorf("asset_access: missing method")
 	default:
-		return fmt.Errorf("asset_access: unknown method %q", raw.Method)
+		return fmt.Errorf("asset_access: unknown method")
 	}
 	return nil
 }

--- a/tmproto/jcs.go
+++ b/tmproto/jcs.go
@@ -112,7 +112,7 @@ func jcsEncodeString(buf *bytes.Buffer, s string) {
 
 func jcsEncodeNumber(buf *bytes.Buffer, f float64) error {
 	if math.IsNaN(f) || math.IsInf(f, 0) {
-		return fmt.Errorf("tmproto: jcs forbids non-finite number %v", f)
+		return fmt.Errorf("tmproto: jcs forbids non-finite number")
 	}
 	if f == 0 {
 		buf.WriteByte('0')
@@ -128,7 +128,7 @@ func jcsEncodeNumber(buf *bytes.Buffer, f float64) error {
 	// reproduce. TMP signing inputs do not carry non-integer floats today;
 	// surfacing an error keeps two implementations from diverging silently
 	// when one starts emitting them.
-	return fmt.Errorf("tmproto: jcs non-integer floats are unsupported (got %v); only integers are canonicalized today", f)
+	return fmt.Errorf("tmproto: jcs non-integer floats are unsupported; only integers are canonicalized today")
 }
 
 func jcsEncodeJSONNumber(buf *bytes.Buffer, n json.Number) error {
@@ -139,7 +139,7 @@ func jcsEncodeJSONNumber(buf *bytes.Buffer, n json.Number) error {
 	if f, err := n.Float64(); err == nil {
 		return jcsEncodeNumber(buf, f)
 	}
-	return fmt.Errorf("tmproto: jcs cannot parse json.Number %q", string(n))
+	return fmt.Errorf("tmproto: jcs cannot parse json.Number")
 }
 
 func jcsEncodeArray(buf *bytes.Buffer, a []any) error {

--- a/tmproto/jcs_test.go
+++ b/tmproto/jcs_test.go
@@ -2,6 +2,8 @@ package tmproto
 
 import (
 	"encoding/json"
+	"math"
+	"strings"
 	"testing"
 )
 
@@ -130,6 +132,24 @@ func TestJCSStringSlice(t *testing.T) {
 func TestJCSRejectsNonIntegerFloats(t *testing.T) {
 	if _, err := jcsMarshal(1.5); err == nil {
 		t.Fatal("non-integer float must be rejected until ECMA-262 number canonicalization is implemented")
+	} else if strings.Contains(err.Error(), "1.5") {
+		t.Fatalf("non-integer float error echoed rejected value: %q", err.Error())
+	}
+}
+
+func TestJCSRejectsNonFiniteFloatsWithoutEcho(t *testing.T) {
+	if _, err := jcsMarshal(math.Inf(1)); err == nil {
+		t.Fatal("non-finite float must be rejected")
+	} else if strings.Contains(err.Error(), "+Inf") || strings.Contains(err.Error(), "Inf") {
+		t.Fatalf("non-finite float error echoed rejected value: %q", err.Error())
+	}
+}
+
+func TestJCSRejectsInvalidJSONNumberWithoutEcho(t *testing.T) {
+	if _, err := jcsMarshal(json.Number("leaky-number")); err == nil {
+		t.Fatal("invalid json.Number must be rejected")
+	} else if strings.Contains(err.Error(), "leaky-number") {
+		t.Fatalf("json.Number error echoed rejected value: %q", err.Error())
 	}
 }
 

--- a/tmproto/robustness_test.go
+++ b/tmproto/robustness_test.go
@@ -113,7 +113,15 @@ func TestAssetAccess_Unmarshal_RejectsUnknownMethod(t *testing.T) {
 	var a AssetAccess
 	err := json.Unmarshal([]byte(`{"method":"quantum_key","token":"x"}`), &a)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `unknown method "quantum_key"`)
+	assert.Contains(t, err.Error(), "unknown method")
+	assert.NotContains(t, err.Error(), "quantum_key")
+}
+
+func TestAssetAccess_Marshal_RejectsUnknownMethodWithoutEcho(t *testing.T) {
+	_, err := json.Marshal(AssetAccess{Method: "quantum_key"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown method")
+	assert.NotContains(t, err.Error(), "quantum_key")
 }
 
 func TestAssetAccess_Unmarshal_RejectsMissingMethod(t *testing.T) {
@@ -191,17 +199,18 @@ func TestContextSignals_Validate(t *testing.T) {
 		name    string
 		sig     ContextSignals
 		wantErr string
+		wantNot string
 	}{
-		{"empty", ContextSignals{}, ""},
-		{"valid", ContextSignals{Sentiment: "neutral", Language: "en"}, ""},
-		{"bad sentiment", ContextSignals{Sentiment: "postive"}, "sentiment"},
-		{"bad language pattern", ContextSignals{Language: "EN"}, "language"},
-		{"summary too long", ContextSignals{Summary: strings.Repeat("x", MaxSummaryLength+1)}, "summary"},
-		{"too many topics", ContextSignals{Topics: make([]string, MaxTopics+1)}, "topics"},
-		{"embedding without model", ContextSignals{Embedding: "x", EmbeddingDims: 256}, "set together"},
-		{"embedding dims too small", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 1}, "outside"},
-		{"embedding dims too large", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 9999}, "outside"},
-		{"valid embedding", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 256}, ""},
+		{"empty", ContextSignals{}, "", ""},
+		{"valid", ContextSignals{Sentiment: "neutral", Language: "en"}, "", ""},
+		{"bad sentiment", ContextSignals{Sentiment: "postive"}, "sentiment", "postive"},
+		{"bad language pattern", ContextSignals{Language: "EN"}, "language", "EN"},
+		{"summary too long", ContextSignals{Summary: strings.Repeat("x", MaxSummaryLength+1)}, "summary", ""},
+		{"too many topics", ContextSignals{Topics: make([]string, MaxTopics+1)}, "topics", ""},
+		{"embedding without model", ContextSignals{Embedding: "x", EmbeddingDims: 256}, "set together", ""},
+		{"embedding dims too small", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 1}, "outside", ""},
+		{"embedding dims too large", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 9999}, "outside", ""},
+		{"valid embedding", ContextSignals{Embedding: "x", EmbeddingModel: "m", EmbeddingDims: 256}, "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -211,6 +220,9 @@ func TestContextSignals_Validate(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantNot != "" {
+					assert.NotContains(t, err.Error(), tc.wantNot)
+				}
 			}
 		})
 	}
@@ -221,10 +233,11 @@ func TestArtifactRef_Validate(t *testing.T) {
 		name    string
 		ref     ArtifactRef
 		wantErr string
+		wantNot string
 	}{
-		{"valid url", ArtifactRef{Type: ArtifactRefTypeURL, Value: "https://x"}, ""},
-		{"missing value", ArtifactRef{Type: ArtifactRefTypeURL}, "value"},
-		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "type"},
+		{"valid url", ArtifactRef{Type: ArtifactRefTypeURL, Value: "https://x"}, "", ""},
+		{"missing value", ArtifactRef{Type: ArtifactRefTypeURL}, "value", ""},
+		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "type", "starlink"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -234,6 +247,9 @@ func TestArtifactRef_Validate(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantNot != "" {
+					assert.NotContains(t, err.Error(), tc.wantNot)
+				}
 			}
 		})
 	}
@@ -244,16 +260,17 @@ func TestAssetAccess_Validate(t *testing.T) {
 		name    string
 		a       AssetAccess
 		wantErr string
+		wantNot string
 	}{
-		{"bearer ok", NewBearerTokenAccess("tok"), ""},
-		{"bearer missing token", AssetAccess{Method: AssetAccessMethodBearerToken}, "token required"},
-		{"sa ok gcp", NewServiceAccountAccess("gcp", nil), ""},
-		{"sa ok aws", NewServiceAccountAccess("aws", nil), ""},
-		{"sa missing provider", AssetAccess{Method: AssetAccessMethodServiceAccount}, "provider required"},
-		{"sa bad provider", AssetAccess{Method: AssetAccessMethodServiceAccount, Provider: "azure"}, "provider"},
-		{"signed ok", NewSignedURLAccess(), ""},
-		{"missing method", AssetAccess{}, "method: required"},
-		{"unknown method", AssetAccess{Method: "unknown"}, "method"},
+		{"bearer ok", NewBearerTokenAccess("tok"), "", ""},
+		{"bearer missing token", AssetAccess{Method: AssetAccessMethodBearerToken}, "token required", ""},
+		{"sa ok gcp", NewServiceAccountAccess("gcp", nil), "", ""},
+		{"sa ok aws", NewServiceAccountAccess("aws", nil), "", ""},
+		{"sa missing provider", AssetAccess{Method: AssetAccessMethodServiceAccount}, "provider required", ""},
+		{"sa bad provider", AssetAccess{Method: AssetAccessMethodServiceAccount, Provider: "azure"}, "provider", "azure"},
+		{"signed ok", NewSignedURLAccess(), "", ""},
+		{"missing method", AssetAccess{}, "method: required", ""},
+		{"unknown method", AssetAccess{Method: "unknown"}, "method", "unknown"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -263,6 +280,9 @@ func TestAssetAccess_Validate(t *testing.T) {
 			} else {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
+				if tc.wantNot != "" {
+					assert.NotContains(t, err.Error(), tc.wantNot)
+				}
 			}
 		})
 	}

--- a/tmproto/tmpx.go
+++ b/tmproto/tmpx.go
@@ -121,7 +121,7 @@ func EncodeTmpxPlaintext(country string, entries []TmpxEntry, ts time.Time) ([]b
 
 func encodeTmpxPlaintextWith(country string, entries []TmpxEntry, ts time.Time, r io.Reader) ([]byte, error) {
 	if len(country) != 2 || !isASCIIUpper(country[0]) || !isASCIIUpper(country[1]) {
-		return nil, fmt.Errorf("tmproto: tmpx country must be ISO 3166-1 alpha-2 (uppercase ASCII), got %q", country)
+		return nil, fmt.Errorf("tmproto: tmpx country must be ISO 3166-1 alpha-2 uppercase ASCII")
 	}
 	if len(entries) > 255 {
 		return nil, fmt.Errorf("tmproto: tmpx supports at most 255 entries, got %d", len(entries))

--- a/tmproto/tmpx_test.go
+++ b/tmproto/tmpx_test.go
@@ -264,6 +264,13 @@ func TestEncodeTmpxPlaintextRejectsBadCountry(t *testing.T) {
 			t.Errorf("country %q must be rejected", c)
 		}
 	}
+	_, err := EncodeTmpxPlaintext("LEAKY", nil, time.Now())
+	if err == nil {
+		t.Fatal("country LEAKY must be rejected")
+	}
+	if strings.Contains(err.Error(), "LEAKY") {
+		t.Fatalf("country error echoed rejected value: %q", err.Error())
+	}
 }
 
 func TestEncodeTmpxPlaintextRejectsWrongTokenSize(t *testing.T) {

--- a/tmproto/validate_ladder.go
+++ b/tmproto/validate_ladder.go
@@ -70,11 +70,11 @@ func (c *ContextSignals) Validate() error {
 		return fmt.Errorf("context_signals.summary: %d chars exceeds max %d", len(c.Summary), MaxSummaryLength)
 	}
 	if c.Language != "" && !bcp47TwoLetter.MatchString(c.Language) {
-		return fmt.Errorf("context_signals.language: %q does not match pattern ^[a-z]{2}$", c.Language)
+		return fmt.Errorf("context_signals.language: does not match pattern ^[a-z]{2}$")
 	}
 	if c.Sentiment != "" {
 		if _, ok := validSentiment[c.Sentiment]; !ok {
-			return fmt.Errorf("context_signals.sentiment: %q not in [positive, negative, neutral, mixed]", c.Sentiment)
+			return fmt.Errorf("context_signals.sentiment: not in [positive, negative, neutral, mixed]")
 		}
 	}
 	// Embedding triad: all three must be set together.
@@ -95,7 +95,7 @@ func (r *ArtifactRef) Validate() error {
 		return nil
 	}
 	if _, ok := validArtifactRefType[r.Type]; !ok {
-		return fmt.Errorf("artifact_ref.type: %q not a known ArtifactRefType", r.Type)
+		return fmt.Errorf("artifact_ref.type: not a known ArtifactRefType")
 	}
 	if r.Value == "" {
 		return fmt.Errorf("artifact_ref.value: required")
@@ -114,7 +114,7 @@ func (a *AssetAccess) Validate() error {
 		return fmt.Errorf("asset_access.method: required")
 	}
 	if _, ok := validAssetAccessMethod[a.Method]; !ok {
-		return fmt.Errorf("asset_access.method: %q not a known AssetAccessMethod", a.Method)
+		return fmt.Errorf("asset_access.method: not a known AssetAccessMethod")
 	}
 	switch a.Method {
 	case AssetAccessMethodBearerToken:
@@ -126,7 +126,7 @@ func (a *AssetAccess) Validate() error {
 			return fmt.Errorf("asset_access: provider required for method=service_account")
 		}
 		if a.Provider != "gcp" && a.Provider != "aws" {
-			return fmt.Errorf("asset_access.provider: %q not in [gcp, aws]", a.Provider)
+			return fmt.Errorf("asset_access.provider: not in [gcp, aws]")
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- removes caller-supplied value echoes from TMP validator/canonicalization errors in:
  - `ContextSignals.Validate`
  - `ArtifactRef.Validate`
  - `AssetAccess` validate/marshal/unmarshal paths
  - TMPX country validation
  - JCS number validation
- adds regression tests proving rejected values like `quantum_key`, `starlink`, `azure`, `LEAKY`, and invalid JSON numbers do not appear in returned errors

Closes #190.

## Why

Several TMP validation errors can flow to HTTP responses or caller-visible logs. AGENTS.md requires generic caller-facing messages and no user-controlled values in response text. This keeps the field-level diagnostics while removing reflected values.

## Validation

- `go test ./tmproto`
- `go test ./...`
- `golangci-lint run ./tmproto/...`
- targeted grep for remaining `%q` / `%v` echoes in the swept files
- `git diff --check`
