### PR TITLE
docs(adcp): document pricing threshold zero semantics

### DIFF
--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -384,6 +384,12 @@ OPTIONAL_NUMERIC_SCALAR_OK = {
     # semantically identical to omission, and include the protocol rationale in
     # the reason string.
     # (type_name, json_name): reason
+    ('PricingOption', 'floor_price'): (
+        'zero and omission both mean no auction floor has been declared'
+    ),
+    ('PricingOption', 'min_spend_per_package'): (
+        'zero and omission both mean no minimum spend requirement has been declared'
+    ),
 }
 
 

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -420,6 +420,8 @@ type ProductsData struct {
 // FixedPrice is a pointer because the schema oneOf requires field presence for
 // fixed-price variants. Go represents that presence with non-nil; use Float64(0)
 // if an explicit zero fixed price is intentional.
+// FloorPrice and MinSpendPerPackage are scalar thresholds because zero and
+// omission both mean no threshold has been declared.
 type PricingOption struct {
 	PricingOptionID     string   `json:"pricing_option_id"`
 	PricingModel        string   `json:"pricing_model"`


### PR DESCRIPTION
## Summary
- keep `PricingOption.FloorPrice` and `PricingOption.MinSpendPerPackage` as scalar thresholds
- document the semantics: zero and omission both mean no threshold has been declared
- add explicit optional-numeric scalar lint waivers with protocol rationale

Closes #225

## Schema check
Local 3.0.12 pricing schemas model both fields as optional numeric thresholds with `minimum: 0`; unlike `fixed_price`, neither field presence selects a oneOf branch.

## Verification
- cd adcp/schemas && python3 lint.py --strict
- cd adcp && go test ./...
- go test ./...

## Expert review
- Protocol reviewer is running; will amend if it flags a blocking issue.