### PR TITLE
fix(adcp): narrow optimization target tool schema

### DIFF
--- a/adcp/addtool.go
+++ b/adcp/addtool.go
@@ -94,6 +94,10 @@ func allowAdditionalProperties(s *jsonschema.Schema) {
 		}
 	}
 
+	if isOptimizationGoalSchema(s) {
+		applyOptimizationGoalSchemaOverride(s)
+	}
+
 	// Remove properties that serialize to `true` (the accept-anything schema
 	// generated for `any`/`interface{}` fields). These cause validation errors
 	// in some schema validators. The field is still accepted because
@@ -101,10 +105,6 @@ func allowAdditionalProperties(s *jsonschema.Schema) {
 	// overrides so tool discovery does not lose protocol fields.
 	for name, prop := range s.Properties {
 		if isTrueSchema(prop) {
-			if name == "target" && isOptimizationGoalSchema(s) {
-				s.Properties[name] = optimizationGoalTargetJSONSchema()
-				continue
-			}
 			delete(s.Properties, name)
 			// Also remove from required if present
 			s.Required = slices.DeleteFunc(s.Required, func(s string) bool { return s == name })
@@ -152,7 +152,7 @@ func isTrueSchema(s *jsonschema.Schema) bool {
 }
 
 func isOptimizationGoalSchema(s *jsonschema.Schema) bool {
-	if s == nil || s.Type != "object" || s.Properties == nil {
+	if s == nil || s.Type != "object" || s.Properties == nil || len(s.OneOf) > 0 {
 		return false
 	}
 	if _, ok := s.Properties["kind"]; !ok {
@@ -161,16 +161,68 @@ func isOptimizationGoalSchema(s *jsonschema.Schema) bool {
 	_, hasMetric := s.Properties["metric"]
 	_, hasEventSources := s.Properties["event_sources"]
 	_, hasTarget := s.Properties["target"]
-	return hasTarget && (hasMetric || hasEventSources)
+	return hasTarget && hasMetric && hasEventSources
 }
 
-func optimizationGoalTargetJSONSchema() *jsonschema.Schema {
+// applyOptimizationGoalSchemaOverride replaces the flattened Go type schema
+// with the protocol's metric/event branches. Branches deliberately omit
+// additionalProperties so tool inputs remain forward-compatible with Extra.
+func applyOptimizationGoalSchemaOverride(s *jsonschema.Schema) {
+	props := s.Properties
+	s.Type = ""
+	s.Properties = nil
+	s.Required = nil
+	s.PropertyOrder = nil
+	s.OneOf = []*jsonschema.Schema{
+		optimizationGoalBranchJSONSchema("metric", map[string]*jsonschema.Schema{
+			"metric":                props["metric"],
+			"reach_unit":            props["reach_unit"],
+			"target_frequency":      props["target_frequency"],
+			"view_duration_seconds": props["view_duration_seconds"],
+			"target":                optimizationGoalMetricTargetJSONSchema(),
+			"priority":              props["priority"],
+		}, []string{"kind", "metric"}),
+		optimizationGoalBranchJSONSchema("event", map[string]*jsonschema.Schema{
+			"event_sources":      props["event_sources"],
+			"target":             optimizationGoalEventTargetJSONSchema(),
+			"attribution_window": props["attribution_window"],
+			"priority":           props["priority"],
+		}, []string{"kind", "event_sources"}),
+	}
+}
+
+func optimizationGoalMetricTargetJSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{OneOf: []*jsonschema.Schema{
 		optimizationGoalTargetVariantSchema("cost_per", true, "Target cost per unit of the metric or conversion event."),
 		optimizationGoalTargetVariantSchema("threshold_rate", true, "Minimum per-impression rate for the metric."),
+	}}
+}
+
+func optimizationGoalEventTargetJSONSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{OneOf: []*jsonschema.Schema{
+		optimizationGoalTargetVariantSchema("cost_per", true, "Target cost per unit of the metric or conversion event."),
 		optimizationGoalTargetVariantSchema("per_ad_spend", true, "Target return per unit of ad spend."),
 		optimizationGoalTargetVariantSchema("maximize_value", false, "Maximize total conversion value within budget."),
 	}}
+}
+
+func optimizationGoalBranchJSONSchema(kind string, properties map[string]*jsonschema.Schema, required []string) *jsonschema.Schema {
+	kindValue := any(kind)
+	branchProperties := make(map[string]*jsonschema.Schema, len(properties)+1)
+	for name, prop := range properties {
+		if prop != nil {
+			branchProperties[name] = prop
+		}
+	}
+	branchProperties["kind"] = &jsonschema.Schema{
+		Type:  "string",
+		Const: &kindValue,
+	}
+	return &jsonschema.Schema{
+		Type:       "object",
+		Properties: branchProperties,
+		Required:   required,
+	}
 }
 
 func optimizationGoalTargetVariantSchema(kind string, withValue bool, description string) *jsonschema.Schema {

--- a/adcp/addtool_test.go
+++ b/adcp/addtool_test.go
@@ -3,7 +3,6 @@ package adcp
 import (
 	"encoding/json"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
@@ -142,19 +141,123 @@ func TestPermissiveSchemaVsDefaultSchema(t *testing.T) {
 func TestPermissiveSchemaPreservesOptimizationGoalTarget(t *testing.T) {
 	schema := permissiveSchemaFor[PackageInput]()
 
-	b, err := json.Marshal(schema)
-	require.NoError(t, err, "failed to marshal package input schema")
-	body := string(b)
+	goalSchema := findOptimizationGoalSchema(t, schema)
+	assertOptimizationGoalBranches(t, goalSchema)
+}
 
-	assert.Contains(t, body, `"optimization_goals"`, "expected optimization_goals in schema")
-	assert.Contains(t, body, `"target"`, "expected optimization goal target in schema")
-	for _, want := range []string{
-		`"const":"cost_per"`,
-		`"const":"threshold_rate"`,
-		`"const":"per_ad_spend"`,
-		`"const":"maximize_value"`,
-	} {
-		assert.Contains(t, body, want, "expected target variant %s in schema", want)
+func TestPermissiveSchemaForOptimizationGoalUsesProtocolBranches(t *testing.T) {
+	schema := permissiveSchemaFor[OptimizationGoal]()
+
+	assertOptimizationGoalBranches(t, schema)
+}
+
+func assertOptimizationGoalBranches(t *testing.T, goalSchema *jsonschema.Schema) {
+	t.Helper()
+
+	require.Len(t, goalSchema.OneOf, 2, "expected metric and event optimization goal branches")
+
+	metricBranch := optimizationGoalBranchByKind(t, goalSchema, "metric")
+	assert.Nil(t, metricBranch.AdditionalProperties, "metric branch should remain permissive")
+	assert.NotContains(t, metricBranch.Required, "target", "metric target should remain optional")
+	metricTarget := metricBranch.Properties["target"]
+	require.NotNil(t, metricTarget, "expected metric target schema")
+	assertTargetKinds(t, metricTarget, "cost_per", "threshold_rate")
+
+	eventBranch := optimizationGoalBranchByKind(t, goalSchema, "event")
+	assert.Nil(t, eventBranch.AdditionalProperties, "event branch should remain permissive")
+	assert.NotContains(t, eventBranch.Required, "target", "event target should remain optional")
+	eventTarget := eventBranch.Properties["target"]
+	require.NotNil(t, eventTarget, "expected event target schema")
+	assertTargetKinds(t, eventTarget, "cost_per", "per_ad_spend", "maximize_value")
+}
+
+func findOptimizationGoalSchema(t *testing.T, schema *jsonschema.Schema) *jsonschema.Schema {
+	t.Helper()
+	seen := map[*jsonschema.Schema]bool{}
+	var walk func(*jsonschema.Schema) *jsonschema.Schema
+	walk = func(s *jsonschema.Schema) *jsonschema.Schema {
+		if s == nil || seen[s] {
+			return nil
+		}
+		seen[s] = true
+		if len(s.OneOf) == 2 {
+			if branchHasKind(s.OneOf[0], "metric") && branchHasKind(s.OneOf[1], "event") {
+				return s
+			}
+			if branchHasKind(s.OneOf[0], "event") && branchHasKind(s.OneOf[1], "metric") {
+				return s
+			}
+		}
+		for _, prop := range s.Properties {
+			if found := walk(prop); found != nil {
+				return found
+			}
+		}
+		if found := walk(s.Items); found != nil {
+			return found
+		}
+		for _, sub := range s.OneOf {
+			if found := walk(sub); found != nil {
+				return found
+			}
+		}
+		for _, sub := range s.AnyOf {
+			if found := walk(sub); found != nil {
+				return found
+			}
+		}
+		for _, sub := range s.AllOf {
+			if found := walk(sub); found != nil {
+				return found
+			}
+		}
+		for _, def := range s.Defs {
+			if found := walk(def); found != nil {
+				return found
+			}
+		}
+		return nil
 	}
-	assert.True(t, strings.Count(body, `"const":"threshold_rate"`) >= 1, "expected threshold_rate target variant")
+	found := walk(schema)
+	require.NotNil(t, found, "expected optimization goal schema")
+	return found
+}
+
+func optimizationGoalBranchByKind(t *testing.T, schema *jsonschema.Schema, kind string) *jsonschema.Schema {
+	t.Helper()
+	for _, branch := range schema.OneOf {
+		if branchHasKind(branch, kind) {
+			return branch
+		}
+	}
+	t.Fatalf("expected optimization goal branch kind %q", kind)
+	return nil
+}
+
+func branchHasKind(schema *jsonschema.Schema, kind string) bool {
+	if schema == nil || schema.Properties == nil {
+		return false
+	}
+	kindSchema := schema.Properties["kind"]
+	if kindSchema == nil || kindSchema.Const == nil {
+		return false
+	}
+	value, ok := (*kindSchema.Const).(string)
+	return ok && value == kind
+}
+
+func assertTargetKinds(t *testing.T, schema *jsonschema.Schema, kinds ...string) {
+	t.Helper()
+	require.Len(t, schema.OneOf, len(kinds), "target branch count")
+	for _, want := range kinds {
+		found := false
+		for _, branch := range schema.OneOf {
+			assert.Nil(t, branch.AdditionalProperties, "target branch should remain permissive")
+			if branchHasKind(branch, want) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected target kind %q", want)
+	}
 }


### PR DESCRIPTION
Closes #217.

## Summary
- rebuild the permissive MCP schema for `OptimizationGoal` as explicit `metric` and `event` branches
- expose metric targets as only `cost_per` and `threshold_rate`
- expose event targets as only `cost_per`, `per_ad_spend`, and `maximize_value`
- keep branch schemas permissive and keep `target` optional

## Validation
- `go test ./...`
- `cd adcp && go test ./...`
- `cd adcp/schemas && python3 -m unittest generate_test.py`
- `git diff --check`

## Expert review
- protocol reviewer: no blocking findings; added the suggested non-blocking coverage for permissive branches and optional targets