### PR TITLE
feat(adcp)!: type inline feedback and delivery fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 40
+        run: python3 generate.py --coverage-max-unreviewed-any 38
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -15,6 +15,12 @@ be populated.
   `ListCreativesRequest.Sort` is `*adcp.ListCreativesSort`, and
   `ArtifactWebhookPayload.Pagination` is `*adcp.ArtifactWebhookPagination`.
   Use nil to omit them.
+- Two more generated inline object fields that previously used `any` are now
+  typed: `PerformanceFeedback.MeasurementPeriod` is
+  `adcp.DatetimeRange`, and `PlannedDelivery.Geo` is `*adcp.PlannedDeliveryGeo`.
+  Populate `DatetimeRange.Start` and `DatetimeRange.End`; zero-value
+  `DatetimeRange{}` is not a valid wire payload. Use nil to omit
+  `PlannedDelivery.Geo`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -243,6 +243,50 @@ func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
 		"batch_number":    float64(1),
 		"total_batches":   float64(3),
 	}, wire["pagination"])
+
+	out, err = json.Marshal(PerformanceFeedback{
+		FeedbackID: "pf-1",
+		MediaBuyID: "mb-1",
+		MeasurementPeriod: DatetimeRange{
+			Start: "2026-05-01T00:00:00Z",
+			End:   "2026-05-28T00:00:00Z",
+		},
+		PerformanceIndex: 1.2,
+		MetricType:       MetricTypeClickThroughRate,
+		FeedbackSource:   FeedbackSourcePlatformAnalytics,
+		Status:           "accepted",
+		SubmittedAt:      "2026-05-28T00:00:00Z",
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"start": "2026-05-01T00:00:00Z",
+		"end":   "2026-05-28T00:00:00Z",
+	}, wire["measurement_period"])
+
+	out, err = json.Marshal(PerformanceFeedback{})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"start": "",
+		"end":   "",
+	}, wire["measurement_period"])
+
+	out, err = json.Marshal(PlannedDelivery{
+		Geo: &PlannedDeliveryGeo{
+			Countries: []string{"US"},
+			Regions:   []string{"US-NY"},
+		},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"countries": []any{"US"},
+		"regions":   []any{"US-NY"},
+	}, wire["geo"])
 }
 
 func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -635,6 +635,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "ArtifactWebhookPagination",
         "content-standards/artifact-webhook-payload.json#/properties/pagination",
     ),
+    (
+        "PlannedDeliveryGeo",
+        "core/planned-delivery.json#/properties/geo",
+    ),
 ])
 
 # Shared inline helper types are generated from one schema pointer but reused by
@@ -816,6 +820,8 @@ INLINE_TYPE_HINTS = {
     ('CreativeFormat', 'accessibility'): '*CreativeFormatAccessibility',
     ('Signal', 'range'): '*SignalRange',
     ('DeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
+    ('PerformanceFeedback', 'measurement_period'): 'DatetimeRange',
+    ('PlannedDelivery', 'geo'): '*PlannedDeliveryGeo',
     ('MediaBuyDeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PackageDelivery', 'quartile_data'): '*DeliveryQuartileData',
     ('CreateMediaBuyRequest', 'total_budget'): '*MediaBuyBudget',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -720,6 +720,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "pagination",
             "*ArtifactWebhookPagination",
         )
+        self.assert_field_type(
+            "core/performance-feedback.json",
+            "PerformanceFeedback",
+            "measurement_period",
+            "DatetimeRange",
+        )
+        self.assert_field_type(
+            "core/planned-delivery.json",
+            "PlannedDelivery",
+            "geo",
+            "*PlannedDeliveryGeo",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -740,6 +752,13 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("BatchNumber int `json:\"batch_number,omitempty\"`", pagination_generated)
         self.assertIn("TotalBatches int `json:\"total_batches,omitempty\"`", pagination_generated)
 
+        geo_schema = generate.load_schema_spec(
+            "core/planned-delivery.json#/properties/geo",
+        )
+        geo_generated = generate.schema_to_struct("PlannedDeliveryGeo", geo_schema)
+        self.assertIn("Countries []string `json:\"countries,omitempty\"`", geo_generated)
+        self.assertIn("Regions []string `json:\"regions,omitempty\"`", geo_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -749,6 +768,8 @@ class InlineObjectGenerationTest(unittest.TestCase):
 
         self.assertNotIn(("ListCreativesRequest", "sort"), records)
         self.assertNotIn(("ArtifactWebhookPayload", "pagination"), records)
+        self.assertNotIn(("PerformanceFeedback", "measurement_period"), records)
+        self.assertNotIn(("PlannedDelivery", "geo"), records)
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5931,7 +5931,7 @@ type PerformanceFeedback struct {
 	MediaBuyID string `json:"media_buy_id"` // Publisher's media buy identifier
 	PackageID string `json:"package_id,omitempty"` // Specific package within the media buy (if feedback is package-specific)
 	CreativeID string `json:"creative_id,omitempty"` // Specific creative asset (if feedback is creative-specific)
-	MeasurementPeriod any `json:"measurement_period"` // Time period for performance measurement
+	MeasurementPeriod DatetimeRange `json:"measurement_period"` // Time period for performance measurement
 	PerformanceIndex float64 `json:"performance_index"` // Normalized performance score (0.0 = no value, 1.0 = expected, >1.0 = above expec
 	MetricType string `json:"metric_type"` // The business metric being measured
 	FeedbackSource string `json:"feedback_source"` // Source of the performance data
@@ -5996,7 +5996,7 @@ type FrequencyCap struct {
 
 // PlannedDelivery — The seller's interpreted delivery parameters for a media buy. Represents what the seller will actual
 type PlannedDelivery struct {
-	Geo any `json:"geo,omitempty"` // Geographic targeting the seller will apply.
+	Geo *PlannedDeliveryGeo `json:"geo,omitempty"` // Geographic targeting the seller will apply.
 	Channels []string `json:"channels,omitempty"` // Channels the seller will deliver on.
 	StartTime string `json:"start_time,omitempty"` // Actual flight start the seller will use.
 	EndTime string `json:"end_time,omitempty"` // Actual flight end the seller will use.
@@ -7045,6 +7045,12 @@ type ArtifactWebhookPagination struct {
 	TotalArtifacts int `json:"total_artifacts,omitempty"` // Total artifacts in the delivery period
 	BatchNumber int `json:"batch_number,omitempty"` // Current batch number (1-indexed)
 	TotalBatches int `json:"total_batches,omitempty"` // Total batches for this delivery period
+}
+
+// PlannedDeliveryGeo — Geographic targeting the seller will apply.
+type PlannedDeliveryGeo struct {
+	Countries []string `json:"countries,omitempty"` // ISO 3166-1 alpha-2 country codes where ads will deliver.
+	Regions []string `json:"regions,omitempty"` // ISO 3166-2 subdivision codes where ads will deliver.
 }
 
 // --- Tool request/response types ---

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 40
+python3 generate.py --coverage-max-unreviewed-any 38
 ```
 
-The generator currently reports 200 generated dynamic `any` uses:
+The generator currently reports 198 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 160 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 40 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 38 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 40
+python3 generate.py --coverage-max-unreviewed-any 38
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -53,10 +53,8 @@ the new dynamic shape is reviewed in the same PR.
 | `CatalogFieldMapping.Value` | `value` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `CatalogFieldMapping.Default` | `default` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `EventCustomData.Contents` | `contents` | `[]any` | `array_item:inline_object` | `core/event-custom-data.json` |
-| `PerformanceFeedback.MeasurementPeriod` | `measurement_period` | `any` | `inline_object` | `core/performance-feedback.json` |
 | `CreativeBrief.Messaging` | `messaging` | `any` | `inline_object` | `core/creative-brief.json` |
 | `CreativeBrief.Compliance` | `compliance` | `any` | `inline_object` | `core/creative-brief.json` |
-| `PlannedDelivery.Geo` | `geo` | `any` | `inline_object` | `core/planned-delivery.json` |
 | `UserMatch.UIDs` | `uids` | `[]any` | `array_item:inline_object` | `core/user-match.json` |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
 | `SyncGovernanceSuccess.Accounts` | `accounts` | `[]any` | `array_item:inline_object` | `account/sync-governance-response.json#/oneOf/0` |
@@ -90,16 +88,14 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 28 unreviewed fallbacks are direct inline
+This is the largest generator gap: 26 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
-Start here for the first reduction pass. Good candidates are low-risk leaf
-objects:
-
-- `PerformanceFeedback.MeasurementPeriod`
-- `PlannedDelivery.Geo`
+The first reduction passes typed low-risk leaf objects. Continue with inline
+objects that have stable, schema-owned property sets before moving into arrays
+of inline objects.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary
- reuse `DatetimeRange` for `PerformanceFeedback.measurement_period` instead of leaving it as `any`
- generate `PlannedDeliveryGeo` for `PlannedDelivery.geo`
- lower the unreviewed generated `any` CI baseline from 40 to 38 and document the SDK migration impact

Refs #259.

## Impact
This is an exported Go SDK typing change. Callers that assigned arbitrary `any` values to these fields should now use the typed structs. `PerformanceFeedback.MeasurementPeriod` is required by the schema and now uses the existing `DatetimeRange` type; `PlannedDelivery.Geo` remains optional via `nil`.

## Validation
- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 38`
- `cd adcp && go test .`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `git diff --check`