### PR TITLE
chore(adcp): classify catalog literal any fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 29
+        run: python3 generate.py --coverage-max-unreviewed-any 27
 
       - name: Check generated code is up to date
         run: |

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1107,6 +1107,8 @@ INTENTIONAL_ANY_FIELDS = {
     ('CreativeFormatCardDetailed', 'manifest'): 'visual card manifest shape is format-defined',
     ('LogEventRequest', 'events'): 'event payloads are seller/buyer-defined',
     ('Catalog', 'items'): 'inline catalog item schema depends on catalog type',
+    ('CatalogFieldMapping', 'value'): 'catalog static literal values can be strings, numbers, booleans, arrays, or objects',
+    ('CatalogFieldMapping', 'default'): 'catalog fallback literal values can be strings, numbers, booleans, arrays, or objects',
     ('ProductFilterGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('GeoProximityGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('SimulationSuccess', 'simulated'): 'test-controller simulation payload is scenario-specific',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1056,6 +1056,22 @@ class InlineObjectGenerationTest(unittest.TestCase):
             ),
             allowed,
         )
+        self.assertIn(
+            (
+                "CatalogFieldMapping",
+                "value",
+                "catalog static literal values can be strings, numbers, booleans, arrays, or objects",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "CatalogFieldMapping",
+                "default",
+                "catalog fallback literal values can be strings, numbers, booleans, arrays, or objects",
+            ),
+            allowed,
+        )
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 29
+python3 generate.py --coverage-max-unreviewed-any 27
 ```
 
 The generator currently reports 192 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 163 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 29 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 165 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 27 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 29
+python3 generate.py --coverage-max-unreviewed-any 27
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -46,8 +46,6 @@ the new dynamic shape is reviewed in the same PR.
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
 | `PolicyEntry.Exemplars` | `exemplars` | `any` | `inline_object` | `governance/policy-entry.json` |
-| `CatalogFieldMapping.Value` | `value` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
-| `CatalogFieldMapping.Default` | `default` | `any` | `unspecified_schema_type` | `core/catalog-field-mapping.json` |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
 | `SyncGovernanceSuccess.Accounts` | `accounts` | `[]any` | `array_item:inline_object` | `account/sync-governance-response.json#/oneOf/0` |
 | `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
@@ -113,10 +111,8 @@ classify them as intentional open payloads with a specific allowlist reason.
 
 ### Schema Clarification
 
-Three fallbacks come from schemas without enough type information:
+One fallback comes from a schema without enough type information:
 
-- `CatalogFieldMapping.Value`
-- `CatalogFieldMapping.Default`
 - `ControllerError.CurrentState`
 
 These should usually be fixed in the protocol schema. A Go-only type override is


### PR DESCRIPTION
## Summary
- mark CatalogFieldMapping.value/default as intentional dynamic literal values
- add coverage assertions for those allowlist reasons
- lower generated unreviewed-any coverage from 29 to 27 and refresh the baseline docs

## Tests
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 27
- go test ./...
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- cd cmd/router && go test ./...
- cd targeting/prommetrics && go test ./...
- cd reference/context-agent && go test ./...
- cd e2e && go test ./...
- git diff --check