### PR TITLE
feat(adcp)!: type optimization goal targets

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -162,6 +162,7 @@ be populated.
 | `Package.OptimizationGoals` | `[]adcp.OptimizationGoal` |
 | `PackageInput.OptimizationGoals` | `[]adcp.OptimizationGoal` |
 | `PackageUpdate.OptimizationGoals` | `[]adcp.OptimizationGoal` |
+| `OptimizationGoal.Target` | `adcp.OptimizationGoalTarget` |
 | `GetMediaBuysRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
 | `GetMediaBuyDeliveryRequest.StatusFilter` | `*adcp.MediaBuyStatusFilter` |
 | `GetMediaBuyDeliveryRequest.AttributionWindow` | `*adcp.DeliveryAttributionWindow` |
@@ -276,9 +277,34 @@ feedback := adcp.ProvidePerformanceFeedbackRequest{
   and `Ext`.
 - `OptimizationGoals` fields now use `[]adcp.OptimizationGoal` instead of
   `[]any`. Nested `event_sources`, `target_frequency`, and `attribution_window`
-  are typed; the nested `target` oneOf remains `any` until nested union
-  generation lands. `OptimizationGoal.Extra` preserves unknown top-level fields
-  when round-tripping newer goal variants through replacement-style updates.
+  are typed, and the nested `target` oneOf is now the
+  `adcp.OptimizationGoalTarget` interface. Use concrete target variants such as
+  `adcp.OptimizationGoalCostPerTarget`,
+  `adcp.OptimizationGoalThresholdRateTarget`,
+  `adcp.OptimizationGoalPerAdSpendTarget`, and
+  `adcp.OptimizationGoalMaximizeValueTarget`. Unknown future target variants
+  round-trip through `adcp.OptimizationGoalRawTarget`.
+  `OptimizationGoal.Extra` preserves unknown top-level fields when
+  round-tripping newer goal variants through replacement-style updates.
+
+```go
+goal := adcp.OptimizationGoal{
+  Kind:   "metric",
+  Metric: "reach",
+  Target: adcp.OptimizationGoalThresholdRateTarget{Value: 0.7},
+}
+
+switch target := goal.Target.(type) {
+case *adcp.OptimizationGoalThresholdRateTarget:
+  _ = target.Value
+case adcp.OptimizationGoalThresholdRateTarget:
+  _ = target.Value
+}
+```
+
+JSON unmarshal always produces the pointer form; the value form is what you get
+when constructing goals directly in Go.
+
 - `SyncCreativesRequest.Assignments` is now `[]adcp.SyncCreativeAssignment`.
 - `Config.CreateMediaBuy` now returns `adcp.CreateMediaBuyResult`, which is
   implemented by the generated schema variants. Return

--- a/adcp/addtool.go
+++ b/adcp/addtool.go
@@ -97,9 +97,14 @@ func allowAdditionalProperties(s *jsonschema.Schema) {
 	// Remove properties that serialize to `true` (the accept-anything schema
 	// generated for `any`/`interface{}` fields). These cause validation errors
 	// in some schema validators. The field is still accepted because
-	// additionalProperties is not restricted.
+	// additionalProperties is not restricted. Known typed interfaces get schema
+	// overrides so tool discovery does not lose protocol fields.
 	for name, prop := range s.Properties {
 		if isTrueSchema(prop) {
+			if name == "target" && isOptimizationGoalSchema(s) {
+				s.Properties[name] = optimizationGoalTargetJSONSchema()
+				continue
+			}
 			delete(s.Properties, name)
 			// Also remove from required if present
 			s.Required = slices.DeleteFunc(s.Required, func(s string) bool { return s == name })
@@ -144,6 +149,51 @@ func isTrueSchema(s *jsonschema.Schema) bool {
 		return false
 	}
 	return string(b) == "true"
+}
+
+func isOptimizationGoalSchema(s *jsonschema.Schema) bool {
+	if s == nil || s.Type != "object" || s.Properties == nil {
+		return false
+	}
+	if _, ok := s.Properties["kind"]; !ok {
+		return false
+	}
+	_, hasMetric := s.Properties["metric"]
+	_, hasEventSources := s.Properties["event_sources"]
+	_, hasTarget := s.Properties["target"]
+	return hasTarget && (hasMetric || hasEventSources)
+}
+
+func optimizationGoalTargetJSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{OneOf: []*jsonschema.Schema{
+		optimizationGoalTargetVariantSchema("cost_per", true, "Target cost per unit of the metric or conversion event."),
+		optimizationGoalTargetVariantSchema("threshold_rate", true, "Minimum per-impression rate for the metric."),
+		optimizationGoalTargetVariantSchema("per_ad_spend", true, "Target return per unit of ad spend."),
+		optimizationGoalTargetVariantSchema("maximize_value", false, "Maximize total conversion value within budget."),
+	}}
+}
+
+func optimizationGoalTargetVariantSchema(kind string, withValue bool, description string) *jsonschema.Schema {
+	kindValue := any(kind)
+	properties := map[string]*jsonschema.Schema{
+		"kind": {
+			Type:  "string",
+			Const: &kindValue,
+		},
+	}
+	required := []string{"kind"}
+	if withValue {
+		properties["value"] = &jsonschema.Schema{
+			Type: "number",
+		}
+		required = append(required, "value")
+	}
+	return &jsonschema.Schema{
+		Type:        "object",
+		Description: description,
+		Properties:  properties,
+		Required:    required,
+	}
 }
 
 // jsonRoundTrip marshals a value to JSON and back, ensuring struct tags

--- a/adcp/addtool_test.go
+++ b/adcp/addtool_test.go
@@ -3,6 +3,7 @@ package adcp
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -136,4 +137,24 @@ func TestPermissiveSchemaVsDefaultSchema(t *testing.T) {
 	// Our permissive schema should NOT
 	permissive := permissiveSchemaFor[testInput]()
 	assert.Nil(t, permissive.AdditionalProperties, "expected permissive schema to have nil additionalProperties")
+}
+
+func TestPermissiveSchemaPreservesOptimizationGoalTarget(t *testing.T) {
+	schema := permissiveSchemaFor[PackageInput]()
+
+	b, err := json.Marshal(schema)
+	require.NoError(t, err, "failed to marshal package input schema")
+	body := string(b)
+
+	assert.Contains(t, body, `"optimization_goals"`, "expected optimization_goals in schema")
+	assert.Contains(t, body, `"target"`, "expected optimization goal target in schema")
+	for _, want := range []string{
+		`"const":"cost_per"`,
+		`"const":"threshold_rate"`,
+		`"const":"per_ad_spend"`,
+		`"const":"maximize_value"`,
+	} {
+		assert.Contains(t, body, want, "expected target variant %s in schema", want)
+	}
+	assert.True(t, strings.Count(body, `"const":"threshold_rate"`) >= 1, "expected threshold_rate target variant")
 }

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -389,7 +389,7 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 						Max:    3,
 						Window: Duration{Interval: 7, Unit: "days"},
 					},
-					Target:   map[string]any{"kind": "threshold_rate", "value": 0.7},
+					Target:   OptimizationGoalThresholdRateTarget{Value: 0.7},
 					Priority: 1,
 				}},
 			},
@@ -580,7 +580,7 @@ func TestGeneratedOptimizationGoalUnmarshalNestedShapes(t *testing.T) {
 				"value_field": "value",
 				"value_factor": 1.5
 			}],
-			"target": {"kind": "per_ad_spend", "value": 4},
+			"target": {"kind": "per_ad_spend", "value": 4, "future_target_field": "ok"},
 			"future_goal_field": {"keep": true},
 			"attribution_window": {
 				"post_click": {"interval": 7, "unit": "days"},
@@ -609,9 +609,12 @@ func TestGeneratedOptimizationGoalUnmarshalNestedShapes(t *testing.T) {
 	if goal.AttributionWindow == nil || goal.AttributionWindow.PostClick.Interval != 7 || goal.AttributionWindow.PostView == nil {
 		t.Fatalf("attribution_window not typed: %#v", goal.AttributionWindow)
 	}
-	target, ok := goal.Target.(map[string]any)
-	if !ok || target["kind"] != "per_ad_spend" {
-		t.Fatalf("target oneOf should remain a raw map, got %#v", goal.Target)
+	target, ok := goal.Target.(*OptimizationGoalPerAdSpendTarget)
+	if !ok || target.Kind != "per_ad_spend" || target.Value != 4 {
+		t.Fatalf("target oneOf should decode as per_ad_spend, got %#v", goal.Target)
+	}
+	if target.Extra["future_target_field"] != "ok" {
+		t.Fatalf("target extra field was not preserved: %#v", target.Extra)
 	}
 	extra, ok := goal.Extra["future_goal_field"].(map[string]any)
 	if !ok || extra["keep"] != true {
@@ -624,6 +627,9 @@ func TestGeneratedOptimizationGoalUnmarshalNestedShapes(t *testing.T) {
 	}
 	if !strings.Contains(string(roundTrip), `"future_goal_field":{"keep":true}`) {
 		t.Fatalf("round trip dropped unknown top-level goal field: %s", roundTrip)
+	}
+	if !strings.Contains(string(roundTrip), `"target":{"future_target_field":"ok","kind":"per_ad_spend","value":4}`) {
+		t.Fatalf("round trip dropped unknown target field: %s", roundTrip)
 	}
 
 	collidingExtra, err := json.Marshal(OptimizationGoal{
@@ -669,9 +675,135 @@ func TestGeneratedOptimizationGoalUnmarshalMetricShape(t *testing.T) {
 	if goal.TargetFrequency.Window.Interval != 7 || goal.TargetFrequency.Window.Unit != "days" {
 		t.Fatalf("target_frequency window not typed: %#v", goal.TargetFrequency.Window)
 	}
-	target, ok := goal.Target.(map[string]any)
-	if !ok || target["kind"] != "threshold_rate" {
-		t.Fatalf("target oneOf should remain a raw map, got %#v", goal.Target)
+	target, ok := goal.Target.(*OptimizationGoalThresholdRateTarget)
+	if !ok || target.Kind != "threshold_rate" || target.Value != 0.65 {
+		t.Fatalf("target oneOf should decode as threshold_rate, got %#v", goal.Target)
+	}
+}
+
+func TestGeneratedOptimizationGoalTargetVariants(t *testing.T) {
+	cases := []struct {
+		name  string
+		value OptimizationGoalTarget
+		want  string
+	}{
+		{
+			name:  "cost per",
+			value: OptimizationGoalCostPerTarget{Value: 2.5},
+			want:  `{"kind":"cost_per","value":2.5}`,
+		},
+		{
+			name:  "threshold rate",
+			value: OptimizationGoalThresholdRateTarget{Value: 0.25},
+			want:  `{"kind":"threshold_rate","value":0.25}`,
+		},
+		{
+			name:  "per ad spend",
+			value: OptimizationGoalPerAdSpendTarget{Value: 4},
+			want:  `{"kind":"per_ad_spend","value":4}`,
+		},
+		{
+			name:  "maximize value",
+			value: OptimizationGoalMaximizeValueTarget{},
+			want:  `{"kind":"maximize_value"}`,
+		},
+		{
+			name: "maximize value drops colliding value extra",
+			value: OptimizationGoalMaximizeValueTarget{
+				Extra: map[string]any{
+					"value":               99,
+					"future_target_field": "ok",
+				},
+			},
+			want: `{"future_target_field":"ok","kind":"maximize_value"}`,
+		},
+		{
+			name: "target extra",
+			value: OptimizationGoalThresholdRateTarget{
+				Value: 0.5,
+				Extra: map[string]any{
+					"future_target_field": "ok",
+					"kind":                "wrong",
+					"value":               99,
+				},
+			},
+			want: `{"future_target_field":"ok","kind":"threshold_rate","value":0.5}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.value)
+			if err != nil {
+				t.Fatalf("marshal target: %v", err)
+			}
+			if string(raw) != tc.want {
+				t.Fatalf("target JSON = %s, want %s", raw, tc.want)
+			}
+		})
+	}
+
+	var unknown OptimizationGoal
+	if err := json.Unmarshal([]byte(`{
+		"kind": "event",
+		"event_sources": [{"event_source_id": "pixel-1", "event_type": "purchase"}],
+		"target": {"kind": "future_target", "future_target_field": true}
+	}`), &unknown); err != nil {
+		t.Fatalf("unmarshal unknown target: %v", err)
+	}
+	rawTarget, ok := unknown.Target.(*OptimizationGoalRawTarget)
+	if !ok || rawTarget.Kind != "future_target" {
+		t.Fatalf("unknown target did not decode as raw target: %#v", unknown.Target)
+	}
+	if rawTarget.Extra["future_target_field"] != true {
+		t.Fatalf("raw target extra not preserved: %#v", rawTarget.Extra)
+	}
+	roundTrip, err := json.Marshal(unknown)
+	if err != nil {
+		t.Fatalf("marshal unknown target: %v", err)
+	}
+	if !strings.Contains(string(roundTrip), `"target":{"future_target_field":true,"kind":"future_target"}`) {
+		t.Fatalf("unknown target did not round-trip: %s", roundTrip)
+	}
+
+	var nilCostPer *OptimizationGoalCostPerTarget
+	withoutTarget, err := json.Marshal(OptimizationGoal{
+		Kind:   "metric",
+		Metric: "clicks",
+		Target: nilCostPer,
+	})
+	if err != nil {
+		t.Fatalf("marshal typed nil target: %v", err)
+	}
+	if strings.Contains(string(withoutTarget), `"target"`) {
+		t.Fatalf("typed nil target should omit target: %s", withoutTarget)
+	}
+}
+
+func TestGeneratedOptimizationGoalCostPerTargetSharedAcrossGoalKinds(t *testing.T) {
+	raw := []byte(`{
+		"optimization_goals": [
+			{"kind": "metric", "metric": "clicks", "target": {"kind": "cost_per", "value": 1.25}},
+			{
+				"kind": "event",
+				"event_sources": [{"event_source_id": "pixel-1", "event_type": "purchase"}],
+				"target": {"kind": "cost_per", "value": 8.5}
+			}
+		]
+	}`)
+	var req PackageInput
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal cost_per targets: %v", err)
+	}
+	if len(req.OptimizationGoals) != 2 {
+		t.Fatalf("optimization_goals len = %d, want 2", len(req.OptimizationGoals))
+	}
+	metricTarget, ok := req.OptimizationGoals[0].Target.(*OptimizationGoalCostPerTarget)
+	if !ok || metricTarget.Value != 1.25 {
+		t.Fatalf("metric cost_per target = %#v", req.OptimizationGoals[0].Target)
+	}
+	eventTarget, ok := req.OptimizationGoals[1].Target.(*OptimizationGoalCostPerTarget)
+	if !ok || eventTarget.Value != 8.5 {
+		t.Fatalf("event cost_per target = %#v", req.OptimizationGoals[1].Target)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -52,6 +52,8 @@ KNOWN_TYPES = {
     # the union into a single struct with all variant fields.
     'PricingOption', 'Deployment', 'PublisherPropertySelector',
     'OptimizationGoal',
+    'OptimizationGoalCostPerTarget', 'OptimizationGoalThresholdRateTarget',
+    'OptimizationGoalPerAdSpendTarget', 'OptimizationGoalMaximizeValueTarget',
     # From inputs.go (hand-written types that need custom Go code)
     'EmptyInput',
     'AccountInput', 'GovernanceAccountInput',
@@ -700,6 +702,10 @@ HAND_WRITTEN_SCHEMA_SPECS = {
     'IdentityKeyOrigins': 'protocol/get-adcp-capabilities-response.json#/properties/identity/properties/key_origins',
     'IdentityCompromiseNotification': 'protocol/get-adcp-capabilities-response.json#/properties/identity/properties/compromise_notification',
     'ComplianceTestingCapabilities': 'protocol/get-adcp-capabilities-response.json#/properties/compliance_testing',
+    'OptimizationGoalCostPerTarget': 'core/optimization-goal.json#/oneOf/0/properties/target/oneOf/0',
+    'OptimizationGoalThresholdRateTarget': 'core/optimization-goal.json#/oneOf/0/properties/target/oneOf/1',
+    'OptimizationGoalPerAdSpendTarget': 'core/optimization-goal.json#/oneOf/1/properties/target/oneOf/1',
+    'OptimizationGoalMaximizeValueTarget': 'core/optimization-goal.json#/oneOf/1/properties/target/oneOf/2',
 }
 
 # Map schema-derived Go names to the preferred Go name. Applied both when

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -8,6 +8,18 @@ from collections import OrderedDict
 import generate
 
 
+def without_descriptions(value):
+    if isinstance(value, dict):
+        return {
+            key: without_descriptions(item)
+            for key, item in value.items()
+            if key != "description"
+        }
+    if isinstance(value, list):
+        return [without_descriptions(item) for item in value]
+    return value
+
+
 def scalar_or_array_schema(min_items=1, description="Test union"):
     return {
         "description": description,
@@ -241,6 +253,24 @@ class EnumGenerationTest(unittest.TestCase):
             with open(f"{tmp}/enum_test.go", "w") as f:
                 f.write(source)
             subprocess.run(["go", "test", "."], cwd=tmp, check=True)
+
+
+class OptimizationGoalSchemaTest(unittest.TestCase):
+    def test_cost_per_target_branches_stay_structurally_equivalent(self):
+        schema = generate.load_schema("core/optimization-goal.json")
+        metric_cost_per = generate.json_pointer_get(
+            schema,
+            "/oneOf/0/properties/target/oneOf/0",
+        )
+        event_cost_per = generate.json_pointer_get(
+            schema,
+            "/oneOf/1/properties/target/oneOf/0",
+        )
+
+        self.assertEqual(
+            without_descriptions(metric_cost_per),
+            without_descriptions(event_cost_per),
+        )
 
 
 if __name__ == "__main__":

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -433,17 +433,17 @@ type PricingOption struct {
 }
 
 // OptimizationGoal is a flattened representation of the optimization-goal
-// oneOf. Target remains the nested raw oneOf payload, while Extra preserves
-// schema-allowed future fields so read-modify-write callers do not strip
-// unknown goal metadata on replacement updates. Extra keys that collide with
-// typed fields are ignored when marshaling; set the typed field instead.
+// oneOf. Extra preserves schema-allowed future fields so read-modify-write
+// callers do not strip unknown goal metadata on replacement updates. Extra keys
+// that collide with typed fields are ignored when marshaling; set the typed
+// field instead.
 type OptimizationGoal struct {
 	Kind                string                             `json:"kind,omitempty"`
 	Metric              string                             `json:"metric,omitempty"`
 	ReachUnit           string                             `json:"reach_unit,omitempty"`
 	TargetFrequency     *OptimizationGoalTargetFrequency   `json:"target_frequency,omitempty"`
 	ViewDurationSeconds float64                            `json:"view_duration_seconds,omitempty"`
-	Target              any                                `json:"target,omitempty"`
+	Target              OptimizationGoalTarget             `json:"target,omitempty"`
 	Priority            int                                `json:"priority,omitempty"`
 	EventSources        []OptimizationGoalEventSource      `json:"event_sources,omitempty"`
 	AttributionWindow   *OptimizationGoalAttributionWindow `json:"attribution_window,omitempty"`
@@ -473,7 +473,7 @@ func (g OptimizationGoal) MarshalJSON() ([]byte, error) {
 	if g.ViewDurationSeconds != 0 {
 		out["view_duration_seconds"] = g.ViewDurationSeconds
 	}
-	if g.Target != nil {
+	if !isNilOptimizationGoalTarget(g.Target) {
 		out["target"] = g.Target
 	}
 	if g.Priority != 0 {
@@ -506,8 +506,17 @@ func isOptimizationGoalTypedJSONField(key string) bool {
 }
 
 func (g *OptimizationGoal) UnmarshalJSON(data []byte) error {
-	type alias OptimizationGoal
-	var typed alias
+	var typed struct {
+		Kind                string                             `json:"kind,omitempty"`
+		Metric              string                             `json:"metric,omitempty"`
+		ReachUnit           string                             `json:"reach_unit,omitempty"`
+		TargetFrequency     *OptimizationGoalTargetFrequency   `json:"target_frequency,omitempty"`
+		ViewDurationSeconds float64                            `json:"view_duration_seconds,omitempty"`
+		Target              json.RawMessage                    `json:"target,omitempty"`
+		Priority            int                                `json:"priority,omitempty"`
+		EventSources        []OptimizationGoalEventSource      `json:"event_sources,omitempty"`
+		AttributionWindow   *OptimizationGoalAttributionWindow `json:"attribution_window,omitempty"`
+	}
 	if err := json.Unmarshal(data, &typed); err != nil {
 		return err
 	}
@@ -522,7 +531,26 @@ func (g *OptimizationGoal) UnmarshalJSON(data []byte) error {
 		}
 	}
 
-	*g = OptimizationGoal(typed)
+	var target OptimizationGoalTarget
+	if len(typed.Target) > 0 && string(typed.Target) != "null" {
+		var err error
+		target, err = unmarshalOptimizationGoalTarget(typed.Target)
+		if err != nil {
+			return err
+		}
+	}
+
+	*g = OptimizationGoal{
+		Kind:                typed.Kind,
+		Metric:              typed.Metric,
+		ReachUnit:           typed.ReachUnit,
+		TargetFrequency:     typed.TargetFrequency,
+		ViewDurationSeconds: typed.ViewDurationSeconds,
+		Target:              target,
+		Priority:            typed.Priority,
+		EventSources:        typed.EventSources,
+		AttributionWindow:   typed.AttributionWindow,
+	}
 	if len(raw) == 0 {
 		g.Extra = nil
 		return nil
@@ -536,6 +564,275 @@ func (g *OptimizationGoal) UnmarshalJSON(data []byte) error {
 		g.Extra[k] = value
 	}
 	return nil
+}
+
+// OptimizationGoalTarget is a typed optimization-goal target variant.
+// Unknown future target objects decode as *OptimizationGoalRawTarget.
+// Go types do not enforce which target kinds are legal for metric vs event
+// goals; sellers should still validate the full OptimizationGoal against the
+// schema and their product capabilities.
+type OptimizationGoalTarget interface {
+	isOptimizationGoalTarget()
+}
+
+// OptimizationGoalCostPerTarget is a target cost per unit of the metric or
+// conversion event. MarshalJSON emits kind=cost_per.
+type OptimizationGoalCostPerTarget struct {
+	Kind  string         `json:"kind"`
+	Value float64        `json:"value"`
+	Extra map[string]any `json:"-"`
+}
+
+func (OptimizationGoalCostPerTarget) isOptimizationGoalTarget() {}
+
+func (t OptimizationGoalCostPerTarget) MarshalJSON() ([]byte, error) {
+	return marshalOptimizationGoalTarget("cost_per", t.Value, true, t.Extra)
+}
+
+func (t *OptimizationGoalCostPerTarget) UnmarshalJSON(data []byte) error {
+	var typed struct {
+		Kind  string  `json:"kind"`
+		Value float64 `json:"value"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	t.Kind = typed.Kind
+	t.Value = typed.Value
+	extra, err := unmarshalOptimizationGoalTargetExtra(data, "kind", "value")
+	if err != nil {
+		return err
+	}
+	t.Extra = extra
+	return nil
+}
+
+// OptimizationGoalThresholdRateTarget is a minimum per-impression target rate.
+// MarshalJSON emits kind=threshold_rate.
+type OptimizationGoalThresholdRateTarget struct {
+	Kind  string         `json:"kind"`
+	Value float64        `json:"value"`
+	Extra map[string]any `json:"-"`
+}
+
+func (OptimizationGoalThresholdRateTarget) isOptimizationGoalTarget() {}
+
+func (t OptimizationGoalThresholdRateTarget) MarshalJSON() ([]byte, error) {
+	return marshalOptimizationGoalTarget("threshold_rate", t.Value, true, t.Extra)
+}
+
+func (t *OptimizationGoalThresholdRateTarget) UnmarshalJSON(data []byte) error {
+	var typed struct {
+		Kind  string  `json:"kind"`
+		Value float64 `json:"value"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	t.Kind = typed.Kind
+	t.Value = typed.Value
+	extra, err := unmarshalOptimizationGoalTargetExtra(data, "kind", "value")
+	if err != nil {
+		return err
+	}
+	t.Extra = extra
+	return nil
+}
+
+// OptimizationGoalPerAdSpendTarget is a return per unit of ad spend target.
+// MarshalJSON emits kind=per_ad_spend.
+type OptimizationGoalPerAdSpendTarget struct {
+	Kind  string         `json:"kind"`
+	Value float64        `json:"value"`
+	Extra map[string]any `json:"-"`
+}
+
+func (OptimizationGoalPerAdSpendTarget) isOptimizationGoalTarget() {}
+
+func (t OptimizationGoalPerAdSpendTarget) MarshalJSON() ([]byte, error) {
+	return marshalOptimizationGoalTarget("per_ad_spend", t.Value, true, t.Extra)
+}
+
+func (t *OptimizationGoalPerAdSpendTarget) UnmarshalJSON(data []byte) error {
+	var typed struct {
+		Kind  string  `json:"kind"`
+		Value float64 `json:"value"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	t.Kind = typed.Kind
+	t.Value = typed.Value
+	extra, err := unmarshalOptimizationGoalTargetExtra(data, "kind", "value")
+	if err != nil {
+		return err
+	}
+	t.Extra = extra
+	return nil
+}
+
+// OptimizationGoalMaximizeValueTarget maximizes total conversion value within
+// budget. MarshalJSON emits kind=maximize_value.
+type OptimizationGoalMaximizeValueTarget struct {
+	Kind  string         `json:"kind"`
+	Extra map[string]any `json:"-"`
+}
+
+func (OptimizationGoalMaximizeValueTarget) isOptimizationGoalTarget() {}
+
+func (t OptimizationGoalMaximizeValueTarget) MarshalJSON() ([]byte, error) {
+	return marshalOptimizationGoalTarget("maximize_value", 0, false, t.Extra)
+}
+
+func (t *OptimizationGoalMaximizeValueTarget) UnmarshalJSON(data []byte) error {
+	var typed struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	t.Kind = typed.Kind
+	extra, err := unmarshalOptimizationGoalTargetExtra(data, "kind")
+	if err != nil {
+		return err
+	}
+	t.Extra = extra
+	return nil
+}
+
+// OptimizationGoalRawTarget preserves unknown future target variants.
+type OptimizationGoalRawTarget struct {
+	Kind  string         `json:"kind,omitempty"`
+	Extra map[string]any `json:"-"`
+}
+
+func (OptimizationGoalRawTarget) isOptimizationGoalTarget() {}
+
+func (t OptimizationGoalRawTarget) MarshalJSON() ([]byte, error) {
+	out := make(map[string]any, len(t.Extra))
+	for k, v := range t.Extra {
+		if k == "kind" {
+			continue
+		}
+		out[k] = v
+	}
+	if t.Kind != "" {
+		out["kind"] = t.Kind
+	}
+	return json.Marshal(out)
+}
+
+func (t *OptimizationGoalRawTarget) UnmarshalJSON(data []byte) error {
+	var typed struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return err
+	}
+	t.Kind = typed.Kind
+	extra, err := unmarshalOptimizationGoalTargetExtra(data, "kind")
+	if err != nil {
+		return err
+	}
+	t.Extra = extra
+	return nil
+}
+
+func unmarshalOptimizationGoalTarget(data []byte) (OptimizationGoalTarget, error) {
+	var typed struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(data, &typed); err != nil {
+		return nil, err
+	}
+	switch typed.Kind {
+	case "cost_per":
+		var target OptimizationGoalCostPerTarget
+		if err := json.Unmarshal(data, &target); err != nil {
+			return nil, err
+		}
+		return &target, nil
+	case "threshold_rate":
+		var target OptimizationGoalThresholdRateTarget
+		if err := json.Unmarshal(data, &target); err != nil {
+			return nil, err
+		}
+		return &target, nil
+	case "per_ad_spend":
+		var target OptimizationGoalPerAdSpendTarget
+		if err := json.Unmarshal(data, &target); err != nil {
+			return nil, err
+		}
+		return &target, nil
+	case "maximize_value":
+		var target OptimizationGoalMaximizeValueTarget
+		if err := json.Unmarshal(data, &target); err != nil {
+			return nil, err
+		}
+		return &target, nil
+	default:
+		var target OptimizationGoalRawTarget
+		if err := json.Unmarshal(data, &target); err != nil {
+			return nil, err
+		}
+		return &target, nil
+	}
+}
+
+func marshalOptimizationGoalTarget(kind string, value float64, includeValue bool, extra map[string]any) ([]byte, error) {
+	out := make(map[string]any, len(extra))
+	for k, v := range extra {
+		if k == "kind" || k == "value" {
+			continue
+		}
+		out[k] = v
+	}
+	out["kind"] = kind
+	if includeValue {
+		out["value"] = value
+	}
+	return json.Marshal(out)
+}
+
+func isNilOptimizationGoalTarget(target OptimizationGoalTarget) bool {
+	switch t := target.(type) {
+	case nil:
+		return true
+	case *OptimizationGoalCostPerTarget:
+		return t == nil
+	case *OptimizationGoalThresholdRateTarget:
+		return t == nil
+	case *OptimizationGoalPerAdSpendTarget:
+		return t == nil
+	case *OptimizationGoalMaximizeValueTarget:
+		return t == nil
+	case *OptimizationGoalRawTarget:
+		return t == nil
+	default:
+		return false
+	}
+}
+
+func unmarshalOptimizationGoalTargetExtra(data []byte, typedKeys ...string) (map[string]any, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	for _, key := range typedKeys {
+		delete(raw, key)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	extra := make(map[string]any, len(raw))
+	for k, v := range raw {
+		var value any
+		if err := json.Unmarshal(v, &value); err != nil {
+			return nil, err
+		}
+		extra[k] = value
+	}
+	return extra, nil
 }
 
 type MediaBuyListItem struct {


### PR DESCRIPTION
## Summary

- change `OptimizationGoal.Target` from raw `any` to the `OptimizationGoalTarget` interface
- add schema-backed target variants for `cost_per`, `threshold_rate`, `per_ad_spend`, and `maximize_value`, plus `OptimizationGoalRawTarget` for future target kinds
- preserve additive target fields through each variant `Extra` map while forcing canonical `kind` on marshal
- patch MCP tool schema generation so `PackageInput.optimization_goals[].target` still publishes a concrete target `oneOf` instead of being dropped as an interface/true schema
- document the target migration and read-side type-switch convention

Closes #213.

## Expert review notes

- Protocol review found no blockers and confirmed one shared `OptimizationGoalCostPerTarget` is correct for both metric and event goals because both schema branches use the same wire shape.
- DX review found the MCP schema regression from interface typing; this PR adds the schema override and regression test.
- Go types still do not enforce every outer goal kind vs target kind invariant; sellers should validate the full goal against schema/product capabilities.

## Validation

- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 42`
- `cd adcp/schemas && python3 -m unittest generate_test.py`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`

BREAKING CHANGE: `OptimizationGoal.Target` now uses `adcp.OptimizationGoalTarget` instead of `any`.