### PR TITLE
feat(adcp)!: type compliance policy and event inline fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 36
+        run: python3 generate.py --coverage-max-unreviewed-any 33
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -27,6 +27,11 @@ be populated.
 - `AccountSetup.Message` now always marshals when `AccountSetup` is present,
   matching the schema-required `message` field.
 - `CreativeBriefMessaging.CTA` uses Go acronym casing for the `cta` JSON field.
+- Three additional inline object fields that previously used `any` are now
+  typed: `CreativeBrief.Compliance` is `*adcp.CreativeBriefCompliance`,
+  `EventCustomData.Contents` is `[]adcp.EventContentItem`, and
+  `PolicyCategoryDefinition.RegulatoryFrameworks` is
+  `[]adcp.PolicyRegulatoryFramework`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -643,6 +643,24 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "CreativeBriefMessaging",
         "core/creative-brief.json#/properties/messaging",
     ),
+    (
+        "CreativeBriefCompliance",
+        "core/creative-brief.json#/properties/compliance",
+    ),
+    (
+        "CreativeBriefDisclosure",
+        "core/creative-brief.json#/properties/compliance"
+        "/properties/required_disclosures/items",
+    ),
+    (
+        "EventContentItem",
+        "core/event-custom-data.json#/properties/contents/items",
+    ),
+    (
+        "PolicyRegulatoryFramework",
+        "governance/policy-category-definition.json"
+        "#/properties/regulatory_frameworks/items",
+    ),
 ])
 
 # Shared inline helper types are generated from one schema pointer but reused by
@@ -841,6 +859,10 @@ INLINE_TYPE_HINTS = {
     ('PerformanceFeedback', 'measurement_period'): 'DatetimeRange',
     ('PlannedDelivery', 'geo'): '*PlannedDeliveryGeo',
     ('CreativeBrief', 'messaging'): '*CreativeBriefMessaging',
+    ('CreativeBrief', 'compliance'): '*CreativeBriefCompliance',
+    ('CreativeBriefCompliance', 'required_disclosures'): 'CreativeBriefDisclosure',
+    ('EventCustomData', 'contents'): 'EventContentItem',
+    ('PolicyCategoryDefinition', 'regulatory_frameworks'): 'PolicyRegulatoryFramework',
     ('MediaBuyDeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PackageDelivery', 'quartile_data'): '*DeliveryQuartileData',
     ('CreateMediaBuyRequest', 'total_budget'): '*MediaBuyBudget',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -744,6 +744,24 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "messaging",
             "*CreativeBriefMessaging",
         )
+        self.assert_field_type(
+            "core/creative-brief.json",
+            "CreativeBrief",
+            "compliance",
+            "*CreativeBriefCompliance",
+        )
+        self.assert_field_type(
+            "core/event-custom-data.json",
+            "EventCustomData",
+            "contents",
+            "[]EventContentItem",
+        )
+        self.assert_field_type(
+            "governance/policy-category-definition.json",
+            "PolicyCategoryDefinition",
+            "regulatory_frameworks",
+            "[]PolicyRegulatoryFramework",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -783,6 +801,60 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("CTA string `json:\"cta,omitempty\"`", messaging_generated)
         self.assertIn("KeyMessages []string `json:\"key_messages,omitempty\"`", messaging_generated)
 
+        compliance_schema = generate.load_schema_spec(
+            "core/creative-brief.json#/properties/compliance",
+        )
+        compliance_generated = generate.schema_to_struct(
+            "CreativeBriefCompliance",
+            compliance_schema,
+        )
+        self.assertIn(
+            "RequiredDisclosures []CreativeBriefDisclosure `json:\"required_disclosures,omitempty\"`",
+            compliance_generated,
+        )
+        self.assertIn(
+            "ProhibitedClaims []string `json:\"prohibited_claims,omitempty\"`",
+            compliance_generated,
+        )
+
+        disclosure_schema = generate.load_schema_spec(
+            "core/creative-brief.json#/properties/compliance"
+            "/properties/required_disclosures/items",
+        )
+        disclosure_generated = generate.schema_to_struct(
+            "CreativeBriefDisclosure",
+            disclosure_schema,
+        )
+        self.assertIn("Text string `json:\"text\"`", disclosure_generated)
+        self.assertIn(
+            "Jurisdictions []string `json:\"jurisdictions,omitempty\"`",
+            disclosure_generated,
+        )
+        self.assertIn("Persistence string `json:\"persistence,omitempty\"`", disclosure_generated)
+
+        event_item_schema = generate.load_schema_spec(
+            "core/event-custom-data.json#/properties/contents/items",
+        )
+        event_item_generated = generate.schema_to_struct(
+            "EventContentItem",
+            event_item_schema,
+        )
+        self.assertIn("ID string `json:\"id\"`", event_item_generated)
+        self.assertIn("Quantity int `json:\"quantity,omitempty\"`", event_item_generated)
+        self.assertIn("Price float64 `json:\"price,omitempty\"`", event_item_generated)
+
+        framework_schema = generate.load_schema_spec(
+            "governance/policy-category-definition.json"
+            "#/properties/regulatory_frameworks/items",
+        )
+        framework_generated = generate.schema_to_struct(
+            "PolicyRegulatoryFramework",
+            framework_schema,
+        )
+        self.assertIn("Name string `json:\"name\"`", framework_generated)
+        self.assertIn("Summary string `json:\"summary\"`", framework_generated)
+        self.assertIn("PolicyIDs []string `json:\"policy_ids,omitempty\"`", framework_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -796,6 +868,9 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("PlannedDelivery", "geo"), records)
         self.assertNotIn(("Account", "setup"), records)
         self.assertNotIn(("CreativeBrief", "messaging"), records)
+        self.assertNotIn(("CreativeBrief", "compliance"), records)
+        self.assertNotIn(("EventCustomData", "contents"), records)
+        self.assertNotIn(("PolicyCategoryDefinition", "regulatory_frameworks"), records)
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5420,7 +5420,7 @@ type PolicyCategoryDefinition struct {
 	CategoryID string `json:"category_id"` // Unique identifier for this category. Used in plan.policy_categories, signal-defi
 	Name string `json:"name"` // Human-readable name (e.g., 'Children-Directed Content').
 	Description string `json:"description"` // What this category covers. Defines the boundary — what campaigns or data fall un
-	RegulatoryFrameworks []any `json:"regulatory_frameworks,omitempty"` // Key regulations and standards grouped under this category. Governance agents use
+	RegulatoryFrameworks []PolicyRegulatoryFramework `json:"regulatory_frameworks,omitempty"` // Key regulations and standards grouped under this category. Governance agents use
 	RestrictedAttributes []string `json:"restricted_attributes,omitempty"` // Restricted attribute categories that regulations in this category prohibit for t
 	RequiresHumanReview *bool `json:"requires_human_review,omitempty"` // When true, any plan declaring this category MUST set plan.human_review_required
 	Industries []string `json:"industries,omitempty"` // Industries where this category commonly applies (e.g., 'pharmaceutical' for age_
@@ -5921,7 +5921,7 @@ type EventCustomData struct {
 	ContentCategory string `json:"content_category,omitempty"` // Category of the product or content
 	NumItems int `json:"num_items,omitempty"` // Number of items in the event
 	SearchString string `json:"search_string,omitempty"` // Search query for search events
-	Contents []any `json:"contents,omitempty"` // Per-item details for e-commerce events
+	Contents []EventContentItem `json:"contents,omitempty"` // Per-item details for e-commerce events
 	Ext any `json:"ext,omitempty"`
 }
 
@@ -5949,7 +5949,7 @@ type CreativeBrief struct {
 	Territory string `json:"territory,omitempty"` // Creative territory or positioning the campaign should occupy
 	Messaging *CreativeBriefMessaging `json:"messaging,omitempty"` // Messaging framework for the campaign
 	ReferenceAssets []ReferenceAsset `json:"reference_assets,omitempty"` // Visual and strategic reference materials such as mood boards, product shots, exa
-	Compliance any `json:"compliance,omitempty"` // Regulatory and legal compliance requirements for this campaign. Campaign-specifi
+	Compliance *CreativeBriefCompliance `json:"compliance,omitempty"` // Regulatory and legal compliance requirements for this campaign. Campaign-specifi
 }
 
 // ReferenceAsset — A reference asset that provides creative context. Carries visual materials (mood boards, product sho
@@ -7059,6 +7059,36 @@ type CreativeBriefMessaging struct {
 	Tagline string `json:"tagline,omitempty"` // Supporting tagline or sub-headline
 	CTA string `json:"cta,omitempty"` // Call-to-action text
 	KeyMessages []string `json:"key_messages,omitempty"` // Key messages to communicate in priority order
+}
+
+// CreativeBriefCompliance — Regulatory and legal compliance requirements for this campaign. Campaign-specific, regional, and pro
+type CreativeBriefCompliance struct {
+	RequiredDisclosures []CreativeBriefDisclosure `json:"required_disclosures,omitempty"` // Disclosures that must appear in creatives for this campaign. Each disclosure spe
+	ProhibitedClaims []string `json:"prohibited_claims,omitempty"` // Claims that must not appear in creatives for this campaign. Creative agents shou
+}
+
+type CreativeBriefDisclosure struct {
+	Text string `json:"text"` // The disclosure text that must appear in the creative
+	Position string `json:"position,omitempty"` // Where the disclosure should appear within the creative. prominent: clearly visib
+	Jurisdictions []string `json:"jurisdictions,omitempty"` // Jurisdictions where this disclosure is required. ISO 3166-1 alpha-2 country code
+	Regulation string `json:"regulation,omitempty"` // The regulation or legal authority requiring this disclosure (e.g., 'SEC Rule 156
+	MinDurationMs int `json:"min_duration_ms,omitempty"` // Minimum display duration in milliseconds. For video/audio disclosures, how long
+	Language string `json:"language,omitempty"` // Language of the disclosure text as a BCP 47 language tag (e.g., 'en', 'fr-CA', '
+	Persistence string `json:"persistence,omitempty"` // How long the disclosure must persist during content playback or display. When om
+}
+
+type EventContentItem struct {
+	ID string `json:"id"` // Product or content identifier
+	Quantity int `json:"quantity,omitempty"` // Quantity of this item
+	Price float64 `json:"price,omitempty"` // Price per unit of this item
+	Brand string `json:"brand,omitempty"` // Brand name of this item
+}
+
+type PolicyRegulatoryFramework struct {
+	Name string `json:"name"` // Name of the regulation or standard (e.g., 'US COPPA').
+	Jurisdictions []string `json:"jurisdictions,omitempty"` // ISO 3166-1 alpha-2 codes where this framework applies.
+	Summary string `json:"summary"` // Brief summary of what the framework requires or prohibits.
+	PolicyIDs []string `json:"policy_ids,omitempty"` // Registry policy IDs that implement this framework.
 }
 
 // --- Tool request/response types ---


### PR DESCRIPTION
## Summary
- generate schema-backed inline types for creative brief compliance/disclosures, event content items, and policy regulatory frameworks
- wire those generated types into CreativeBrief, EventCustomData, and PolicyCategoryDefinition
- lower the generated unreviewed-any CI gate from 36 to 33

Refs #259.

## Validation
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 33
- go test ./...
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- git diff --check

BREAKING CHANGE: CreativeBrief.Compliance, EventCustomData.Contents, and PolicyCategoryDefinition.RegulatoryFrameworks now use schema-backed generated types instead of any.