### PR TITLE
feat(adcp)!: type inline sort and artifact pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 42
+        run: python3 generate.py --coverage-max-unreviewed-any 40
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,10 @@ Optional object references are pointers: nil omits the field, and `&T{}` or
 `adcp.Ptr(T{})` emits it. Required fields inside the nested struct still need to
 be populated.
 
+- Two inline object fields that previously used `any` are now typed:
+  `ListCreativesRequest.Sort` is `*adcp.ListCreativesSort`, and
+  `ArtifactWebhookPayload.Pagination` is `*adcp.ArtifactWebhookPagination`.
+  Use nil to omit them.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -209,6 +209,42 @@ func TestPackageOptionalNumericNilOmitsFields(t *testing.T) {
 	assert.NotContains(t, wire, "bid_price")
 }
 
+func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
+	out, err := json.Marshal(ListCreativesRequest{
+		Sort: &ListCreativesSort{
+			Field:     CreativeSortFieldName,
+			Direction: SortDirectionAsc,
+		},
+	})
+	require.NoError(t, err)
+	var wire map[string]any
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"field":     "name",
+		"direction": "asc",
+	}, wire["sort"])
+
+	out, err = json.Marshal(ArtifactWebhookPayload{
+		IdempotencyKey: "idem-1",
+		MediaBuyID:     "mb-1",
+		BatchID:        "batch-1",
+		Timestamp:      "2026-05-28T00:00:00Z",
+		Pagination: &ArtifactWebhookPagination{
+			TotalArtifacts: 25,
+			BatchNumber:    1,
+			TotalBatches:   3,
+		},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"total_artifacts": float64(25),
+		"batch_number":    float64(1),
+		"total_batches":   float64(3),
+	}, wire["pagination"])
+}
+
 func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {
 	out, err := json.Marshal(CreativeAssignment{
 		CreativeID: "cr-typed",

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -627,6 +627,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "OptimizationGoalAttributionWindow",
         "core/optimization-goal.json#/oneOf/1/properties/attribution_window",
     ),
+    (
+        "ListCreativesSort",
+        "creative/list-creatives-request.json#/properties/sort",
+    ),
+    (
+        "ArtifactWebhookPagination",
+        "content-standards/artifact-webhook-payload.json#/properties/pagination",
+    ),
 ])
 
 # Shared inline helper types are generated from one schema pointer but reused by
@@ -775,6 +783,7 @@ INLINE_TYPE_HINTS = {
     ('LogEventRequest', 'events'): 'map[string]any',
     ('ActivateSignalRequest', 'destinations'): 'DestinationInput',
     ('GetSignalsRequest', 'filters'): 'SignalFilters',
+    ('ListCreativesRequest', 'sort'): '*ListCreativesSort',
     ('SyncPlansRequest', 'plans'): 'Plan',
     ('GetProductsResponse', 'proposals'): 'Proposal',
     ('PackageUpdate', 'keyword_targets_add'): 'KeywordTargetUpdate',
@@ -831,6 +840,7 @@ INLINE_TYPE_HINTS = {
     ('GetCollectionListRequest', 'pagination'): '*CollectionRequestPagination',
     ('CollectionListChangedWebhook', 'change_summary'): '*CollectionChangeSummary',
     ('PropertyListChangedWebhook', 'change_summary'): '*PropertyChangeSummary',
+    ('ArtifactWebhookPayload', 'pagination'): '*ArtifactWebhookPagination',
     ('RightsConstraint', 'rights_agent'): 'RightsAgentRef',
     ('Product', 'product_card'): '*ProductCard',
     ('Product', 'product_card_detailed'): '*ProductCardDetailed',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -691,6 +691,66 @@ class OptionalNumericPolicyTest(unittest.TestCase):
         self.assertEqual("*float64", bid_price_type)
 
 
+class InlineObjectGenerationTest(unittest.TestCase):
+    def assert_field_type(self, schema_path, type_name, json_name, want):
+        schema = generate.load_schema(schema_path)
+        prop = generate.schema_properties(schema)[json_name]
+        required_set = generate.schema_required_names(schema)
+
+        go_type, reason = generate.field_go_type_info(
+            type_name,
+            json_name,
+            prop,
+            required_set,
+        )
+
+        self.assertEqual(want, go_type)
+        self.assertIsNone(reason)
+
+    def test_low_risk_inline_objects_are_typed(self):
+        self.assert_field_type(
+            "creative/list-creatives-request.json",
+            "ListCreativesRequest",
+            "sort",
+            "*ListCreativesSort",
+        )
+        self.assert_field_type(
+            "content-standards/artifact-webhook-payload.json",
+            "ArtifactWebhookPayload",
+            "pagination",
+            "*ArtifactWebhookPagination",
+        )
+
+    def test_inline_object_structs_are_generated_from_schema_pointers(self):
+        sort_schema = generate.load_schema_spec(
+            "creative/list-creatives-request.json#/properties/sort",
+        )
+        sort_generated = generate.schema_to_struct("ListCreativesSort", sort_schema)
+        self.assertIn("Field string `json:\"field,omitempty\"`", sort_generated)
+        self.assertIn("Direction string `json:\"direction,omitempty\"`", sort_generated)
+
+        pagination_schema = generate.load_schema_spec(
+            "content-standards/artifact-webhook-payload.json#/properties/pagination",
+        )
+        pagination_generated = generate.schema_to_struct(
+            "ArtifactWebhookPagination",
+            pagination_schema,
+        )
+        self.assertIn("TotalArtifacts int `json:\"total_artifacts,omitempty\"`", pagination_generated)
+        self.assertIn("BatchNumber int `json:\"batch_number,omitempty\"`", pagination_generated)
+        self.assertIn("TotalBatches int `json:\"total_batches,omitempty\"`", pagination_generated)
+
+    def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
+        records = [
+            (record["type"], record["json"])
+            for record in generate.any_coverage_report()["records"]
+            if not record["allowed"]
+        ]
+
+        self.assertNotIn(("ListCreativesRequest", "sort"), records)
+        self.assertNotIn(("ArtifactWebhookPayload", "pagination"), records)
+
+
 class PackageSchemaOwnershipTest(unittest.TestCase):
     def assert_generated_struct_fields(self, schema_path, type_name, expected_fields):
         schema = generate.load_schema(schema_path)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -7034,6 +7034,19 @@ type OptimizationGoalAttributionWindow struct {
 	PostView *Duration `json:"post_view,omitempty"` // Post-view attribution window. Conversions within this duration after an ad impre
 }
 
+// ListCreativesSort — Sorting parameters
+type ListCreativesSort struct {
+	Field string `json:"field,omitempty"` // Field to sort by
+	Direction string `json:"direction,omitempty"` // Sort direction
+}
+
+// ArtifactWebhookPagination — Pagination info when batching large artifact sets
+type ArtifactWebhookPagination struct {
+	TotalArtifacts int `json:"total_artifacts,omitempty"` // Total artifacts in the delivery period
+	BatchNumber int `json:"batch_number,omitempty"` // Current batch number (1-indexed)
+	TotalBatches int `json:"total_batches,omitempty"` // Total batches for this delivery period
+}
+
 // --- Tool request/response types ---
 
 // GetAdcpCapabilitiesRequest — Request payload for get_adcp_capabilities task. Protocol-level capability discovery that works acros
@@ -7445,7 +7458,7 @@ type SyncCreativesRequest struct {
 type ListCreativesRequest struct {
 	AdcpMajorVersion int `json:"adcp_major_version,omitempty"` // The AdCP major version the buyer's payloads conform to. Sellers validate against
 	Filters *CreativeFilters `json:"filters,omitempty"`
-	Sort any `json:"sort,omitempty"` // Sorting parameters
+	Sort *ListCreativesSort `json:"sort,omitempty"` // Sorting parameters
 	Pagination *PaginationRequest `json:"pagination,omitempty"`
 	IncludeAssignments *bool `json:"include_assignments,omitempty"` // Include package assignment information in response
 	IncludeSnapshot *bool `json:"include_snapshot,omitempty"` // Include a lightweight delivery snapshot per creative (lifetime impressions and l
@@ -7791,7 +7804,7 @@ type ArtifactWebhookPayload struct {
 	BatchID string `json:"batch_id"` // Unique identifier for this batch of artifacts. Use for deduplication and acknowl
 	Timestamp string `json:"timestamp"` // When this batch was generated (ISO 8601)
 	Artifacts []any `json:"artifacts"` // Content artifacts from delivered impressions
-	Pagination any `json:"pagination,omitempty"` // Pagination info when batching large artifact sets
+	Pagination *ArtifactWebhookPagination `json:"pagination,omitempty"` // Pagination info when batching large artifact sets
 	Ext any `json:"ext,omitempty"`
 }
 

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 42
+python3 generate.py --coverage-max-unreviewed-any 40
 ```
 
-The generator currently reports 202 generated dynamic `any` uses:
+The generator currently reports 200 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 160 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 42 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 40 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 42
+python3 generate.py --coverage-max-unreviewed-any 40
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -66,7 +66,6 @@ the new dynamic shape is reviewed in the same PR.
 | `GetProductsResponse.Incomplete` | `incomplete` | `[]any` | `array_item:inline_object` | `media-buy/get-products-response.json` |
 | `CreateMediaBuyResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/create-media-buy-response.json` |
 | `ProvidePerformanceFeedbackResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/provide-performance-feedback-response.json` |
-| `ListCreativesRequest.Sort` | `sort` | `any` | `inline_object` | `creative/list-creatives-request.json` |
 | `PreviewCreativeRequest.Inputs` | `inputs` | `[]any` | `array_item:inline_object` | `creative/preview-creative-request.json` |
 | `PreviewCreativeRequest.Requests` | `requests` | `[]any` | `array_item:inline_object` | `creative/preview-creative-request.json` |
 | `GetSignalsResponse.Signals` | `signals` | `[]any` | `array_item:inline_object` | `signals/get-signals-response.json` |
@@ -86,13 +85,12 @@ the new dynamic shape is reviewed in the same PR.
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
 | `MCPWebhookPayload.Result` | `result` | `any` | `unknown_ref:/schemas/3.0.12/core/async-response-data.json` | `core/mcp-webhook-payload.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
-| `ArtifactWebhookPayload.Pagination` | `pagination` | `any` | `inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
 
 ### Inline Object Generation
 
-This is the largest generator gap: 30 unreviewed fallbacks are direct inline
+This is the largest generator gap: 28 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
@@ -100,10 +98,8 @@ detection across generated names.
 Start here for the first reduction pass. Good candidates are low-risk leaf
 objects:
 
-- `ListCreativesRequest.Sort`
 - `PerformanceFeedback.MeasurementPeriod`
 - `PlannedDelivery.Geo`
-- `ArtifactWebhookPayload.Pagination`
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary
- generate first-class Go structs for two low-risk inline object schemas
- type `ListCreativesRequest.Sort` as `*ListCreativesSort` and `ArtifactWebhookPayload.Pagination` as `*ArtifactWebhookPagination`
- lower the unreviewed generated `any` CI baseline from 42 to 40 and document the SDK migration impact

Refs #259.

## Impact
This is an exported Go SDK typing change. Callers that assigned arbitrary `any` values to these two fields should now use the generated structs, or `nil` to omit the fields.

## Validation
- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 40`
- `cd adcp && go test .`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `git diff --check`