### PR TITLE
test(adcp): harden inline enum generation

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -634,7 +634,11 @@ INLINE_SCHEMA_TYPES = OrderedDict([
 INLINE_ENUM_TYPES = OrderedDict([
     (
         "OptimizationMetric",
-        "core/optimization-goal.json#/oneOf/0/properties/metric",
+        {
+            "schema": "core/optimization-goal.json",
+            "one_of_kind": "metric",
+            "property": "metric",
+        },
     ),
 ])
 
@@ -1506,15 +1510,48 @@ def enum_to_type(name, desc, values):
 
     return '\n'.join(lines)
 
+def inline_enum_origin(spec):
+    if isinstance(spec, str):
+        return spec
+    schema = spec.get('schema')
+    kind = spec.get('one_of_kind')
+    prop = spec.get('property')
+    return f'{schema} oneOf kind={kind} property={prop}'
+
+def load_inline_enum_schema(spec):
+    if isinstance(spec, str):
+        return load_schema_spec(spec)
+
+    schema_spec = spec.get('schema')
+    kind = spec.get('one_of_kind')
+    prop = spec.get('property')
+    if not schema_spec or not kind or not prop:
+        raise ValueError(f'invalid inline enum config: {spec!r}')
+
+    schema = load_schema_spec(schema_spec)
+    matches = []
+    for branch in schema.get('oneOf', []):
+        props = branch.get('properties', {})
+        kind_schema = props.get('kind', {})
+        if kind_schema.get('const') == kind:
+            matches.append(props.get(prop, {}))
+
+    origin = inline_enum_origin(spec)
+    if not matches:
+        raise ValueError(f'{origin} did not match a oneOf branch')
+    if len(matches) > 1:
+        raise ValueError(f'{origin} matched multiple oneOf branches')
+    return matches[0]
+
 def generate_enums():
     """Generate Go string constants for all enum schemas."""
     lines = []
     seen = {}
 
-    def append_enum(name, schema, origin, required=False):
+    def append_enum(name, schema, origin, error_if_empty=False):
         values = schema.get('enum', [])
         if not values:
-            if required:
+            if error_if_empty:
                 raise ValueError(f'{origin} no longer defines enum values for {name}')
             return
         if name in seen:
@@ -1533,8 +1570,9 @@ def generate_enums():
             append_enum(name, schema, str(f.relative_to(SCRIPT_DIR)))
 
     for name, spec in INLINE_ENUM_TYPES.items():
-        schema = load_schema_spec(spec)
-        append_enum(name, schema, spec, required=True)
+        schema = load_inline_enum_schema(spec)
+        origin = inline_enum_origin(spec)
+        append_enum(name, schema, origin, error_if_empty=True)
 
     return '\n'.join(lines)
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -218,39 +218,148 @@ class EnumGenerationTest(unittest.TestCase):
             generate.enum_members("TestStatus", ["active", 1])
 
     def test_generate_enums_includes_inline_optimization_metric_helpers(self):
-        schema = generate.load_schema_spec(
-            "core/optimization-goal.json#/oneOf/0/properties/metric"
-        )
         src = generate.generate_enums()
 
         self.assertIn("type OptimizationMetric = string", src)
+        self.assertIn('OptimizationMetricClicks OptimizationMetric = "clicks"', src)
         self.assertIn("func KnownOptimizationMetricValues() []OptimizationMetric", src)
         self.assertIn("func IsKnownOptimizationMetric(v OptimizationMetric) bool", src)
+        schema = generate.load_inline_enum_schema(generate.INLINE_ENUM_TYPES["OptimizationMetric"])
         for value in schema["enum"]:
             const_name = "OptimizationMetric" + generate.pascal_case(value)
             self.assertIn(f'{const_name} OptimizationMetric = "{value}"', src)
+
+    def test_generate_enums_resolves_inline_enum_by_kind(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "TestInlineEnum",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
+            ),
+        ])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"const": "event"},
+                            "value": {"enum": ["wrong"]},
+                        },
+                    },
+                    {
+                        "properties": {
+                            "kind": {"const": "metric"},
+                            "value": {"enum": ["right"]},
+                        },
+                    },
+                ],
+            }
+
+        generate.load_schema_spec = load_schema_spec
+
+        src = generate.generate_enums()
+        self.assertIn('TestInlineEnumRight TestInlineEnum = "right"', src)
+        self.assertNotIn("TestInlineEnumWrong", src)
 
     def test_generate_enums_rejects_duplicate_inline_enum_name(self):
         generate.INLINE_ENUM_TYPES = OrderedDict([
             (
                 "MediaBuyStatus",
-                "core/optimization-goal.json#/oneOf/0/properties/metric",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
             ),
         ])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"const": "metric"},
+                            "value": {"enum": ["x"]},
+                        },
+                    },
+                ],
+            }
+
+        generate.load_schema_spec = load_schema_spec
 
         with self.assertRaisesRegex(ValueError, "duplicate enum type MediaBuyStatus"):
             generate.generate_enums()
 
     def test_generate_enums_requires_inline_enum_values(self):
-        generate.INLINE_ENUM_TYPES = OrderedDict([("TestInlineEnum", "test.json#/properties/value")])
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "TestInlineEnum",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
+            ),
+        ])
 
         def load_schema_spec(spec):
-            self.assertEqual("test.json#/properties/value", spec)
-            return {"type": "string"}
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"const": "metric"},
+                            "value": {"type": "string"},
+                        },
+                    },
+                ],
+            }
 
         generate.load_schema_spec = load_schema_spec
 
         with self.assertRaisesRegex(ValueError, "no longer defines enum values"):
+            generate.generate_enums()
+
+    def test_generate_enums_rejects_duplicate_inline_kind_matches(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "TestInlineEnum",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
+            ),
+        ])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"const": "metric"},
+                            "value": {"enum": ["first"]},
+                        },
+                    },
+                    {
+                        "properties": {
+                            "kind": {"const": "metric"},
+                            "value": {"enum": ["second"]},
+                        },
+                    },
+                ],
+            }
+
+        generate.load_schema_spec = load_schema_spec
+
+        with self.assertRaisesRegex(ValueError, "matched multiple oneOf branches"):
             generate.generate_enums()
 
     @unittest.skipUnless(shutil.which("go"), "go command not found")


### PR DESCRIPTION
## Summary
- replace the live OptimizationMetric inline enum pointer with a discriminator-aware `{schema, one_of_kind, property}` config
- keep inline enum output stable while avoiding brittle `oneOf/0` branch ordering
- pin an expected `OptimizationMetricClicks` literal and add self-contained tests for kind lookup, duplicate names, and missing enum values
- rename the internal `append_enum(required=...)` flag to `error_if_empty`

Closes #232

## Verification
- cd adcp/schemas && python3 -m unittest discover -p "*_test.py"
- cd adcp/schemas && python3 lint.py --strict
- cd adcp && go test ./...
- go test ./...

## Expert review
- Code-review expert is running; will amend if it flags a blocking issue.