### PR TITLE
fix(tmproto): remove caller-derived tmpx diagnostics

### DIFF
--- a/tmproto/tmpx.go
+++ b/tmproto/tmpx.go
@@ -120,19 +120,21 @@ func EncodeTmpxPlaintext(country string, entries []TmpxEntry, ts time.Time) ([]b
 }
 
 func encodeTmpxPlaintextWith(country string, entries []TmpxEntry, ts time.Time, r io.Reader) ([]byte, error) {
+	// TMPX validation errors are caller-visible, so diagnostics below avoid
+	// echoing submitted values, indices, type IDs, or counts.
 	if len(country) != 2 || !isASCIIUpper(country[0]) || !isASCIIUpper(country[1]) {
-		return nil, fmt.Errorf("tmproto: tmpx country must be ISO 3166-1 alpha-2 uppercase ASCII")
+		return nil, errors.New("tmproto: tmpx country invalid; expected ISO 3166-1 alpha-2 uppercase ASCII")
 	}
 	if len(entries) > 255 {
-		return nil, fmt.Errorf("tmproto: tmpx supports at most 255 entries, got %d", len(entries))
+		return nil, errors.New("tmproto: tmpx entries exceed maximum")
 	}
-	for i, e := range entries {
+	for _, e := range entries {
 		size, ok := TmpxTokenSize(e.TypeID)
 		if !ok {
-			return nil, fmt.Errorf("tmproto: tmpx entry %d has unknown type id %d", i, e.TypeID)
+			return nil, errors.New("tmproto: tmpx entry has unknown type id")
 		}
 		if len(e.Token) != size {
-			return nil, fmt.Errorf("tmproto: tmpx entry %d (type %d) token must be %d bytes, got %d", i, e.TypeID, size, len(e.Token))
+			return nil, errors.New("tmproto: tmpx entry token has invalid size")
 		}
 	}
 
@@ -181,7 +183,7 @@ func isASCIIUpper(b byte) bool { return b >= 'A' && b <= 'Z' }
 // callers should pass nil unless the buyer profile defines a value.
 func SealTmpx(recipient TmpxRecipient, info, plaintext []byte) (string, error) {
 	if recipient.Kid == "" || len(recipient.Kid) > TmpxMaxKidLen {
-		return "", fmt.Errorf("tmproto: tmpx kid must be 1..%d chars", TmpxMaxKidLen)
+		return "", errors.New("tmproto: tmpx kid must be 1..8 chars")
 	}
 	if recipient.PublicKey == nil {
 		return "", errors.New("tmproto: tmpx recipient public key required")
@@ -293,7 +295,7 @@ func labeledExtract(salt, label, ikm, suiteID []byte) ([]byte, error) {
 // future caller can't silently truncate.
 func labeledExpand(prk, label, info []byte, length int, suiteID []byte) ([]byte, error) {
 	if length < 0 || length > 0xffff {
-		return nil, fmt.Errorf("tmproto: hpke labeled_expand length %d outside uint16 range", length)
+		return nil, errors.New("tmproto: hpke labeled_expand length outside uint16 range")
 	}
 	labeledInfo := make([]byte, 0, 2+7+len(suiteID)+len(label)+len(info))
 	labeledInfo = binary.BigEndian.AppendUint16(labeledInfo, uint16(length))

--- a/tmproto/tmpx_test.go
+++ b/tmproto/tmpx_test.go
@@ -262,15 +262,23 @@ func TestEncodeTmpxPlaintextRejectsBadCountry(t *testing.T) {
 		_, err := EncodeTmpxPlaintext(c, nil, time.Now())
 		if err == nil {
 			t.Errorf("country %q must be rejected", c)
+			continue
+		}
+		if c == "us" {
+			if !strings.Contains(err.Error(), "country invalid") {
+				t.Fatalf("unexpected country error: %v", err)
+			}
+			assertErrorOmits(t, err, "us")
 		}
 	}
 	_, err := EncodeTmpxPlaintext("LEAKY", nil, time.Now())
 	if err == nil {
 		t.Fatal("country LEAKY must be rejected")
 	}
-	if strings.Contains(err.Error(), "LEAKY") {
-		t.Fatalf("country error echoed rejected value: %q", err.Error())
+	if !strings.Contains(err.Error(), "country invalid") {
+		t.Fatalf("unexpected country error: %v", err)
 	}
+	assertErrorOmits(t, err, "LEAKY")
 }
 
 func TestEncodeTmpxPlaintextRejectsWrongTokenSize(t *testing.T) {
@@ -280,6 +288,10 @@ func TestEncodeTmpxPlaintextRejectsWrongTokenSize(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for wrong token size")
 	}
+	if !strings.Contains(err.Error(), "invalid size") {
+		t.Fatalf("unexpected token-size error: %v", err)
+	}
+	assertErrorOmits(t, err, "too short", "9", "32")
 }
 
 func TestEncodeTmpxPlaintextRejectsUnknownType(t *testing.T) {
@@ -289,6 +301,25 @@ func TestEncodeTmpxPlaintextRejectsUnknownType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown type id")
 	}
+	if !strings.Contains(err.Error(), "unknown type id") {
+		t.Fatalf("unexpected type-id error: %v", err)
+	}
+	assertErrorOmits(t, err, "200")
+}
+
+func TestEncodeTmpxPlaintextRejectsTooManyEntriesWithoutCount(t *testing.T) {
+	entries := make([]TmpxEntry, 256)
+	for i := range entries {
+		entries[i] = TmpxEntry{TypeID: TmpxTypeUID2, Token: bytes.Repeat([]byte{0}, 32)}
+	}
+	_, err := EncodeTmpxPlaintext("US", entries, time.Now())
+	if err == nil {
+		t.Fatal("expected error for too many entries")
+	}
+	if !strings.Contains(err.Error(), "entries exceed maximum") {
+		t.Fatalf("unexpected entries error: %v", err)
+	}
+	assertErrorOmits(t, err, "255", "256")
 }
 
 func TestSealTmpxKidValidation(t *testing.T) {
@@ -300,6 +331,31 @@ func TestSealTmpxKidValidation(t *testing.T) {
 	rcp.Kid = "abcdefghi" // 9 chars, exceeds spec max of 8
 	if _, err := SealTmpx(rcp, nil, []byte("x")); err == nil {
 		t.Error("9-char kid must be rejected")
+	} else {
+		assertErrorOmits(t, err, "abcdefghi", "9")
+	}
+}
+
+func TestLabeledExpandRejectsOutOfRangeLengthWithoutEcho(t *testing.T) {
+	_, err := labeledExpand(nil, nil, nil, 0x10000, nil)
+	if err == nil {
+		t.Fatal("expected error for out-of-range length")
+	}
+	if !strings.Contains(err.Error(), "outside uint16 range") {
+		t.Fatalf("unexpected length error: %v", err)
+	}
+	assertErrorOmits(t, err, "65536")
+}
+
+func assertErrorOmits(t *testing.T, err error, forbidden ...string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	for _, s := range forbidden {
+		if strings.Contains(err.Error(), s) {
+			t.Fatalf("error %q echoed forbidden value %q", err.Error(), s)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #202.

Policy choice: TMPX caller-visible errors should not include caller-derived values, including bounded structural counts.

- remove submitted counts, entry indices, type IDs, token sizes, and kid lengths from TMPX validation errors
- add a short code comment documenting why TMPX validation diagnostics are intentionally value-free
- add regression tests for lowercase `us`, rejected country values, wrong token sizes, unknown type IDs, too many entries, overlong kid, and `labeledExpand` length overflow

## Expert review

Security reviewer found no required fixes. Their test-strength suggestion for `labeledExpand` and stable message fragments was folded in before publish.

## Validation

- `go test ./tmproto`
- `go test ./...`
- `git diff --check`
