### PR TITLE
feat(adcp): add typed validation helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,28 @@ When handler logic needs strict current-schema validation, use the generated
 helpers: `KnownMediaBuyStatusValues()`, `IsKnownMediaBuyStatus(status)`, and
 `ParseMediaBuyStatus(raw)`.
 
+For typed structs whose schema-required fields cannot be represented by Go's
+zero values, use the SDK validators before request submission or handler-side
+acceptance. Validation is opt-in and intentionally narrower than full JSON
+Schema validation: it catches required fields and schema invariants the Go type
+cannot express, but keeps unknown enum and oneOf variant values
+forward-compatible unless `adcp.WithStrictEnums()` is supplied.
+
+```go
+goal := adcp.OptimizationGoal{
+    Kind:   "event",
+    Target: adcp.OptimizationGoalCostPerTarget{Value: 10},
+    EventSources: []adcp.OptimizationGoalEventSource{{
+        EventSourceID: "pixel-1",
+        EventType:     "purchase",
+    }},
+}
+
+if issues := goal.Validate(); len(issues) > 0 {
+    // Map issue.Code and issue.Field to your request error handling.
+}
+```
+
 ## Request signing (AdCP 3.0 optional, 4.0 required)
 
 `adcp/signing` implements the AdCP RFC 9421 request-signing profile — optional in 3.0, required for spend-committing operations in 4.0. The package is self-validating against the spec's [conformance vectors](https://adcontextprotocol.org/compliance/latest/test-vectors/request-signing/): all 8 positive + 20 negative vectors pass, and signed Ed25519 signatures match the committed positive-vector bytes.

--- a/adcp/validation.go
+++ b/adcp/validation.go
@@ -1,0 +1,393 @@
+package adcp
+
+import "fmt"
+
+// ValidationIssue describes one opt-in SDK validation finding.
+// Field is a JSON-style field path; Code is a stable machine-readable token
+// suitable for mapping to AdCP INVALID_FIELD responses.
+type ValidationIssue struct {
+	Field   string
+	Code    string
+	Message string
+}
+
+func (i ValidationIssue) Error() string {
+	return fmt.Sprintf("%s: %s", i.Field, i.Message)
+}
+
+type validationConfig struct {
+	strictEnums bool
+}
+
+// ValidationOption configures opt-in SDK validators.
+type ValidationOption func(*validationConfig)
+
+// WithStrictEnums reports values outside the current schema enum or oneOf
+// variant set. Validators are forward-compatible by default and only require
+// current-schema membership when this option is supplied.
+func WithStrictEnums() ValidationOption {
+	return func(cfg *validationConfig) {
+		cfg.strictEnums = true
+	}
+}
+
+func newValidationConfig(opts []ValidationOption) validationConfig {
+	var cfg validationConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+
+// ValidateOptimizationGoal checks required fields and current-schema invariants
+// that Go zero values cannot express. It is intentionally not a full JSON
+// Schema validator: unknown enum values are allowed unless WithStrictEnums is
+// supplied, and product/account capability checks still belong to the seller.
+func ValidateOptimizationGoal(goal OptimizationGoal, opts ...ValidationOption) []ValidationIssue {
+	return goal.Validate(opts...)
+}
+
+// Validate checks required fields and current-schema invariants that Go zero
+// values cannot express. Call it before submitting package requests or updates
+// that include optimization_goals.
+func (g OptimizationGoal) Validate(opts ...ValidationOption) []ValidationIssue {
+	cfg := newValidationConfig(opts)
+	var issues []ValidationIssue
+
+	switch g.Kind {
+	case "":
+		issues = appendRequired(issues, "kind")
+		return issues
+	case "metric":
+		issues = append(issues, validateMetricOptimizationGoal(g, cfg)...)
+	case "event":
+		issues = append(issues, validateEventOptimizationGoal(g, cfg)...)
+	default:
+		if cfg.strictEnums {
+			issues = appendUnknownVariant(issues, "kind")
+		}
+	}
+
+	if g.Priority != 0 && g.Priority < 1 {
+		issues = append(issues, ValidationIssue{
+			Field:   "priority",
+			Code:    "INVALID_VALUE",
+			Message: "priority must be at least 1 when set",
+		})
+	}
+
+	return issues
+}
+
+func validateMetricOptimizationGoal(g OptimizationGoal, cfg validationConfig) []ValidationIssue {
+	var issues []ValidationIssue
+
+	if g.Metric == "" {
+		issues = appendRequired(issues, "metric")
+	} else if cfg.strictEnums && !isKnownOptimizationMetric(g.Metric) {
+		issues = appendUnknownEnum(issues, "metric")
+	}
+
+	if g.Metric == "reach" {
+		if g.ReachUnit == "" {
+			issues = appendRequired(issues, "reach_unit")
+		} else if cfg.strictEnums && !IsKnownReachUnit(ReachUnit(g.ReachUnit)) {
+			issues = appendUnknownEnum(issues, "reach_unit")
+		}
+	}
+	if g.TargetFrequency != nil {
+		issues = append(issues, g.TargetFrequency.validate("target_frequency", cfg)...)
+	}
+	if g.ViewDurationSeconds < 0 {
+		issues = append(issues, ValidationIssue{
+			Field:   "view_duration_seconds",
+			Code:    "INVALID_VALUE",
+			Message: "view_duration_seconds must be greater than 0 when set",
+		})
+	}
+	if !isNilOptimizationGoalTarget(g.Target) {
+		issues = append(issues, validateOptimizationGoalTarget(g.Target, "metric", "target", cfg)...)
+	}
+
+	return issues
+}
+
+func validateEventOptimizationGoal(g OptimizationGoal, cfg validationConfig) []ValidationIssue {
+	var issues []ValidationIssue
+
+	if len(g.EventSources) == 0 {
+		issues = appendRequired(issues, "event_sources")
+	}
+	for i, source := range g.EventSources {
+		issues = append(issues, source.validate(fmt.Sprintf("event_sources[%d]", i), cfg)...)
+	}
+	if !isNilOptimizationGoalTarget(g.Target) {
+		issues = append(issues, validateOptimizationGoalTarget(g.Target, "event", "target", cfg)...)
+		if optimizationTargetNeedsValueField(g.Target) && !eventSourcesIncludeValueField(g.EventSources) {
+			issues = append(issues, ValidationIssue{
+				Field:   "event_sources",
+				Code:    "REQUIRED_FIELD",
+				Message: "at least one event source value_field is required for this target kind",
+			})
+		}
+	}
+	if g.AttributionWindow != nil {
+		issues = append(issues, g.AttributionWindow.validate("attribution_window", cfg)...)
+	}
+
+	return issues
+}
+
+func (f *OptimizationGoalTargetFrequency) validate(path string, cfg validationConfig) []ValidationIssue {
+	if f == nil {
+		return nil
+	}
+	var issues []ValidationIssue
+
+	if f.Min == 0 && f.Max == 0 {
+		issues = append(issues, ValidationIssue{
+			Field:   path,
+			Code:    "REQUIRED_FIELD",
+			Message: "min or max is required",
+		})
+	}
+	if f.Min < 0 {
+		issues = append(issues, ValidationIssue{
+			Field:   path + ".min",
+			Code:    "INVALID_VALUE",
+			Message: "min must be at least 1 when set",
+		})
+	}
+	if f.Max < 0 {
+		issues = append(issues, ValidationIssue{
+			Field:   path + ".max",
+			Code:    "INVALID_VALUE",
+			Message: "max must be at least 1 when set",
+		})
+	}
+	if f.Min > 0 && f.Max > 0 && f.Max < f.Min {
+		issues = append(issues, ValidationIssue{
+			Field:   path + ".max",
+			Code:    "INVALID_VALUE",
+			Message: "max must be greater than or equal to min",
+		})
+	}
+	issues = append(issues, f.Window.validate(path+".window", cfg)...)
+
+	return issues
+}
+
+func (s OptimizationGoalEventSource) validate(path string, cfg validationConfig) []ValidationIssue {
+	var issues []ValidationIssue
+
+	if s.EventSourceID == "" {
+		issues = appendRequired(issues, path+".event_source_id")
+	}
+	if s.EventType == "" {
+		issues = appendRequired(issues, path+".event_type")
+	} else {
+		if cfg.strictEnums && !IsKnownEventType(EventType(s.EventType)) {
+			issues = appendUnknownEnum(issues, path+".event_type")
+		}
+		if s.EventType == "custom" && s.CustomEventName == "" {
+			issues = appendRequired(issues, path+".custom_event_name")
+		}
+	}
+
+	return issues
+}
+
+func (w *OptimizationGoalAttributionWindow) validate(path string, cfg validationConfig) []ValidationIssue {
+	if w == nil {
+		return nil
+	}
+	issues := w.PostClick.validate(path+".post_click", cfg)
+	if w.PostView != nil {
+		issues = append(issues, w.PostView.validate(path+".post_view", cfg)...)
+	}
+	return issues
+}
+
+func (d Duration) validate(path string, cfg validationConfig) []ValidationIssue {
+	var issues []ValidationIssue
+
+	if d.Interval == 0 {
+		issues = appendRequired(issues, path+".interval")
+	} else if d.Interval < 0 {
+		issues = append(issues, ValidationIssue{
+			Field:   path + ".interval",
+			Code:    "INVALID_VALUE",
+			Message: "interval must be at least 1",
+		})
+	}
+	if d.Unit == "" {
+		issues = appendRequired(issues, path+".unit")
+	} else {
+		if cfg.strictEnums && !isKnownDurationUnit(d.Unit) {
+			issues = appendUnknownEnum(issues, path+".unit")
+		}
+		if d.Unit == "campaign" && d.Interval > 0 && d.Interval != 1 {
+			issues = append(issues, ValidationIssue{
+				Field:   path + ".interval",
+				Code:    "INVALID_VALUE",
+				Message: "interval must be 1 when unit is campaign",
+			})
+		}
+	}
+
+	return issues
+}
+
+func validateOptimizationGoalTarget(target OptimizationGoalTarget, goalKind, path string, cfg validationConfig) []ValidationIssue {
+	var issues []ValidationIssue
+
+	switch t := target.(type) {
+	case *OptimizationGoalCostPerTarget:
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case OptimizationGoalCostPerTarget:
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case *OptimizationGoalThresholdRateTarget:
+		if goalKind != "metric" {
+			issues = append(issues, unsupportedTarget(path+".kind", "threshold_rate", goalKind))
+		}
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case OptimizationGoalThresholdRateTarget:
+		if goalKind != "metric" {
+			issues = append(issues, unsupportedTarget(path+".kind", "threshold_rate", goalKind))
+		}
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case *OptimizationGoalPerAdSpendTarget:
+		if goalKind != "event" {
+			issues = append(issues, unsupportedTarget(path+".kind", "per_ad_spend", goalKind))
+		}
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case OptimizationGoalPerAdSpendTarget:
+		if goalKind != "event" {
+			issues = append(issues, unsupportedTarget(path+".kind", "per_ad_spend", goalKind))
+		}
+		issues = append(issues, validatePositiveTargetValue(t.Value, path+".value")...)
+	case *OptimizationGoalMaximizeValueTarget:
+		if goalKind != "event" {
+			issues = append(issues, unsupportedTarget(path+".kind", "maximize_value", goalKind))
+		}
+	case OptimizationGoalMaximizeValueTarget:
+		if goalKind != "event" {
+			issues = append(issues, unsupportedTarget(path+".kind", "maximize_value", goalKind))
+		}
+	case *OptimizationGoalRawTarget:
+		issues = append(issues, validateRawOptimizationGoalTarget(t, path, cfg)...)
+	case OptimizationGoalRawTarget:
+		issues = append(issues, validateRawOptimizationGoalTarget(&t, path, cfg)...)
+	}
+
+	return issues
+}
+
+func validateRawOptimizationGoalTarget(target *OptimizationGoalRawTarget, path string, cfg validationConfig) []ValidationIssue {
+	if target == nil {
+		return nil
+	}
+	if target.Kind != "" {
+		if cfg.strictEnums {
+			return appendUnknownVariant(nil, path+".kind")
+		}
+		return nil
+	}
+	return []ValidationIssue{{
+		Field:   path + ".kind",
+		Code:    "REQUIRED_FIELD",
+		Message: "kind is required",
+	}}
+}
+
+func validatePositiveTargetValue(value float64, path string) []ValidationIssue {
+	if value > 0 {
+		return nil
+	}
+	return []ValidationIssue{{
+		Field:   path,
+		Code:    "INVALID_VALUE",
+		Message: "value must be greater than 0",
+	}}
+}
+
+func optimizationTargetNeedsValueField(target OptimizationGoalTarget) bool {
+	switch target.(type) {
+	case *OptimizationGoalPerAdSpendTarget, OptimizationGoalPerAdSpendTarget,
+		*OptimizationGoalMaximizeValueTarget, OptimizationGoalMaximizeValueTarget:
+		return true
+	default:
+		return false
+	}
+}
+
+func eventSourcesIncludeValueField(sources []OptimizationGoalEventSource) bool {
+	for _, source := range sources {
+		if source.ValueField != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func unsupportedTarget(path, targetKind, goalKind string) ValidationIssue {
+	return ValidationIssue{
+		Field:   path,
+		Code:    "UNSUPPORTED_TARGET_KIND",
+		Message: fmt.Sprintf("%s target is not supported for %s goals", targetKind, goalKind),
+	}
+}
+
+func appendRequired(issues []ValidationIssue, field string) []ValidationIssue {
+	return append(issues, ValidationIssue{
+		Field:   field,
+		Code:    "REQUIRED_FIELD",
+		Message: "field is required",
+	})
+}
+
+func appendUnknownEnum(issues []ValidationIssue, field string) []ValidationIssue {
+	return append(issues, ValidationIssue{
+		Field:   field,
+		Code:    "UNKNOWN_ENUM_VALUE",
+		Message: "value is not in the current schema enum",
+	})
+}
+
+func appendUnknownVariant(issues []ValidationIssue, field string) []ValidationIssue {
+	return append(issues, ValidationIssue{
+		Field:   field,
+		Code:    "UNKNOWN_VARIANT",
+		Message: "value is not a current schema variant",
+	})
+}
+
+func isKnownOptimizationMetric(v string) bool {
+	switch v {
+	case "clicks",
+		"views",
+		"completed_views",
+		"viewed_seconds",
+		"attention_seconds",
+		"attention_score",
+		"engagements",
+		"follows",
+		"saves",
+		"profile_visits",
+		"reach":
+		return true
+	default:
+		return false
+	}
+}
+
+func isKnownDurationUnit(v string) bool {
+	switch v {
+	case "seconds", "minutes", "hours", "days", "campaign":
+		return true
+	default:
+		return false
+	}
+}

--- a/adcp/validation_test.go
+++ b/adcp/validation_test.go
@@ -1,0 +1,199 @@
+package adcp
+
+import "testing"
+
+func hasValidationIssue(issues []ValidationIssue, field, code string) bool {
+	for _, issue := range issues {
+		if issue.Field == field && issue.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateOptimizationGoal_ValidMetricReach(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind:      "metric",
+		Metric:    "reach",
+		ReachUnit: "households",
+		TargetFrequency: &OptimizationGoalTargetFrequency{
+			Min:    2,
+			Max:    4,
+			Window: Duration{Interval: 7, Unit: "days"},
+		},
+		Target: OptimizationGoalCostPerTarget{Value: 1.25},
+	}
+
+	if issues := goal.Validate(WithStrictEnums()); len(issues) != 0 {
+		t.Fatalf("Validate issues = %#v, want none", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_ValidEventGoal(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind: "event",
+		EventSources: []OptimizationGoalEventSource{{
+			EventSourceID: "pixel-1",
+			EventType:     "purchase",
+			ValueField:    "value",
+		}},
+		Target: OptimizationGoalPerAdSpendTarget{Value: 4},
+		AttributionWindow: &OptimizationGoalAttributionWindow{
+			PostClick: Duration{Interval: 7, Unit: "days"},
+		},
+	}
+
+	if issues := ValidateOptimizationGoal(goal, WithStrictEnums()); len(issues) != 0 {
+		t.Fatalf("ValidateOptimizationGoal issues = %#v, want none", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_RequiredFields(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind: "event",
+		EventSources: []OptimizationGoalEventSource{{
+			EventType: "custom",
+		}},
+		AttributionWindow: &OptimizationGoalAttributionWindow{},
+	}
+
+	issues := goal.Validate()
+	for _, want := range []struct {
+		field string
+		code  string
+	}{
+		{"event_sources[0].event_source_id", "REQUIRED_FIELD"},
+		{"event_sources[0].custom_event_name", "REQUIRED_FIELD"},
+		{"attribution_window.post_click.interval", "REQUIRED_FIELD"},
+		{"attribution_window.post_click.unit", "REQUIRED_FIELD"},
+	} {
+		if !hasValidationIssue(issues, want.field, want.code) {
+			t.Fatalf("Validate missing issue %s/%s in %#v", want.field, want.code, issues)
+		}
+	}
+}
+
+func TestValidateOptimizationGoal_TargetFrequencyRequiredWindow(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind:      "metric",
+		Metric:    "reach",
+		ReachUnit: "individuals",
+		TargetFrequency: &OptimizationGoalTargetFrequency{
+			Min: 2,
+		},
+	}
+
+	issues := goal.Validate()
+	for _, want := range []struct {
+		field string
+		code  string
+	}{
+		{"target_frequency.window.interval", "REQUIRED_FIELD"},
+		{"target_frequency.window.unit", "REQUIRED_FIELD"},
+	} {
+		if !hasValidationIssue(issues, want.field, want.code) {
+			t.Fatalf("Validate missing issue %s/%s in %#v", want.field, want.code, issues)
+		}
+	}
+}
+
+func TestValidateOptimizationGoal_StrictEnumsAreOptIn(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind:   "metric",
+		Metric: "future_metric",
+	}
+
+	if issues := goal.Validate(); hasValidationIssue(issues, "metric", "UNKNOWN_ENUM_VALUE") {
+		t.Fatalf("Validate reported strict enum issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := goal.Validate(WithStrictEnums()); !hasValidationIssue(issues, "metric", "UNKNOWN_ENUM_VALUE") {
+		t.Fatalf("Validate missing strict enum issue: %#v", issues)
+	}
+
+	future := OptimizationGoal{Kind: "future_goal_kind"}
+	if issues := future.Validate(); hasValidationIssue(issues, "kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate reported strict variant issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := future.Validate(WithStrictEnums()); !hasValidationIssue(issues, "kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate missing strict variant issue: %#v", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_EventSourceStrictEnum(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind: "event",
+		EventSources: []OptimizationGoalEventSource{{
+			EventSourceID: "pixel-1",
+			EventType:     "future_event",
+		}},
+	}
+
+	if issues := goal.Validate(); hasValidationIssue(issues, "event_sources[0].event_type", "UNKNOWN_ENUM_VALUE") {
+		t.Fatalf("Validate reported strict enum issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := goal.Validate(WithStrictEnums()); !hasValidationIssue(issues, "event_sources[0].event_type", "UNKNOWN_ENUM_VALUE") {
+		t.Fatalf("Validate missing strict event enum issue: %#v", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_TargetRules(t *testing.T) {
+	metric := OptimizationGoal{
+		Kind:   "metric",
+		Metric: "clicks",
+		Target: OptimizationGoalPerAdSpendTarget{Value: 0},
+	}
+	metricIssues := metric.Validate()
+	if !hasValidationIssue(metricIssues, "target.kind", "UNSUPPORTED_TARGET_KIND") {
+		t.Fatalf("Validate missing unsupported target issue: %#v", metricIssues)
+	}
+	if !hasValidationIssue(metricIssues, "target.value", "INVALID_VALUE") {
+		t.Fatalf("Validate missing target value issue: %#v", metricIssues)
+	}
+
+	event := OptimizationGoal{
+		Kind: "event",
+		EventSources: []OptimizationGoalEventSource{{
+			EventSourceID: "pixel-1",
+			EventType:     "purchase",
+		}},
+		Target: OptimizationGoalMaximizeValueTarget{},
+	}
+	eventIssues := event.Validate()
+	if !hasValidationIssue(eventIssues, "event_sources", "REQUIRED_FIELD") {
+		t.Fatalf("Validate missing value_field requirement: %#v", eventIssues)
+	}
+
+	futureTarget := OptimizationGoal{
+		Kind:   "metric",
+		Metric: "clicks",
+		Target: OptimizationGoalRawTarget{Kind: "future_target"},
+	}
+	if issues := futureTarget.Validate(); hasValidationIssue(issues, "target.kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate reported strict raw target issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := futureTarget.Validate(WithStrictEnums()); !hasValidationIssue(issues, "target.kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate missing strict raw target issue: %#v", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_DurationRules(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind:      "metric",
+		Metric:    "reach",
+		ReachUnit: "devices",
+		TargetFrequency: &OptimizationGoalTargetFrequency{
+			Max:    3,
+			Window: Duration{Interval: 2, Unit: "campaign"},
+		},
+	}
+	issues := goal.Validate(WithStrictEnums())
+	if !hasValidationIssue(issues, "target_frequency.window.interval", "INVALID_VALUE") {
+		t.Fatalf("Validate missing campaign interval issue: %#v", issues)
+	}
+
+	goal.TargetFrequency.Window.Unit = "fortnights"
+	issues = goal.Validate(WithStrictEnums())
+	if !hasValidationIssue(issues, "target_frequency.window.unit", "UNKNOWN_ENUM_VALUE") {
+		t.Fatalf("Validate missing duration unit enum issue: %#v", issues)
+	}
+}


### PR DESCRIPTION
Closes #215.

## Summary
- add opt-in `ValidationIssue` / `ValidationOption` primitives and `OptimizationGoal.Validate` helpers
- validate optimization-goal required fields, known target branch constraints, duration invariants, and value-field requirements
- keep unknown enum and future oneOf variant values forward-compatible by default, with `WithStrictEnums()` for current-schema strict checks
- document how callers should run SDK validation before request submission or handler-side acceptance

## Verification
- `go test ./...`
- `cd adcp && go test ./...`
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`