### PR TITLE
fix(adcp): stamp create media buy response metadata

### DIFF
--- a/adcp/seller.go
+++ b/adcp/seller.go
@@ -108,6 +108,7 @@ func Register(server *mcp.Server, cfg Config) {
 					result, out, e := errorToResult(err)
 					return attachContext(result, input.Context), out, e
 				}
+				stampCreateMediaBuyResult(buy, sandbox, input.Context)
 				result, out, err := MediaBuyResponse(buy)
 				return attachContext(result, input.Context), out, err
 			})
@@ -401,6 +402,20 @@ func resolveAccount(ctx context.Context, resolver func(context.Context, AccountR
 		return nil, result
 	}
 	return acct, nil
+}
+
+func stampCreateMediaBuyResult(result CreateMediaBuyResult, sandbox bool, context any) {
+	switch v := result.(type) {
+	case *CreateMediaBuySuccess:
+		if v.Sandbox == nil {
+			v.Sandbox = Bool(sandbox)
+		}
+		v.Context = context
+	case *CreateMediaBuySubmitted:
+		v.Context = context
+	case *CreateMediaBuyError:
+		v.Context = context
+	}
 }
 
 // detectProtocols returns supported_protocols values inferred from the

--- a/adcp/seller_test.go
+++ b/adcp/seller_test.go
@@ -261,6 +261,72 @@ func TestRegisteredHandlersAttachContext(t *testing.T) {
 	}
 }
 
+func TestRegisteredCreateMediaBuyStampsVariants(t *testing.T) {
+	ctxValue := map[string]any{"trace_id": "ctx-1", "retry": false}
+	args := map[string]any{"context": ctxValue}
+
+	t.Run("success stamps sandbox and context", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			Sandbox: true,
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+				return &CreateMediaBuySuccess{
+					MediaBuyID: "mb-1",
+					Packages:   []Package{},
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.Equal(t, ctxValue, wire["context"])
+		assert.Equal(t, true, wire["sandbox"])
+	})
+
+	t.Run("success preserves explicit sandbox", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			Sandbox: true,
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+				return &CreateMediaBuySuccess{
+					MediaBuyID: "mb-1",
+					Packages:   []Package{},
+					Sandbox:    Bool(false),
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.Equal(t, ctxValue, wire["context"])
+		assert.Equal(t, false, wire["sandbox"])
+	})
+
+	t.Run("submitted stamps context", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+				return &CreateMediaBuySubmitted{
+					TaskID: "task-1",
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.Equal(t, ctxValue, wire["context"])
+		assert.Equal(t, "submitted", wire["status"])
+	})
+
+	t.Run("schema error stamps context", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+				return &CreateMediaBuyError{
+					Errors: []AdcpError{{"code": "INVALID_REQUEST", "message": "bad request"}},
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.True(t, result.IsError)
+		assert.Equal(t, ctxValue, wire["context"])
+	})
+}
+
 func baseTestConfig(cfg Config) Config {
 	cfg.IdempotencyReplayTTL = 24 * time.Hour
 	if cfg.Capabilities == nil {


### PR DESCRIPTION
## Summary
- stamp Config.Sandbox and request context onto create_media_buy success variants before response building
- stamp request context onto submitted and schema-error variants
- preserve explicitly supplied success sandbox values

Closes #149

## Tests
- go test . (from adcp/)
- go test ./...
- git diff --check