### PR TITLE
test(adcp): cover update media buy optional typing

### DIFF
--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -33,6 +33,58 @@ func TestPtr(t *testing.T) {
 	assert.Equal(t, Duration{Interval: 5, Unit: "minutes"}, *duration)
 }
 
+func TestUpdateMediaBuyOptionalFlagsMarshal(t *testing.T) {
+	out, err := json.Marshal(UpdateMediaBuyRequest{
+		IdempotencyKey: "idem-123456789012",
+		Account:        AccountReference{AccountID: "acct-1"},
+		MediaBuyID:     "mb-1",
+		Paused:         Bool(true),
+	})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, true, wire["paused"])
+	assert.NotContains(t, wire, "canceled")
+
+	out, err = json.Marshal(UpdateMediaBuyRequest{
+		IdempotencyKey: "idem-123456789013",
+		Account:        AccountReference{AccountID: "acct-1"},
+		MediaBuyID:     "mb-1",
+		Canceled:       Bool(false),
+	})
+	require.NoError(t, err)
+
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, false, wire["canceled"])
+	assert.NotContains(t, wire, "paused")
+}
+
+func TestPackageUpdateOptionalFlagsAndCreativeAssignmentsMarshal(t *testing.T) {
+	out, err := json.Marshal(PackageUpdate{
+		PackageID: "pkg-1",
+		Paused:    Bool(false),
+		CreativeAssignments: []CreativeAssignment{{
+			CreativeID: "cr-1",
+			Weight:     Float64(0),
+		}},
+	})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, false, wire["paused"])
+	assert.NotContains(t, wire, "canceled")
+	assignments, ok := wire["creative_assignments"].([]any)
+	require.True(t, ok)
+	require.Len(t, assignments, 1)
+	assignment, ok := assignments[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "cr-1", assignment["creative_id"])
+	assert.Equal(t, float64(0), assignment["weight"])
+}
+
 func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {
 	out, err := json.Marshal(CreativeAssignment{
 		CreativeID: "cr-typed",


### PR DESCRIPTION
## Summary
- add marshal coverage for `UpdateMediaBuyRequest.Canceled *bool` so omitted flags stay absent and explicit false can be sent
- add package update marshal coverage for optional pause flags and typed `[]CreativeAssignment`
- verifies #164 is satisfied by the generated request/package update types

Closes #164

## Verification
- cd adcp && go test ./...
- go test ./...