### PR TITLE
chore(adcp): classify async webhook result union

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 27
+        run: python3 generate.py --coverage-max-unreviewed-any 26
 
       - name: Check generated code is up to date
         run: |

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1109,6 +1109,7 @@ INTENTIONAL_ANY_FIELDS = {
     ('Catalog', 'items'): 'inline catalog item schema depends on catalog type',
     ('CatalogFieldMapping', 'value'): 'catalog static literal values can be strings, numbers, booleans, arrays, or objects',
     ('CatalogFieldMapping', 'default'): 'catalog fallback literal values can be strings, numbers, booleans, arrays, or objects',
+    ('MCPWebhookPayload', 'result'): 'async webhook result is a task-specific response union',
     ('ProductFilterGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('GeoProximityGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('SimulationSuccess', 'simulated'): 'test-controller simulation payload is scenario-specific',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1072,6 +1072,14 @@ class InlineObjectGenerationTest(unittest.TestCase):
             ),
             allowed,
         )
+        self.assertIn(
+            (
+                "MCPWebhookPayload",
+                "result",
+                "async webhook result is a task-specific response union",
+            ),
+            allowed,
+        )
 
 
 class PackageSchemaOwnershipTest(unittest.TestCase):

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 27
+python3 generate.py --coverage-max-unreviewed-any 26
 ```
 
 The generator currently reports 192 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 165 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 27 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 26 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 27
+python3 generate.py --coverage-max-unreviewed-any 26
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -70,7 +70,6 @@ the new dynamic shape is reviewed in the same PR.
 | `ReportPlanOutcomeResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/report-plan-outcome-response.json` |
 | `ReportPlanOutcomeResponse.PlanSummary` | `plan_summary` | `any` | `inline_object` | `governance/report-plan-outcome-response.json` |
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
-| `MCPWebhookPayload.Result` | `result` | `any` | `unknown_ref:/schemas/3.0.12/core/async-response-data.json` | `core/mcp-webhook-payload.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
@@ -102,12 +101,9 @@ hand-written pattern already used for selected oneOf responses.
 
 ### Unknown References
 
-One fallback is missing a registry entry:
-
-- `MCPWebhookPayload.Result` -> `core/async-response-data.json`
-
-Do not paper over these with `any`. Add real schemas to the generation graph, or
-classify them as intentional open payloads with a specific allowlist reason.
+No unreviewed unknown `$ref` fallbacks remain. Future unknown refs should be
+added to the generation graph unless the target schema is an intentionally open
+or union-shaped payload with a specific allowlist reason.
 
 ### Schema Clarification
 


### PR DESCRIPTION
## Summary
- mark MCPWebhookPayload.result as an intentional task-specific async response union
- add coverage assertion for the allowlist reason
- lower generated unreviewed-any coverage from 27 to 26 and refresh baseline docs

## Tests
- cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 26
- go test ./...
- cd adcp && go test .
- cd reference/seller-agent && go test ./...
- cd cmd/router && go test ./...
- cd targeting/prommetrics && go test ./...
- cd reference/context-agent && go test ./...
- cd e2e && go test ./...
- git diff --check