### PR TITLE
test(codegen): emit deprecated field comments

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -964,6 +964,20 @@ def safe_comment(text, max_len=80):
     prevent code injection via schema descriptions."""
     return text.replace('\n', ' ').replace('\r', '')[:max_len].rstrip() if text else ''
 
+def deprecated_comment(prop):
+    """Return the Go deprecation notice for a deprecated schema property."""
+    if not prop.get('deprecated'):
+        return ''
+    desc = prop.get('description', '').replace('\n', ' ').replace('\r', '').strip()
+    desc = re.sub(r'^\s*deprecated\s*:\s*', '', desc, flags=re.IGNORECASE)
+    first_sentence = re.match(r'(.+?\.)(?:\s|$)', desc)
+    if first_sentence:
+        desc = first_sentence.group(1)
+    desc = safe_comment(desc, 120)
+    if desc:
+        return f'Deprecated: {desc}'
+    return 'Deprecated: This field is deprecated.'
+
 def load_schema(path):
     """Load a JSON schema file, preserving property order."""
     path = Path(path)
@@ -1351,6 +1365,9 @@ def schema_to_struct(name, schema):
         desc = safe_comment(prop.get('description', ''), 80)
         comment = f' // {desc}' if desc else ''
 
+        deprecated = deprecated_comment(prop)
+        if deprecated:
+            fields.append(f'\t// {deprecated}')
         fields.append(f'\t{go_name} {go_type} {tag}{comment}')
 
     desc = safe_comment(schema.get('description', ''), 100)

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -474,6 +474,57 @@ class EnumGenerationTest(unittest.TestCase):
             subprocess.run(["go", "test", "."], cwd=tmp, check=True)
 
 
+class StructGenerationTest(unittest.TestCase):
+    def test_deprecated_property_emits_go_deprecation_comment(self):
+        schema = {
+            "type": "object",
+            "properties": OrderedDict(
+                [
+                    (
+                        "status",
+                        {
+                            "type": "string",
+                            "description": "Deprecated: Use media_buy_status instead.",
+                            "deprecated": True,
+                        },
+                    )
+                ]
+            ),
+        }
+
+        got = generate.schema_to_struct("CreateMediaBuySuccess", schema)
+
+        self.assertIn(
+            "\t// Deprecated: Use media_buy_status instead.\n"
+            "\tStatus string `json:\"status,omitempty\"` // Deprecated: Use media_buy_status instead.",
+            got,
+        )
+
+    def test_deprecated_property_without_description_emits_fallback_comment(self):
+        schema = {
+            "type": "object",
+            "properties": OrderedDict(
+                [
+                    (
+                        "legacy_id",
+                        {
+                            "type": "string",
+                            "deprecated": True,
+                        },
+                    )
+                ]
+            ),
+        }
+
+        got = generate.schema_to_struct("DeprecatedFallback", schema)
+
+        self.assertIn(
+            "\t// Deprecated: This field is deprecated.\n"
+            "\tLegacyID string `json:\"legacy_id,omitempty\"`",
+            got,
+        )
+
+
 class OptimizationGoalSchemaTest(unittest.TestCase):
     def setUp(self):
         self.schema = generate.load_schema("core/optimization-goal.json")

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5829,7 +5829,9 @@ type Targeting struct {
 	GeoPostalAreas []GeoPostalAreaTarget `json:"geo_postal_areas,omitempty"` // Restrict delivery to specific postal areas. Each entry specifies the postal syst
 	GeoPostalAreasExclude []GeoPostalAreaTarget `json:"geo_postal_areas_exclude,omitempty"` // Exclude specific postal areas from delivery. Each entry specifies the postal sys
 	DaypartTargets []DaypartTarget `json:"daypart_targets,omitempty"` // Restrict delivery to specific time windows. Each entry specifies days of week an
+	// Deprecated: Use TMP provider fields instead.
 	AxeIncludeSegment string `json:"axe_include_segment,omitempty"` // Deprecated: Use TMP provider fields instead. AXE segment ID to include for targe
+	// Deprecated: Use TMP provider fields instead.
 	AxeExcludeSegment string `json:"axe_exclude_segment,omitempty"` // Deprecated: Use TMP provider fields instead. AXE segment ID to exclude from targ
 	AudienceInclude []string `json:"audience_include,omitempty"` // Restrict delivery to members of these first-party CRM audiences. Only users pres
 	AudienceExclude []string `json:"audience_exclude,omitempty"` // Suppress delivery to members of these first-party CRM audiences. Matched users a
@@ -7483,6 +7485,7 @@ type GetSignalsRequest struct {
 	Destinations []Destination `json:"destinations,omitempty"` // Filter signals to those activatable on specific agents/platforms. When omitted,
 	Countries []string `json:"countries,omitempty"` // Countries where signals will be used (ISO 3166-1 alpha-2 codes). When omitted, n
 	Filters *SignalFilters `json:"filters,omitempty"`
+	// Deprecated: Use pagination.max_results instead.
 	MaxResults int `json:"max_results,omitempty"` // DEPRECATED: Use pagination.max_results instead. When both fields are present, ag
 	Pagination *PaginationRequest `json:"pagination,omitempty"` // Pagination parameters. Use pagination.max_results (max: 100, default: 50) and pa
 	Context any `json:"context,omitempty"`


### PR DESCRIPTION
## Summary
- emit Go `// Deprecated:` comments for generated fields whose JSON Schema property has `deprecated: true`
- normalize descriptions that already start with Deprecated:/DEPRECATED:
- add synthetic generator tests and regenerate current deprecated fields

Closes #134

## Tests
- python3 -m unittest generate_test.py lint_test.py (from adcp/schemas)
- python3 generate.py > ../types_gen.go
- go test ./...
- git diff --check