### PR TITLE
ci: track pinned cosign release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.*\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+cosign-release:\\s*(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s"
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "github-releases"
+      ],
+      "matchPackageNames": [
+        "sigstore/cosign"
+      ],
+      "semanticCommitType": "ci"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         with:
+          # renovate: datasource=github-releases depName=sigstore/cosign versioning=semver
           cosign-release: v3.0.6
 
       - name: Download upstream schemas

--- a/.github/workflows/identity-agent-image.yml
+++ b/.github/workflows/identity-agent-image.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        with:
+          # renovate: datasource=github-releases depName=sigstore/cosign versioning=semver
+          cosign-release: v3.0.6
 
       - name: Sign image (keyless OIDC)
         # Signs every pushed tag against the build's content digest, so all


### PR DESCRIPTION
## Summary
- pin the installed cosign binary in the identity-agent image workflow
- add Renovate regex tracking for annotated cosign-release workflow inputs

Closes #207

## Tests
- python3 -m json.tool .github/renovate.json >/dev/null
- node -e regex extraction check for both workflow cosign-release inputs
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/identity-agent-image.yml
- npx --yes --package renovate renovate-config-validator .github/renovate.json
- git diff --check