### PR TITLE
test(schemas): document optional numeric policy

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -873,6 +873,11 @@ INLINE_TYPE_HINTS = {
     ('Package', 'optimization_goals'): 'OptimizationGoal',
     ('PackageInput', 'optimization_goals'): 'OptimizationGoal',
     ('PackageUpdate', 'optimization_goals'): 'OptimizationGoal',
+    # Optional numeric policy: use a pointer only when omission and explicit
+    # zero are both valid and semantically distinct. value_factor defaults to 1
+    # and explicit 0 zeroes this event source. view_duration_seconds has
+    # exclusiveMinimum: 0, so explicit 0 is invalid and the hand-written
+    # OptimizationGoal field intentionally stays float64.
     ('OptimizationGoalEventSource', 'value_factor'): '*float64',
 }
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -256,14 +256,16 @@ class EnumGenerationTest(unittest.TestCase):
 
 
 class OptimizationGoalSchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.schema = generate.load_schema("core/optimization-goal.json")
+
     def test_cost_per_target_branches_stay_structurally_equivalent(self):
-        schema = generate.load_schema("core/optimization-goal.json")
         metric_cost_per = generate.json_pointer_get(
-            schema,
+            self.schema,
             "/oneOf/0/properties/target/oneOf/0",
         )
         event_cost_per = generate.json_pointer_get(
-            schema,
+            self.schema,
             "/oneOf/1/properties/target/oneOf/0",
         )
 
@@ -271,6 +273,28 @@ class OptimizationGoalSchemaTest(unittest.TestCase):
             without_descriptions(metric_cost_per),
             without_descriptions(event_cost_per),
         )
+
+    def test_optional_numeric_policy_for_optimization_goal_fields(self):
+        event_source = generate.json_pointer_get(
+            self.schema,
+            "/oneOf/1/properties/event_sources/items",
+        )
+        value_factor_type, _ = generate.field_go_type_info(
+            "OptimizationGoalEventSource",
+            "value_factor",
+            event_source["properties"]["value_factor"],
+            set(event_source.get("required", [])),
+        )
+        self.assertEqual("*float64", value_factor_type)
+
+        metric_goal = generate.json_pointer_get(self.schema, "/oneOf/0")
+        view_duration_type, _ = generate.field_go_type_info(
+            "OptimizationGoal",
+            "view_duration_seconds",
+            metric_goal["properties"]["view_duration_seconds"],
+            set(metric_goal.get("required", [])),
+        )
+        self.assertEqual("float64", view_duration_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- document the optional numeric field policy near the `value_factor` generator override
- add generator tests proving `OptimizationGoalEventSource.value_factor` remains `*float64` because explicit zero is load-bearing
- add generator tests proving `OptimizationGoal.view_duration_seconds` stays `float64` because schema `exclusiveMinimum: 0` makes explicit zero invalid
- retain the structural equality guard for shared optimization-goal `cost_per` target branches

Closes #214.

## Validation

- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 42`
- `cd adcp/schemas && python3 -m unittest generate_test.py`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`