### PR TITLE
test(codegen): guard shared inline overrides

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -629,6 +629,22 @@ INLINE_SCHEMA_TYPES = OrderedDict([
     ),
 ])
 
+# Shared inline helper types are generated from one schema pointer but reused by
+# INLINE_TYPE_HINTS for sibling schema pointers. lint.py verifies these siblings
+# keep the same property set before we keep reusing a single Go type.
+SHARED_INLINE_OVERRIDES = {
+    "DeliveryReportingDimension": [
+        "media-buy/get-media-buy-delivery-request.json"
+        "#/properties/reporting_dimensions/properties/device_type",
+        "media-buy/get-media-buy-delivery-request.json"
+        "#/properties/reporting_dimensions/properties/device_platform",
+        "media-buy/get-media-buy-delivery-request.json"
+        "#/properties/reporting_dimensions/properties/audience",
+        "media-buy/get-media-buy-delivery-request.json"
+        "#/properties/reporting_dimensions/properties/placement",
+    ],
+}
+
 # Named enum helpers generated from inline JSON Schema pointers. These cover
 # important SDK validation values that are not standalone enum schema files.
 INLINE_ENUM_TYPES = OrderedDict([

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -312,6 +312,50 @@ def validate_inline_schema_specs():
     return reports
 
 
+def validate_shared_inline_overrides():
+    """Verify shared inline helper types still match each reused schema shape."""
+    reports = []
+    for type_name, schema_specs in gen.SHARED_INLINE_OVERRIDES.items():
+        loaded = []
+        error_count = len(reports)
+        for schema_spec in schema_specs:
+            path_part = schema_spec.split('#', 1)[0]
+            schema_path = SCRIPT_DIR / path_part
+            if not schema_path.exists():
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'schema not found: {schema_path}',
+                })
+                continue
+            try:
+                schema = load_schema_spec(schema_spec)
+            except SCHEMA_RESOLUTION_ERRORS as e:
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'could not resolve schema pointer: {e}',
+                })
+                continue
+            loaded.append((schema_spec, schema_property_set(schema)))
+        if len(reports) != error_count or len(loaded) != len(schema_specs):
+            continue
+
+        anchor_spec, anchor_props = loaded[0]
+        for schema_spec, props in loaded[1:]:
+            if props == anchor_props:
+                continue
+            reports.append({
+                'type': type_name,
+                'schema': schema_spec,
+                'anchor_schema': anchor_spec,
+                'missing': sorted(anchor_props - props),
+                'extra': sorted(props - anchor_props),
+                'error': 'shared inline override schema properties differ',
+            })
+    return reports
+
+
 def validate_union_schema_specs():
     """Smoke-test generated union schema pointers and shared-helper equivalence."""
     reports = []
@@ -621,6 +665,7 @@ def main():
     reports = []
     no_schema = []
     inline_schema_errors = validate_inline_schema_specs()
+    shared_inline_errors = validate_shared_inline_overrides()
     union_schema_errors = validate_union_schema_specs()
     optional_numeric_reports = optional_numeric_pointer_reports(go_structs)
 
@@ -645,6 +690,7 @@ def main():
             'drift': reports,
             'no_schema_correspondent': no_schema,
             'inline_schema_errors': inline_schema_errors,
+            'shared_inline_errors': shared_inline_errors,
             'union_schema_errors': union_schema_errors,
             'optional_numeric_pointer': optional_numeric_reports,
         }
@@ -656,6 +702,18 @@ def main():
                 print()
                 print(f'  {r["type"]}  ({r.get("schema", "?")})')
                 print(f'    error: {r["error"]}')
+            print()
+        if shared_inline_errors:
+            print(f'Shared inline override errors in {len(shared_inline_errors)} type(s):')
+            for r in shared_inline_errors:
+                print()
+                print(f'  {r["type"]}  ({r.get("schema", "?")})')
+                print(f'    anchor: {r.get("anchor_schema", "?")}')
+                print(f'    error:  {r["error"]}')
+                if r.get('missing'):
+                    print(f'    missing: {", ".join(r["missing"])}')
+                if r.get('extra'):
+                    print(f'    extra:   {", ".join(r["extra"])}')
             print()
         if union_schema_errors:
             print(f'Union schema pointer errors in {len(union_schema_errors)} type(s):')
@@ -699,10 +757,13 @@ def main():
             for t in no_schema:
                 print(f'  - {t}')
 
-    has_problems = bool(inline_schema_errors) or bool(union_schema_errors) or bool(reports) or (
-        bool(optional_numeric_reports)
-    ) or (
-        args.strict and bool(no_schema)
+    has_problems = (
+        bool(inline_schema_errors)
+        or bool(shared_inline_errors)
+        or bool(union_schema_errors)
+        or bool(reports)
+        or bool(optional_numeric_reports)
+        or (args.strict and bool(no_schema))
     )
     return 1 if (args.strict and has_problems) else 0
 

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -3,6 +3,36 @@ import unittest
 import lint
 
 
+class SharedInlineOverrideLintTest(unittest.TestCase):
+    def test_shared_inline_override_reports_property_drift(self):
+        original_overrides = lint.gen.SHARED_INLINE_OVERRIDES
+        original_load_schema_spec = lint.load_schema_spec
+        try:
+            lint.gen.SHARED_INLINE_OVERRIDES = {
+                "SharedShape": [
+                    "core/product.json#/properties/a",
+                    "core/product.json#/properties/b",
+                ],
+            }
+
+            def load_schema_spec(spec):
+                if spec.endswith("/a"):
+                    return {"properties": {"enabled": {}}}
+                return {"properties": {"enabled": {}, "limit": {}}}
+
+            lint.load_schema_spec = load_schema_spec
+
+            reports = lint.validate_shared_inline_overrides()
+        finally:
+            lint.gen.SHARED_INLINE_OVERRIDES = original_overrides
+            lint.load_schema_spec = original_load_schema_spec
+
+        self.assertEqual(1, len(reports))
+        self.assertEqual("SharedShape", reports[0]["type"])
+        self.assertEqual(["limit"], reports[0]["extra"])
+        self.assertEqual([], reports[0]["missing"])
+
+
 class OptionalNumericPointerLintTest(unittest.TestCase):
     def test_zero_invalid_honors_numeric_bounds(self):
         self.assertFalse(lint.numeric_zero_invalid({"type": "number", "minimum": 0}))


### PR DESCRIPTION
## Summary

- add `SHARED_INLINE_OVERRIDES` for shared inline helper reuse
- teach schema lint to compare sibling override property sets against the anchor schema
- add unit coverage for field-level drift reporting

Closes #177.

## Validation

- `cd adcp/schemas && python3 -m py_compile generate.py lint.py`
- `cd adcp/schemas && python3 -m unittest discover -p "*_test.py"`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py > /tmp/adcp-types-gen-check.go && diff -u ../types_gen.go /tmp/adcp-types-gen-check.go`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`