### PR TITLE
feat(identityagent): canonicalize audience/fcap identities on the TMPX-off path

### DIFF
--- a/targeting/identityagent/canonicalizer.go
+++ b/targeting/identityagent/canonicalizer.go
@@ -1,0 +1,205 @@
+package identityagent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/tmpxdecoders"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// IdentityCanonicalizer decodes inbound IdentityToken.UserToken strings into
+// their canonical binary form so audience and frequency-cap lookups key on
+// the same shape ExposureLog.user_token publishes downstream — lowercase-hex
+// of the decoded bytes — regardless of whether TMPX sealing is enabled on
+// this deployment.
+//
+// It exists as a sibling of TMPXSealer so the canonicalization step runs
+// independently of TMPX recipient configuration. Deployments that don't
+// emit TMPX tokens still benefit from the consistent key form; deployments
+// that do still hand the same decoded slice to the sealer so the per-request
+// decode pass (in particular the LiveRamp sidecar call for RampIDs) happens
+// at most once.
+//
+// Construct with NewIdentityCanonicalizer. A nil *IdentityCanonicalizer
+// signals "no canonicalization configured" — the handler falls back to the
+// legacy pass-through behavior in that case. The handler treats a non-nil
+// canonicalizer with an empty decoder map the same way as a populated one:
+// every identity is dropped at decode time, which matches the
+// "missing-config = silent drop" pattern used elsewhere in the agent.
+type IdentityCanonicalizer struct {
+	// decoders maps each TMPX-encodable UID type to the adapter that
+	// converts user_token strings into the canonical binary form. UID types
+	// without a registered decoder are dropped at decode time so audience
+	// and frequency-cap lookups don't waste round trips on keys the
+	// buyer-master populator will never have published.
+	decoders map[tmproto.UIDType]TmpxTokenDecoder
+
+	// logger and recorder are used to surface per-identity drop events on
+	// the same TmpxIdentityDrop counter the sealer uses — operationally
+	// the signal is identical (mapping problem, decoder problem,
+	// content-shape problem). Both may be nil; helpers fall back to
+	// slog.Default() and a no-op recorder respectively.
+	logger   *slog.Logger
+	recorder Recorder
+}
+
+// NewIdentityCanonicalizer builds an IdentityCanonicalizer backed by the
+// default decoder registry. lrClient is the optional LiveRamp sidecar used
+// to decode RampID and RampID-derived identities. When nil, those UID
+// types have no decoder registered and identities of those types are
+// silently dropped from the canonicalized shadow request (the same
+// behavior the TMPX path applies). Pass nil — not a typed nil pointer to
+// a concrete client — to disable (Go's interface-nil rules treat a typed
+// nil as non-nil).
+//
+// Returns a populated canonicalizer for any LiveRamp configuration: even
+// without the sidecar the default registry yields the format-only decoders
+// (MAID, HashedEmail, ID5) which cover the common case. Callers that
+// explicitly want to opt out of canonicalization entirely (and preserve
+// the legacy "publisher wire string flows through to audience/fcap"
+// behavior) should pass a nil *IdentityCanonicalizer to the handler.
+func NewIdentityCanonicalizer(lrClient LiveRampSidecar, logger *slog.Logger, recorder Recorder) *IdentityCanonicalizer {
+	// The decoder package's LiveRampClient interface is structurally
+	// identical to LiveRampSidecar, so any concrete type that satisfies
+	// one satisfies the other. We assign through an interface variable to
+	// keep the nil check correct (avoid the typed-nil trap).
+	var decoderAdapter tmpxdecoders.LiveRampClient
+	if lrClient != nil {
+		decoderAdapter = lrClient
+	}
+	decoders := buildTmpxDecoders(tmpxdecoders.RegistryOptions{LiveRampClient: decoderAdapter})
+	if logger != nil {
+		logCanonicalizerLayout(logger, decoders)
+	}
+	return &IdentityCanonicalizer{
+		decoders: decoders,
+		logger:   logger,
+		recorder: recorder,
+	}
+}
+
+// log returns the canonicalizer's logger, falling back to slog.Default()
+// when none was configured.
+func (c *IdentityCanonicalizer) log() *slog.Logger {
+	if c.logger != nil {
+		return c.logger
+	}
+	return slog.Default()
+}
+
+// recordDrop emits a TmpxIdentityDrop counter for an identity that did not
+// produce a canonical binary form. Safe to call when recorder is nil.
+// Reuses the existing TmpxIdentityDrop series — operationally the same
+// signal ("this UID type wasn't decodable here") whether or not TMPX is
+// enabled on the deployment.
+func (c *IdentityCanonicalizer) recordDrop(ctx context.Context, reason string, uid tmproto.UIDType) {
+	if c.recorder == nil {
+		return
+	}
+	c.recorder.TmpxIdentityDrop(ctx, reason, string(uid))
+}
+
+// Decode runs every supplied identity through its UID-type decoder and
+// returns the results in input order. Per-identity drops (unmapped, no
+// decoder, decoder drop sentinel, decoder error, size mismatch) are
+// surfaced on the recorder's TmpxIdentityDrop counter — see the constants
+// in metrics.go for the reason set.
+//
+// Dropped identities have Bytes == nil in the returned slice; downstream
+// stages (audienceEligibleIdentities, TMPXSealer.SealDecoded) skip them
+// silently.
+//
+// Decode shares its result between the audience/fcap shadow path and the
+// TMPX seal path so LiveRamp-backed RampIDs make at most one sidecar
+// call per request.
+func (c *IdentityCanonicalizer) Decode(ctx context.Context, ids []tmproto.IdentityToken) []DecodedIdentity {
+	return decodeIdentities(ctx, ids, c.decoders, c.log(), c.recordDrop)
+}
+
+// decodeIdentities is the shared decode loop used by both
+// IdentityCanonicalizer.Decode and TMPXSealer.Decode. Extracting it keeps
+// the per-identity drop bookkeeping (counter reasons, size validation)
+// in one place so the canonicalization path can't silently diverge from
+// the seal path.
+//
+// recordDrop is supplied by the caller so each owner attributes drops to
+// its own recorder/logger context without this helper having to know
+// which it is.
+func decodeIdentities(
+	ctx context.Context,
+	ids []tmproto.IdentityToken,
+	decoders map[tmproto.UIDType]TmpxTokenDecoder,
+	logger *slog.Logger,
+	recordDrop func(ctx context.Context, reason string, uid tmproto.UIDType),
+) []DecodedIdentity {
+	out := make([]DecodedIdentity, len(ids))
+	for i, id := range ids {
+		out[i].UIDType = id.UIDType
+		typeID, ok := uidToTmpxTypeID[id.UIDType]
+		if !ok {
+			recordDrop(ctx, TmpxDropUnmapped, id.UIDType)
+			continue
+		}
+		decoder, ok := decoders[id.UIDType]
+		if !ok {
+			recordDrop(ctx, TmpxDropNoDecoder, id.UIDType)
+			continue
+		}
+		bin, err := decoder.Decode(ctx, id.UserToken)
+		if err != nil {
+			if errors.Is(err, ErrDropIdentity) {
+				recordDrop(ctx, TmpxDropDecoderDrop, id.UIDType)
+				continue
+			}
+			recordDrop(ctx, TmpxDropDecoderError, id.UIDType)
+			logger.Warn("identity decoder error — dropping identity",
+				"uid_type", id.UIDType,
+				"error", err)
+			continue
+		}
+		wantSize, _ := tmproto.TmpxTokenSize(typeID)
+		if len(bin) != wantSize {
+			recordDrop(ctx, TmpxDropSizeMismatch, id.UIDType)
+			logger.Warn("identity decoder returned wrong byte length — dropping identity",
+				"uid_type", id.UIDType,
+				"got", len(bin),
+				"want", wantSize)
+			continue
+		}
+		out[i].Bytes = bin
+	}
+	return out
+}
+
+// logCanonicalizerLayout emits a startup line describing which UID types
+// will round-trip through canonicalization and which will be dropped. The
+// signal mirrors logDecoderLayout but doesn't talk about TMPX priority:
+// the canonicalizer is unaware of (and unaffected by) the TMPX_PRIORITY
+// ordering — every decodable identity is canonicalized.
+func logCanonicalizerLayout(logger *slog.Logger, decoders map[tmproto.UIDType]TmpxTokenDecoder) {
+	enabled := make([]tmproto.UIDType, 0, len(decoders))
+	dropped := make([]tmproto.UIDType, 0, len(uidToTmpxTypeID))
+	for uid := range uidToTmpxTypeID {
+		if _, ok := decoders[uid]; ok {
+			enabled = append(enabled, uid)
+		} else {
+			dropped = append(dropped, uid)
+		}
+	}
+	sortUIDs(enabled)
+	sortUIDs(dropped)
+	attrs := []any{"enabled_uid_types", joinUIDs(enabled)}
+	if len(dropped) > 0 {
+		attrs = append(attrs, "dropped_uid_types", joinUIDs(dropped))
+	}
+	switch {
+	case len(enabled) == 0:
+		logger.Warn("identity canonicalization enabled but no UID type has a decoder — every identity will be dropped at decode time", attrs...)
+	case len(dropped) > 0:
+		logger.Info("identity canonicalization enabled; some UID types will be dropped (no decoder configured)", attrs...)
+	default:
+		logger.Info("identity canonicalization enabled with decoders for every UID type", attrs...)
+	}
+}

--- a/targeting/identityagent/canonicalizer_test.go
+++ b/targeting/identityagent/canonicalizer_test.go
@@ -1,0 +1,82 @@
+package identityagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// TestNewIdentityCanonicalizer_NilLiveRamp_BuildsFormatOnlyDecoders verifies
+// that a deployment without a LiveRamp sidecar still gets canonicalization
+// for the format-only UID types (MAID, HashedEmail, ID5). RampID and
+// RampIDDerived are dropped at decode time without an external client.
+func TestNewIdentityCanonicalizer_NilLiveRamp_BuildsFormatOnlyDecoders(t *testing.T) {
+	canon := NewIdentityCanonicalizer(nil, nil, nil)
+	require.NotNil(t, canon)
+	for _, uid := range []tmproto.UIDType{tmproto.UIDTypeMAID, tmproto.UIDTypeHashedEmail, tmproto.UIDTypeID5} {
+		_, ok := canon.decoders[uid]
+		assert.Truef(t, ok, "format-only decoder must be present for %s even without LiveRamp", uid)
+	}
+	_, hasRampID := canon.decoders[tmproto.UIDTypeRampID]
+	assert.False(t, hasRampID, "RampID requires a LiveRamp client and must be absent without one")
+}
+
+// TestNewIdentityCanonicalizer_WithLiveRamp_AddsRampIDDecoders confirms
+// that supplying the LiveRamp sidecar adds RampID and RampIDDerived to
+// the decoder map.
+func TestNewIdentityCanonicalizer_WithLiveRamp_AddsRampIDDecoders(t *testing.T) {
+	canon := NewIdentityCanonicalizer(newFixedLiveRampClient(), nil, nil)
+	require.NotNil(t, canon)
+	for _, uid := range []tmproto.UIDType{tmproto.UIDTypeRampID, tmproto.UIDTypeRampIDDerived} {
+		_, ok := canon.decoders[uid]
+		assert.Truef(t, ok, "LiveRamp-backed decoder must be present for %s when sidecar is configured", uid)
+	}
+}
+
+// TestIdentityCanonicalizer_Decode_ProducesCanonicalBytes confirms the
+// canonicalizer's decode pass yields the same DecodedIdentity slice the
+// TMPXSealer's Decode would — verifying audienceEligibleIdentities sees
+// identical canonical form on both code paths.
+func TestIdentityCanonicalizer_Decode_ProducesCanonicalBytes(t *testing.T) {
+	canon := &IdentityCanonicalizer{decoders: defaultTestDecoders(t)}
+
+	ids := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeMAID, UserToken: validUserTokenFor(tmproto.UIDTypeMAID)},
+		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: validUserTokenFor(tmproto.UIDTypeHashedEmail)},
+		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"},          // no decoder
+		{UIDType: tmproto.UIDTypeOther, UserToken: "ignored"},          // no mapping
+	}
+	decoded := canon.Decode(t.Context(), ids)
+	require.Len(t, decoded, 4)
+	assert.NotEmpty(t, decoded[0].Bytes, "MAID must be decoded")
+	assert.NotEmpty(t, decoded[1].Bytes, "HashedEmail must be decoded")
+	assert.Empty(t, decoded[2].Bytes, "UID2 (no decoder) must be dropped")
+	assert.Empty(t, decoded[3].Bytes, "Other (no mapping) must be dropped")
+
+	shadow := audienceEligibleIdentities(decoded)
+	require.Len(t, shadow, 2)
+	assert.Equal(t, "550e8400e29b41d4a716446655440000", shadow[0].UserToken,
+		"audience must see canonical lowercase-hex of MAID UUID")
+}
+
+// TestIdentityCanonicalizer_Decode_RecordsDropsLikeSealer confirms the
+// canonicalizer reuses the TmpxIdentityDrop counter so operators don't
+// need to learn a second drop-reason vocabulary.
+func TestIdentityCanonicalizer_Decode_RecordsDropsLikeSealer(t *testing.T) {
+	rec := newTestRecorder()
+	canon := &IdentityCanonicalizer{
+		decoders: defaultTestDecoders(t),
+		recorder: rec,
+	}
+	canon.Decode(t.Context(), []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeOther, UserToken: "x"},                 // unmapped
+		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"},           // no decoder
+		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: "deadbeef"},    // decoder_error (too short)
+	})
+	assert.Equal(t, 1, rec.dropCount(TmpxDropUnmapped, string(tmproto.UIDTypeOther)))
+	assert.Equal(t, 1, rec.dropCount(TmpxDropNoDecoder, string(tmproto.UIDTypeUID2)))
+	assert.Equal(t, 1, rec.dropCount(TmpxDropDecoderError, string(tmproto.UIDTypeHashedEmail)))
+}

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -23,6 +23,7 @@ import (
 type identityHandler struct {
 	service                    *Service
 	tmpx                       *TMPXSealer
+	canonicalizer              *IdentityCanonicalizer
 	requestTimeout             time.Duration
 	requestBodyLimit           int64
 	responseTTL                time.Duration
@@ -33,8 +34,17 @@ type identityHandler struct {
 
 // IdentityHandlerConfig packages the inputs for NewIdentityHandler.
 type IdentityHandlerConfig struct {
-	Service          *Service
-	TMPXSealer       *TMPXSealer
+	Service    *Service
+	TMPXSealer *TMPXSealer
+	// Canonicalizer decodes inbound IdentityToken.UserToken strings into
+	// the canonical lowercase-hex key form audience/fcap services lookup
+	// on. Construct via NewIdentityCanonicalizer (typically alongside
+	// TMPXSealer) so the per-request decode pass runs once and feeds
+	// both the shadow request and the TMPX seal step. Nil disables
+	// canonicalization — the inbound request is forwarded to
+	// service.Evaluate unmodified, preserving the legacy "publisher wire
+	// string is the key" behavior.
+	Canonicalizer    *IdentityCanonicalizer
 	RequestTimeout   time.Duration
 	RequestBodyLimit int64
 	ResponseTTL      time.Duration
@@ -65,6 +75,7 @@ func NewIdentityHandler(cfg IdentityHandlerConfig) http.Handler {
 	return &identityHandler{
 		service:                    cfg.Service,
 		tmpx:                       cfg.TMPXSealer,
+		canonicalizer:              cfg.Canonicalizer,
 		requestTimeout:             cfg.RequestTimeout,
 		requestBodyLimit:           cfg.RequestBodyLimit,
 		responseTTL:                cfg.ResponseTTL,
@@ -154,7 +165,21 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.tmpx != nil && len(eligible) > 0 {
 		tmpxStart := time.Now()
-		if token, terr := h.tmpx.SealDecoded(ctx, decoded); terr != nil {
+		// When a canonicalizer ran, decoded already holds the per-request
+		// decode pass and we pass it through to keep the LiveRamp sidecar
+		// at one call per request. When canonicalization is opted-out
+		// (decoded is nil) the sealer falls back to its own decode pass
+		// — Seal(=Decode+SealDecoded) covers that explicitly.
+		var (
+			token string
+			terr  error
+		)
+		if decoded != nil {
+			token, terr = h.tmpx.SealDecoded(ctx, decoded)
+		} else {
+			token, terr = h.tmpx.Seal(ctx, req.Identities)
+		}
+		if terr != nil {
 			h.logger.Warn("tmpx generation failed, response will omit tmpx",
 				"request_id", req.RequestID, "error", terr)
 			h.recorder.StageOutcome(ctx, StageTMPX, OutcomeError)
@@ -232,28 +257,34 @@ func (h *identityHandler) recordCompletion(ctx context.Context, start time.Time,
 // service.Evaluate, along with the decoded identity slice the TMPX seal
 // path will consume.
 //
-// When TMPX is enabled, the request's identities are decoded once via
-// h.tmpx.Decode (so LiveRamp-backed RampIDs hit the sidecar at most once
-// per request) and a shallow shadow request is built whose Identities
-// slice carries only the entries that successfully decoded, with
-// UserToken set to the decoded byte form — that way
-// identityhash.Hash(user_token) inside audience/fcap keys onto the
-// canonical decoded form, matching whatever the buyer-master populator
-// publishes downstream.
+// When a canonicalizer is configured the request's identities are decoded
+// once (so LiveRamp-backed RampIDs hit the sidecar at most once per
+// request) and a shallow shadow request is built whose Identities slice
+// carries only the entries that successfully decoded, with UserToken set
+// to the canonical lowercase-hex form of the decoded bytes — that way
+// identityhash.Hash(user_token) inside audience/fcap keys onto the same
+// shape ExposureLog.user_token publishes downstream, which is the
+// keying convention downstream marker writers and buyer-master readers
+// honor. The same decoded slice flows through to TMPXSealer.SealDecoded
+// when TMPX is enabled, so the decode pass runs exactly once per request
+// regardless of whether one or both of canonicalization and sealing are
+// active.
 //
-// When TMPX is disabled, no decode is performed and the original request
-// passes through unchanged — preserving legacy behavior for deployments
-// that don't ship TMPX tokens.
+// When no canonicalizer is configured no decode is performed and the
+// original request passes through unchanged — preserving legacy behavior
+// for deployments that have opted out of canonicalization. (Production
+// wires a canonicalizer in by default; this branch is the explicit
+// opt-out and the test-fixture default.)
 //
 // The returned shadow shares backing storage for every IdentityMatchRequest
 // field except Identities; the caller must not append to those slices.
 // service.Evaluate is the only consumer and does its own value copy of
 // the request before mutating PackageIDs.
 func (h *identityHandler) buildServiceRequest(ctx context.Context, req *tmproto.IdentityMatchRequest) (*tmproto.IdentityMatchRequest, []DecodedIdentity) {
-	if h.tmpx == nil {
+	if h.canonicalizer == nil {
 		return req, nil
 	}
-	decoded := h.tmpx.Decode(ctx, req.Identities)
+	decoded := h.canonicalizer.Decode(ctx, req.Identities)
 	shadow := *req
 	shadow.Identities = audienceEligibleIdentities(decoded)
 	return &shadow, decoded

--- a/targeting/identityagent/handler_test.go
+++ b/targeting/identityagent/handler_test.go
@@ -168,11 +168,14 @@ func TestIdentityHandlerUnsupportedMajorVersionIsGenericAndLogged(t *testing.T) 
 	assert.NotContains(t, logErr, "999")
 }
 
-// TestBuildServiceRequest_TMPXDisabled_PassesThroughUnchanged covers the
-// legacy code path: when the handler has no sealer, the request flows to
-// service.Evaluate exactly as received — no decode, no shadow.
-func TestBuildServiceRequest_TMPXDisabled_PassesThroughUnchanged(t *testing.T) {
-	h := &identityHandler{tmpx: nil}
+// TestBuildServiceRequest_NoCanonicalizer_PassesThroughUnchanged covers the
+// legacy code path: when the handler has neither a canonicalizer nor a
+// sealer, the request flows to service.Evaluate exactly as received — no
+// decode, no shadow. This is the opt-out behavior for deployments that
+// explicitly want the publisher-supplied wire string as the audience/fcap
+// lookup key.
+func TestBuildServiceRequest_NoCanonicalizer_PassesThroughUnchanged(t *testing.T) {
+	h := &identityHandler{tmpx: nil, canonicalizer: nil}
 	req := &tmproto.IdentityMatchRequest{
 		RequestID: "req-1",
 		Identities: []tmproto.IdentityToken{
@@ -180,25 +183,67 @@ func TestBuildServiceRequest_TMPXDisabled_PassesThroughUnchanged(t *testing.T) {
 		},
 	}
 	got, decoded := h.buildServiceRequest(t.Context(), req)
-	assert.Same(t, req, got, "TMPX-off must pass through the original request pointer")
-	assert.Nil(t, decoded, "TMPX-off must not produce a decoded slice")
+	assert.Same(t, req, got, "missing canonicalizer must pass through the original request pointer")
+	assert.Nil(t, decoded, "missing canonicalizer must not produce a decoded slice")
 }
 
-// TestBuildServiceRequest_TMPXEnabled_ShadowsAudienceIdentitiesWithCanonicalForm
-// pins the shadow-request contract: when TMPX is enabled, the request
-// that flows into service.Evaluate carries audience/fcap-eligible
-// identities only, and their UserToken is the canonical lowercase-hex
-// form of the decoded bytes — matching ExposureLog.user_token per its
-// proto spec, which is the keying convention downstream marker writers
-// and buyer-master readers honor.
-//
-// MAID and HashedEmail have decoders → survive with canonical hex in
-// UserToken.
-// UID2 has no registered decoder → dropped at decode time.
-// UIDTypeOther has no TMPX mapping → dropped entirely.
-func TestBuildServiceRequest_TMPXEnabled_ShadowsAudienceIdentitiesWithCanonicalForm(t *testing.T) {
-	cfg := &TMPXSealer{decoders: defaultTestDecoders(t)}
-	h := &identityHandler{tmpx: cfg}
+// TestBuildServiceRequest_CanonicalizerOnly_TMPXOff is the bug-fix
+// regression test: a deployment with the canonicalizer wired in but TMPX
+// sealing disabled (no JWKS, no recipient) must still see audience/fcap
+// keyed on the canonical lowercase-hex form of the decoded bytes — not
+// on the publisher-supplied wire string. Otherwise TMPX-on and TMPX-off
+// deployments key the same logical user differently and downstream
+// marker-writer lookups diverge.
+func TestBuildServiceRequest_CanonicalizerOnly_TMPXOff(t *testing.T) {
+	h := &identityHandler{
+		tmpx:          nil,
+		canonicalizer: testCanonicalizer(t),
+	}
+
+	maidUUID := validUserTokenFor(tmproto.UIDTypeMAID)
+	hashedEmail := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req := &tmproto.IdentityMatchRequest{
+		RequestID: "req-off",
+		Identities: []tmproto.IdentityToken{
+			{UIDType: tmproto.UIDTypeMAID, UserToken: maidUUID},
+			{UIDType: tmproto.UIDTypeHashedEmail, UserToken: hashedEmail},
+			{UIDType: tmproto.UIDTypeUID2, UserToken: fixtureToken("uid2-no-decoder")},
+			{UIDType: tmproto.UIDTypeOther, UserToken: "ignored"},
+		},
+	}
+
+	shadow, decoded := h.buildServiceRequest(t.Context(), req)
+
+	require.NotSame(t, req, shadow, "canonicalizer-on must produce a new shadow request even with TMPX off")
+	require.Len(t, shadow.Identities, 2,
+		"only MAID and HashedEmail have decoders; UID2 (no decoder) and UIDTypeOther (no mapping) are dropped")
+
+	// The audience/fcap keys must be the canonical lowercase-hex form of
+	// the decoded bytes — identical to the form TMPX-on deployments
+	// would produce. Before the fix this test would have observed the
+	// raw publisher-supplied strings instead.
+	wantMAIDHex := "550e8400e29b41d4a716446655440000"
+	wantHashedEmailHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	assert.Equal(t, tmproto.UIDTypeMAID, shadow.Identities[0].UIDType)
+	assert.Equal(t, wantMAIDHex, shadow.Identities[0].UserToken,
+		"TMPX-off deployments must still key audience/fcap on the canonical lowercase-hex form")
+	assert.Equal(t, tmproto.UIDTypeHashedEmail, shadow.Identities[1].UIDType)
+	assert.Equal(t, wantHashedEmailHex, shadow.Identities[1].UserToken)
+
+	require.Len(t, decoded, 4, "positional correspondence is preserved; dropped entries have nil Bytes")
+}
+
+// TestBuildServiceRequest_CanonicalizerAndTMPXOn_SharedDecodePass pins the
+// shadow-request contract for the TMPX-on path: the request that flows
+// into service.Evaluate carries audience/fcap-eligible identities with
+// UserToken set to the canonical lowercase-hex form, and the same
+// decoded slice is returned for the TMPX seal step so LiveRamp-backed
+// RampIDs make at most one sidecar call per request.
+func TestBuildServiceRequest_CanonicalizerAndTMPXOn_SharedDecodePass(t *testing.T) {
+	h := &identityHandler{
+		tmpx:          &TMPXSealer{decoders: defaultTestDecoders(t)},
+		canonicalizer: testCanonicalizer(t),
+	}
 
 	maidUUID := validUserTokenFor(tmproto.UIDTypeMAID)
 	hashedEmail := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -214,17 +259,11 @@ func TestBuildServiceRequest_TMPXEnabled_ShadowsAudienceIdentitiesWithCanonicalF
 
 	shadow, decoded := h.buildServiceRequest(t.Context(), req)
 
-	require.NotSame(t, req, shadow, "TMPX-on must produce a new shadow request")
+	require.NotSame(t, req, shadow, "canonicalizer-on must produce a new shadow request")
 	require.NotEqual(t, &req.Identities, &shadow.Identities, "shadow must have its own Identities slice")
 	assert.Equal(t, req.RequestID, shadow.RequestID, "non-Identities fields must survive the shadow copy")
 
-	// Two identities survive (MAID, HashedEmail). UID2 lacks a decoder
-	// and unmapped UIDTypeOther are filtered out.
 	require.Len(t, shadow.Identities, 2)
-
-	// The canonical key form is the lowercase-hex of the decoded bytes:
-	// MAID's dashed UUID collapses to its 32-char hex, and HashedEmail's
-	// hex input round-trips through decode→hex unchanged.
 	wantMAIDHex := "550e8400e29b41d4a716446655440000"
 	wantHashedEmailHex := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	assert.Equal(t, tmproto.UIDTypeMAID, shadow.Identities[0].UIDType)
@@ -232,16 +271,24 @@ func TestBuildServiceRequest_TMPXEnabled_ShadowsAudienceIdentitiesWithCanonicalF
 		"audience/fcap must see UserToken in the canonical lowercase-hex form so identityhash.Hash "+
 			"keys match the form ExposureLog.user_token publishes downstream")
 	assert.Equal(t, tmproto.UIDTypeHashedEmail, shadow.Identities[1].UIDType)
-	assert.Equal(t, wantHashedEmailHex, shadow.Identities[1].UserToken,
-		"HashedEmail UserToken must be the lowercase-hex of the SHA-256 input")
+	assert.Equal(t, wantHashedEmailHex, shadow.Identities[1].UserToken)
 
 	// The full decoded slice (including the dropped UID2/Other entries)
 	// flows separately to the TMPX seal path. Length matches the input
 	// so positional correspondence is preserved; dropped entries have
 	// nil/empty Bytes.
 	require.Len(t, decoded, 4)
-	assert.NotEmpty(t, decoded[0].Bytes, "MAID must be decoded for TMPX too")
-	assert.NotEmpty(t, decoded[1].Bytes, "HashedEmail must be decoded for TMPX too")
+	assert.NotEmpty(t, decoded[0].Bytes, "MAID must be decoded once and shared with TMPX")
+	assert.NotEmpty(t, decoded[1].Bytes, "HashedEmail must be decoded once and shared with TMPX")
 	assert.Empty(t, decoded[2].Bytes, "UID2 has no decoder and must be dropped at decode")
 	assert.Empty(t, decoded[3].Bytes, "UIDTypeOther has no TMPX mapping and must be dropped at decode")
+}
+
+// testCanonicalizer constructs an IdentityCanonicalizer wired to the same
+// fake LiveRamp client the TMPXSealer test decoders use, so the
+// MAID/HashedEmail/ID5 format decoders and the RampID decoders match
+// what production would produce.
+func testCanonicalizer(t *testing.T) *IdentityCanonicalizer {
+	t.Helper()
+	return &IdentityCanonicalizer{decoders: defaultTestDecoders(t)}
 }

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -61,6 +61,7 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string) e
 	identityHandler := NewIdentityHandler(IdentityHandlerConfig{
 		Service:                    bundle.service,
 		TMPXSealer:                 bundle.tmpx,
+		Canonicalizer:              bundle.canonicalizer,
 		RequestTimeout:             cfg.RequestTimeout,
 		RequestBodyLimit:           int64(cfg.RequestBodyLimitBytes),
 		ResponseTTL:                cfg.ResponseTTL,
@@ -259,6 +260,7 @@ type bundle struct {
 	fcapCloser       interface{ Close() error }
 	keystore         tmproto.KeyStore
 	tmpx             *TMPXSealer
+	canonicalizer    *IdentityCanonicalizer
 	cancelBackground context.CancelFunc
 }
 
@@ -390,6 +392,14 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 		return nil, fmt.Errorf("tmpx: %w", err)
 	}
 
+	// The canonicalizer is constructed independently of TMPX configuration:
+	// even deployments that never emit a TMPX token need audience/fcap
+	// lookups keyed on the canonical decoded form so they see the same
+	// shape ExposureLog.user_token publishes downstream. The same
+	// LiveRamp sidecar (when configured) backs RampID decoding here as in
+	// the sealer.
+	canonicalizer := NewIdentityCanonicalizer(lrSidecar, logger, recorder)
+
 	return &bundle{
 		service:          svc,
 		configSvc:        configSvc,
@@ -398,6 +408,7 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 		fcapCloser:       fcapCloser,
 		keystore:         keystore,
 		tmpx:             tmpx,
+		canonicalizer:    canonicalizer,
 		cancelBackground: cancelBg,
 	}, nil
 }

--- a/targeting/identityagent/tmpx.go
+++ b/targeting/identityagent/tmpx.go
@@ -318,47 +318,15 @@ func joinUIDs(s []tmproto.UIDType) string {
 // Dropped identities have Bytes == nil in the returned slice; downstream
 // stages (SealDecoded, audience/fcap lookups) skip them silently.
 //
-// The handler calls Decode once per request and shares the result so
-// LiveRamp-backed RampIDs make at most one sidecar call per request even
-// when both TMPX and audience need them.
+// In production the per-request decode pass is owned by the canonicalizer
+// (see IdentityCanonicalizer.Decode); the handler hands SealDecoded the
+// already-decoded slice so LiveRamp-backed RampIDs make at most one
+// sidecar call per request. This method remains so callers (including the
+// Seal convenience wrapper and the reference / test code) that already
+// hold a *TMPXSealer can still decode against the sealer's own registry
+// without taking a dependency on IdentityCanonicalizer.
 func (s *TMPXSealer) Decode(ctx context.Context, ids []tmproto.IdentityToken) []DecodedIdentity {
-	out := make([]DecodedIdentity, len(ids))
-	for i, id := range ids {
-		out[i].UIDType = id.UIDType
-		typeID, ok := uidToTmpxTypeID[id.UIDType]
-		if !ok {
-			s.recordDrop(ctx, TmpxDropUnmapped, id.UIDType)
-			continue
-		}
-		decoder, ok := s.decoders[id.UIDType]
-		if !ok {
-			s.recordDrop(ctx, TmpxDropNoDecoder, id.UIDType)
-			continue
-		}
-		bin, err := decoder.Decode(ctx, id.UserToken)
-		if err != nil {
-			if errors.Is(err, ErrDropIdentity) {
-				s.recordDrop(ctx, TmpxDropDecoderDrop, id.UIDType)
-				continue
-			}
-			s.recordDrop(ctx, TmpxDropDecoderError, id.UIDType)
-			s.log().Warn("tmpx decoder error — dropping identity",
-				"uid_type", id.UIDType,
-				"error", err)
-			continue
-		}
-		wantSize, _ := tmproto.TmpxTokenSize(typeID)
-		if len(bin) != wantSize {
-			s.recordDrop(ctx, TmpxDropSizeMismatch, id.UIDType)
-			s.log().Warn("tmpx decoder returned wrong byte length — dropping identity",
-				"uid_type", id.UIDType,
-				"got", len(bin),
-				"want", wantSize)
-			continue
-		}
-		out[i].Bytes = bin
-	}
-	return out
+	return decodeIdentities(ctx, ids, s.decoders, s.log(), s.recordDrop)
 }
 
 // Seal is a convenience that runs Decode and then SealDecoded. Callers


### PR DESCRIPTION
## Summary

Follow-up to #174. Before this PR, `identityHandler.buildServiceRequest`
short-circuited when no `TMPXSealer` was configured and forwarded the
publisher-supplied `IdentityMatchRequest` unchanged. With the changes
landed in #174 the TMPX-on path now keys audience and frequency-cap
lookups on the canonical lowercase-hex form of the decoded bytes
(matching `ExposureLog.user_token` per its proto spec), but the TMPX-off
path still keyed them on the publisher wire string — e.g.
`hash("550e8400-e29b-41d4-a716-446655440000")` for a MAID instead of
`hash("550e8400e29b41d4a716446655440000")`. Two different lookup keys
for the same logical user; only deployments matching whichever shape the
buyer-master populator uses could ever match.

This PR decouples the decoder registry from `TMPXSealer` so the
canonicalization step runs regardless of whether sealing is enabled.

## Design

Adds an `IdentityCanonicalizer` sibling type in the `identityagent`
package that owns the decoder registry (built via
`tmpxdecoders.NewDefaultRegistry`). `NewIdentityCanonicalizer` accepts
the same `LiveRampSidecar` interface `NewTMPXSealer` does. The shared
per-identity decode loop (with its TmpxIdentityDrop counter
bookkeeping and size validation) was extracted into a package-private
`decodeIdentities` helper so the canonicalizer and the sealer can't
silently diverge on drop semantics.

`identityHandler` now holds an optional `*IdentityCanonicalizer`
independent of its `*TMPXSealer`. `buildServiceRequest` decodes once
through the canonicalizer and feeds the same `[]DecodedIdentity` slice
to both the audience/fcap shadow request (via `audienceEligibleIdentities`)
and `TMPXSealer.SealDecoded` — so LiveRamp-backed RampIDs still make at
most one sidecar call per request even when both paths are active.

Wiring in `setup.go` constructs the canonicalizer alongside the sealer
using the same `LiveRampSidecar` instance. Production gets
canonicalization by default; the legacy pass-through behavior remains
available as an explicit opt-out (a nil `*IdentityCanonicalizer` on the
handler).

`TMPXSealer.Decode` is kept (now delegating to the shared helper)
because `Seal` and the existing test code path still call it; renaming
or relocating `TMPXSealer`'s methods was out of scope.

## Behavioral change

Any TMPX-off deployment that was implicitly relying on
`hash(publisher_wire_string)` as its audience/fcap key (because the old
short-circuit forwarded the request unchanged) will switch to
`hash(canonical_hex(decoded_bytes))` after this PR — which is the same
key the buyer-master populator publishes and the same key TMPX-on
deployments already use. Deployments that genuinely need the legacy
behavior must opt out explicitly by passing `Canonicalizer: nil` to
`NewIdentityHandler`.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] New: `TestBuildServiceRequest_CanonicalizerOnly_TMPXOff` — the
  bug-fix regression: TMPX-off with canonicalizer present yields the
  canonical lowercase-hex form on the shadow request.
- [x] New: `TestBuildServiceRequest_NoCanonicalizer_PassesThroughUnchanged`
  — the explicit opt-out (legacy behavior) still works.
- [x] New: `TestBuildServiceRequest_CanonicalizerAndTMPXOn_SharedDecodePass`
  — TMPX-on plus canonicalizer share the decode pass; replaces the
  previous TMPX-on shadow test.
- [x] New: `IdentityCanonicalizer` decode/drop-reason tests in
  `canonicalizer_test.go`.
- [x] Existing `TMPXSealer.Decode` / `Seal` / `selectEntries` tests
  still pass — they exercise the shared helper indirectly so the
  refactor is byte-for-byte equivalent on that path.

## Open question

Should the handler treat a non-nil canonicalizer with an empty decoder
map (no LiveRamp config and the format-only decoders explicitly
disabled — not reachable through the current API but expressible if
someone constructs the type directly) as fail-fast at startup, or
preserve today's "silent drop every identity" behavior? The PR keeps
the silent-drop semantics to match the existing "missing config = silent
drop" pattern, but I'd appreciate an owning-team eye on that call.