### PR TITLE
fix(schemas): preserve lint tests during bundle sync

### DIFF
--- a/adcp/schemas/download.sh
+++ b/adcp/schemas/download.sh
@@ -69,6 +69,7 @@ PROTECTED=(
   generate.py
   generate_test.py
   lint.py
+  lint_test.py
 )
 
 VERSION="${1:-$(cat "$VERSION_FILE" | tr -d '[:space:]')}"


### PR DESCRIPTION
## Summary
- add lint_test.py to the schema downloader protected-file allowlist
- keep the test file from being deleted by the rsync --delete bundle sync step

Refs #205

## Tests
- ADCP_TRUST_PINNED_BUNDLE=0 ./download.sh (local macOS live verification passes)
- python3 -m unittest lint_test.py (from adcp/schemas)
- git diff --check

## Note
Attempted to close #205 by adding adcp/schemas/download.sh to the live-verification CI predicate, but GitHub Actions Linux runners still fail live verification for 3.0.12 with: invalid signature when validating ASN.1 encoded signature. Leaving #205 open until that upstream/runner path is stable.