### PR TITLE
feat(adcp)!: type user match UIDs and format macros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 33
+        run: python3 generate.py --coverage-max-unreviewed-any 31
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -32,6 +32,9 @@ be populated.
   `EventCustomData.Contents` is `[]adcp.EventContentItem`, and
   `PolicyCategoryDefinition.RegulatoryFrameworks` is
   `[]adcp.PolicyRegulatoryFramework`.
+- Two more generated fields that previously used `any` are now typed:
+  `CreativeFormat.SupportedMacros` is `[]string`, and `UserMatch.UIDs` is
+  `[]adcp.UserMatchUID`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -661,6 +661,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/policy-category-definition.json"
         "#/properties/regulatory_frameworks/items",
     ),
+    (
+        "UserMatchUID",
+        "core/user-match.json#/properties/uids/items",
+    ),
 ])
 
 # Shared inline helper types are generated from one schema pointer but reused by
@@ -854,6 +858,7 @@ INLINE_TYPE_HINTS = {
     ('ReportingWebhook', 'authentication'): 'LegacyWebhookAuthentication',
     ('Package', 'cancellation'): '*PackageCancellation',
     ('CreativeFormat', 'accessibility'): '*CreativeFormatAccessibility',
+    ('CreativeFormat', 'supported_macros'): 'string',
     ('Signal', 'range'): '*SignalRange',
     ('DeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PerformanceFeedback', 'measurement_period'): 'DatetimeRange',
@@ -863,6 +868,7 @@ INLINE_TYPE_HINTS = {
     ('CreativeBriefCompliance', 'required_disclosures'): 'CreativeBriefDisclosure',
     ('EventCustomData', 'contents'): 'EventContentItem',
     ('PolicyCategoryDefinition', 'regulatory_frameworks'): 'PolicyRegulatoryFramework',
+    ('UserMatch', 'uids'): 'UserMatchUID',
     ('MediaBuyDeliveryTotals', 'quartile_data'): '*DeliveryQuartileData',
     ('PackageDelivery', 'quartile_data'): '*DeliveryQuartileData',
     ('CreateMediaBuyRequest', 'total_budget'): '*MediaBuyBudget',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -762,6 +762,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "regulatory_frameworks",
             "[]PolicyRegulatoryFramework",
         )
+        self.assert_field_type(
+            "core/format.json",
+            "CreativeFormat",
+            "supported_macros",
+            "[]string",
+        )
+        self.assert_field_type(
+            "core/user-match.json",
+            "UserMatch",
+            "uids",
+            "[]UserMatchUID",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -855,6 +867,13 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Summary string `json:\"summary\"`", framework_generated)
         self.assertIn("PolicyIDs []string `json:\"policy_ids,omitempty\"`", framework_generated)
 
+        uid_schema = generate.load_schema_spec(
+            "core/user-match.json#/properties/uids/items",
+        )
+        uid_generated = generate.schema_to_struct("UserMatchUID", uid_schema)
+        self.assertIn("Type string `json:\"type\"`", uid_generated)
+        self.assertIn("Value string `json:\"value\"`", uid_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -871,6 +890,8 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("CreativeBrief", "compliance"), records)
         self.assertNotIn(("EventCustomData", "contents"), records)
         self.assertNotIn(("PolicyCategoryDefinition", "regulatory_frameworks"), records)
+        self.assertNotIn(("CreativeFormat", "supported_macros"), records)
+        self.assertNotIn(("UserMatch", "uids"), records)
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5683,7 +5683,7 @@ type CreativeFormat struct {
 	Renders []Render `json:"renders,omitempty"` // Specification of rendered pieces for this format. Most formats produce a single
 	Assets []AssetSlot `json:"assets,omitempty"` // Array of all assets supported for this format. Each asset is identified by its a
 	Delivery map[string]any `json:"delivery,omitempty"` // Delivery method specifications (e.g., hosted, VAST, third-party tags)
-	SupportedMacros []any `json:"supported_macros,omitempty"` // List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUST
+	SupportedMacros []string `json:"supported_macros,omitempty"` // List of universal macros supported by this format (e.g., MEDIA_BUY_ID, CACHEBUST
 	InputFormatIDs []FormatRef `json:"input_format_ids,omitempty"` // Array of format IDs this format accepts as input creative manifests. When presen
 	OutputFormatIDs []FormatRef `json:"output_format_ids,omitempty"` // Array of format IDs that this format can produce as output. When present, indica
 	FormatCard *CreativeFormatCard `json:"format_card,omitempty"` // Optional standard visual card (300x400px) for displaying this format in user int
@@ -6050,7 +6050,7 @@ type RightsConstraint struct {
 
 // UserMatch — User identifiers for attribution matching. Supports universal IDs, hashed identifiers, click IDs, an
 type UserMatch struct {
-	UIDs []any `json:"uids,omitempty"` // Universal ID values for user matching
+	UIDs []UserMatchUID `json:"uids,omitempty"` // Universal ID values for user matching
 	HashedEmail string `json:"hashed_email,omitempty"` // SHA-256 hash of lowercase, trimmed email address. Buyer must normalize before ha
 	HashedPhone string `json:"hashed_phone,omitempty"` // SHA-256 hash of E.164-formatted phone number (e.g. +12065551234). Buyer must nor
 	ClickID string `json:"click_id,omitempty"` // Platform click identifier (fbclid, gclid, ttclid, ScCid, etc.)
@@ -7089,6 +7089,11 @@ type PolicyRegulatoryFramework struct {
 	Jurisdictions []string `json:"jurisdictions,omitempty"` // ISO 3166-1 alpha-2 codes where this framework applies.
 	Summary string `json:"summary"` // Brief summary of what the framework requires or prohibits.
 	PolicyIDs []string `json:"policy_ids,omitempty"` // Registry policy IDs that implement this framework.
+}
+
+type UserMatchUID struct {
+	Type string `json:"type"` // Universal ID type
+	Value string `json:"value"` // Universal ID value
 }
 
 // --- Tool request/response types ---


### PR DESCRIPTION
## Summary
- type CreativeFormat.supported_macros as []string, matching its string-or-enum schema
- generate UserMatchUID and use []UserMatchUID for UserMatch.uids
- lower the generated unreviewed-any CI gate from 33 to 31

Refs #259.

## Validation
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 31
- go test ./...
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- git diff --check

BREAKING CHANGE: CreativeFormat.SupportedMacros is now []string and UserMatch.UIDs is now []UserMatchUID instead of []any.