### PR TITLE
feat(adcp): generate optimization metric enum helpers

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -629,6 +629,15 @@ INLINE_SCHEMA_TYPES = OrderedDict([
     ),
 ])
 
+# Named enum helpers generated from inline JSON Schema pointers. These cover
+# important SDK validation values that are not standalone enum schema files.
+INLINE_ENUM_TYPES = OrderedDict([
+    (
+        "OptimizationMetric",
+        "core/optimization-goal.json#/oneOf/0/properties/metric",
+    ),
+])
+
 # Named helper types generated for simple union schemas. These cover the common
 # protocol shape "single scalar or array of the same scalar" without falling
 # back to `any`.
@@ -1500,21 +1509,32 @@ def enum_to_type(name, desc, values):
 def generate_enums():
     """Generate Go string constants for all enum schemas."""
     lines = []
-    enum_dir = SCRIPT_DIR / ENUM_DIR
-    if not enum_dir.exists():
-        return ''
+    seen = {}
 
-    for f in sorted(enum_dir.iterdir()):
-        if not f.suffix == '.json':
-            continue
-        schema = load_schema(f)
-        name = pascal_case(f.stem)
+    def append_enum(name, schema, origin, required=False):
         values = schema.get('enum', [])
         if not values:
-            continue
-
+            if required:
+                raise ValueError(f'{origin} no longer defines enum values for {name}')
+            return
+        if name in seen:
+            raise ValueError(f'duplicate enum type {name}: {seen[name]} and {origin}')
+        seen[name] = origin
         desc = schema.get('description', '')
         lines.append(enum_to_type(name, desc, values))
+
+    enum_dir = SCRIPT_DIR / ENUM_DIR
+    if enum_dir.exists():
+        for f in sorted(enum_dir.iterdir()):
+            if not f.suffix == '.json':
+                continue
+            schema = load_schema(f)
+            name = pascal_case(f.stem)
+            append_enum(name, schema, str(f.relative_to(SCRIPT_DIR)))
+
+    for name, spec in INLINE_ENUM_TYPES.items():
+        schema = load_schema_spec(spec)
+        append_enum(name, schema, spec, required=True)
 
     return '\n'.join(lines)
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -183,6 +183,14 @@ class UnionHelperGenerationTest(unittest.TestCase):
 
 
 class EnumGenerationTest(unittest.TestCase):
+    def setUp(self):
+        self.original_inline_enum_types = generate.INLINE_ENUM_TYPES
+        self.original_load_schema_spec = generate.load_schema_spec
+
+    def tearDown(self):
+        generate.INLINE_ENUM_TYPES = self.original_inline_enum_types
+        generate.load_schema_spec = self.original_load_schema_spec
+
     def test_enum_helpers_are_opt_in_and_do_not_echo_rejected_value(self):
         src = generate.enum_to_type("TestStatus", "Test enum", ["active", "pending-start"])
 
@@ -208,6 +216,42 @@ class EnumGenerationTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             generate.enum_members("TestStatus", ["active", 1])
+
+    def test_generate_enums_includes_inline_optimization_metric_helpers(self):
+        schema = generate.load_schema_spec(
+            "core/optimization-goal.json#/oneOf/0/properties/metric"
+        )
+        src = generate.generate_enums()
+
+        self.assertIn("type OptimizationMetric = string", src)
+        self.assertIn("func KnownOptimizationMetricValues() []OptimizationMetric", src)
+        self.assertIn("func IsKnownOptimizationMetric(v OptimizationMetric) bool", src)
+        for value in schema["enum"]:
+            const_name = "OptimizationMetric" + generate.pascal_case(value)
+            self.assertIn(f'{const_name} OptimizationMetric = "{value}"', src)
+
+    def test_generate_enums_rejects_duplicate_inline_enum_name(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "MediaBuyStatus",
+                "core/optimization-goal.json#/oneOf/0/properties/metric",
+            ),
+        ])
+
+        with self.assertRaisesRegex(ValueError, "duplicate enum type MediaBuyStatus"):
+            generate.generate_enums()
+
+    def test_generate_enums_requires_inline_enum_values(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([("TestInlineEnum", "test.json#/properties/value")])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json#/properties/value", spec)
+            return {"type": "string"}
+
+        generate.load_schema_spec = load_schema_spec
+
+        with self.assertRaisesRegex(ValueError, "no longer defines enum values"):
+            generate.generate_enums()
 
     @unittest.skipUnless(shutil.which("go"), "go command not found")
     def test_enum_helpers_runtime(self):

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5298,6 +5298,48 @@ func ParseWebhookSecurityMethod(s string) (WebhookSecurityMethod, error) {
 	return "", fmt.Errorf("unknown WebhookSecurityMethod value")
 }
 
+// OptimizationMetric — Seller-native metric to optimize for. Delivery metrics: clicks (link clicks, swi
+type OptimizationMetric = string
+const (
+	OptimizationMetricClicks OptimizationMetric = "clicks"
+	OptimizationMetricViews OptimizationMetric = "views"
+	OptimizationMetricCompletedViews OptimizationMetric = "completed_views"
+	OptimizationMetricViewedSeconds OptimizationMetric = "viewed_seconds"
+	OptimizationMetricAttentionSeconds OptimizationMetric = "attention_seconds"
+	OptimizationMetricAttentionScore OptimizationMetric = "attention_score"
+	OptimizationMetricEngagements OptimizationMetric = "engagements"
+	OptimizationMetricFollows OptimizationMetric = "follows"
+	OptimizationMetricSaves OptimizationMetric = "saves"
+	OptimizationMetricProfileVisits OptimizationMetric = "profile_visits"
+	OptimizationMetricReach OptimizationMetric = "reach"
+)
+
+// KnownOptimizationMetricValues returns the current schema-defined values for OptimizationMetric.
+func KnownOptimizationMetricValues() []OptimizationMetric {
+	return []OptimizationMetric{OptimizationMetricClicks, OptimizationMetricViews, OptimizationMetricCompletedViews, OptimizationMetricViewedSeconds, OptimizationMetricAttentionSeconds, OptimizationMetricAttentionScore, OptimizationMetricEngagements, OptimizationMetricFollows, OptimizationMetricSaves, OptimizationMetricProfileVisits, OptimizationMetricReach}
+}
+
+// IsKnownOptimizationMetric reports whether v is one of the current schema-defined OptimizationMetric values.
+// It is an opt-in strict helper; JSON unmarshalling preserves unknown values.
+func IsKnownOptimizationMetric(v OptimizationMetric) bool {
+	switch v {
+	case OptimizationMetricClicks, OptimizationMetricViews, OptimizationMetricCompletedViews, OptimizationMetricViewedSeconds, OptimizationMetricAttentionSeconds, OptimizationMetricAttentionScore, OptimizationMetricEngagements, OptimizationMetricFollows, OptimizationMetricSaves, OptimizationMetricProfileVisits, OptimizationMetricReach:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseOptimizationMetric returns s as OptimizationMetric when s is one of the current schema-defined values.
+// It is an opt-in strict helper; JSON unmarshalling preserves unknown values.
+func ParseOptimizationMetric(s string) (OptimizationMetric, error) {
+	v := OptimizationMetric(s)
+	if IsKnownOptimizationMetric(v) {
+		return v, nil
+	}
+	return "", fmt.Errorf("unknown OptimizationMetric value")
+}
+
 // --- Union helper types ---
 
 // MediaBuyStatusFilter — Filter by status. Can be a single status or array of statuses

--- a/adcp/validation.go
+++ b/adcp/validation.go
@@ -86,7 +86,7 @@ func validateMetricOptimizationGoal(g OptimizationGoal, cfg validationConfig) []
 
 	if g.Metric == "" {
 		issues = appendRequired(issues, "metric")
-	} else if cfg.strictEnums && !isKnownOptimizationMetric(g.Metric) {
+	} else if cfg.strictEnums && !IsKnownOptimizationMetric(OptimizationMetric(g.Metric)) {
 		issues = appendUnknownEnum(issues, "metric")
 	}
 
@@ -362,25 +362,6 @@ func appendUnknownVariant(issues []ValidationIssue, field string) []ValidationIs
 		Code:    "UNKNOWN_VARIANT",
 		Message: "value is not a current schema variant",
 	})
-}
-
-func isKnownOptimizationMetric(v string) bool {
-	switch v {
-	case "clicks",
-		"views",
-		"completed_views",
-		"viewed_seconds",
-		"attention_seconds",
-		"attention_score",
-		"engagements",
-		"follows",
-		"saves",
-		"profile_visits",
-		"reach":
-		return true
-	default:
-		return false
-	}
 }
 
 func isKnownDurationUnit(v string) bool {

--- a/targeting/identityagent/handler_test.go
+++ b/targeting/identityagent/handler_test.go
@@ -159,7 +159,13 @@ func TestIdentityHandlerUnsupportedMajorVersionIsGenericAndLogged(t *testing.T) 
 	assert.Contains(t, logText, "invalid identity-match request")
 	assert.Contains(t, logText, `"request_id":"id-version"`)
 	assert.Contains(t, logText, "adcp_major_version is not supported")
-	assert.NotContains(t, logText, "999")
+
+	var logEntry map[string]any
+	require.NoError(t, json.Unmarshal(logs.Bytes(), &logEntry))
+	logErr, ok := logEntry["error"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "adcp_major_version is not supported", logErr)
+	assert.NotContains(t, logErr, "999")
 }
 
 // TestBuildServiceRequest_TMPXDisabled_PassesThroughUnchanged covers the


### PR DESCRIPTION
Closes #229.

## Summary
- add an inline enum registry to `adcp/schemas/generate.py` for schema pointer-backed enum helpers
- generate `OptimizationMetric` constants plus `Known` / `IsKnown` / `Parse` helpers from `core/optimization-goal.json`
- switch strict optimization-goal validation to the generated `IsKnownOptimizationMetric` helper
- fail generation on duplicate inline enum names or inline pointers that stop being enums

## Verification
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp && go test ./...`\n- `go test ./...`