### PR TITLE
docs(seller-agent): clarify budget spend simulation

### DIFF
--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -578,6 +578,8 @@ func (b *backend) simulateBudgetSpend(p adcp.SimulateBudgetParams) (*adcp.Simula
 	}
 	total := mediaBuyBudget(buy)
 	spend := total * p.SpendPercentage
+	// Budget-spend simulation advances financial pacing only; use
+	// simulateDelivery when impressions or clicks should move too.
 	for _, pkg := range buy.Packages {
 		if total == 0 {
 			continue


### PR DESCRIPTION
## Summary

- document that `simulateBudgetSpend` advances spend only
- clarify that `simulateDelivery` is the path for moving impressions/clicks too

Closes #165.

## Validation

- `cd reference/seller-agent && go test ./...`
- `git diff --check`