### PR TITLE
test(tmproto): tighten sanitization assertions

### DIFF
--- a/tmproto/robustness_test.go
+++ b/tmproto/robustness_test.go
@@ -237,7 +237,7 @@ func TestArtifactRef_Validate(t *testing.T) {
 	}{
 		{"valid url", ArtifactRef{Type: ArtifactRefTypeURL, Value: "https://x"}, "", ""},
 		{"missing value", ArtifactRef{Type: ArtifactRefTypeURL}, "value", ""},
-		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "type", "starlink"},
+		{"unknown type", ArtifactRef{Type: "starlink", Value: "x"}, "not a known ArtifactRefType", "starlink"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -270,7 +270,7 @@ func TestAssetAccess_Validate(t *testing.T) {
 		{"sa bad provider", AssetAccess{Method: AssetAccessMethodServiceAccount, Provider: "azure"}, "provider", "azure"},
 		{"signed ok", NewSignedURLAccess(), "", ""},
 		{"missing method", AssetAccess{}, "method: required", ""},
-		{"unknown method", AssetAccess{Method: "unknown"}, "method", "unknown"},
+		{"unknown method", AssetAccess{Method: "unknown"}, "not a known AssetAccessMethod", "unknown"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- tightens ArtifactRef unknown-type regression to assert the specific `not a known ArtifactRefType` class
- tightens AssetAccess unknown-method regression to assert the specific `not a known AssetAccessMethod` class
- keeps the caller-value redaction assertions intact

Closes #200.

## Validation
- `go test ./tmproto -run 'Test(ArtifactRef|AssetAccess)_Validate'`\n- `go test ./tmproto`\n- `golangci-lint run ./tmproto/...`\n- `git diff --check`