### PR TITLE
fix(tmproto): hide malformed signature decoder details

### DIFF
--- a/tmproto/signing.go
+++ b/tmproto/signing.go
@@ -400,7 +400,7 @@ func decodeSignature(s string) ([]byte, error) {
 	}
 	raw, err := base64.RawURLEncoding.DecodeString(s)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrSignatureMalformed, err)
+		return nil, ErrSignatureMalformed
 	}
 	if len(raw) != ed25519.SignatureSize {
 		return nil, fmt.Errorf("%w: signature length %d", ErrSignatureMalformed, len(raw))

--- a/tmproto/signing_test.go
+++ b/tmproto/signing_test.go
@@ -294,9 +294,13 @@ func TestVerifyRevokedKeyRejected(t *testing.T) {
 func TestVerifyMalformedSignatureRejected(t *testing.T) {
 	_, ks := newTestSigner(t)
 	req := &ContextMatchRequest{RequestID: "r", PropertyRID: "p", PlacementID: "pl"}
-	err := VerifyContextMatch(req, "https://x", "!!!not-base64!!!", "test-key-1", ks, time.Now())
+	leakySignature := "!!!not-base64!!!"
+	err := VerifyContextMatch(req, "https://x", leakySignature, "test-key-1", ks, time.Now())
 	if !errors.Is(err, ErrSignatureMalformed) {
 		t.Fatalf("expected ErrSignatureMalformed, got %v", err)
+	}
+	if strings.Contains(err.Error(), leakySignature) || strings.Contains(err.Error(), "illegal base64") || strings.Contains(err.Error(), "byte") {
+		t.Fatalf("malformed signature error leaked decoder details: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- returns `ErrSignatureMalformed` directly when `X-AdCP-Signature` is not valid base64url
- adds a regression test that malformed signature errors do not include the submitted signature, base64 decoder text, or byte offsets

Closes #199.

## Validation
- `go test ./tmproto`
- `go test ./...`
- `golangci-lint run ./tmproto/...`
- `git diff --check`