### PR TITLE
fix(adcp)!: preserve CTA acronym casing

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -24,6 +24,7 @@ be populated.
 - Two additional inline object fields that previously used `any` are now typed:
   `Account.Setup` is `*adcp.AccountSetup`, and `CreativeBrief.Messaging` is
   `*adcp.CreativeBriefMessaging`. `AccountSetup` now includes `ExpiresAt`.
+- `CreativeBriefMessaging.CTA` uses Go acronym casing for the `cta` JSON field.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -312,7 +312,7 @@ func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
 		Messaging: &CreativeBriefMessaging{
 			Headline:    "Fresh arrivals",
 			Tagline:     "Built for warmer days",
-			Cta:         "Shop now",
+			CTA:         "Shop now",
 			KeyMessages: []string{"lightweight", "durable"},
 		},
 	})

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1177,7 +1177,7 @@ def pascal_case(s):
     'ids' -> 'IDs'), which matters for Go idioms like FormatIDs, PropertyIDs."""
     parts = re.split(r'[-_]', s)
     result = []
-    acronyms = {'id', 'url', 'uri', 'api', 'http', 'html', 'css', 'json', 'xml', 'uid', 'ip', 'rid', 'cpm', 'cpc', 'cpa', 'mcp', 'ai', 'c2pa'}
+    acronyms = {'id', 'url', 'uri', 'api', 'http', 'html', 'css', 'json', 'xml', 'uid', 'ip', 'rid', 'cpm', 'cpc', 'cpa', 'cta', 'mcp', 'ai', 'c2pa'}
     for p in parts:
         lp = p.lower()
         if lp in acronyms:

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -780,7 +780,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         )
         self.assertIn("Headline string `json:\"headline,omitempty\"`", messaging_generated)
         self.assertIn("Tagline string `json:\"tagline,omitempty\"`", messaging_generated)
-        self.assertIn("Cta string `json:\"cta,omitempty\"`", messaging_generated)
+        self.assertIn("CTA string `json:\"cta,omitempty\"`", messaging_generated)
         self.assertIn("KeyMessages []string `json:\"key_messages,omitempty\"`", messaging_generated)
 
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -7057,7 +7057,7 @@ type PlannedDeliveryGeo struct {
 type CreativeBriefMessaging struct {
 	Headline string `json:"headline,omitempty"` // Primary headline
 	Tagline string `json:"tagline,omitempty"` // Supporting tagline or sub-headline
-	Cta string `json:"cta,omitempty"` // Call-to-action text
+	CTA string `json:"cta,omitempty"` // Call-to-action text
 	KeyMessages []string `json:"key_messages,omitempty"` // Key messages to communicate in priority order
 }
 


### PR DESCRIPTION
## Summary
- add `cta` to the generator acronym set
- regenerate `CreativeBriefMessaging.CTA` while keeping the JSON tag as `cta`
- update tests and migration note for the Go field rename

Closes #267.

## Impact
This is a Go SDK source-level rename from `CreativeBriefMessaging.Cta` to `CreativeBriefMessaging.CTA`. Wire JSON remains unchanged.

## Validation
- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 36`
- `cd adcp && go test .`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `git diff --check`