### PR TITLE
feat(adcp)!: type account setup and creative messaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 38
+        run: python3 generate.py --coverage-max-unreviewed-any 36
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -21,6 +21,9 @@ be populated.
   Populate `DatetimeRange.Start` and `DatetimeRange.End`; zero-value
   `DatetimeRange{}` is not a valid wire payload. Use nil to omit
   `PlannedDelivery.Geo`.
+- Two additional inline object fields that previously used `any` are now typed:
+  `Account.Setup` is `*adcp.AccountSetup`, and `CreativeBrief.Messaging` is
+  `*adcp.CreativeBriefMessaging`. `AccountSetup` now includes `ExpiresAt`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -287,6 +287,44 @@ func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
 		"countries": []any{"US"},
 		"regions":   []any{"US-NY"},
 	}, wire["geo"])
+
+	out, err = json.Marshal(Account{
+		AccountID: "acct-1",
+		Name:      "Acme",
+		Status:    "pending_approval",
+		Setup: &AccountSetup{
+			URL:       "https://seller.example.com/onboarding",
+			Message:   "Complete account setup",
+			ExpiresAt: "2026-06-01T00:00:00Z",
+		},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"url":        "https://seller.example.com/onboarding",
+		"message":    "Complete account setup",
+		"expires_at": "2026-06-01T00:00:00Z",
+	}, wire["setup"])
+
+	out, err = json.Marshal(CreativeBrief{
+		Name: "Spring launch",
+		Messaging: &CreativeBriefMessaging{
+			Headline:    "Fresh arrivals",
+			Tagline:     "Built for warmer days",
+			Cta:         "Shop now",
+			KeyMessages: []string{"lightweight", "durable"},
+		},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	assert.Equal(t, map[string]any{
+		"headline":     "Fresh arrivals",
+		"tagline":      "Built for warmer days",
+		"cta":          "Shop now",
+		"key_messages": []any{"lightweight", "durable"},
+	}, wire["messaging"])
 }
 
 func TestCreativeAssignmentTypedFieldsOverrideExtraCollisions(t *testing.T) {

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -639,6 +639,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "PlannedDeliveryGeo",
         "core/planned-delivery.json#/properties/geo",
     ),
+    (
+        "CreativeBriefMessaging",
+        "core/creative-brief.json#/properties/messaging",
+    ),
 ])
 
 # Shared inline helper types are generated from one schema pointer but reused by
@@ -802,6 +806,7 @@ INLINE_TYPE_HINTS = {
     ('Product', 'delivery_measurement'): '*ProductDeliveryMeasurement',
     ('Product', 'catalog_match'): '*ProductCatalogMatch',
     ('Account', 'credit_limit'): '*AccountCreditLimit',
+    ('Account', 'setup'): '*AccountSetup',
     ('Account', 'governance_agents'): 'AccountGovernanceAgent',
     ('Account', 'reporting_bucket'): '*ReportingBucket',
     ('Targeting', 'geo_metros'): 'GeoMetroTarget',
@@ -822,6 +827,7 @@ INLINE_TYPE_HINTS = {
     ('DeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PerformanceFeedback', 'measurement_period'): 'DatetimeRange',
     ('PlannedDelivery', 'geo'): '*PlannedDeliveryGeo',
+    ('CreativeBrief', 'messaging'): '*CreativeBriefMessaging',
     ('MediaBuyDeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PackageDelivery', 'quartile_data'): '*DeliveryQuartileData',
     ('CreateMediaBuyRequest', 'total_budget'): '*MediaBuyBudget',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -732,6 +732,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "geo",
             "*PlannedDeliveryGeo",
         )
+        self.assert_field_type(
+            "core/account.json",
+            "Account",
+            "setup",
+            "*AccountSetup",
+        )
+        self.assert_field_type(
+            "core/creative-brief.json",
+            "CreativeBrief",
+            "messaging",
+            "*CreativeBriefMessaging",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -759,6 +771,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Countries []string `json:\"countries,omitempty\"`", geo_generated)
         self.assertIn("Regions []string `json:\"regions,omitempty\"`", geo_generated)
 
+        messaging_schema = generate.load_schema_spec(
+            "core/creative-brief.json#/properties/messaging",
+        )
+        messaging_generated = generate.schema_to_struct(
+            "CreativeBriefMessaging",
+            messaging_schema,
+        )
+        self.assertIn("Headline string `json:\"headline,omitempty\"`", messaging_generated)
+        self.assertIn("Tagline string `json:\"tagline,omitempty\"`", messaging_generated)
+        self.assertIn("Cta string `json:\"cta,omitempty\"`", messaging_generated)
+        self.assertIn("KeyMessages []string `json:\"key_messages,omitempty\"`", messaging_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -770,6 +794,8 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ArtifactWebhookPayload", "pagination"), records)
         self.assertNotIn(("PerformanceFeedback", "measurement_period"), records)
         self.assertNotIn(("PlannedDelivery", "geo"), records)
+        self.assertNotIn(("Account", "setup"), records)
+        self.assertNotIn(("CreativeBrief", "messaging"), records)
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -369,8 +369,9 @@ type AccountResult struct {
 }
 
 type AccountSetup struct {
-	URL     string `json:"url,omitempty"`
-	Message string `json:"message,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Message   string `json:"message,omitempty"`
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 type GovernanceResult struct {

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5810,7 +5810,7 @@ type Account struct {
 	RateCard string `json:"rate_card,omitempty"` // Identifier for the rate card applied to this account
 	PaymentTerms string `json:"payment_terms,omitempty"` // Payment terms agreed for this account. Binding for all invoices when the account
 	CreditLimit *AccountCreditLimit `json:"credit_limit,omitempty"` // Maximum outstanding balance allowed
-	Setup any `json:"setup,omitempty"` // Present when status is 'pending_approval'. Contains next steps for completing ac
+	Setup *AccountSetup `json:"setup,omitempty"` // Present when status is 'pending_approval'. Contains next steps for completing ac
 	AccountScope string `json:"account_scope,omitempty"`
 	GovernanceAgents []AccountGovernanceAgent `json:"governance_agents,omitempty"` // Governance agent endpoints registered on this account. Authentication credential
 	ReportingBucket *ReportingBucket `json:"reporting_bucket,omitempty"` // Cloud storage bucket where the seller delivers offline reporting files for this
@@ -5947,7 +5947,7 @@ type CreativeBrief struct {
 	Tone string `json:"tone,omitempty"` // Desired tone for this campaign, modulating the brand's base tone (e.g., 'playful
 	Audience string `json:"audience,omitempty"` // Target audience description for this campaign
 	Territory string `json:"territory,omitempty"` // Creative territory or positioning the campaign should occupy
-	Messaging any `json:"messaging,omitempty"` // Messaging framework for the campaign
+	Messaging *CreativeBriefMessaging `json:"messaging,omitempty"` // Messaging framework for the campaign
 	ReferenceAssets []ReferenceAsset `json:"reference_assets,omitempty"` // Visual and strategic reference materials such as mood boards, product shots, exa
 	Compliance any `json:"compliance,omitempty"` // Regulatory and legal compliance requirements for this campaign. Campaign-specifi
 }
@@ -7051,6 +7051,14 @@ type ArtifactWebhookPagination struct {
 type PlannedDeliveryGeo struct {
 	Countries []string `json:"countries,omitempty"` // ISO 3166-1 alpha-2 country codes where ads will deliver.
 	Regions []string `json:"regions,omitempty"` // ISO 3166-2 subdivision codes where ads will deliver.
+}
+
+// CreativeBriefMessaging — Messaging framework for the campaign
+type CreativeBriefMessaging struct {
+	Headline string `json:"headline,omitempty"` // Primary headline
+	Tagline string `json:"tagline,omitempty"` // Supporting tagline or sub-headline
+	Cta string `json:"cta,omitempty"` // Call-to-action text
+	KeyMessages []string `json:"key_messages,omitempty"` // Key messages to communicate in priority order
 }
 
 // --- Tool request/response types ---

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 38
+python3 generate.py --coverage-max-unreviewed-any 36
 ```
 
-The generator currently reports 198 generated dynamic `any` uses:
+The generator currently reports 196 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 160 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 38 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 36 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 38
+python3 generate.py --coverage-max-unreviewed-any 36
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -48,12 +48,10 @@ the new dynamic shape is reviewed in the same PR.
 | `PolicyEntry.Exemplars` | `exemplars` | `any` | `inline_object` | `governance/policy-entry.json` |
 | `PolicyCategoryDefinition.RegulatoryFrameworks` | `regulatory_frameworks` | `[]any` | `array_item:inline_object` | `governance/policy-category-definition.json` |
 | `CreativeFormat.SupportedMacros` | `supported_macros` | `[]any` | `array_item:union` | `core/format.json` |
-| `Account.Setup` | `setup` | `any` | `inline_object` | `core/account.json` |
 | `Targeting.GeoProximity` | `geo_proximity` | `[]any` | `array_item:inline_object` | `core/targeting.json` |
 | `CatalogFieldMapping.Value` | `value` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `CatalogFieldMapping.Default` | `default` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `EventCustomData.Contents` | `contents` | `[]any` | `array_item:inline_object` | `core/event-custom-data.json` |
-| `CreativeBrief.Messaging` | `messaging` | `any` | `inline_object` | `core/creative-brief.json` |
 | `CreativeBrief.Compliance` | `compliance` | `any` | `inline_object` | `core/creative-brief.json` |
 | `UserMatch.UIDs` | `uids` | `[]any` | `array_item:inline_object` | `core/user-match.json` |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
@@ -88,14 +86,16 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 26 unreviewed fallbacks are direct inline
+This is the largest generator gap: 24 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets before moving into arrays
-of inline objects.
+of inline objects. The next direct-object candidates are governance/reporting
+shapes such as `CheckGovernanceRequest.DeliveryMetrics` and
+`ReportPlanOutcomeRequest.Delivery`.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary
- type `Account.Setup` as the existing `*AccountSetup` helper and add its `expires_at` field
- generate `CreativeBriefMessaging` for `CreativeBrief.messaging`
- lower the unreviewed generated `any` CI baseline from 38 to 36 and document the SDK migration impact

Refs #259.

## Impact
This is an exported Go SDK typing change. Callers that assigned arbitrary `any` values to `Account.Setup` or `CreativeBrief.Messaging` should now use the typed structs. Wire JSON stays the same.

## Validation
- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 36`
- `cd adcp && go test .`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `git diff --check`