### PR TITLE
feat(adcp)!: type targeting geo proximity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 30
+        run: python3 generate.py --coverage-max-unreviewed-any 29
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -42,6 +42,10 @@ be populated.
   `map[string]bool`, matching the schema's open feature-flag bag. GeoJSON
   coordinates remain `[]any` because Polygon and MultiPolygon coordinate arrays
   have different nesting shapes.
+- `Targeting.GeoProximity` is now `[]adcp.GeoProximityTarget` instead of
+  `[]any`. Latitude and longitude are `*float64` so explicit zero coordinates
+  still marshal. `GeoProximityGeometry.Coordinates` remains `[]any` for the
+  same GeoJSON Polygon/MultiPolygon nesting reason.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -103,6 +107,7 @@ be populated.
 | `ProductFilters.RequiredFeatures` | `map[string]bool` |
 | `ProductFilters.SignalTargeting` | `[]adcp.SignalTargeting` |
 | `ProductFilters.GeoProximity` | `[]adcp.ProductFilterGeoProximity` |
+| `Targeting.GeoProximity` | `[]adcp.GeoProximityTarget` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -346,6 +346,22 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "core/targeting.json#/properties/geo_postal_areas/items",
     ),
     (
+        "GeoProximityTarget",
+        "core/targeting.json#/properties/geo_proximity/items",
+    ),
+    (
+        "GeoProximityTravelTime",
+        "core/targeting.json#/properties/geo_proximity/items/properties/travel_time",
+    ),
+    (
+        "GeoProximityRadius",
+        "core/targeting.json#/properties/geo_proximity/items/properties/radius",
+    ),
+    (
+        "GeoProximityGeometry",
+        "core/targeting.json#/properties/geo_proximity/items/properties/geometry",
+    ),
+    (
         "AgeRestriction",
         "core/targeting.json#/properties/age_restriction",
     ),
@@ -895,6 +911,12 @@ INLINE_TYPE_HINTS = {
     ('Targeting', 'geo_metros_exclude'): 'GeoMetroTarget',
     ('Targeting', 'geo_postal_areas'): 'GeoPostalAreaTarget',
     ('Targeting', 'geo_postal_areas_exclude'): 'GeoPostalAreaTarget',
+    ('Targeting', 'geo_proximity'): 'GeoProximityTarget',
+    ('GeoProximityTarget', 'lat'): '*float64',
+    ('GeoProximityTarget', 'lng'): '*float64',
+    ('GeoProximityTarget', 'travel_time'): '*GeoProximityTravelTime',
+    ('GeoProximityTarget', 'radius'): '*GeoProximityRadius',
+    ('GeoProximityTarget', 'geometry'): '*GeoProximityGeometry',
     ('Targeting', 'age_restriction'): '*AgeRestriction',
     ('Targeting', 'keyword_targets'): 'KeywordTarget',
     ('Targeting', 'negative_keywords'): 'NegativeKeywordTarget',
@@ -1086,6 +1108,7 @@ INTENTIONAL_ANY_FIELDS = {
     ('LogEventRequest', 'events'): 'event payloads are seller/buyer-defined',
     ('Catalog', 'items'): 'inline catalog item schema depends on catalog type',
     ('ProductFilterGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
+    ('GeoProximityGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('SimulationSuccess', 'simulated'): 'test-controller simulation payload is scenario-specific',
     ('SimulationSuccess', 'cumulative'): 'test-controller cumulative state is scenario-specific',
     ('CheckGovernanceRequest', 'payload'): 'governance can evaluate different protocol payloads',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -805,6 +805,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "[]ProductFilterGeoProximity",
         )
         self.assert_field_type(
+            "core/targeting.json",
+            "Targeting",
+            "geo_proximity",
+            "[]GeoProximityTarget",
+        )
+        self.assert_field_type(
             "core/signal-targeting.json",
             "SignalTargeting",
             "min_value",
@@ -974,6 +980,38 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Type string `json:\"type\"`", geometry_generated)
         self.assertIn("Coordinates []any `json:\"coordinates\"`", geometry_generated)
 
+        targeting_proximity_schema = generate.load_schema_spec(
+            "core/targeting.json#/properties/geo_proximity/items",
+        )
+        targeting_proximity_generated = generate.schema_to_struct(
+            "GeoProximityTarget",
+            targeting_proximity_schema,
+        )
+        self.assertIn("Lat *float64 `json:\"lat,omitempty\"`", targeting_proximity_generated)
+        self.assertIn("Lng *float64 `json:\"lng,omitempty\"`", targeting_proximity_generated)
+        self.assertIn(
+            "TravelTime *GeoProximityTravelTime `json:\"travel_time,omitempty\"`",
+            targeting_proximity_generated,
+        )
+        self.assertIn(
+            "Geometry *GeoProximityGeometry `json:\"geometry,omitempty\"`",
+            targeting_proximity_generated,
+        )
+        self.assertIn("Ext any `json:\"ext,omitempty\"`", targeting_proximity_generated)
+
+        targeting_geometry_schema = generate.load_schema_spec(
+            "core/targeting.json#/properties/geo_proximity/items/properties/geometry",
+        )
+        targeting_geometry_generated = generate.schema_to_struct(
+            "GeoProximityGeometry",
+            targeting_geometry_schema,
+        )
+        self.assertIn("Type string `json:\"type\"`", targeting_geometry_generated)
+        self.assertIn(
+            "Coordinates []any `json:\"coordinates\"`",
+            targeting_geometry_generated,
+        )
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -995,6 +1033,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("GetProductsRequest", "filters"), records)
         self.assertNotIn(("ProductFilters", "required_features"), records)
         self.assertNotIn(("ProductFilters", "signal_targeting"), records)
+        self.assertNotIn(("Targeting", "geo_proximity"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])
@@ -1004,6 +1043,14 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn(
             (
                 "ProductFilterGeometry",
+                "coordinates",
+                "GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "GeoProximityGeometry",
                 "coordinates",
                 "GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon",
             ),

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5881,7 +5881,7 @@ type Targeting struct {
 	DeviceType []string `json:"device_type,omitempty"` // Restrict to specific device form factors. Use for campaigns targeting hardware c
 	DeviceTypeExclude []string `json:"device_type_exclude,omitempty"` // Exclude specific device form factors from delivery (e.g., exclude CTV for app-in
 	StoreCatchments []TargetingStoreCatchment `json:"store_catchments,omitempty"` // Target users within store catchment areas from a synced store catalog. Each entr
-	GeoProximity []any `json:"geo_proximity,omitempty"` // Target users within travel time, distance, or a custom boundary around arbitrary
+	GeoProximity []GeoProximityTarget `json:"geo_proximity,omitempty"` // Target users within travel time, distance, or a custom boundary around arbitrary
 	Language []string `json:"language,omitempty"` // Restrict to users with specific language preferences. ISO 639-1 codes (e.g., 'en
 	KeywordTargets []KeywordTarget `json:"keyword_targets,omitempty"` // Keyword targeting for search and retail media platforms. Restricts delivery to q
 	NegativeKeywords []NegativeKeywordTarget `json:"negative_keywords,omitempty"` // Keywords to exclude from delivery. Queries matching these keywords will not trig
@@ -6384,6 +6384,35 @@ type GeoMetroTarget struct {
 type GeoPostalAreaTarget struct {
 	System string `json:"system"` // Postal code system (e.g., 'us_zip', 'gb_outward'). System name encodes country a
 	Values []string `json:"values"` // Postal codes within the system (e.g., ['10001', '10002'] for us_zip)
+}
+
+type GeoProximityTarget struct {
+	Lat *float64 `json:"lat,omitempty"` // Latitude in decimal degrees (WGS 84). Required for travel_time and radius method
+	Lng *float64 `json:"lng,omitempty"` // Longitude in decimal degrees (WGS 84). Required for travel_time and radius metho
+	Label string `json:"label,omitempty"` // Human-readable label for this entry (e.g., 'Düsseldorf', 'Heathrow Airport', 'Pr
+	TravelTime *GeoProximityTravelTime `json:"travel_time,omitempty"` // Travel time limit for isochrone calculation. The platform resolves this to a geo
+	TransportMode string `json:"transport_mode,omitempty"` // Transportation mode for isochrone calculation. Required when travel_time is prov
+	Radius *GeoProximityRadius `json:"radius,omitempty"` // Simple radius from the point. The platform draws a circle of this distance aroun
+	Geometry *GeoProximityGeometry `json:"geometry,omitempty"` // Pre-computed GeoJSON geometry defining the proximity boundary. Use when the buye
+	Ext any `json:"ext,omitempty"`
+}
+
+// GeoProximityTravelTime — Travel time limit for isochrone calculation. The platform resolves this to a geographic boundary bas
+type GeoProximityTravelTime struct {
+	Value float64 `json:"value"` // Travel time limit.
+	Unit string `json:"unit"`
+}
+
+// GeoProximityRadius — Simple radius from the point. The platform draws a circle of this distance around the coordinates.
+type GeoProximityRadius struct {
+	Value float64 `json:"value"` // Radius distance.
+	Unit string `json:"unit"` // Distance unit.
+}
+
+// GeoProximityGeometry — Pre-computed GeoJSON geometry defining the proximity boundary. Use when the buyer has already calcul
+type GeoProximityGeometry struct {
+	Type string `json:"type"` // GeoJSON geometry type.
+	Coordinates []any `json:"coordinates"` // GeoJSON coordinates array. For Polygon: array of linear rings. For MultiPolygon:
 }
 
 // AgeRestriction — Age restriction for compliance. Use for legal requirements (alcohol, gambling), not audience targeti

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 30
+python3 generate.py --coverage-max-unreviewed-any 29
 ```
 
-The generator currently reports 191 generated dynamic `any` uses:
+The generator currently reports 192 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 161 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 30 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 163 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 29 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 30
+python3 generate.py --coverage-max-unreviewed-any 29
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -46,7 +46,6 @@ the new dynamic shape is reviewed in the same PR.
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
 | `PolicyEntry.Exemplars` | `exemplars` | `any` | `inline_object` | `governance/policy-entry.json` |
-| `Targeting.GeoProximity` | `geo_proximity` | `[]any` | `array_item:inline_object` | `core/targeting.json` |
 | `CatalogFieldMapping.Value` | `value` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `CatalogFieldMapping.Default` | `default` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |


### PR DESCRIPTION
## Summary
- generate schema-backed GeoProximityTarget helper types for Targeting.GeoProximity
- preserve targeting ext and keep GeoJSON coordinates as an explicitly reviewed dynamic shape
- lower generated unreviewed-any coverage from 30 to 29 and refresh migration/baseline docs

## Tests
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 29
- go test ./...
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- cd cmd/router && go test ./...
- cd targeting/prommetrics && go test ./...
- cd reference/context-agent && go test ./...
- cd e2e && go test ./...
- git diff --check