### PR TITLE
test(tmproto): pin unknown-type and unknown-method wantErr substrings

### DIFF
--- a/tmproto/robustness_test.go
+++ b/tmproto/robustness_test.go
@@ -237,7 +237,7 @@ func TestArtifactRef_Validate(t *testing.T) {
 	}{
 		{"valid url", ArtifactRef{Type: ArtifactRefTypeURL, Value: "https://x"}, "", ""},
 		{"missing value", ArtifactRef{Type: ArtifactRefTypeURL}, "value", ""},
-		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "type", "starlink"},
+		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "not a known ArtifactRefType", "starlink"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -270,7 +270,7 @@ func TestAssetAccess_Validate(t *testing.T) {
 		{"sa bad provider", AssetAccess{Method: AssetAccessMethodServiceAccount, Provider: "azure"}, "provider", "azure"},
 		{"signed ok", NewSignedURLAccess(), "", ""},
 		{"missing method", AssetAccess{}, "method: required", ""},
-		{"unknown method", AssetAccess{Method: "unknown"}, "method", "unknown"},
+		{"unknown method", AssetAccess{Method: "unknown"}, "not a known AssetAccessMethod", "unknown"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #200.

Tightens two overly-broad `wantErr` substrings in `tmproto/robustness_test.go` that were too generic to catch wrong-error regressions:

- `TestArtifactRef_Validate` "unknown type": `"type"` → `"not a known ArtifactRefType"`
- `TestAssetAccess_Validate` "unknown method": `"method"` → `"not a known AssetAccessMethod"`

The old substrings matched any error containing the field-name prefix (`artifact_ref.type`, `asset_access.method`), so a regression that returned a different error class (e.g., `"required"` instead of `"not a known …"`) would still pass. The new substrings pin the exact discriminating phrases already emitted by `validate_ladder.go`, making wrong-error regressions visible while keeping the no-caller-bytes invariant intact (`wantNot` guards are unchanged). No production code touched.

## What tested

- `go build ./...` — clean
- `go vet ./tmproto/...` — clean
- `go test ./tmproto/... ok 0.035s` — all 195 tests pass including the two tightened cases
- `go test ./... ok` — full root-module suite passes

## Pre-PR review

- code-reviewer: approved — new wantErr substrings confirmed as verbatim substrings of production errors; wantNot guards preserved; no production code changed; no blockers
- ad-tech-protocol-expert: approved — pins closed-enum rejection class correctly per TMP sanitization policy; no blockers

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01MjgZzyRVRrXju1ozznUSLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjgZzyRVRrXju1ozznUSLT)_