### PR TITLE
feat(adcp)!: preserve optional numeric zero values

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,12 @@ Optional object references are pointers: nil omits the field, and `&T{}` or
 `adcp.Ptr(T{})` emits it. Required fields inside the nested struct still need to
 be populated.
 
+- Optional numeric fields where explicit zero is meaningful are now pointers:
+  `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
+  `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
+  `CreativeAsset.Weight`, and `KeywordTarget.BidPrice`. Use nil to omit the
+  field, and `adcp.Ptr(0.0)` when the wire payload must include an explicit
+  zero.
 - `UpdateMediaBuyRequest.Canceled` and `PackageUpdate.Canceled` are `*bool`.
   Use nil when the field is absent and `adcp.Bool(true)` when requesting
   cancellation. The AdCP schema constrains `canceled` to true; do not send

--- a/adcp/generated_product_refs_test.go
+++ b/adcp/generated_product_refs_test.go
@@ -14,7 +14,7 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 		PublisherProperties: []PublisherPropertySelector{{PublisherDomain: "example.com", SelectionType: "all"}},
 		FormatIDs:           []FormatRef{{AgentURL: "https://seller.example/mcp", ID: "display_300x250"}},
 		DeliveryType:        "guaranteed",
-		PricingOptions:      []PricingOption{{PricingOptionID: "pd-cpm", PricingModel: "cpm", FixedPrice: 15, Currency: "USD"}},
+		PricingOptions:      []PricingOption{{PricingOptionID: "pd-cpm", PricingModel: "cpm", FixedPrice: Ptr(15.0), Currency: "USD"}},
 		Placements: []Placement{{
 			PlacementID: "homepage",
 			Name:        "Homepage",
@@ -22,7 +22,7 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 		}},
 		Forecast: &DeliveryForecast{
 			Points: []ForecastPoint{{
-				Budget: 1000,
+				Budget: Ptr(1000.0),
 				Metrics: map[string]ForecastRange{
 					"impressions": {Mid: 100000},
 				},
@@ -176,6 +176,156 @@ func TestGeneratedProductRefsMarshalTypedFields(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Fatalf("marshaled product missing %s:\n%s", want, body)
 		}
+	}
+}
+
+func TestOptionalNumericPointersPreserveExplicitZero(t *testing.T) {
+	cases := []struct {
+		name  string
+		v     any
+		want  []string
+		deny  []string
+		check func(t *testing.T, raw []byte)
+	}{
+		{
+			name: "pricing option nil fixed price",
+			v:    PricingOption{PricingOptionID: "auction", PricingModel: "cpm", Currency: "USD"},
+			deny: []string{`"fixed_price"`},
+		},
+		{
+			name: "pricing option zero fixed price",
+			v:    PricingOption{PricingOptionID: "fixed-zero", PricingModel: "cpm", Currency: "USD", FixedPrice: Ptr(0.0)},
+			want: []string{`"fixed_price":0`},
+			check: func(t *testing.T, raw []byte) {
+				var got PricingOption
+				requireJSONRoundTrip(t, raw, &got)
+				if got.FixedPrice == nil || *got.FixedPrice != 0 {
+					t.Fatalf("fixed_price = %v, want pointer to 0", got.FixedPrice)
+				}
+			},
+		},
+		{
+			name: "forecast point nil budget",
+			v:    ForecastPoint{Metrics: map[string]ForecastRange{"impressions": {Mid: 1000}}},
+			deny: []string{`"budget"`},
+		},
+		{
+			name: "forecast point zero budget",
+			v:    ForecastPoint{Budget: Ptr(0.0), Metrics: map[string]ForecastRange{"impressions": {Mid: 1000}}},
+			want: []string{`"budget":0`},
+			check: func(t *testing.T, raw []byte) {
+				var got ForecastPoint
+				requireJSONRoundTrip(t, raw, &got)
+				if got.Budget == nil || *got.Budget != 0 {
+					t.Fatalf("budget = %v, want pointer to 0", got.Budget)
+				}
+			},
+		},
+		{
+			name: "audience selector nil bounds",
+			v: AudienceSelector{
+				Type:      "signal",
+				SignalID:  &SignalID{AgentURL: "https://signals.example/mcp", ID: "score"},
+				ValueType: "numeric",
+			},
+			deny: []string{`"min_value"`, `"max_value"`},
+		},
+		{
+			name: "audience selector zero bounds",
+			v: AudienceSelector{
+				Type:      "signal",
+				SignalID:  &SignalID{AgentURL: "https://signals.example/mcp", ID: "score"},
+				ValueType: "numeric",
+				MinValue:  Ptr(0.0),
+				MaxValue:  Ptr(0.0),
+			},
+			want: []string{`"min_value":0`, `"max_value":0`},
+			check: func(t *testing.T, raw []byte) {
+				var got AudienceSelector
+				requireJSONRoundTrip(t, raw, &got)
+				if got.MinValue == nil || *got.MinValue != 0 {
+					t.Fatalf("min_value = %v, want pointer to 0", got.MinValue)
+				}
+				if got.MaxValue == nil || *got.MaxValue != 0 {
+					t.Fatalf("max_value = %v, want pointer to 0", got.MaxValue)
+				}
+			},
+		},
+		{
+			name: "creative asset nil weight",
+			v: CreativeAsset{
+				CreativeID: "creative-1",
+				Name:       "Creative",
+				FormatID:   FormatRef{AgentURL: "https://seller.example/mcp", ID: "display"},
+				Assets:     map[string]any{"image": "asset-1"},
+			},
+			deny: []string{`"weight"`},
+		},
+		{
+			name: "creative asset zero weight",
+			v: CreativeAsset{
+				CreativeID: "creative-1",
+				Name:       "Creative",
+				FormatID:   FormatRef{AgentURL: "https://seller.example/mcp", ID: "display"},
+				Assets:     map[string]any{"image": "asset-1"},
+				Weight:     Ptr(0.0),
+			},
+			want: []string{`"weight":0`},
+			check: func(t *testing.T, raw []byte) {
+				var got CreativeAsset
+				requireJSONRoundTrip(t, raw, &got)
+				if got.Weight == nil || *got.Weight != 0 {
+					t.Fatalf("weight = %v, want pointer to 0", got.Weight)
+				}
+			},
+		},
+		{
+			name: "keyword target nil bid price",
+			v:    KeywordTarget{Keyword: "running shoes", MatchType: "phrase"},
+			deny: []string{`"bid_price"`},
+		},
+		{
+			name: "keyword target zero bid price",
+			v:    KeywordTarget{Keyword: "running shoes", MatchType: "phrase", BidPrice: Ptr(0.0)},
+			want: []string{`"bid_price":0`},
+			check: func(t *testing.T, raw []byte) {
+				var got KeywordTarget
+				requireJSONRoundTrip(t, raw, &got)
+				if got.BidPrice == nil || *got.BidPrice != 0 {
+					t.Fatalf("bid_price = %v, want pointer to 0", got.BidPrice)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.v)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			body := string(raw)
+			for _, want := range tc.want {
+				if !strings.Contains(body, want) {
+					t.Fatalf("marshaled payload missing %s:\n%s", want, body)
+				}
+			}
+			for _, deny := range tc.deny {
+				if strings.Contains(body, deny) {
+					t.Fatalf("marshaled payload unexpectedly contained %s:\n%s", deny, body)
+				}
+			}
+			if tc.check != nil {
+				tc.check(t, raw)
+			}
+		})
+	}
+}
+
+func requireJSONRoundTrip(t *testing.T, raw []byte, v any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, v); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -878,6 +878,11 @@ INLINE_TYPE_HINTS = {
     # and explicit 0 zeroes this event source. view_duration_seconds has
     # exclusiveMinimum: 0, so explicit 0 is invalid and the hand-written
     # OptimizationGoal field intentionally stays float64.
+    ('CreativeAsset', 'weight'): '*float64',
+    ('KeywordTarget', 'bid_price'): '*float64',
+    ('AudienceSelector', 'min_value'): '*float64',
+    ('AudienceSelector', 'max_value'): '*float64',
+    ('ForecastPoint', 'budget'): '*float64',
     ('OptimizationGoalEventSource', 'value_factor'): '*float64',
 }
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -325,5 +325,59 @@ class OptimizationGoalSchemaTest(unittest.TestCase):
         self.assertEqual("float64", view_duration_type)
 
 
+class OptionalNumericPolicyTest(unittest.TestCase):
+    def assert_field_type(self, schema_path, type_name, json_name, want):
+        schema = generate.load_schema(schema_path)
+        prop = generate.schema_properties(schema)[json_name]
+        required_set = generate.schema_required_names(schema)
+
+        go_type, _ = generate.field_go_type_info(
+            type_name,
+            json_name,
+            prop,
+            required_set,
+        )
+
+        self.assertEqual(want, go_type)
+
+    def test_zero_valid_optional_numeric_fields_use_pointers(self):
+        self.assert_field_type(
+            "core/creative-asset.json",
+            "CreativeAsset",
+            "weight",
+            "*float64",
+        )
+        targeting = generate.load_schema("core/targeting.json")
+        keyword_target = generate.json_pointer_get(
+            targeting,
+            "/properties/keyword_targets/items",
+        )
+        bid_price_type, _ = generate.field_go_type_info(
+            "KeywordTarget",
+            "bid_price",
+            keyword_target["properties"]["bid_price"],
+            set(keyword_target.get("required", [])),
+        )
+        self.assertEqual("*float64", bid_price_type)
+        self.assert_field_type(
+            "core/audience-selector.json",
+            "AudienceSelector",
+            "min_value",
+            "*float64",
+        )
+        self.assert_field_type(
+            "core/audience-selector.json",
+            "AudienceSelector",
+            "max_value",
+            "*float64",
+        )
+        self.assert_field_type(
+            "core/forecast-point.json",
+            "ForecastPoint",
+            "budget",
+            "*float64",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -358,6 +358,143 @@ def validate_union_schema_specs():
     return reports
 
 
+OPTIONAL_NUMERIC_OMISSION_HINTS = (
+    'default:',
+    'defaults to',
+    'default is',
+    'if omitted',
+    'omit for',
+    'omit to',
+    'when omitted',
+    'if present',
+    'when present',
+    'when provided',
+    'if provided',
+    'required when',
+    'populated when',
+    'when specified',
+    'optional override',
+)
+
+OPTIONAL_NUMERIC_SCALAR_OK = {
+    # (type_name, json_name): reason
+}
+
+
+def numeric_zero_invalid(prop):
+    """Return True when schema constraints reject an explicit numeric zero."""
+    minimum = prop.get('minimum')
+    if minimum is not None:
+        try:
+            if float(minimum) > 0:
+                return True
+        except (TypeError, ValueError):
+            pass
+
+    exclusive_minimum = prop.get('exclusiveMinimum')
+    if exclusive_minimum is True:
+        try:
+            return float(prop.get('minimum', 0)) >= 0
+        except (TypeError, ValueError):
+            return True
+    if (
+        exclusive_minimum is not False and
+        isinstance(exclusive_minimum, (int, float))
+    ):
+        if float(exclusive_minimum) >= 0:
+            return True
+
+    enum = prop.get('enum')
+    if enum is not None and 0 not in enum and 0.0 not in enum:
+        return True
+
+    return False
+
+
+def numeric_omission_is_semantically_distinct(prop):
+    """Heuristic for optional numerics where omission means more than zero."""
+    if 'default' in prop:
+        try:
+            return float(prop['default']) != 0
+        except (TypeError, ValueError):
+            return True
+
+    description = (prop.get('description') or '').lower()
+    return any(hint in description for hint in OPTIONAL_NUMERIC_OMISSION_HINTS)
+
+
+def optional_numeric_pointer_candidate(json_name, prop, required_set):
+    if json_name in required_set:
+        return False
+    if prop.get('type') not in ('integer', 'number'):
+        return False
+    return (
+        not numeric_zero_invalid(prop) and
+        numeric_omission_is_semantically_distinct(prop)
+    )
+
+
+def optional_numeric_pointer_reports(go_structs):
+    """Find optional numeric fields that need pointers to preserve omission."""
+    reports = []
+
+    for entry in gen.generated_schema_entries():
+        if entry['kind'] != 'struct':
+            continue
+        props = gen.schema_properties(entry['schema_obj'])
+        required_set = gen.schema_required_names(entry['schema_obj'])
+        for json_name, prop in props.items():
+            if not isinstance(prop, dict):
+                continue
+            if not optional_numeric_pointer_candidate(json_name, prop, required_set):
+                continue
+            go_type, _ = gen.field_go_type_info(
+                entry['name'], json_name, prop, required_set,
+            )
+            if go_type in ('int', 'float64') and (
+                entry['name'], json_name,
+            ) not in OPTIONAL_NUMERIC_SCALAR_OK:
+                reports.append({
+                    'owner': 'generated',
+                    'type': entry['name'],
+                    'schema': entry['schema'],
+                    'json': json_name,
+                    'go_type': go_type,
+                    'description': prop.get('description', ''),
+                })
+
+    for type_name, go_fields in sorted(go_structs.items()):
+        schema_spec = resolve_schema_spec(type_name)
+        if schema_spec is None:
+            continue
+        try:
+            schema = load_schema_spec(schema_spec)
+        except SCHEMA_RESOLUTION_ERRORS:
+            continue
+        props = gen.schema_properties(schema)
+        required_set = gen.schema_required_names(schema)
+        fields_by_json = {tag: go_type for _, go_type, tag, _ in go_fields}
+        for json_name, prop in props.items():
+            if not isinstance(prop, dict):
+                continue
+            if not optional_numeric_pointer_candidate(json_name, prop, required_set):
+                continue
+            go_type = fields_by_json.get(json_name)
+            if go_type in ('int', 'float64') and (
+                type_name, json_name,
+            ) not in OPTIONAL_NUMERIC_SCALAR_OK:
+                reports.append({
+                    'owner': 'hand-written',
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'json': json_name,
+                    'go_type': go_type,
+                    'description': prop.get('description', ''),
+                })
+
+    return reports
+
+
 def resolve_schema_spec(type_name):
     """Return schema spec for `type_name`, or None."""
     if type_name in EXPLICIT_SCHEMA:
@@ -479,6 +616,7 @@ def main():
     no_schema = []
     inline_schema_errors = validate_inline_schema_specs()
     union_schema_errors = validate_union_schema_specs()
+    optional_numeric_reports = optional_numeric_pointer_reports(go_structs)
 
     for type_name in sorted(gen.KNOWN_TYPES):
         if type_name in EXEMPT:
@@ -502,6 +640,7 @@ def main():
             'no_schema_correspondent': no_schema,
             'inline_schema_errors': inline_schema_errors,
             'union_schema_errors': union_schema_errors,
+            'optional_numeric_pointer': optional_numeric_reports,
         }
         print(json.dumps(out, indent=2))
     else:
@@ -518,6 +657,18 @@ def main():
                 print()
                 print(f'  {r["type"]}  ({r.get("schema", "?")})')
                 print(f'    error: {r["error"]}')
+            print()
+        if optional_numeric_reports:
+            print(
+                'Optional numeric pointer issues in '
+                f'{len(optional_numeric_reports)} field(s):'
+            )
+            for r in optional_numeric_reports:
+                print()
+                print(f'  {r["type"]}.{r["json"]}  ({r["schema"]})')
+                print(f'    owner:   {r["owner"]}')
+                print(f'    Go type: {r["go_type"]}')
+                print('    fix:     use *int/*float64 or add an OPTIONAL_NUMERIC_SCALAR_OK waiver')
             print()
         if reports:
             print(f'Schema drift detected in {len(reports)} type(s):')
@@ -543,6 +694,8 @@ def main():
                 print(f'  - {t}')
 
     has_problems = bool(inline_schema_errors) or bool(union_schema_errors) or bool(reports) or (
+        bool(optional_numeric_reports)
+    ) or (
         args.strict and bool(no_schema)
     )
     return 1 if (args.strict and has_problems) else 0

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -1,0 +1,116 @@
+import unittest
+
+import lint
+
+
+class OptionalNumericPointerLintTest(unittest.TestCase):
+    def test_zero_invalid_honors_numeric_bounds(self):
+        self.assertFalse(lint.numeric_zero_invalid({"type": "number", "minimum": 0}))
+        self.assertTrue(lint.numeric_zero_invalid({"type": "number", "minimum": 1}))
+        self.assertTrue(lint.numeric_zero_invalid({"type": "number", "exclusiveMinimum": 0}))
+        self.assertTrue(lint.numeric_zero_invalid({
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": True,
+        }))
+
+    def test_zero_invalid_ignores_boolean_false_exclusive_minimum(self):
+        self.assertFalse(lint.numeric_zero_invalid({
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": False,
+        }))
+
+    def test_omission_hint_uses_defaults_and_descriptions(self):
+        self.assertTrue(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "default": 1,
+        }))
+        self.assertFalse(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "default": 0,
+        }))
+        self.assertTrue(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "description": "Omit for no maximum.",
+        }))
+        self.assertTrue(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "description": "If omitted, platform determines rotation.",
+        }))
+        self.assertTrue(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "description": "When omitted, inherit the package bid.",
+        }))
+        self.assertFalse(lint.numeric_omission_is_semantically_distinct({
+            "type": "number",
+            "description": "Unique reach when reach_unit is omitted.",
+        }))
+
+    def test_optional_numeric_pointer_candidate(self):
+        prop = {
+            "type": "number",
+            "minimum": 0,
+            "description": "Minimum value. Omit for no minimum.",
+        }
+        self.assertTrue(lint.optional_numeric_pointer_candidate("min_value", prop, set()))
+        self.assertFalse(lint.optional_numeric_pointer_candidate("min_value", prop, {"min_value"}))
+        self.assertFalse(lint.optional_numeric_pointer_candidate(
+            "view_duration_seconds",
+            {"type": "number", "exclusiveMinimum": 0, "description": "Minimum view duration."},
+            set(),
+        ))
+
+    def test_optional_numeric_lint_catches_current_schema_candidates(self):
+        reports = lint.optional_numeric_pointer_reports(lint.parse_go_structs())
+        report_keys = {(r["type"], r["json"]) for r in reports}
+
+        self.assertNotIn(("CreativeAsset", "weight"), report_keys)
+        self.assertNotIn(("KeywordTarget", "bid_price"), report_keys)
+
+        original_hints = lint.gen.INLINE_TYPE_HINTS
+        try:
+            lint.gen.INLINE_TYPE_HINTS = {
+                key: value for key, value in original_hints.items()
+                if key not in {
+                    ("CreativeAsset", "weight"),
+                    ("KeywordTarget", "bid_price"),
+                }
+            }
+            lint.gen._reset_will_generate_cache()
+
+            reports = lint.optional_numeric_pointer_reports(lint.parse_go_structs())
+            report_keys = {(r["type"], r["json"]) for r in reports}
+
+            self.assertIn(("CreativeAsset", "weight"), report_keys)
+            self.assertIn(("KeywordTarget", "bid_price"), report_keys)
+        finally:
+            lint.gen.INLINE_TYPE_HINTS = original_hints
+            lint.gen._reset_will_generate_cache()
+
+    def test_optional_numeric_lint_honors_explicit_waivers(self):
+        original_hints = lint.gen.INLINE_TYPE_HINTS
+        original_waivers = lint.OPTIONAL_NUMERIC_SCALAR_OK
+        try:
+            lint.gen.INLINE_TYPE_HINTS = {
+                key: value for key, value in original_hints.items()
+                if key != ("CreativeAsset", "weight")
+            }
+            lint.OPTIONAL_NUMERIC_SCALAR_OK = {
+                **original_waivers,
+                ("CreativeAsset", "weight"): "test waiver",
+            }
+            lint.gen._reset_will_generate_cache()
+
+            reports = lint.optional_numeric_pointer_reports(lint.parse_go_structs())
+            report_keys = {(r["type"], r["json"]) for r in reports}
+
+            self.assertNotIn(("CreativeAsset", "weight"), report_keys)
+        finally:
+            lint.gen.INLINE_TYPE_HINTS = original_hints
+            lint.OPTIONAL_NUMERIC_SCALAR_OK = original_waivers
+            lint.gen._reset_will_generate_cache()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -419,7 +419,7 @@ type PricingOption struct {
 	PricingOptionID     string   `json:"pricing_option_id"`
 	PricingModel        string   `json:"pricing_model"`
 	Currency            string   `json:"currency"`
-	FixedPrice          float64  `json:"fixed_price,omitempty"`
+	FixedPrice          *float64 `json:"fixed_price,omitempty"`
 	FloorPrice          float64  `json:"floor_price,omitempty"`
 	MinSpendPerPackage  float64  `json:"min_spend_per_package,omitempty"`
 	MaxBid              *bool    `json:"max_bid,omitempty"`

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5399,8 +5399,8 @@ type AudienceSelector struct {
 	ValueType string `json:"value_type,omitempty"` // Discriminator for numeric signals
 	Value *bool `json:"value,omitempty"` // Whether to include (true) or exclude (false) users matching this signal
 	Values []string `json:"values,omitempty"` // Values to target. Users with any of these values will be included.
-	MinValue float64 `json:"min_value,omitempty"` // Minimum value (inclusive). Omit for no minimum. Must be <= max_value when both a
-	MaxValue float64 `json:"max_value,omitempty"` // Maximum value (inclusive). Omit for no maximum. Must be >= min_value when both a
+	MinValue *float64 `json:"min_value,omitempty"` // Minimum value (inclusive). Omit for no minimum. Must be <= max_value when both a
+	MaxValue *float64 `json:"max_value,omitempty"` // Maximum value (inclusive). Omit for no maximum. Must be >= min_value when both a
 	Description string `json:"description,omitempty"` // Natural language description of the audience (e.g., 'likely EV buyers', 'high ne
 	Category string `json:"category,omitempty"` // Optional grouping hint for the governance agent (e.g., 'demographic', 'behaviora
 }
@@ -5483,7 +5483,7 @@ type DeliveryForecast struct {
 // ForecastPoint — A forecast data point. When budget is present, the point pairs a spend level with expected delivery
 type ForecastPoint struct {
 	Label string `json:"label,omitempty"` // Human-readable name for this forecast point. Required when forecast_range_unit i
-	Budget float64 `json:"budget,omitempty"` // Budget amount for this forecast point. Required for spend curves; omit for avail
+	Budget *float64 `json:"budget,omitempty"` // Budget amount for this forecast point. Required for spend curves; omit for avail
 	Metrics map[string]ForecastRange `json:"metrics"` // Forecasted metric values. Keys are forecastable-metric enum values for delivery/
 }
 
@@ -5671,7 +5671,7 @@ type CreativeAsset struct {
 	Inputs []CreativeAssetInput `json:"inputs,omitempty"` // Preview contexts for generative formats - defines what scenarios to generate pre
 	Tags []string `json:"tags,omitempty"` // User-defined tags for organization and searchability
 	Status string `json:"status,omitempty"` // For generative creatives: set to 'approved' to finalize, 'rejected' to request r
-	Weight float64 `json:"weight,omitempty"` // Optional delivery weight for creative rotation when uploading via create_media_b
+	Weight *float64 `json:"weight,omitempty"` // Optional delivery weight for creative rotation when uploading via create_media_b
 	PlacementIDs []string `json:"placement_ids,omitempty"` // Optional array of placement IDs where this creative should run when uploading vi
 	IndustryIdentifiers []IndustryIdentifier `json:"industry_identifiers,omitempty"` // Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast cl
 	Provenance *Provenance `json:"provenance,omitempty"` // Provenance metadata for this creative. Serves as the default provenance for all
@@ -6315,7 +6315,7 @@ type AgeRestriction struct {
 type KeywordTarget struct {
 	Keyword string `json:"keyword"` // The keyword to target
 	MatchType string `json:"match_type"`
-	BidPrice float64 `json:"bid_price,omitempty"` // Per-keyword bid price, denominated in the same currency as the package's pricing
+	BidPrice *float64 `json:"bid_price,omitempty"` // Per-keyword bid price, denominated in the same currency as the package's pricing
 }
 
 type NegativeKeywordTarget struct {

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -37,10 +37,10 @@ func sellerAgentURL() string {
 
 func baseProducts() map[string]*adcp.Product {
 	items := []adcp.Product{
-		newProduct("premium-display", "Premium Display", "High-impact display placements across our premium publisher network.", "guaranteed", []string{"display"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "display_300x250"}}, []adcp.PricingOption{{PricingOptionID: "pd-cpm-15", PricingModel: "cpm", FixedPrice: 15.00, Currency: "USD"}}),
+		newProduct("premium-display", "Premium Display", "High-impact display placements across our premium publisher network.", "guaranteed", []string{"display"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "display_300x250"}}, []adcp.PricingOption{{PricingOptionID: "pd-cpm-15", PricingModel: "cpm", FixedPrice: adcp.Ptr(15.00), Currency: "USD"}}),
 		newProduct("video-preroll", "Video Pre-Roll", "15 and 30 second pre-roll video ads.", "non_guaranteed", []string{"video"}, []adcp.FormatRef{{AgentURL: agentURL, ID: "video_30s"}, {AgentURL: agentURL, ID: "video-15s"}}, []adcp.PricingOption{
-			{PricingOptionID: "vp-cpm-25", PricingModel: "cpm", FixedPrice: 25.00, Currency: "USD"},
-			{PricingOptionID: "vp-cpcv-05", PricingModel: "cpcv", FixedPrice: 0.05, Currency: "USD"},
+			{PricingOptionID: "vp-cpm-25", PricingModel: "cpm", FixedPrice: adcp.Ptr(25.00), Currency: "USD"},
+			{PricingOptionID: "vp-cpcv-05", PricingModel: "cpcv", FixedPrice: adcp.Ptr(0.05), Currency: "USD"},
 		}),
 	}
 
@@ -168,7 +168,7 @@ func (b *backend) seedProduct(productID string, fixture map[string]any) {
 			}
 		}
 	}
-	product := newProduct(productID, productID, "Seeded storyboard product.", deliveryType, channels, formatIDs, []adcp.PricingOption{{PricingOptionID: "default", PricingModel: "cpm", FixedPrice: 10, Currency: "USD"}})
+	product := newProduct(productID, productID, "Seeded storyboard product.", deliveryType, channels, formatIDs, []adcp.PricingOption{{PricingOptionID: "default", PricingModel: "cpm", FixedPrice: adcp.Ptr(10.0), Currency: "USD"}})
 	b.products[productID] = &product
 }
 
@@ -194,7 +194,7 @@ func (b *backend) seedPricingOption(productID, pricingOptionID string, fixture m
 	if v, ok := fixture["fixed_price"].(float64); ok {
 		fixedPrice = v
 	}
-	product.PricingOptions = append(product.PricingOptions, adcp.PricingOption{PricingOptionID: pricingOptionID, PricingModel: model, Currency: currency, FixedPrice: fixedPrice})
+	product.PricingOptions = append(product.PricingOptions, adcp.PricingOption{PricingOptionID: pricingOptionID, PricingModel: model, Currency: currency, FixedPrice: adcp.Ptr(fixedPrice)})
 }
 
 func (b *backend) updateMediaBuy(input adcp.UpdateMediaBuyRequest) (*mcp.CallToolResult, any, error) {

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -523,8 +523,8 @@ func TestCustomScenario_SeedPricingOption(t *testing.T) {
 	for _, opt := range p.PricingOptions {
 		if opt.PricingOptionID == "custom-cpm-5" {
 			found = true
-			if opt.FixedPrice != 5.0 {
-				t.Errorf("want fixed_price 5.0, got %.2f", opt.FixedPrice)
+			if opt.FixedPrice == nil || *opt.FixedPrice != 5.0 {
+				t.Errorf("want fixed_price 5.0, got %v", opt.FixedPrice)
 			}
 		}
 	}

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -84,7 +84,7 @@ var products = []adcp.Product{
             {PublisherDomain: "shop.example", SelectionType: "all"},
         },
         PricingOptions: []adcp.PricingOption{
-            {PricingOptionID: "sp-cpc", PricingModel: "cpc", FixedPrice: 0.50, Currency: "USD"},
+            {PricingOptionID: "sp-cpc", PricingModel: "cpc", FixedPrice: adcp.Ptr(0.50), Currency: "USD"},
         },
         FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "product-card"}},
         ReportingCapabilities: adcp.ReportingCapabilities{

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -69,7 +69,7 @@ var products = []adcp.Product{
             {PublisherDomain: "example.com", SelectionType: "all"},
         },
         PricingOptions: []adcp.PricingOption{
-            {PricingOptionID: "pd-cpm", PricingModel: "cpm", FixedPrice: 15.00, Currency: "USD"},
+            {PricingOptionID: "pd-cpm", PricingModel: "cpm", FixedPrice: adcp.Ptr(15.00), Currency: "USD"},
         },
         FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "banner-300x250"}},
         ReportingCapabilities: adcp.ReportingCapabilities{
@@ -383,7 +383,7 @@ Use lowercase pricing models: `"cpm"`, `"cpc"`, `"cpcv"`, not `"CPM"`.
     Description: "Primetime 30-second broadcast spots.",
     Channels: []string{"broadcast"}, DeliveryType: "guaranteed",
     PricingOptions: []adcp.PricingOption{
-        {PricingOptionID: "unit-30s", PricingModel: "unit", FixedPrice: 5000, Currency: "USD"},
+        {PricingOptionID: "unit-30s", PricingModel: "unit", FixedPrice: adcp.Ptr(5000.0), Currency: "USD"},
     },
     FormatIDs: []adcp.FormatRef{{AgentURL: agentURL, ID: "broadcast-30s"}},
     CancellationPolicy: &adcp.CancellationPolicy{


### PR DESCRIPTION
Closes #220.

## Summary
- add strict schema lint for optional numeric fields where omission and explicit zero have distinct semantics
- change `PricingOption.FixedPrice`, `AudienceSelector.MinValue`, `AudienceSelector.MaxValue`, `ForecastPoint.Budget`, `CreativeAsset.Weight`, and `KeywordTarget.BidPrice` to `*float64`
- regenerate schema types and update reference seller / skill examples to use `adcp.Ptr(...)`
- document the source-breaking SDK migration in `MIGRATING.md`
- add generator, lint, and nil-vs-`Ptr(0)` JSON round-trip regression tests

## Breaking change
Exported Go struct fields above now require pointers. Use nil to omit the field and `adcp.Ptr(0.0)` to emit an explicit zero.

## Validation
- `go test ./...`
- `cd adcp && go test ./...`
- `cd reference/seller-agent && go test ./...`
- `cd adcp/schemas && python3 -m unittest discover -p "*_test.py"`
- `cd adcp/schemas && python3 lint.py --strict`
- `git diff --check`

## Expert review
- protocol reviewer: field choices justified; requested breaking marker/migration note and valid audience selector fixture
- code reviewer: previous false negatives fixed for `CreativeAsset.weight` and `KeywordTarget.bid_price`; waiver and round-trip tests added