### PR TITLE
test(adcp): polish inline enum generator guards

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1511,17 +1511,12 @@ def enum_to_type(name, desc, values):
     return '\n'.join(lines)
 
 def inline_enum_origin(spec):
-    if isinstance(spec, str):
-        return spec
     schema = spec.get('schema')
     kind = spec.get('one_of_kind')
     prop = spec.get('property')
     return f'{schema} oneOf kind={kind} property={prop}'
 
 def load_inline_enum_schema(spec):
-    if isinstance(spec, str):
-        return load_schema_spec(spec)
-
     schema_spec = spec.get('schema')
     kind = spec.get('one_of_kind')
     prop = spec.get('property')
@@ -1533,6 +1528,12 @@ def load_inline_enum_schema(spec):
     for branch in schema.get('oneOf', []):
         props = branch.get('properties', {})
         kind_schema = props.get('kind', {})
+        # The resolver intentionally requires exactly one const discriminator
+        # match. If upstream splits a kind into sub-variants, add a more precise
+        # selector instead of picking one branch implicitly.
+        # Single-value enum discriminators are also not accepted here; they fail
+        # with a no-match build error until the config shape explicitly supports
+        # that selector form.
         if kind_schema.get('const') == kind:
             matches.append(props.get(prop, {}))
 
@@ -1543,10 +1544,10 @@ def load_inline_enum_schema(spec):
         raise ValueError(f'{origin} matched multiple oneOf branches')
     return matches[0]
 
-def generate_enums():
+def generate_enums(_seen=None):
     """Generate Go string constants for all enum schemas."""
     lines = []
-    seen = {}
+    seen = dict(_seen or {})
 
     def append_enum(name, schema, origin, error_if_empty=False):
         values = schema.get('enum', [])
@@ -1570,7 +1571,10 @@ def generate_enums():
             append_enum(name, schema, str(f.relative_to(SCRIPT_DIR)))
 
     for name, spec in INLINE_ENUM_TYPES.items():
-        schema = load_inline_enum_schema(spec)
+        try:
+            schema = load_inline_enum_schema(spec)
+        except ValueError as e:
+            raise ValueError(f'INLINE_ENUM_TYPES[{name!r}]: {e}') from e
         origin = inline_enum_origin(spec)
         append_enum(name, schema, origin, error_if_empty=True)
 

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -294,7 +294,7 @@ class EnumGenerationTest(unittest.TestCase):
         generate.load_schema_spec = load_schema_spec
 
         with self.assertRaisesRegex(ValueError, "duplicate enum type MediaBuyStatus"):
-            generate.generate_enums()
+            generate.generate_enums(_seen={"MediaBuyStatus": "enums/media-buy-status.json"})
 
     def test_generate_enums_requires_inline_enum_values(self):
         generate.INLINE_ENUM_TYPES = OrderedDict([
@@ -360,6 +360,72 @@ class EnumGenerationTest(unittest.TestCase):
         generate.load_schema_spec = load_schema_spec
 
         with self.assertRaisesRegex(ValueError, "matched multiple oneOf branches"):
+            generate.generate_enums()
+
+    def test_generate_enums_rejects_unmatched_inline_kind(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "TestInlineEnum",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
+            ),
+        ])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"const": "event"},
+                            "value": {"enum": ["wrong"]},
+                        },
+                    },
+                ],
+            }
+
+        generate.load_schema_spec = load_schema_spec
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"INLINE_ENUM_TYPES\['TestInlineEnum'\].*did not match a oneOf branch",
+        ):
+            generate.generate_enums()
+
+    def test_generate_enums_does_not_match_single_value_enum_discriminator(self):
+        generate.INLINE_ENUM_TYPES = OrderedDict([
+            (
+                "TestInlineEnum",
+                {
+                    "schema": "test.json",
+                    "one_of_kind": "metric",
+                    "property": "value",
+                },
+            ),
+        ])
+
+        def load_schema_spec(spec):
+            self.assertEqual("test.json", spec)
+            return {
+                "oneOf": [
+                    {
+                        "properties": {
+                            "kind": {"enum": ["metric"]},
+                            "value": {"enum": ["x"]},
+                        },
+                    },
+                ],
+            }
+
+        generate.load_schema_spec = load_schema_spec
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"INLINE_ENUM_TYPES\['TestInlineEnum'\].*did not match a oneOf branch",
+        ):
             generate.generate_enums()
 
     @unittest.skipUnless(shutil.which("go"), "go command not found")


### PR DESCRIPTION
## Summary

- remove the dead string-spec path from inline enum config resolution
- make inline enum config errors name the failing `INLINE_ENUM_TYPES` key
- make the duplicate-name test self-contained with an injectable seen map
- lock no-match behavior for unmatched and single-value-enum discriminators

Closes #236.

## Validation

- `cd adcp/schemas && python3 -m unittest discover -p "*_test.py"`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py > /tmp/adcp-types-gen-check.go && diff -u ../types_gen.go /tmp/adcp-types-gen-check.go`
- `git diff --check`
- `go test ./...`
- `cd adcp && go test ./...`