### PR TITLE
fix(argus): support fork PR reviews safely

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -20,7 +20,7 @@ name: AI PR Review (Argus)
 # upstream is surfaced weekly by sync-argus-upstream-check.yml.
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - labeled
@@ -40,8 +40,13 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # This workflow uses pull_request_target so fork PRs can access the
+      # review App token and Anthropic secret. Never check out the PR head or
+      # execute PR-controlled code in this job. Keep the workspace pinned to the
+      # trusted base SHA and inspect the PR through GitHub APIs / gh pr diff.
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
       # ─────────────────────────────────────────────────────────────────────
@@ -147,18 +152,11 @@ jobs:
             echo "No prior bot APPROVED review — running full review."
             exit 0
           fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            git fetch --quiet origin "$PRIOR_SHA" 2>/dev/null || true
-          fi
-          if ! git cat-file -e "$PRIOR_SHA" 2>/dev/null; then
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Prior review SHA $PRIOR_SHA unreachable (likely force-pushed) — running full review."
-            exit 0
-          fi
-          CHANGED="$(git diff --name-only "$PRIOR_SHA" "$HEAD_SHA")"
+          CHANGED="$(gh api "/repos/${REPO}/compare/${PRIOR_SHA}...${HEAD_SHA}" \
+            --jq '.files[]?.filename' 2>/dev/null || true)"
           if [ -z "$CHANGED" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No file changes since prior approval at $PRIOR_SHA — skipping."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Could not compare $PRIOR_SHA...$HEAD_SHA (likely force-pushed or fork edge case) — running full review."
             exit 0
           fi
           # Trivial paths in adcp-go — re-pushes touching only these skip re-review.
@@ -197,12 +195,18 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          PROMPT_BODY="$(cat .github/ai-review/expert-adcp-reviewer.md)"
+          if ! git cat-file -e "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md" 2>/dev/null; then
+            echo "::error::Prompt file does not exist at base SHA ${BASE_SHA}. Self-modification gate should have caught this."
+            exit 1
+          fi
+          PROMPT_BODY="$(git show "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md")"
+          SENTINEL="ARGUS_$(openssl rand -hex 8)_EOF"
           {
-            echo 'ARGUS_PROMPT<<ARGUS_EOF'
+            echo "ARGUS_PROMPT<<${SENTINEL}"
             echo "$PROMPT_BODY"
             echo ''
             echo '---'
@@ -212,7 +216,7 @@ jobs:
             echo "- PR_NUMBER: $PR_NUMBER"
             echo "- REPO: $REPO"
             echo "- PR_BASE_REF: $PR_BASE_REF"
-            echo 'ARGUS_EOF'
+            echo "${SENTINEL}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Argus PR Review


### PR DESCRIPTION
## Summary
- run Argus on pull_request_target so fork PRs can access the review App token and Anthropic secret
- keep checkout pinned to the trusted base SHA and inspect PR changes through GitHub APIs
- avoid local prior-SHA diffs in the skip check, falling back to full review when compare data is unavailable
- read the review prompt from the trusted base SHA with a randomized heredoc sentinel

## Validation
- git diff --check