### PR TITLE
fix(tmproto): sanitize validation error responses

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -142,7 +142,8 @@ func (r *Router) HandleContextMatch(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if err := ValidateContextRequest(&cmReq); err != nil {
-		r.writeError(w, cmReq.RequestID, tmproto.ErrorCodeInvalidRequest, err.Error())
+		r.logValidationFailure("invalid context-match request", req, cmReq.RequestID, err)
+		r.writeError(w, tmproto.SafeRequestIDForEcho(cmReq.RequestID), tmproto.ErrorCodeInvalidRequest, "invalid request")
 		return
 	}
 
@@ -201,7 +202,8 @@ func (r *Router) HandleIdentityMatch(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if err := ValidateIdentityRequest(&imReq); err != nil {
-		r.writeError(w, imReq.RequestID, tmproto.ErrorCodeInvalidRequest, err.Error())
+		r.logValidationFailure("invalid identity-match request", req, imReq.RequestID, err)
+		r.writeError(w, tmproto.SafeRequestIDForEcho(imReq.RequestID), tmproto.ErrorCodeInvalidRequest, "invalid request")
 		return
 	}
 
@@ -505,4 +507,14 @@ func (r *Router) writeError(w http.ResponseWriter, requestID string, code tmprot
 	}); err != nil {
 		r.logger.Debug("failed to write error response", "error", err)
 	}
+}
+
+func (r *Router) logValidationFailure(message string, req *http.Request, requestID string, err error) {
+	attrs := []any{"method", req.Method, "path", req.URL.Path, "error", err}
+	if safeID := tmproto.SafeRequestIDForEcho(requestID); safeID != "" {
+		attrs = append(attrs, "request_id", safeID)
+	} else if requestID != "" {
+		attrs = append(attrs, "request_id_valid", false)
+	}
+	r.logger.Warn(message, attrs...)
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -193,6 +193,104 @@ func TestRouterContextMatch_EndToEnd(t *testing.T) {
 	assert.Equal(t, "pkg-1", resp.Offers[0].PackageID)
 }
 
+func TestRouterContextMatch_ValidationErrorIsGenericAndLogged(t *testing.T) {
+	var logs bytes.Buffer
+	router := testRouter(nil)
+	router.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+
+	reqBody := `{
+		"type": "context_match_request",
+		"request_id": "ctx-invalid",
+		"property_id": "bad:property",
+		"property_type": "website",
+		"placement_id": "sidebar",
+		"package_ids": ["pkg-1"]
+	}`
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(reqBody))
+	router.HandleContextMatch(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, tmproto.ErrorCodeInvalidRequest, resp.Code)
+	assert.Equal(t, "ctx-invalid", resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, resp.Message, "property_id")
+
+	logText := logs.String()
+	assert.Contains(t, logText, "invalid context-match request")
+	assert.Contains(t, logText, `"method":"POST"`)
+	assert.Contains(t, logText, `"path":"/tmp/context"`)
+	assert.Contains(t, logText, "ctx-invalid")
+	assert.Contains(t, logText, "property_id contains invalid characters")
+}
+
+func TestRouterIdentityMatch_InvalidRequestIDIsNotEchoed(t *testing.T) {
+	var logs bytes.Buffer
+	router := testRouter(nil)
+	router.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+
+	reqBody := `{
+		"type": "identity_match_request",
+		"request_id": "bad/id",
+		"seller_agent_url": "https://seller.example.com/agent",
+		"identities": [{"user_token": "tok_test_abc", "uid_type": "uid2"}],
+		"package_ids": ["pkg-1"]
+	}`
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tmp/identity", strings.NewReader(reqBody))
+	router.HandleIdentityMatch(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, w.Body.String(), "bad/id")
+
+	logText := logs.String()
+	assert.Contains(t, logText, "invalid identity-match request")
+	assert.Contains(t, logText, `"method":"POST"`)
+	assert.Contains(t, logText, `"path":"/tmp/identity"`)
+	assert.Contains(t, logText, `"request_id_valid":false`)
+	assert.NotContains(t, logText, "bad/id")
+}
+
+func TestRouterContextMatch_LongRequestIDIsNotEchoed(t *testing.T) {
+	var logs bytes.Buffer
+	router := testRouter(nil)
+	router.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+
+	longID := strings.Repeat("a", tmproto.MaxIDLength+1)
+	body, err := json.Marshal(tmproto.ContextMatchRequest{
+		Type:         tmproto.TypeContextMatchRequest,
+		RequestID:    longID,
+		PropertyID:   "pub-test",
+		PropertyType: tmproto.PropertyTypeWebsite,
+		PlacementID:  "sidebar",
+		PackageIDs:   []string{"pkg-1"},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tmp/context", bytes.NewReader(body))
+	router.HandleContextMatch(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, w.Body.String(), longID)
+
+	logText := logs.String()
+	assert.Contains(t, logText, `"request_id_valid":false`)
+	assert.NotContains(t, logText, longID)
+}
+
 func TestRouterContextMatch_StripsArtifactAccess(t *testing.T) {
 	var receivedBody []byte
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -101,7 +100,8 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := tmproto.ValidateIdentityRequest(&req); err != nil {
-		h.writeError(w, req.RequestID, http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest, err.Error())
+		h.logValidationFailure(r, req.RequestID, err)
+		h.writeError(w, tmproto.SafeRequestIDForEcho(req.RequestID), http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest, "invalid request")
 		h.recordCompletion(ctx, start, "bad_request")
 		return
 	}
@@ -111,9 +111,9 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// names VERSION_UNSUPPORTED here, but the error.json schema's
 			// `code` enum does not include it. Use invalid_request — the
 			// closest valid code — until the spec is internally
-			// consistent. The message preserves diagnostic detail.
-			h.writeError(w, req.RequestID, http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest,
-				fmt.Sprintf("adcp_major_version %d is not supported", req.AdcpMajorVersion))
+			// consistent.
+			h.logValidationFailure(r, req.RequestID, errors.New("adcp_major_version is not supported"))
+			h.writeError(w, tmproto.SafeRequestIDForEcho(req.RequestID), http.StatusBadRequest, tmproto.ErrorCodeInvalidRequest, "invalid request")
 			h.recordCompletion(ctx, start, "bad_request")
 			return
 		}
@@ -214,6 +214,16 @@ func (h *identityHandler) writeError(w http.ResponseWriter, requestID string, st
 	_, _ = w.Write(body)
 }
 
+func (h *identityHandler) logValidationFailure(r *http.Request, requestID string, err error) {
+	attrs := []any{"method", r.Method, "path", r.URL.Path, "error", err}
+	if safeID := tmproto.SafeRequestIDForEcho(requestID); safeID != "" {
+		attrs = append(attrs, "request_id", safeID)
+	} else if requestID != "" {
+		attrs = append(attrs, "request_id_valid", false)
+	}
+	h.logger.Warn("invalid identity-match request", attrs...)
+}
+
 func (h *identityHandler) recordCompletion(ctx context.Context, start time.Time, status string) {
 	h.recorder.RequestCompleted(ctx, status, time.Since(start))
 }
@@ -248,4 +258,3 @@ func (h *identityHandler) buildServiceRequest(ctx context.Context, req *tmproto.
 	shadow.Identities = audienceEligibleIdentities(decoded)
 	return &shadow, decoded
 }
-

--- a/targeting/identityagent/handler_test.go
+++ b/targeting/identityagent/handler_test.go
@@ -1,13 +1,166 @@
 package identityagent
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+func TestIdentityHandlerValidationErrorIsGenericAndLogged(t *testing.T) {
+	var logs bytes.Buffer
+	h := NewIdentityHandler(IdentityHandlerConfig{
+		RequestTimeout:             time.Second,
+		RequestBodyLimit:           64 * 1024,
+		ResponseTTL:                time.Minute,
+		SupportedADCPMajorVersions: []int{3},
+		Logger:                     slog.New(slog.NewJSONHandler(&logs, nil)),
+	})
+
+	body := `{
+		"type": "identity_match_request",
+		"request_id": "id-invalid",
+		"identities": [{"user_token": "tok_test_abc", "uid_type": "uid2"}]
+	}`
+	req := httptest.NewRequest("POST", "/identity", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, tmproto.ErrorCodeInvalidRequest, resp.Code)
+	assert.Equal(t, "id-invalid", resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, resp.Message, "seller_agent_url")
+
+	logText := logs.String()
+	assert.Contains(t, logText, "invalid identity-match request")
+	assert.Contains(t, logText, `"method":"POST"`)
+	assert.Contains(t, logText, `"path":"/identity"`)
+	assert.Contains(t, logText, "id-invalid")
+	assert.Contains(t, logText, "seller_agent_url is required")
+}
+
+func TestIdentityHandlerInvalidRequestIDIsNotEchoed(t *testing.T) {
+	var logs bytes.Buffer
+	h := NewIdentityHandler(IdentityHandlerConfig{
+		RequestTimeout:             time.Second,
+		RequestBodyLimit:           64 * 1024,
+		ResponseTTL:                time.Minute,
+		SupportedADCPMajorVersions: []int{3},
+		Logger:                     slog.New(slog.NewJSONHandler(&logs, nil)),
+	})
+
+	body := `{
+		"type": "identity_match_request",
+		"request_id": "bad/id",
+		"seller_agent_url": "https://seller.example.com/agent",
+		"identities": [{"user_token": "tok_test_abc", "uid_type": "uid2"}]
+	}`
+	req := httptest.NewRequest("POST", "/identity", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, w.Body.String(), "bad/id")
+
+	logText := logs.String()
+	assert.Contains(t, logText, "invalid identity-match request")
+	assert.Contains(t, logText, `"method":"POST"`)
+	assert.Contains(t, logText, `"path":"/identity"`)
+	assert.Contains(t, logText, `"request_id_valid":false`)
+	assert.NotContains(t, logText, "bad/id")
+}
+
+func TestIdentityHandlerLongRequestIDIsNotEchoed(t *testing.T) {
+	var logs bytes.Buffer
+	h := NewIdentityHandler(IdentityHandlerConfig{
+		RequestTimeout:             time.Second,
+		RequestBodyLimit:           64 * 1024,
+		ResponseTTL:                time.Minute,
+		SupportedADCPMajorVersions: []int{3},
+		Logger:                     slog.New(slog.NewJSONHandler(&logs, nil)),
+	})
+
+	longID := strings.Repeat("a", tmproto.MaxIDLength+1)
+	body, err := json.Marshal(tmproto.IdentityMatchRequest{
+		Type:           tmproto.TypeIdentityMatchRequest,
+		RequestID:      longID,
+		SellerAgentURL: "https://seller.example.com/agent",
+		Identities: []tmproto.IdentityToken{
+			{UserToken: "tok_test_abc", UIDType: tmproto.UIDTypeUID2},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/identity", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Empty(t, resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, w.Body.String(), longID)
+
+	logText := logs.String()
+	assert.Contains(t, logText, `"request_id_valid":false`)
+	assert.NotContains(t, logText, longID)
+}
+
+func TestIdentityHandlerUnsupportedMajorVersionIsGenericAndLogged(t *testing.T) {
+	var logs bytes.Buffer
+	h := NewIdentityHandler(IdentityHandlerConfig{
+		RequestTimeout:             time.Second,
+		RequestBodyLimit:           64 * 1024,
+		ResponseTTL:                time.Minute,
+		SupportedADCPMajorVersions: []int{3},
+		Logger:                     slog.New(slog.NewJSONHandler(&logs, nil)),
+	})
+
+	body, err := json.Marshal(tmproto.IdentityMatchRequest{
+		Type:             tmproto.TypeIdentityMatchRequest,
+		RequestID:        "id-version",
+		SellerAgentURL:   "https://seller.example.com/agent",
+		AdcpMajorVersion: 999,
+		Identities: []tmproto.IdentityToken{
+			{UserToken: "tok_test_abc", UIDType: tmproto.UIDTypeUID2},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("POST", "/identity", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var resp tmproto.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "id-version", resp.RequestID)
+	assert.Equal(t, "invalid request", resp.Message)
+	assert.NotContains(t, w.Body.String(), "999")
+
+	logText := logs.String()
+	assert.Contains(t, logText, "invalid identity-match request")
+	assert.Contains(t, logText, `"request_id":"id-version"`)
+	assert.Contains(t, logText, "adcp_major_version is not supported")
+	assert.NotContains(t, logText, "999")
+}
 
 // TestBuildServiceRequest_TMPXDisabled_PassesThroughUnchanged covers the
 // legacy code path: when the handler has no sealer, the request flows to

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -57,6 +57,19 @@ func validateSafeID(field, value string) error {
 	return nil
 }
 
+// SafeRequestIDForEcho returns requestID only when it satisfies the same
+// constraints as request_id validation. HTTP boundaries use it before echoing a
+// parsed request_id in an error response or structured log.
+func SafeRequestIDForEcho(requestID string) string {
+	if requestID == "" {
+		return ""
+	}
+	if err := validateSafeID("request_id", requestID); err != nil {
+		return ""
+	}
+	return requestID
+}
+
 func validateProtocolVersion(v string) error {
 	if v == "" || v == "1.0" {
 		return nil

--- a/tmproto/validate_test.go
+++ b/tmproto/validate_test.go
@@ -98,6 +98,13 @@ func TestValidateIdentityRequest(t *testing.T) {
 	}
 }
 
+func TestSafeRequestIDForEcho(t *testing.T) {
+	assert.Equal(t, "req-1", SafeRequestIDForEcho("req-1"))
+	assert.Empty(t, SafeRequestIDForEcho(""))
+	assert.Empty(t, SafeRequestIDForEcho("bad/id"))
+	assert.Empty(t, SafeRequestIDForEcho(strings.Repeat("a", MaxIDLength+1)))
+}
+
 func TestValidateIdentityRequest_AllValidUIDTypes(t *testing.T) {
 	types := []UIDType{
 		UIDTypeRampID, UIDTypeRampIDDerived, UIDTypeID5, UIDTypeUID2,


### PR DESCRIPTION
## Summary

Closes #201.

- stop returning `ValidateContextRequest` / `ValidateIdentityRequest` error strings to router callers
- add structured warning logs for validation failures with method, path, safe request_id, and server-side diagnostic error
- apply the same generic response treatment to unsupported `adcp_major_version` in the identity agent
- add `tmproto.SafeRequestIDForEcho` so response/request-id redaction stays aligned with TMP request_id validation
- add regression coverage for generic wire errors, request context logging, invalid/overlong request_id redaction, and unsupported major-version handling

## Expert review

- security-reviewer found the unsupported `adcp_major_version` branch still reflected caller-controlled input; fixed in this PR
- code-reviewer suggested pinning method/path logging and de-duplicating request-id echo safety; folded in before publish

## Validation

- `go test ./router ./tmproto ./targeting/identityagent`
- `go test ./...`
- `git diff --check`
