### PR TITLE
fix(adcp)!: drift-check account setup schema shape

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -24,6 +24,8 @@ be populated.
 - Two additional inline object fields that previously used `any` are now typed:
   `Account.Setup` is `*adcp.AccountSetup`, and `CreativeBrief.Messaging` is
   `*adcp.CreativeBriefMessaging`. `AccountSetup` now includes `ExpiresAt`.
+- `AccountSetup.Message` now always marshals when `AccountSetup` is present,
+  matching the schema-required `message` field.
 - `CreativeBriefMessaging.CTA` uses Go acronym casing for the `cta` JSON field.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -753,6 +753,19 @@ HAND_WRITTEN_SCHEMA_SPECS = {
     'OptimizationGoalMaximizeValueTarget': 'core/optimization-goal.json#/oneOf/1/properties/target/oneOf/2',
 }
 
+# Hand-written inline types that do not have standalone schema files but should
+# still be structurally drift-checked against their owning schema pointers.
+HAND_WRITTEN_INLINE_SCHEMA_SPECS = {
+    'AccountSetup': [
+        'core/account.json#/properties/setup',
+        'account/sync-accounts-response.json#/oneOf/0/properties/accounts/items/properties/setup',
+        'bundled/creative/list-creatives-response.json#/properties/creatives/items/properties/account/properties/setup',
+        'bundled/creative/sync-creatives-response.json#/oneOf/0/properties/creatives/items/properties/account/properties/setup',
+        'bundled/media-buy/create-media-buy-response.json#/oneOf/0/properties/account/properties/setup',
+        'bundled/media-buy/get-media-buys-response.json#/properties/media_buys/items/properties/account/properties/setup',
+    ],
+}
+
 # Map schema-derived Go names to the preferred Go name. Applied both when
 # resolving $ref targets and when emitting core/tool schema structs, so a
 # schema named brand-ref.json emits as `type BrandReference struct` and every

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -356,6 +356,24 @@ def validate_shared_inline_overrides():
     return reports
 
 
+def validate_hand_written_inline_schema_specs(go_structs):
+    """Diff hand-written inline structs against their owning schema pointers."""
+    reports = []
+    for type_name, schema_specs in gen.HAND_WRITTEN_INLINE_SCHEMA_SPECS.items():
+        go_fields = go_structs.get(type_name)
+        if go_fields is None:
+            reports.append({
+                'type': type_name,
+                'error': 'hand-written inline type not found in scanned Go sources',
+            })
+            continue
+        for schema_spec in schema_specs:
+            drift = diff_type(type_name, go_fields, schema_spec)
+            if drift:
+                reports.append(drift)
+    return reports
+
+
 def validate_union_schema_specs():
     """Smoke-test generated union schema pointers and shared-helper equivalence."""
     reports = []
@@ -668,6 +686,8 @@ def main():
     shared_inline_errors = validate_shared_inline_overrides()
     union_schema_errors = validate_union_schema_specs()
     optional_numeric_reports = optional_numeric_pointer_reports(go_structs)
+    hand_written_inline_reports = validate_hand_written_inline_schema_specs(go_structs)
+    reports.extend(hand_written_inline_reports)
 
     for type_name in sorted(gen.KNOWN_TYPES):
         if type_name in EXEMPT:

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -1,6 +1,14 @@
 import unittest
+from unittest import mock
 
 import lint
+
+
+ACCOUNT_SETUP_SCHEMA_SPECS = lint.gen.HAND_WRITTEN_INLINE_SCHEMA_SPECS["AccountSetup"]
+ACCOUNT_SETUP_SCHEMA_PATHS_EXIST = all(
+    (lint.SCRIPT_DIR / spec.split("#", 1)[0]).exists()
+    for spec in ACCOUNT_SETUP_SCHEMA_SPECS
+)
 
 
 class SharedInlineOverrideLintTest(unittest.TestCase):
@@ -31,6 +39,40 @@ class SharedInlineOverrideLintTest(unittest.TestCase):
         self.assertEqual("SharedShape", reports[0]["type"])
         self.assertEqual(["limit"], reports[0]["extra"])
         self.assertEqual([], reports[0]["missing"])
+
+
+class HandWrittenInlineSchemaLintTest(unittest.TestCase):
+    @unittest.skipUnless(ACCOUNT_SETUP_SCHEMA_PATHS_EXIST, "account setup schemas are not present")
+    def test_current_account_setup_shape_is_drift_checked(self):
+        reports = lint.validate_hand_written_inline_schema_specs(lint.parse_go_structs())
+
+        self.assertEqual([], [r for r in reports if r["type"] == "AccountSetup"])
+
+    def test_hand_written_inline_schema_reports_required_omitempty(self):
+        schema_spec = "missing/schema.json#/properties/setup"
+        specs = {
+            "InlineShape": [schema_spec],
+        }
+        schema = {
+            "properties": {
+                "message": {"type": "string"},
+            },
+            "required": ["message"],
+        }
+
+        with (
+            mock.patch.object(lint.Path, "exists", return_value=True),
+            mock.patch.object(lint.gen, "HAND_WRITTEN_INLINE_SCHEMA_SPECS", specs),
+            mock.patch.object(lint, "load_schema_spec", return_value=schema) as load_schema_spec,
+        ):
+            reports = lint.validate_hand_written_inline_schema_specs({
+                "InlineShape": [("Message", "string", "message", True)],
+            })
+
+        load_schema_spec.assert_called_once_with(schema_spec)
+        self.assertEqual(1, len(reports))
+        self.assertEqual("InlineShape", reports[0]["type"])
+        self.assertEqual(["message"], reports[0]["required_with_omitempty"])
 
 
 class OptionalNumericPointerLintTest(unittest.TestCase):

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -370,7 +370,7 @@ type AccountResult struct {
 
 type AccountSetup struct {
 	URL       string `json:"url,omitempty"`
-	Message   string `json:"message,omitempty"`
+	Message   string `json:"message"`
 	ExpiresAt string `json:"expires_at,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add a generator-owned map for hand-written inline schema drift targets
- teach the schema drift linter to validate AccountSetup against both setup schema pointers
- make AccountSetup.Message non-omitempty so the Go wire shape matches the schema-required field

Closes #266.

## Validation
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- go test ./...
- cd reference/seller-agent && go test ./...
- git diff --check HEAD~1..HEAD

BREAKING CHANGE: AccountSetup.Message now always marshals when AccountSetup is present to match the schema-required message field.