### PR TITLE
feat(adcp)!: type optimization goals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 45
+        run: python3 generate.py --coverage-max-unreviewed-any 42
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -159,6 +159,9 @@ be populated.
 | `PackageDelivery.ByAudience` | `[]adcp.PackageAudienceDelivery` |
 | `PackageDelivery.ByPlacement` | `[]adcp.PackagePlacementDelivery` |
 | `PackageDelivery.DailyBreakdown` | `[]adcp.PackageDailyBreakdown` |
+| `Package.OptimizationGoals` | `[]adcp.OptimizationGoal` |
+| `PackageInput.OptimizationGoals` | `[]adcp.OptimizationGoal` |
+| `PackageUpdate.OptimizationGoals` | `[]adcp.OptimizationGoal` |
 | `GetMediaBuysRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
 | `GetMediaBuyDeliveryRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
 | `GetMediaBuyDeliveryRequest.AttributionWindow` | `*adcp.DeliveryAttributionWindow` |
@@ -271,6 +274,11 @@ feedback := adcp.ProvidePerformanceFeedbackRequest{
   exposes schema-backed package update fields such as `Pacing`, `Catalogs`,
   `OptimizationGoals`, keyword add/remove operations, `Creatives`, `Context`,
   and `Ext`.
+- `OptimizationGoals` fields now use `[]adcp.OptimizationGoal` instead of
+  `[]any`. Nested `event_sources`, `target_frequency`, and `attribution_window`
+  are typed; the nested `target` oneOf remains `any` until nested union
+  generation lands. `OptimizationGoal.Extra` preserves unknown top-level fields
+  when round-tripping newer goal variants through replacement-style updates.
 - `SyncCreativesRequest.Assignments` is now `[]adcp.SyncCreativeAssignment`.
 - `Config.CreateMediaBuy` now returns `adcp.CreateMediaBuyResult`, which is
   implemented by the generated schema variants. Return

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -375,6 +375,74 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "package input optimization goals",
+			value: PackageInput{
+				ProductID:       "prod-1",
+				PricingOptionID: "po-1",
+				Budget:          1000,
+				OptimizationGoals: []OptimizationGoal{{
+					Kind:      "metric",
+					Metric:    "reach",
+					ReachUnit: "household",
+					TargetFrequency: &OptimizationGoalTargetFrequency{
+						Min:    1,
+						Max:    3,
+						Window: Duration{Interval: 7, Unit: "days"},
+					},
+					Target:   map[string]any{"kind": "threshold_rate", "value": 0.7},
+					Priority: 1,
+				}},
+			},
+			want: []string{
+				`"optimization_goals":[{"kind":"metric","metric":"reach","priority":1,"reach_unit":"household","target":{"kind":"threshold_rate","value":0.7},"target_frequency":{"min":1,"max":3,"window":{"interval":7,"unit":"days"}}}]`,
+			},
+		},
+		{
+			name: "optimization goal preserves explicit zero value factor",
+			value: PackageInput{
+				ProductID:       "prod-1",
+				PricingOptionID: "po-1",
+				Budget:          1000,
+				OptimizationGoals: []OptimizationGoal{{
+					Kind: "event",
+					EventSources: []OptimizationGoalEventSource{{
+						EventSourceID: "pixel-1",
+						EventType:     "purchase",
+						ValueFactor:   Ptr(0.0),
+					}},
+				}},
+			},
+			want: []string{
+				`"value_factor":0`,
+			},
+		},
+		{
+			name: "package optimization goals typed",
+			value: Package{
+				PackageID: "pkg-1",
+				OptimizationGoals: []OptimizationGoal{{
+					Kind:   "metric",
+					Metric: "clicks",
+				}},
+			},
+			want: []string{
+				`"optimization_goals":[{"kind":"metric","metric":"clicks"}]`,
+			},
+		},
+		{
+			name: "package update optimization goals typed",
+			value: PackageUpdate{
+				PackageID: "pkg-1",
+				OptimizationGoals: []OptimizationGoal{{
+					Kind:   "metric",
+					Metric: "views",
+				}},
+			},
+			want: []string{
+				`"optimization_goals":[{"kind":"metric","metric":"views"}]`,
+			},
+		},
+		{
 			name: "creative agent refs",
 			value: ListCreativeFormatsResponse{
 				Formats: []CreativeFormat{},
@@ -499,6 +567,111 @@ func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
 	}
 	if err := json.Unmarshal([]byte(`{"status_filter":[]}`), &deliveryReq); err == nil {
 		t.Fatal("unmarshal empty status filter succeeded, want error")
+	}
+}
+
+func TestGeneratedOptimizationGoalUnmarshalNestedShapes(t *testing.T) {
+	raw := []byte(`{
+		"optimization_goals": [{
+			"kind": "event",
+			"event_sources": [{
+				"event_source_id": "pixel-1",
+				"event_type": "purchase",
+				"value_field": "value",
+				"value_factor": 1.5
+			}],
+			"target": {"kind": "per_ad_spend", "value": 4},
+			"future_goal_field": {"keep": true},
+			"attribution_window": {
+				"post_click": {"interval": 7, "unit": "days"},
+				"post_view": {"interval": 1, "unit": "days"}
+			},
+			"priority": 1
+		}]
+	}`)
+	var req PackageInput
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal optimization goal: %v", err)
+	}
+	if len(req.OptimizationGoals) != 1 {
+		t.Fatalf("optimization_goals len = %d, want 1", len(req.OptimizationGoals))
+	}
+	goal := req.OptimizationGoals[0]
+	if goal.Kind != "event" || goal.Priority != 1 {
+		t.Fatalf("unexpected optimization goal: %#v", goal)
+	}
+	if len(goal.EventSources) != 1 || goal.EventSources[0].EventSourceID != "pixel-1" {
+		t.Fatalf("event_sources not typed: %#v", goal.EventSources)
+	}
+	if goal.EventSources[0].ValueFactor == nil || *goal.EventSources[0].ValueFactor != 1.5 {
+		t.Fatalf("value_factor did not preserve non-zero pointer value: %#v", goal.EventSources[0].ValueFactor)
+	}
+	if goal.AttributionWindow == nil || goal.AttributionWindow.PostClick.Interval != 7 || goal.AttributionWindow.PostView == nil {
+		t.Fatalf("attribution_window not typed: %#v", goal.AttributionWindow)
+	}
+	target, ok := goal.Target.(map[string]any)
+	if !ok || target["kind"] != "per_ad_spend" {
+		t.Fatalf("target oneOf should remain a raw map, got %#v", goal.Target)
+	}
+	extra, ok := goal.Extra["future_goal_field"].(map[string]any)
+	if !ok || extra["keep"] != true {
+		t.Fatalf("unknown top-level goal field was not preserved: %#v", goal.Extra)
+	}
+
+	roundTrip, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal optimization goal round trip: %v", err)
+	}
+	if !strings.Contains(string(roundTrip), `"future_goal_field":{"keep":true}`) {
+		t.Fatalf("round trip dropped unknown top-level goal field: %s", roundTrip)
+	}
+
+	collidingExtra, err := json.Marshal(OptimizationGoal{
+		Extra: map[string]any{
+			"priority":          99,
+			"future_goal_field": "ok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal optimization goal with colliding extra: %v", err)
+	}
+	if strings.Contains(string(collidingExtra), `"priority":`) {
+		t.Fatalf("known typed field from Extra should not override zero typed value: %s", collidingExtra)
+	}
+	if !strings.Contains(string(collidingExtra), `"future_goal_field":"ok"`) {
+		t.Fatalf("non-colliding Extra field was not preserved: %s", collidingExtra)
+	}
+}
+
+func TestGeneratedOptimizationGoalUnmarshalMetricShape(t *testing.T) {
+	raw := []byte(`{
+		"kind": "metric",
+		"metric": "reach",
+		"reach_unit": "household",
+		"target_frequency": {
+			"min": 2,
+			"max": 5,
+			"window": {"interval": 7, "unit": "days"}
+		},
+		"target": {"kind": "threshold_rate", "value": 0.65},
+		"priority": 1
+	}`)
+	var goal OptimizationGoal
+	if err := json.Unmarshal(raw, &goal); err != nil {
+		t.Fatalf("unmarshal metric optimization goal: %v", err)
+	}
+	if goal.Kind != "metric" || goal.Metric != "reach" || goal.ReachUnit != "household" {
+		t.Fatalf("unexpected metric optimization goal fields: %#v", goal)
+	}
+	if goal.TargetFrequency == nil || goal.TargetFrequency.Min != 2 || goal.TargetFrequency.Max != 5 {
+		t.Fatalf("target_frequency not typed: %#v", goal.TargetFrequency)
+	}
+	if goal.TargetFrequency.Window.Interval != 7 || goal.TargetFrequency.Window.Unit != "days" {
+		t.Fatalf("target_frequency window not typed: %#v", goal.TargetFrequency.Window)
+	}
+	target, ok := goal.Target.(map[string]any)
+	if !ok || target["kind"] != "threshold_rate" {
+		t.Fatalf("target oneOf should remain a raw map, got %#v", goal.Target)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -51,6 +51,7 @@ KNOWN_TYPES = {
     # oneOf schemas — generator produces `type X = any`; hand-writing flattens
     # the union into a single struct with all variant fields.
     'PricingOption', 'Deployment', 'PublisherPropertySelector',
+    'OptimizationGoal',
     # From inputs.go (hand-written types that need custom Go code)
     'EmptyInput',
     'AccountInput', 'GovernanceAccountInput',
@@ -213,6 +214,7 @@ CORE_SCHEMAS = [
     "core/diagnostic-issue.json",
     "core/collection-selector.json",
     "core/package.json",
+    "core/optimization-goal.json",
     "pricing-options/price-breakdown.json",
     "core/media-buy.json",
     "core/pricing-option.json",
@@ -611,6 +613,18 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "#/properties/media_buy_deliveries/items/properties/by_package/items"
         "/allOf/1/properties/daily_breakdown/items",
     ),
+    (
+        "OptimizationGoalTargetFrequency",
+        "core/optimization-goal.json#/oneOf/0/properties/target_frequency",
+    ),
+    (
+        "OptimizationGoalEventSource",
+        "core/optimization-goal.json#/oneOf/1/properties/event_sources/items",
+    ),
+    (
+        "OptimizationGoalAttributionWindow",
+        "core/optimization-goal.json#/oneOf/1/properties/attribution_window",
+    ),
 ])
 
 # Named helper types generated for simple union schemas. These cover the common
@@ -850,6 +864,10 @@ INLINE_TYPE_HINTS = {
     ('CreativeFormat', 'renders'): 'Render',
     ('CreativeFormat', 'assets'): 'AssetSlot',
     ('GetMediaBuysResponse', 'media_buys'): 'MediaBuyData',
+    ('Package', 'optimization_goals'): 'OptimizationGoal',
+    ('PackageInput', 'optimization_goals'): 'OptimizationGoal',
+    ('PackageUpdate', 'optimization_goals'): 'OptimizationGoal',
+    ('OptimizationGoalEventSource', 'value_factor'): '*float64',
 }
 
 for _delivery_metric_type in (

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -99,6 +99,9 @@ EXEMPT = {
     # PublisherPropertySelector is a hand-flattened oneOf; publisher-property-
     # selector.json is a oneOf of three variants and has no top-level properties.
     'PublisherPropertySelector',
+    # OptimizationGoal is hand-flattened from a oneOf and preserves unknown
+    # top-level keys for replacement-update round trips.
+    'OptimizationGoal',
 }
 
 # Map hand-written Go type name → schema path (relative to schemas/).

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -432,6 +432,112 @@ type PricingOption struct {
 	Parameters          any      `json:"parameters,omitempty"`
 }
 
+// OptimizationGoal is a flattened representation of the optimization-goal
+// oneOf. Target remains the nested raw oneOf payload, while Extra preserves
+// schema-allowed future fields so read-modify-write callers do not strip
+// unknown goal metadata on replacement updates. Extra keys that collide with
+// typed fields are ignored when marshaling; set the typed field instead.
+type OptimizationGoal struct {
+	Kind                string                             `json:"kind,omitempty"`
+	Metric              string                             `json:"metric,omitempty"`
+	ReachUnit           string                             `json:"reach_unit,omitempty"`
+	TargetFrequency     *OptimizationGoalTargetFrequency   `json:"target_frequency,omitempty"`
+	ViewDurationSeconds float64                            `json:"view_duration_seconds,omitempty"`
+	Target              any                                `json:"target,omitempty"`
+	Priority            int                                `json:"priority,omitempty"`
+	EventSources        []OptimizationGoalEventSource      `json:"event_sources,omitempty"`
+	AttributionWindow   *OptimizationGoalAttributionWindow `json:"attribution_window,omitempty"`
+	Extra               map[string]any                     `json:"-"`
+}
+
+func (g OptimizationGoal) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(g.Extra))
+	for k, v := range g.Extra {
+		if isOptimizationGoalTypedJSONField(k) {
+			continue
+		}
+		out[k] = v
+	}
+	if g.Kind != "" {
+		out["kind"] = g.Kind
+	}
+	if g.Metric != "" {
+		out["metric"] = g.Metric
+	}
+	if g.ReachUnit != "" {
+		out["reach_unit"] = g.ReachUnit
+	}
+	if g.TargetFrequency != nil {
+		out["target_frequency"] = g.TargetFrequency
+	}
+	if g.ViewDurationSeconds != 0 {
+		out["view_duration_seconds"] = g.ViewDurationSeconds
+	}
+	if g.Target != nil {
+		out["target"] = g.Target
+	}
+	if g.Priority != 0 {
+		out["priority"] = g.Priority
+	}
+	if len(g.EventSources) > 0 {
+		out["event_sources"] = g.EventSources
+	}
+	if g.AttributionWindow != nil {
+		out["attribution_window"] = g.AttributionWindow
+	}
+	return json.Marshal(out)
+}
+
+func isOptimizationGoalTypedJSONField(key string) bool {
+	switch key {
+	case "kind",
+		"metric",
+		"reach_unit",
+		"target_frequency",
+		"view_duration_seconds",
+		"target",
+		"priority",
+		"event_sources",
+		"attribution_window":
+		return true
+	default:
+		return false
+	}
+}
+
+func (g *OptimizationGoal) UnmarshalJSON(data []byte) error {
+	type alias OptimizationGoal
+	var typed alias
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for key := range raw {
+		if isOptimizationGoalTypedJSONField(key) {
+			delete(raw, key)
+		}
+	}
+
+	*g = OptimizationGoal(typed)
+	if len(raw) == 0 {
+		g.Extra = nil
+		return nil
+	}
+	g.Extra = make(map[string]any, len(raw))
+	for k, v := range raw {
+		var value any
+		if err := json.Unmarshal(v, &value); err != nil {
+			return err
+		}
+		g.Extra[k] = value
+	}
+	return nil
+}
+
 type MediaBuyListItem struct {
 	MediaBuyID string    `json:"media_buy_id"`
 	Status     string    `json:"status"`

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5613,7 +5613,7 @@ type Package struct {
 	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"` // Agreed performance standards for this package. When any entry specifies a vendor
 	CreativeAssignments []CreativeAssignment `json:"creative_assignments,omitempty"` // Creative assets assigned to this package
 	FormatIDsToProvide []FormatRef `json:"format_ids_to_provide,omitempty"` // Format IDs that creative assets will be provided for this package
-	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
+	OptimizationGoals []OptimizationGoal `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
 	StartTime string `json:"start_time,omitempty"` // Flight start date/time for this package in ISO 8601 format. When omitted, the pa
 	EndTime string `json:"end_time,omitempty"` // Flight end date/time for this package in ISO 8601 format. When omitted, the pack
 	Paused *bool `json:"paused,omitempty"` // Whether this package is paused by the buyer. Paused packages do not deliver impr
@@ -6092,7 +6092,7 @@ type PackageInput struct {
 	EndTime string `json:"end_time,omitempty"` // Flight end date/time for this package in ISO 8601 format. When omitted, the pack
 	Paused *bool `json:"paused,omitempty"` // Whether this package should be created in a paused state. Paused packages do not
 	Catalogs []Catalog `json:"catalogs,omitempty"` // Catalogs this package promotes. Each catalog MUST have a distinct type (e.g., on
-	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
+	OptimizationGoals []OptimizationGoal `json:"optimization_goals,omitempty"` // Optimization targets for this package. The seller optimizes delivery toward thes
 	TargetingOverlay *Targeting `json:"targeting_overlay,omitempty"`
 	MeasurementTerms *MeasurementTerms `json:"measurement_terms,omitempty"` // Buyer's proposed billing measurement and makegood terms. Overrides product defau
 	PerformanceStandards []PerformanceStandard `json:"performance_standards,omitempty"` // Buyer's proposed performance standards for this package. Overrides product defau
@@ -6116,7 +6116,7 @@ type PackageUpdate struct {
 	Canceled *bool `json:"canceled,omitempty"` // Cancel this specific package. Cancellation is irreversible — canceled packages s
 	CancellationReason string `json:"cancellation_reason,omitempty"` // Reason for canceling this package.
 	Catalogs []Catalog `json:"catalogs,omitempty"` // Replace the catalogs this package promotes. Uses replacement semantics — the pro
-	OptimizationGoals []any `json:"optimization_goals,omitempty"` // Replace all optimization goals for this package. Uses replacement semantics — om
+	OptimizationGoals []OptimizationGoal `json:"optimization_goals,omitempty"` // Replace all optimization goals for this package. Uses replacement semantics — om
 	TargetingOverlay *Targeting `json:"targeting_overlay,omitempty"` // Targeting overlay to apply to this package. Uses replacement semantics — the ful
 	KeywordTargetsAdd []KeywordTargetUpdate `json:"keyword_targets_add,omitempty"` // Keyword targets to add or update on this package. Upserts by (keyword, match_typ
 	KeywordTargetsRemove []KeywordTargetRef `json:"keyword_targets_remove,omitempty"` // Keyword targets to remove from this package. Removes matching (keyword, match_ty
@@ -6967,6 +6967,27 @@ type PackageDailyBreakdown struct {
 	ConversionValue float64 `json:"conversion_value,omitempty"` // Daily conversion value for this package
 	Roas float64 `json:"roas,omitempty"` // Daily return on ad spend (conversion_value / spend)
 	NewToBrandRate float64 `json:"new_to_brand_rate,omitempty"` // Daily fraction of conversions from first-time brand buyers (0 = none, 1 = all)
+}
+
+// OptimizationGoalTargetFrequency — Target frequency band for reach optimization. Only applicable when metric is 'reach'. Frames frequen
+type OptimizationGoalTargetFrequency struct {
+	Min int `json:"min,omitempty"` // Minimum frequency for an entity to be considered meaningfully reached within the
+	Max int `json:"max,omitempty"` // Frequency at which an entity is considered saturated within the window. Impressi
+	Window Duration `json:"window"` // Time window over which frequency is measured (e.g. {"interval": 7, "unit": "days
+}
+
+type OptimizationGoalEventSource struct {
+	EventSourceID string `json:"event_source_id"` // Event source to include (must be configured on this account via sync_event_sourc
+	EventType string `json:"event_type"` // Event type to include from this source (e.g., purchase, lead, app_install, refun
+	CustomEventName string `json:"custom_event_name,omitempty"` // Required when event_type is 'custom'. Platform-specific name for the custom even
+	ValueField string `json:"value_field,omitempty"` // Which field in the event's custom_data carries the monetary value. The seller mu
+	ValueFactor *float64 `json:"value_factor,omitempty"` // Multiplier the seller must apply to value_field before aggregation. Use -1 for r
+}
+
+// OptimizationGoalAttributionWindow — Attribution window for this optimization goal. Values must match an option declared in the seller's
+type OptimizationGoalAttributionWindow struct {
+	PostClick Duration `json:"post_click"` // Post-click attribution window. Conversions within this duration after a click ar
+	PostView *Duration `json:"post_view,omitempty"` // Post-view attribution window. Conversions within this duration after an ad impre
 }
 
 // --- Tool request/response types ---


### PR DESCRIPTION
## Summary

- type package `optimization_goals` surfaces as `[]adcp.OptimizationGoal` on `Package`, `PackageInput`, and `PackageUpdate`
- add schema-owned nested goal helpers for `target_frequency`, `event_sources`, and `attribution_window` while leaving nested `target` as the raw schema oneOf payload
- preserve unknown top-level optimization goal fields through `OptimizationGoal.Extra` so replacement-style update round trips do not strip future schema metadata
- ignore known typed keys in hand-constructed `OptimizationGoal.Extra`, so `Extra` cannot override canonical typed fields
- ratchet generated unreviewed `any` coverage from 45 to 42 and document the exported breaking type changes in `MIGRATING.md`

Refs #176.

## Expert review notes

- Protocol review flagged that `value_factor` must distinguish omission from explicit `0`; the generated helper uses `*float64`.
- Code review flagged that a plain generated struct would drop future top-level goal fields during read-modify-write replacement updates; `OptimizationGoal.Extra` covers that case.
- We are not inventing nested target fields here. `target` stays `any` until nested union generation can model it from schema.
- The local 3.0.12 `core/optimization-goal.json` variants and nested objects declare `additionalProperties: true`, so preserving `Extra` is schema-compatible.

## Validation

- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 42`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 -m unittest generate_test.py`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`