### PR TITLE
feat(adcp)!: type governance delivery metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 26
+        run: python3 generate.py --coverage-max-unreviewed-any 25
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -52,6 +52,10 @@ be populated.
   `[]any`. Latitude and longitude are `*float64` so explicit zero coordinates
   still marshal. `GeoProximityGeometry.Coordinates` remains `[]any` for the
   same GeoJSON Polygon/MultiPolygon nesting reason.
+- `CheckGovernanceRequest.DeliveryMetrics` is now
+  `*adcp.GovernanceDeliveryMetrics` instead of `any`. Optional numeric delivery
+  values such as `Spend` and `Impressions` are pointers so explicit zero values
+  still marshal; use `adcp.Ptr(0.0)` or `adcp.Ptr(0)` when zero is meaningful.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -114,6 +118,7 @@ be populated.
 | `ProductFilters.SignalTargeting` | `[]adcp.SignalTargeting` |
 | `ProductFilters.GeoProximity` | `[]adcp.ProductFilterGeoProximity` |
 | `Targeting.GeoProximity` | `[]adcp.GeoProximityTarget` |
+| `CheckGovernanceRequest.DeliveryMetrics` | `*adcp.GovernanceDeliveryMetrics` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -434,6 +434,20 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "media-buy/get-media-buy-delivery-request.json#/properties/reporting_dimensions/properties/device_type",
     ),
     (
+        "GovernanceDeliveryMetrics",
+        "governance/check-governance-request.json#/properties/delivery_metrics",
+    ),
+    (
+        "GovernanceDeliveryReportingPeriod",
+        "governance/check-governance-request.json#/properties/delivery_metrics"
+        "/properties/reporting_period",
+    ),
+    (
+        "GovernanceAudienceDistribution",
+        "governance/check-governance-request.json#/properties/delivery_metrics"
+        "/properties/audience_distribution",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -955,6 +969,13 @@ INLINE_TYPE_HINTS = {
     ('DeliveryReportingDimensions', 'audience'): '*DeliveryReportingDimension',
     ('DeliveryReportingDimensions', 'placement'): '*DeliveryReportingDimension',
     ('DeliveryReportingGeoDimension', 'system'): 'string',
+    ('CheckGovernanceRequest', 'delivery_metrics'): '*GovernanceDeliveryMetrics',
+    ('GovernanceDeliveryMetrics', 'reporting_period'): 'GovernanceDeliveryReportingPeriod',
+    ('GovernanceDeliveryMetrics', 'spend'): '*float64',
+    ('GovernanceDeliveryMetrics', 'cumulative_spend'): '*float64',
+    ('GovernanceDeliveryMetrics', 'impressions'): '*int',
+    ('GovernanceDeliveryMetrics', 'cumulative_impressions'): '*int',
+    ('GovernanceDeliveryMetrics', 'audience_distribution'): '*GovernanceAudienceDistribution',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -822,6 +822,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "max_value",
             "*float64",
         )
+        self.assert_field_type(
+            "governance/check-governance-request.json",
+            "CheckGovernanceRequest",
+            "delivery_metrics",
+            "*GovernanceDeliveryMetrics",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1012,6 +1018,70 @@ class InlineObjectGenerationTest(unittest.TestCase):
             targeting_geometry_generated,
         )
 
+        delivery_schema = generate.load_schema_spec(
+            "governance/check-governance-request.json#/properties/delivery_metrics",
+        )
+        delivery_generated = generate.schema_to_struct(
+            "GovernanceDeliveryMetrics",
+            delivery_schema,
+        )
+        self.assertIn(
+            "ReportingPeriod GovernanceDeliveryReportingPeriod `json:\"reporting_period\"`",
+            delivery_generated,
+        )
+        self.assertIn("Spend *float64 `json:\"spend,omitempty\"`", delivery_generated)
+        self.assertIn(
+            "CumulativeSpend *float64 `json:\"cumulative_spend,omitempty\"`",
+            delivery_generated,
+        )
+        self.assertIn(
+            "Impressions *int `json:\"impressions,omitempty\"`",
+            delivery_generated,
+        )
+        self.assertIn(
+            "CumulativeImpressions *int `json:\"cumulative_impressions,omitempty\"`",
+            delivery_generated,
+        )
+        self.assertIn(
+            "GeoDistribution map[string]float64 `json:\"geo_distribution,omitempty\"`",
+            delivery_generated,
+        )
+        self.assertIn(
+            "ChannelDistribution map[string]float64 `json:\"channel_distribution,omitempty\"`",
+            delivery_generated,
+        )
+        self.assertIn("Pacing string `json:\"pacing,omitempty\"`", delivery_generated)
+        self.assertIn(
+            "AudienceDistribution *GovernanceAudienceDistribution `json:\"audience_distribution,omitempty\"`",
+            delivery_generated,
+        )
+
+        reporting_period_schema = generate.load_schema_spec(
+            "governance/check-governance-request.json#/properties/delivery_metrics"
+            "/properties/reporting_period",
+        )
+        reporting_period_generated = generate.schema_to_struct(
+            "GovernanceDeliveryReportingPeriod",
+            reporting_period_schema,
+        )
+        self.assertIn("Start string `json:\"start\"`", reporting_period_generated)
+        self.assertIn("End string `json:\"end\"`", reporting_period_generated)
+
+        audience_schema = generate.load_schema_spec(
+            "governance/check-governance-request.json#/properties/delivery_metrics"
+            "/properties/audience_distribution",
+        )
+        audience_generated = generate.schema_to_struct(
+            "GovernanceAudienceDistribution",
+            audience_schema,
+        )
+        self.assertIn("Baseline string `json:\"baseline\"`", audience_generated)
+        self.assertIn("Indices map[string]float64 `json:\"indices\"`", audience_generated)
+        self.assertIn(
+            "CumulativeIndices map[string]float64 `json:\"cumulative_indices,omitempty\"`",
+            audience_generated,
+        )
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1034,6 +1104,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ProductFilters", "required_features"), records)
         self.assertNotIn(("ProductFilters", "signal_targeting"), records)
         self.assertNotIn(("Targeting", "geo_proximity"), records)
+        self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6547,6 +6547,33 @@ type DeliveryReportingDimension struct {
 	SortBy string `json:"sort_by,omitempty"` // Metric to sort breakdown rows by (descending). Falls back to 'spend' if the sell
 }
 
+// GovernanceDeliveryMetrics — Actual delivery performance data. MUST be present for 'delivery' phase. The governance agent compare
+type GovernanceDeliveryMetrics struct {
+	ReportingPeriod GovernanceDeliveryReportingPeriod `json:"reporting_period"` // Start and end timestamps for the reporting window.
+	Spend *float64 `json:"spend,omitempty"` // Total spend during the reporting period.
+	CumulativeSpend *float64 `json:"cumulative_spend,omitempty"` // Total spend since the governed action started.
+	Impressions *int `json:"impressions,omitempty"` // Impressions delivered during the reporting period.
+	CumulativeImpressions *int `json:"cumulative_impressions,omitempty"` // Total impressions since the governed action started.
+	GeoDistribution map[string]float64 `json:"geo_distribution,omitempty"` // Actual geographic distribution. Keys are ISO 3166-1 alpha-2 codes, values are pe
+	ChannelDistribution map[string]float64 `json:"channel_distribution,omitempty"` // Actual channel distribution. Keys are channel enum values, values are percentage
+	Pacing string `json:"pacing,omitempty"` // Whether delivery is ahead of, on track with, or behind the planned pace.
+	AudienceDistribution *GovernanceAudienceDistribution `json:"audience_distribution,omitempty"` // Actual audience composition during the reporting period. Enables mid-flight drif
+}
+
+// GovernanceDeliveryReportingPeriod — Start and end timestamps for the reporting window.
+type GovernanceDeliveryReportingPeriod struct {
+	Start string `json:"start"`
+	End string `json:"end"`
+}
+
+// GovernanceAudienceDistribution — Actual audience composition during the reporting period. Enables mid-flight drift detection when act
+type GovernanceAudienceDistribution struct {
+	Baseline string `json:"baseline"` // Population baseline used for index calculation. 'census': national census or equ
+	BaselineDescription string `json:"baseline_description,omitempty"` // Description of the baseline when baseline is 'custom' (e.g., 'US adults 18+ with
+	Indices map[string]float64 `json:"indices"` // Audience index values for the current reporting period. Keys are seller-defined
+	CumulativeIndices map[string]float64 `json:"cumulative_indices,omitempty"` // Cumulative audience index values since the governed action started. Same key for
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7804,7 +7831,7 @@ type CheckGovernanceRequest struct {
 	GovernanceContext string `json:"governance_context,omitempty"` // Governance context token from a prior check_governance response. Pass this on su
 	Phase string `json:"phase,omitempty"` // The phase of the governed action's lifecycle. 'purchase': initial commitment (cr
 	PlannedDelivery *PlannedDelivery `json:"planned_delivery,omitempty"` // What the seller will actually deliver. Present on execution checks.
-	DeliveryMetrics any `json:"delivery_metrics,omitempty"` // Actual delivery performance data. MUST be present for 'delivery' phase. The gove
+	DeliveryMetrics *GovernanceDeliveryMetrics `json:"delivery_metrics,omitempty"` // Actual delivery performance data. MUST be present for 'delivery' phase. The gove
 	ModificationSummary string `json:"modification_summary,omitempty"` // Human-readable summary of what changed. SHOULD be present for 'modification' pha
 	InvoiceRecipient *BusinessEntity `json:"invoice_recipient,omitempty"` // Invoice recipient from the purchase request. MUST be present when the tool paylo
 	Context any `json:"context,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 26
+python3 generate.py --coverage-max-unreviewed-any 25
 ```
 
-The generator currently reports 192 generated dynamic `any` uses:
+The generator currently reports 191 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 26 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 25 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 26
+python3 generate.py --coverage-max-unreviewed-any 25
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -61,7 +61,6 @@ the new dynamic shape is reviewed in the same PR.
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ControllerError.CurrentState` | `current_state` | `any` | `unspecified_schema_type` | `compliance/comply-test-controller-response.json#/oneOf/5` |
 | `SyncPlansResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/sync-plans-response.json` |
-| `CheckGovernanceRequest.DeliveryMetrics` | `delivery_metrics` | `any` | `inline_object` | `governance/check-governance-request.json` |
 | `CheckGovernanceResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
@@ -76,7 +75,7 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 24 unreviewed fallbacks are direct inline
+This is the largest generator gap: 23 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
@@ -84,8 +83,7 @@ detection across generated names.
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets before moving into arrays
 of inline objects. The next direct-object candidates are governance/reporting
-shapes such as `CheckGovernanceRequest.DeliveryMetrics` and
-`ReportPlanOutcomeRequest.Delivery`.
+shapes such as `ReportPlanOutcomeRequest.Delivery`.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Generate schema-backed inline governance delivery metric types.
- Type `CheckGovernanceRequest.DeliveryMetrics` as `*GovernanceDeliveryMetrics`.
- Preserve explicit zero delivery values by using pointers for optional numeric metrics.
- Lower the unreviewed generated `any` coverage gate from 26 to 25.

## Impact

This is a Go API breaking change for callers that populated `CheckGovernanceRequest.DeliveryMetrics` with arbitrary values. The wire shape remains schema-faithful.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 25`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`
