### PR TITLE
docs(adcp): document ProductFilters extension behavior

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -42,6 +42,12 @@ be populated.
   `map[string]bool`, matching the schema's open feature-flag bag. GeoJSON
   coordinates remain `[]any` because Polygon and MultiPolygon coordinate arrays
   have different nesting shapes.
+  `ProductFilters` does not include an `Ext` or `Extra` field in the AdCP
+  3.0.12 bundle, so arbitrary unknown filter keys that were possible when
+  `Filters` was `any` are no longer represented by the typed Go struct. Put
+  seller-specific request metadata under a schema-backed field where one exists,
+  or wait for the protocol to add an explicit `filters.ext` extension point
+  before relying on typed SDK support.
 - `Targeting.GeoProximity` is now `[]adcp.GeoProximityTarget` instead of
   `[]any`. Latitude and longitude are `*float64` so explicit zero coordinates
   still marshal. `GeoProximityGeometry.Coordinates` remains `[]any` for the

--- a/docs/sdk-typing-policy.md
+++ b/docs/sdk-typing-policy.md
@@ -106,6 +106,15 @@ Decision:
   or accepted in the protocol version being added.
 - Do not promote reference-seller convenience fields into SDK protocol structs
   just because one example needs them.
+- Do not synthesize `Ext` on a typed request struct just because the schema has
+  `additionalProperties: true`. The protocol must define an explicit `ext`
+  field before the SDK exposes one. `ProductFilters` in AdCP 3.0.12 is the
+  concrete precedent: it is typed as schema-authored fields only, and the
+  protocol request for `filters.ext` is tracked upstream in
+  adcontextprotocol/adcp#5120.
+- Avoid `Extra` maps on buyer-constructed request types unless the protocol has
+  a read-modify-write preservation requirement. `Extra` is for preserving
+  unknown response metadata, not for inventing request-side extension surfaces.
 - Avoid flattening `ext` into top-level response objects. If compatibility
   requires flattening temporarily, typed fields are authoritative on collision,
   and the follow-up must identify the schema fields needed to remove flattening.


### PR DESCRIPTION
## Summary
- document that AdCP 3.0.12 ProductFilters has no schema-backed Ext/Extra field
- make the typed Filters breaking behavior explicit for unknown filter keys
- record the SDK policy: no synthetic Ext from additionalProperties and no request-side Extra map without protocol backing
- filed upstream protocol request adcontextprotocol/adcp#5120 for an explicit filters.ext field

Closes #279.

## Tests
- git diff --check