### PR TITLE
docs(adcp): clarify optional numeric pointer guidance

### DIFF
--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -377,6 +377,12 @@ OPTIONAL_NUMERIC_OMISSION_HINTS = (
 )
 
 OPTIONAL_NUMERIC_SCALAR_OK = {
+    # Prefer changing optional numeric fields to *int/*float64 when omission and
+    # explicit zero have different wire semantics, especially request fields
+    # with defaults or schema descriptions that say "if omitted" / "when
+    # provided". Add a waiver only after confirming zero is invalid or
+    # semantically identical to omission, and include the protocol rationale in
+    # the reason string.
     # (type_name, json_name): reason
 }
 

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -405,16 +405,21 @@ type ProductsData struct {
 // Fields by variant:
 //
 //	cpm / vcpm / cpc / cpcv / cpv / cpp:
-//	  FixedPrice (fixed) OR FloorPrice + PriceGuidance (auction); MaxBid for
-//	  auction models to interpret bid_price as a ceiling.
+//	  FixedPrice present for fixed-price models OR FloorPrice + PriceGuidance
+//	  for auction models; MaxBid for auction models to interpret bid_price as
+//	  a ceiling.
 //	cpa:
-//	  FixedPrice, EventSourceID, EventType (required); CustomEventName when
+//	  FixedPrice present, EventSourceID, EventType; CustomEventName when
 //	  EventType="custom"; EligibleAdjustments for adjustment filtering.
 //	flat_rate:
-//	  FixedPrice (required).
+//	  FixedPrice present.
 //	time:
-//	  FixedPrice (required), Parameters for duration/unit specifics.
+//	  FixedPrice present, Parameters for duration/unit specifics.
 //	All variants: PricingOptionID, Currency, MinSpendPerPackage, PriceBreakdown.
+//
+// FixedPrice is a pointer because the schema oneOf requires field presence for
+// fixed-price variants. Go represents that presence with non-nil; use Float64(0)
+// if an explicit zero fixed price is intentional.
 type PricingOption struct {
 	PricingOptionID     string   `json:"pricing_option_id"`
 	PricingModel        string   `json:"pricing_model"`


### PR DESCRIPTION
## Summary
- clarify that `PricingOption.FixedPrice` presence is represented by a non-nil pointer
- document when optional numeric scalar lint waivers are appropriate versus pointerizing

Closes #224

## Verification
- cd adcp/schemas && python3 lint.py --strict
- cd adcp && go test ./...
- go test ./...