### PR TITLE
feat(adcp)!: preserve package request zero values

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -14,9 +14,12 @@ be populated.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
-  `CreativeAsset.Weight`, and `KeywordTarget.BidPrice`. Use nil to omit the
-  field, and `adcp.Ptr(0.0)` when the wire payload must include an explicit
-  zero.
+  `CreativeAsset.Weight`, `KeywordTarget.BidPrice`, `PackageInput.BidPrice`,
+  `PackageInput.Impressions`, `PackageUpdate.Budget`,
+  `PackageUpdate.BidPrice`, `PackageUpdate.Impressions`, and
+  `KeywordTargetUpdate.BidPrice`. Use nil to omit the field, and
+  `adcp.Ptr(0.0)` or `adcp.Float64(0)` when the wire payload must include an
+  explicit zero.
 - `UpdateMediaBuyRequest.Canceled` and `PackageUpdate.Canceled` are `*bool`.
   Use nil when the field is absent and `adcp.Bool(true)` when requesting
   cancellation. The AdCP schema constrains `canceled` to true; do not send

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -63,8 +63,16 @@ func TestUpdateMediaBuyOptionalFlagsMarshal(t *testing.T) {
 
 func TestPackageUpdateOptionalFlagsAndCreativeAssignmentsMarshal(t *testing.T) {
 	out, err := json.Marshal(PackageUpdate{
-		PackageID: "pkg-1",
-		Paused:    Bool(false),
+		PackageID:   "pkg-1",
+		Paused:      Bool(false),
+		Budget:      Float64(0),
+		BidPrice:    Float64(0),
+		Impressions: Float64(0),
+		KeywordTargetsAdd: []KeywordTargetUpdate{{
+			Keyword:   "running shoes",
+			MatchType: "phrase",
+			BidPrice:  Float64(0),
+		}},
 		CreativeAssignments: []CreativeAssignment{{
 			CreativeID: "cr-1",
 			Weight:     Float64(0),
@@ -75,7 +83,16 @@ func TestPackageUpdateOptionalFlagsAndCreativeAssignmentsMarshal(t *testing.T) {
 	var wire map[string]any
 	require.NoError(t, json.Unmarshal(out, &wire))
 	assert.Equal(t, false, wire["paused"])
+	assert.Equal(t, float64(0), wire["budget"])
+	assert.Equal(t, float64(0), wire["bid_price"])
+	assert.Equal(t, float64(0), wire["impressions"])
 	assert.NotContains(t, wire, "canceled")
+	keywords, ok := wire["keyword_targets_add"].([]any)
+	require.True(t, ok)
+	require.Len(t, keywords, 1)
+	keyword, ok := keywords[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(0), keyword["bid_price"])
 	assignments, ok := wire["creative_assignments"].([]any)
 	require.True(t, ok)
 	require.Len(t, assignments, 1)
@@ -83,6 +100,43 @@ func TestPackageUpdateOptionalFlagsAndCreativeAssignmentsMarshal(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "cr-1", assignment["creative_id"])
 	assert.Equal(t, float64(0), assignment["weight"])
+}
+
+func TestPackageInputOptionalZeroAndSchemaFieldsMarshal(t *testing.T) {
+	out, err := json.Marshal(PackageInput{
+		ProductID:       "prod-1",
+		PricingOptionID: "price-1",
+		Budget:          0,
+		FormatIDs:       []FormatRef{{ID: "display-banner"}},
+		Paused:          Bool(false),
+		BidPrice:        Float64(0),
+		Impressions:     Float64(0),
+		Catalogs:        []Catalog{{Type: "products"}},
+		CreativeAssignments: []CreativeAssignment{{
+			CreativeID: "cr-1",
+		}},
+		Creatives: []CreativeAsset{{
+			CreativeID: "cr-new-1",
+			Name:       "New creative",
+			FormatID:   FormatRef{ID: "display-banner"},
+			Assets:     map[string]any{"image": map[string]any{"url": "https://example.com/image.png"}},
+		}},
+		Ext: map[string]any{"buyer_ref": "corr-1"},
+	})
+	require.NoError(t, err)
+
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, float64(0), wire["budget"])
+	assert.Equal(t, false, wire["paused"])
+	assert.Equal(t, float64(0), wire["bid_price"])
+	assert.Equal(t, float64(0), wire["impressions"])
+	assert.Contains(t, wire, "format_ids")
+	assert.Contains(t, wire, "catalogs")
+	assert.Contains(t, wire, "creative_assignments")
+	assert.Contains(t, wire, "creatives")
+	assert.NotContains(t, wire, "buyer_ref")
+	assert.Equal(t, map[string]any{"buyer_ref": "corr-1"}, wire["ext"])
 }
 
 func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -913,6 +913,12 @@ INLINE_TYPE_HINTS = {
     ('AudienceSelector', 'max_value'): '*float64',
     ('ForecastPoint', 'budget'): '*float64',
     ('OptimizationGoalEventSource', 'value_factor'): '*float64',
+    ('PackageInput', 'bid_price'): '*float64',
+    ('PackageInput', 'impressions'): '*float64',
+    ('PackageUpdate', 'budget'): '*float64',
+    ('PackageUpdate', 'bid_price'): '*float64',
+    ('PackageUpdate', 'impressions'): '*float64',
+    ('KeywordTargetUpdate', 'bid_price'): '*float64',
 }
 
 for _delivery_metric_type in (

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -647,6 +647,99 @@ class OptionalNumericPolicyTest(unittest.TestCase):
             "budget",
             "*float64",
         )
+        self.assert_field_type(
+            "media-buy/package-request.json",
+            "PackageInput",
+            "bid_price",
+            "*float64",
+        )
+        self.assert_field_type(
+            "media-buy/package-request.json",
+            "PackageInput",
+            "impressions",
+            "*float64",
+        )
+        self.assert_field_type(
+            "media-buy/package-update.json",
+            "PackageUpdate",
+            "budget",
+            "*float64",
+        )
+        self.assert_field_type(
+            "media-buy/package-update.json",
+            "PackageUpdate",
+            "bid_price",
+            "*float64",
+        )
+        self.assert_field_type(
+            "media-buy/package-update.json",
+            "PackageUpdate",
+            "impressions",
+            "*float64",
+        )
+        package_update = generate.load_schema("media-buy/package-update.json")
+        keyword_add = generate.json_pointer_get(
+            package_update,
+            "/properties/keyword_targets_add/items",
+        )
+        bid_price_type, _ = generate.field_go_type_info(
+            "KeywordTargetUpdate",
+            "bid_price",
+            keyword_add["properties"]["bid_price"],
+            set(keyword_add.get("required", [])),
+        )
+        self.assertEqual("*float64", bid_price_type)
+
+
+class PackageSchemaOwnershipTest(unittest.TestCase):
+    def assert_generated_struct_fields(self, schema_path, type_name, expected_fields):
+        schema = generate.load_schema(schema_path)
+        generated = generate.schema_to_struct(type_name, schema)
+
+        self.assertNotIn("BuyerRef", generated)
+        self.assertNotIn("buyer_ref", generated)
+        for field in expected_fields:
+            with self.subTest(type_name=type_name, field=field):
+                self.assertIn(field, generated)
+
+    def test_package_input_is_schema_owned(self):
+        self.assert_generated_struct_fields(
+            "media-buy/package-request.json",
+            "PackageInput",
+            [
+                "FormatIDs []FormatRef `json:\"format_ids,omitempty\"`",
+                "Paused *bool `json:\"paused,omitempty\"`",
+                "Catalogs []Catalog `json:\"catalogs,omitempty\"`",
+                "OptimizationGoals []OptimizationGoal `json:\"optimization_goals,omitempty\"`",
+                "CreativeAssignments []CreativeAssignment `json:\"creative_assignments,omitempty\"`",
+                "Creatives []CreativeAsset `json:\"creatives,omitempty\"`",
+                "BidPrice *float64 `json:\"bid_price,omitempty\"`",
+                "Impressions *float64 `json:\"impressions,omitempty\"`",
+                "Ext any `json:\"ext,omitempty\"`",
+            ],
+        )
+
+    def test_package_update_is_schema_owned(self):
+        self.assert_generated_struct_fields(
+            "media-buy/package-update.json",
+            "PackageUpdate",
+            [
+                "Paused *bool `json:\"paused,omitempty\"`",
+                "Canceled *bool `json:\"canceled,omitempty\"`",
+                "Catalogs []Catalog `json:\"catalogs,omitempty\"`",
+                "OptimizationGoals []OptimizationGoal `json:\"optimization_goals,omitempty\"`",
+                "KeywordTargetsAdd []KeywordTargetUpdate `json:\"keyword_targets_add,omitempty\"`",
+                "KeywordTargetsRemove []KeywordTargetRef `json:\"keyword_targets_remove,omitempty\"`",
+                "NegativeKeywordsAdd []KeywordTargetRef `json:\"negative_keywords_add,omitempty\"`",
+                "NegativeKeywordsRemove []KeywordTargetRef `json:\"negative_keywords_remove,omitempty\"`",
+                "CreativeAssignments []CreativeAssignment `json:\"creative_assignments,omitempty\"`",
+                "Creatives []CreativeAsset `json:\"creatives,omitempty\"`",
+                "Budget *float64 `json:\"budget,omitempty\"`",
+                "BidPrice *float64 `json:\"bid_price,omitempty\"`",
+                "Impressions *float64 `json:\"impressions,omitempty\"`",
+                "Ext any `json:\"ext,omitempty\"`",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6130,8 +6130,8 @@ type PackageInput struct {
 	Budget float64 `json:"budget"` // Budget allocation for this package in the media buy's currency
 	Pacing string `json:"pacing,omitempty"`
 	PricingOptionID string `json:"pricing_option_id"` // ID of the selected pricing option from the product's pricing_options array
-	BidPrice float64 `json:"bid_price,omitempty"` // Bid price for auction-based pricing options. This is the exact bid/price to hono
-	Impressions float64 `json:"impressions,omitempty"` // Impression goal for this package
+	BidPrice *float64 `json:"bid_price,omitempty"` // Bid price for auction-based pricing options. This is the exact bid/price to hono
+	Impressions *float64 `json:"impressions,omitempty"` // Impression goal for this package
 	StartTime string `json:"start_time,omitempty"` // Flight start date/time for this package in ISO 8601 format. When omitted, the pa
 	EndTime string `json:"end_time,omitempty"` // Flight end date/time for this package in ISO 8601 format. When omitted, the pack
 	Paused *bool `json:"paused,omitempty"` // Whether this package should be created in a paused state. Paused packages do not
@@ -6150,10 +6150,10 @@ type PackageInput struct {
 // PackageUpdate — Package update configuration for update_media_buy. Identifies package by package_id and specifies fi
 type PackageUpdate struct {
 	PackageID string `json:"package_id"` // Seller's ID of package to update
-	Budget float64 `json:"budget,omitempty"` // Updated budget allocation for this package in the currency specified by the pric
+	Budget *float64 `json:"budget,omitempty"` // Updated budget allocation for this package in the currency specified by the pric
 	Pacing string `json:"pacing,omitempty"`
-	BidPrice float64 `json:"bid_price,omitempty"` // Updated bid price for auction-based pricing options. This is the exact bid/price
-	Impressions float64 `json:"impressions,omitempty"` // Updated impression goal for this package
+	BidPrice *float64 `json:"bid_price,omitempty"` // Updated bid price for auction-based pricing options. This is the exact bid/price
+	Impressions *float64 `json:"impressions,omitempty"` // Updated impression goal for this package
 	StartTime string `json:"start_time,omitempty"` // Updated flight start date/time for this package in ISO 8601 format. Must fall wi
 	EndTime string `json:"end_time,omitempty"` // Updated flight end date/time for this package in ISO 8601 format. Must fall with
 	Paused *bool `json:"paused,omitempty"` // Pause/resume specific package (true = paused, false = active)
@@ -6177,7 +6177,7 @@ type PackageUpdate struct {
 type KeywordTargetUpdate struct {
 	Keyword string `json:"keyword"` // The keyword to target
 	MatchType string `json:"match_type"`
-	BidPrice float64 `json:"bid_price,omitempty"` // Per-keyword bid price. Inherits currency and max_bid interpretation from the pac
+	BidPrice *float64 `json:"bid_price,omitempty"` // Per-keyword bid price. Inherits currency and max_bid interpretation from the pac
 }
 
 type KeywordTargetRef struct {


### PR DESCRIPTION
## Summary
- keep PackageInput and PackageUpdate schema-owned with generator tests for the 3.0.12 request/update fields
- remove the need for top-level convenience fields like buyer_ref by asserting correlation data stays under ext
- generate optional package numeric fields as pointers so explicit zero values survive omitempty

## Caller impact
Optional numeric package request fields are now pointers: PackageInput.BidPrice, PackageInput.Impressions, PackageUpdate.Budget, PackageUpdate.BidPrice, PackageUpdate.Impressions, and KeywordTargetUpdate.BidPrice. Callers should use helpers like adcp.Float64(0) when an explicit zero is intended.

Closes #147.

## Tests
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 generate.py > ../types_gen.go
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- go test ./...
- git diff --check
