### PR TITLE
docs(adcp): clarify optimization goal branch validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ acceptance. Validation is opt-in and intentionally narrower than full JSON
 Schema validation: it catches required fields and schema invariants the Go type
 cannot express, but keeps unknown enum and oneOf variant values
 forward-compatible unless `adcp.WithStrictEnums()` is supplied.
+Flattened oneOf types are validated by active branch: event-only fields such as
+`attribution_window` are checked on event goals and ignored on metric goals.
 For value-based event targets such as `per_ad_spend` and `maximize_value`, the
 validator also requires at least one event source `value_field`; that is an SDK
 invariant derived from the schema descriptions, not a general-purpose JSON

--- a/adcp/validation.go
+++ b/adcp/validation.go
@@ -44,14 +44,18 @@ func newValidationConfig(opts []ValidationOption) validationConfig {
 // ValidateOptimizationGoal checks required fields and current-schema invariants
 // that Go zero values cannot express. It is intentionally not a full JSON
 // Schema validator: unknown enum values are allowed unless WithStrictEnums is
-// supplied, and product/account capability checks still belong to the seller.
+// supplied, branch-specific fields are validated only for the active kind, and
+// product/account capability checks still belong to the seller.
 func ValidateOptimizationGoal(goal OptimizationGoal, opts ...ValidationOption) []ValidationIssue {
 	return goal.Validate(opts...)
 }
 
 // Validate checks required fields and current-schema invariants that Go zero
 // values cannot express. Call it before submitting package requests or updates
-// that include optimization_goals.
+// that include optimization_goals. OptimizationGoal is a flattened Go
+// representation of the schema oneOf, so branch-specific fields are validated
+// only for the active kind. For example, AttributionWindow is validated for
+// event goals but ignored for metric goals.
 func (g OptimizationGoal) Validate(opts ...ValidationOption) []ValidationIssue {
 	cfg := newValidationConfig(opts)
 	var issues []ValidationIssue

--- a/adcp/validation_test.go
+++ b/adcp/validation_test.go
@@ -80,6 +80,33 @@ func TestValidateOptimizationGoal_RequiredFields(t *testing.T) {
 	}
 }
 
+func TestValidateOptimizationGoal_BranchSpecificFields(t *testing.T) {
+	invalidAttributionWindow := &OptimizationGoalAttributionWindow{}
+	event := OptimizationGoal{
+		Kind: "event",
+		EventSources: []OptimizationGoalEventSource{{
+			EventSourceID: "pixel-1",
+			EventType:     "purchase",
+		}},
+		AttributionWindow: invalidAttributionWindow,
+	}
+	eventIssues := event.Validate()
+	if !hasValidationIssue(eventIssues, "attribution_window.post_click.interval", "REQUIRED_FIELD") {
+		t.Fatalf("Validate missing event attribution_window issue: %#v", eventIssues)
+	}
+
+	metric := OptimizationGoal{
+		Kind:              "metric",
+		Metric:            "clicks",
+		AttributionWindow: invalidAttributionWindow,
+	}
+	metricIssues := metric.Validate()
+	if hasValidationIssue(metricIssues, "attribution_window.post_click.interval", "REQUIRED_FIELD") ||
+		hasValidationIssue(metricIssues, "attribution_window.post_click.unit", "REQUIRED_FIELD") {
+		t.Fatalf("Validate should ignore event-only attribution_window on metric goal: %#v", metricIssues)
+	}
+}
+
 func TestValidateOptimizationGoal_TargetFrequencyRequiredWindow(t *testing.T) {
 	goal := OptimizationGoal{
 		Kind:      "metric",


### PR DESCRIPTION
## Summary
- document that flattened `OptimizationGoal` validation is scoped to the active `kind` branch
- add regression coverage showing `attribution_window` is validated for event goals but ignored on metric goals
- preserve forward-compatible behavior instead of adding branch-inapplicable-field errors

Closes #228

## Verification
- go test ./...
- cd adcp && go test ./...

## Expert review
- Protocol reviewer found no issues and confirmed this is schema-correct because `OptimizationGoal` is a flattened oneOf and the branches permit additional properties.