### PR TITLE
test(adcp): polish optimization goal validation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ acceptance. Validation is opt-in and intentionally narrower than full JSON
 Schema validation: it catches required fields and schema invariants the Go type
 cannot express, but keeps unknown enum and oneOf variant values
 forward-compatible unless `adcp.WithStrictEnums()` is supplied.
+For value-based event targets such as `per_ad_spend` and `maximize_value`, the
+validator also requires at least one event source `value_field`; that is an SDK
+invariant derived from the schema descriptions, not a general-purpose JSON
+Schema validation pass.
 
 ```go
 goal := adcp.OptimizationGoal{

--- a/adcp/validation.go
+++ b/adcp/validation.go
@@ -86,14 +86,14 @@ func validateMetricOptimizationGoal(g OptimizationGoal, cfg validationConfig) []
 
 	if g.Metric == "" {
 		issues = appendRequired(issues, "metric")
-	} else if cfg.strictEnums && !IsKnownOptimizationMetric(OptimizationMetric(g.Metric)) {
+	} else if cfg.strictEnums && !IsKnownOptimizationMetric(g.Metric) {
 		issues = appendUnknownEnum(issues, "metric")
 	}
 
 	if g.Metric == "reach" {
 		if g.ReachUnit == "" {
 			issues = appendRequired(issues, "reach_unit")
-		} else if cfg.strictEnums && !IsKnownReachUnit(ReachUnit(g.ReachUnit)) {
+		} else if cfg.strictEnums && !IsKnownReachUnit(g.ReachUnit) {
 			issues = appendUnknownEnum(issues, "reach_unit")
 		}
 	}
@@ -104,7 +104,7 @@ func validateMetricOptimizationGoal(g OptimizationGoal, cfg validationConfig) []
 		issues = append(issues, ValidationIssue{
 			Field:   "view_duration_seconds",
 			Code:    "INVALID_VALUE",
-			Message: "view_duration_seconds must be greater than 0 when set",
+			Message: "view_duration_seconds must not be negative",
 		})
 	}
 	if !isNilOptimizationGoalTarget(g.Target) {
@@ -150,21 +150,21 @@ func (f *OptimizationGoalTargetFrequency) validate(path string, cfg validationCo
 		issues = append(issues, ValidationIssue{
 			Field:   path,
 			Code:    "REQUIRED_FIELD",
-			Message: "min or max is required",
+			Message: "min or max must be set to a positive value",
 		})
 	}
 	if f.Min < 0 {
 		issues = append(issues, ValidationIssue{
 			Field:   path + ".min",
 			Code:    "INVALID_VALUE",
-			Message: "min must be at least 1 when set",
+			Message: "min must be greater than 0 when set",
 		})
 	}
 	if f.Max < 0 {
 		issues = append(issues, ValidationIssue{
 			Field:   path + ".max",
 			Code:    "INVALID_VALUE",
-			Message: "max must be at least 1 when set",
+			Message: "max must be greater than 0 when set",
 		})
 	}
 	if f.Min > 0 && f.Max > 0 && f.Max < f.Min {
@@ -188,7 +188,7 @@ func (s OptimizationGoalEventSource) validate(path string, cfg validationConfig)
 	if s.EventType == "" {
 		issues = appendRequired(issues, path+".event_type")
 	} else {
-		if cfg.strictEnums && !IsKnownEventType(EventType(s.EventType)) {
+		if cfg.strictEnums && !IsKnownEventType(s.EventType) {
 			issues = appendUnknownEnum(issues, path+".event_type")
 		}
 		if s.EventType == "custom" && s.CustomEventName == "" {
@@ -280,6 +280,10 @@ func validateOptimizationGoalTarget(target OptimizationGoalTarget, goalKind, pat
 		issues = append(issues, validateRawOptimizationGoalTarget(t, path, cfg)...)
 	case OptimizationGoalRawTarget:
 		issues = append(issues, validateRawOptimizationGoalTarget(&t, path, cfg)...)
+	default:
+		if cfg.strictEnums {
+			issues = appendUnknownVariant(issues, path+".kind")
+		}
 	}
 
 	return issues
@@ -314,6 +318,9 @@ func validatePositiveTargetValue(value float64, path string) []ValidationIssue {
 }
 
 func optimizationTargetNeedsValueField(target OptimizationGoalTarget) bool {
+	// The schema describes per_ad_spend/maximize_value as value-based goals. The
+	// value_field requirement is an SDK invariant derived from those descriptions,
+	// not a complete JSON Schema validation pass.
 	switch target.(type) {
 	case *OptimizationGoalPerAdSpendTarget, OptimizationGoalPerAdSpendTarget,
 		*OptimizationGoalMaximizeValueTarget, OptimizationGoalMaximizeValueTarget:

--- a/adcp/validation_test.go
+++ b/adcp/validation_test.go
@@ -1,6 +1,13 @@
 package adcp
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+type customOptimizationGoalTarget struct{}
+
+func (customOptimizationGoalTarget) isOptimizationGoalTarget() {}
 
 func hasValidationIssue(issues []ValidationIssue, field, code string) bool {
 	for _, issue := range issues {
@@ -174,6 +181,18 @@ func TestValidateOptimizationGoal_TargetRules(t *testing.T) {
 	if issues := futureTarget.Validate(WithStrictEnums()); !hasValidationIssue(issues, "target.kind", "UNKNOWN_VARIANT") {
 		t.Fatalf("Validate missing strict raw target issue: %#v", issues)
 	}
+
+	customTarget := OptimizationGoal{
+		Kind:   "metric",
+		Metric: "clicks",
+		Target: customOptimizationGoalTarget{},
+	}
+	if issues := customTarget.Validate(); hasValidationIssue(issues, "target.kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate reported strict custom target issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := customTarget.Validate(WithStrictEnums()); !hasValidationIssue(issues, "target.kind", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate missing strict custom target issue: %#v", issues)
+	}
 }
 
 func TestValidateOptimizationGoal_DurationRules(t *testing.T) {
@@ -195,5 +214,124 @@ func TestValidateOptimizationGoal_DurationRules(t *testing.T) {
 	issues = goal.Validate(WithStrictEnums())
 	if !hasValidationIssue(issues, "target_frequency.window.unit", "UNKNOWN_ENUM_VALUE") {
 		t.Fatalf("Validate missing duration unit enum issue: %#v", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_PointerTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		goalKind     string
+		eventSources []OptimizationGoalEventSource
+		target       OptimizationGoalTarget
+		field        string
+		code         string
+	}{
+		{
+			name:     "cost per requires positive value",
+			goalKind: "metric",
+			target:   &OptimizationGoalCostPerTarget{},
+			field:    "target.value",
+			code:     "INVALID_VALUE",
+		},
+		{
+			name:     "threshold rate rejected for event",
+			goalKind: "event",
+			eventSources: []OptimizationGoalEventSource{{
+				EventSourceID: "pixel-1",
+				EventType:     "purchase",
+			}},
+			target: &OptimizationGoalThresholdRateTarget{Value: 1},
+			field:  "target.kind",
+			code:   "UNSUPPORTED_TARGET_KIND",
+		},
+		{
+			name:     "per ad spend rejected for metric",
+			goalKind: "metric",
+			target:   &OptimizationGoalPerAdSpendTarget{Value: 1},
+			field:    "target.kind",
+			code:     "UNSUPPORTED_TARGET_KIND",
+		},
+		{
+			name:     "maximize value rejected for metric",
+			goalKind: "metric",
+			target:   &OptimizationGoalMaximizeValueTarget{},
+			field:    "target.kind",
+			code:     "UNSUPPORTED_TARGET_KIND",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			goal := OptimizationGoal{
+				Kind:         tt.goalKind,
+				Metric:       "clicks",
+				EventSources: tt.eventSources,
+				Target:       tt.target,
+			}
+			issues := goal.Validate()
+			if !hasValidationIssue(issues, tt.field, tt.code) {
+				t.Fatalf("Validate missing issue %s/%s in %#v", tt.field, tt.code, issues)
+			}
+		})
+	}
+}
+
+func TestValidateOptimizationGoal_UnmarshaledPointerTarget(t *testing.T) {
+	var goal OptimizationGoal
+	if err := json.Unmarshal([]byte(`{
+		"kind": "event",
+		"event_sources": [{"event_source_id": "pixel-1", "event_type": "purchase"}],
+		"target": {"kind": "per_ad_spend", "value": 4}
+	}`), &goal); err != nil {
+		t.Fatalf("json.Unmarshal optimization goal: %v", err)
+	}
+	if _, ok := goal.Target.(*OptimizationGoalPerAdSpendTarget); !ok {
+		t.Fatalf("target should decode as *OptimizationGoalPerAdSpendTarget, got %#v", goal.Target)
+	}
+	if issues := goal.Validate(); !hasValidationIssue(issues, "event_sources", "REQUIRED_FIELD") {
+		t.Fatalf("Validate missing value_field requirement for decoded target: %#v", issues)
+	}
+
+	goal.EventSources[0].ValueField = "value"
+	if issues := goal.Validate(); len(issues) != 0 {
+		t.Fatalf("Validate issues after value_field = %#v, want none", issues)
+	}
+}
+
+func TestValidateOptimizationGoal_NumericRules(t *testing.T) {
+	goal := OptimizationGoal{
+		Kind:                "metric",
+		Metric:              "views",
+		Priority:            -1,
+		ViewDurationSeconds: -1,
+		TargetFrequency: &OptimizationGoalTargetFrequency{
+			Window: Duration{Interval: 7, Unit: "days"},
+		},
+	}
+
+	issues := goal.Validate()
+	for _, want := range []struct {
+		field string
+		code  string
+	}{
+		{"priority", "INVALID_VALUE"},
+		{"view_duration_seconds", "INVALID_VALUE"},
+		{"target_frequency", "REQUIRED_FIELD"},
+	} {
+		if !hasValidationIssue(issues, want.field, want.code) {
+			t.Fatalf("Validate missing issue %s/%s in %#v", want.field, want.code, issues)
+		}
+	}
+
+	goal.TargetFrequency.Min = -1
+	issues = goal.Validate()
+	if !hasValidationIssue(issues, "target_frequency.min", "INVALID_VALUE") {
+		t.Fatalf("Validate missing target_frequency.min issue: %#v", issues)
+	}
+
+	goal.TargetFrequency.Min = 1
+	goal.TargetFrequency.Max = -1
+	issues = goal.Validate()
+	if !hasValidationIssue(issues, "target_frequency.max", "INVALID_VALUE") {
+		t.Fatalf("Validate missing target_frequency.max issue: %#v", issues)
 	}
 }


### PR DESCRIPTION
## Summary
- add optimization-goal validation coverage for pointer target variants and JSON-decoded targets
- cover negative priority/view-duration/frequency values and clarify zero-as-omitted messages
- document the value_field requirement as a narrow SDK invariant, not a full JSON Schema pass
- keep strict unknown target handling opt-in through WithStrictEnums

Closes #230

## Verification
- go test ./...
- cd adcp && go test ./...
- cd adcp/schemas && python3 lint.py --strict

## Expert review
- DX expert reviewed the plan and flagged the view_duration_seconds wording; fixed before push.
- Code-review expert is running; will amend if it flags a blocking issue.