### PR TITLE
feat(adcp)!: type report plan outcome delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 25
+        run: python3 generate.py --coverage-max-unreviewed-any 24
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -56,6 +56,11 @@ be populated.
   `*adcp.GovernanceDeliveryMetrics` instead of `any`. Optional numeric delivery
   values such as `Spend` and `Impressions` are pointers so explicit zero values
   still marshal; use `adcp.Ptr(0.0)` or `adcp.Ptr(0)` when zero is meaningful.
+- `ReportPlanOutcomeRequest.Delivery` is now
+  `*adcp.ReportPlanOutcomeDelivery` instead of `any`. Optional numeric values
+  such as `Spend`, `CPM`, and `Impressions` are pointers so explicit zero values
+  still marshal. The schema's open `additionalProperties` allowance is not
+  exposed as a synthetic `Extra`/`Ext` map; use the schema-authored fields.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -119,6 +124,7 @@ be populated.
 | `ProductFilters.GeoProximity` | `[]adcp.ProductFilterGeoProximity` |
 | `Targeting.GeoProximity` | `[]adcp.GeoProximityTarget` |
 | `CheckGovernanceRequest.DeliveryMetrics` | `*adcp.GovernanceDeliveryMetrics` |
+| `ReportPlanOutcomeRequest.Delivery` | `*adcp.ReportPlanOutcomeDelivery` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -526,6 +526,66 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 	}
 }
 
+func TestReportPlanOutcomeDeliveryPreservesExplicitZero(t *testing.T) {
+	req := ReportPlanOutcomeRequest{
+		PlanID:            "plan-1",
+		IdempotencyKey:    "idem-1",
+		Outcome:           "delivery",
+		GovernanceContext: "ctx-1",
+		Delivery: Ptr(ReportPlanOutcomeDelivery{
+			ReportingPeriod: Ptr(ReportPlanOutcomeDeliveryReportingPeriod{
+				Start: "2026-06-01T00:00:00Z",
+				End:   "2026-06-01T01:00:00Z",
+			}),
+			Impressions:     Ptr(0),
+			Spend:           Ptr(0.0),
+			CPM:             Ptr(0.0),
+			ViewabilityRate: Ptr(0.0),
+			CompletionRate:  Ptr(0.0),
+		}),
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal report plan outcome request: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"impressions":0`,
+		`"spend":0`,
+		`"cpm":0`,
+		`"viewability_rate":0`,
+		`"completion_rate":0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("marshaled report plan outcome missing %s:\n%s", want, body)
+		}
+	}
+
+	var decoded ReportPlanOutcomeRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal report plan outcome request: %v", err)
+	}
+	if decoded.Delivery == nil {
+		t.Fatal("delivery did not round-trip")
+	}
+	if decoded.Delivery.Impressions == nil || *decoded.Delivery.Impressions != 0 {
+		t.Fatalf("impressions = %v, want pointer to 0", decoded.Delivery.Impressions)
+	}
+	if decoded.Delivery.Spend == nil || *decoded.Delivery.Spend != 0 {
+		t.Fatalf("spend = %v, want pointer to 0", decoded.Delivery.Spend)
+	}
+	if decoded.Delivery.CPM == nil || *decoded.Delivery.CPM != 0 {
+		t.Fatalf("cpm = %v, want pointer to 0", decoded.Delivery.CPM)
+	}
+	if decoded.Delivery.ViewabilityRate == nil || *decoded.Delivery.ViewabilityRate != 0 {
+		t.Fatalf("viewability_rate = %v, want pointer to 0", decoded.Delivery.ViewabilityRate)
+	}
+	if decoded.Delivery.CompletionRate == nil || *decoded.Delivery.CompletionRate != 0 {
+		t.Fatalf("completion_rate = %v, want pointer to 0", decoded.Delivery.CompletionRate)
+	}
+}
+
 func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
 	if got := NewMediaBuyStatusFilter(); got != nil {
 		t.Fatalf("empty status filter constructor returned %#v, want nil", got)

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -448,6 +448,15 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "/properties/audience_distribution",
     ),
     (
+        "ReportPlanOutcomeDelivery",
+        "governance/report-plan-outcome-request.json#/properties/delivery",
+    ),
+    (
+        "ReportPlanOutcomeDeliveryReportingPeriod",
+        "governance/report-plan-outcome-request.json#/properties/delivery"
+        "/properties/reporting_period",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -976,6 +985,13 @@ INLINE_TYPE_HINTS = {
     ('GovernanceDeliveryMetrics', 'impressions'): '*int',
     ('GovernanceDeliveryMetrics', 'cumulative_impressions'): '*int',
     ('GovernanceDeliveryMetrics', 'audience_distribution'): '*GovernanceAudienceDistribution',
+    ('ReportPlanOutcomeRequest', 'delivery'): '*ReportPlanOutcomeDelivery',
+    ('ReportPlanOutcomeDelivery', 'reporting_period'): '*ReportPlanOutcomeDeliveryReportingPeriod',
+    ('ReportPlanOutcomeDelivery', 'impressions'): '*int',
+    ('ReportPlanOutcomeDelivery', 'spend'): '*float64',
+    ('ReportPlanOutcomeDelivery', 'cpm'): '*float64',
+    ('ReportPlanOutcomeDelivery', 'viewability_rate'): '*float64',
+    ('ReportPlanOutcomeDelivery', 'completion_rate'): '*float64',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -828,6 +828,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "delivery_metrics",
             "*GovernanceDeliveryMetrics",
         )
+        self.assert_field_type(
+            "governance/report-plan-outcome-request.json",
+            "ReportPlanOutcomeRequest",
+            "delivery",
+            "*ReportPlanOutcomeDelivery",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1076,11 +1082,52 @@ class InlineObjectGenerationTest(unittest.TestCase):
             audience_schema,
         )
         self.assertIn("Baseline string `json:\"baseline\"`", audience_generated)
+        self.assertIn(
+            "BaselineDescription string `json:\"baseline_description,omitempty\"`",
+            audience_generated,
+        )
         self.assertIn("Indices map[string]float64 `json:\"indices\"`", audience_generated)
         self.assertIn(
             "CumulativeIndices map[string]float64 `json:\"cumulative_indices,omitempty\"`",
             audience_generated,
         )
+
+        outcome_delivery_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-request.json#/properties/delivery",
+        )
+        outcome_delivery_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeDelivery",
+            outcome_delivery_schema,
+        )
+        self.assertIn(
+            "ReportingPeriod *ReportPlanOutcomeDeliveryReportingPeriod `json:\"reporting_period,omitempty\"`",
+            outcome_delivery_generated,
+        )
+        self.assertIn(
+            "Impressions *int `json:\"impressions,omitempty\"`",
+            outcome_delivery_generated,
+        )
+        self.assertIn("Spend *float64 `json:\"spend,omitempty\"`", outcome_delivery_generated)
+        self.assertIn("CPM *float64 `json:\"cpm,omitempty\"`", outcome_delivery_generated)
+        self.assertIn(
+            "ViewabilityRate *float64 `json:\"viewability_rate,omitempty\"`",
+            outcome_delivery_generated,
+        )
+        self.assertIn(
+            "CompletionRate *float64 `json:\"completion_rate,omitempty\"`",
+            outcome_delivery_generated,
+        )
+
+        outcome_reporting_period_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-request.json#/properties/delivery"
+            "/properties/reporting_period",
+        )
+        outcome_reporting_period_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeDeliveryReportingPeriod",
+            outcome_reporting_period_schema,
+        )
+        self.assertIn("Start string `json:\"start\"`", outcome_reporting_period_generated)
+        self.assertIn("End string `json:\"end\"`", outcome_reporting_period_generated)
 
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
@@ -1105,6 +1152,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ProductFilters", "signal_targeting"), records)
         self.assertNotIn(("Targeting", "geo_proximity"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
+        self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6574,6 +6574,22 @@ type GovernanceAudienceDistribution struct {
 	CumulativeIndices map[string]float64 `json:"cumulative_indices,omitempty"` // Cumulative audience index values since the governed action started. Same key for
 }
 
+// ReportPlanOutcomeDelivery — Delivery metrics. Required when outcome is 'delivery'.
+type ReportPlanOutcomeDelivery struct {
+	ReportingPeriod *ReportPlanOutcomeDeliveryReportingPeriod `json:"reporting_period,omitempty"` // Start and end timestamps for the reporting window.
+	Impressions *int `json:"impressions,omitempty"` // Impressions delivered in the period.
+	Spend *float64 `json:"spend,omitempty"` // Spend in the period.
+	CPM *float64 `json:"cpm,omitempty"` // Effective CPM for the period.
+	ViewabilityRate *float64 `json:"viewability_rate,omitempty"` // Viewability rate (0-1).
+	CompletionRate *float64 `json:"completion_rate,omitempty"` // Video completion rate (0-1).
+}
+
+// ReportPlanOutcomeDeliveryReportingPeriod — Start and end timestamps for the reporting window.
+type ReportPlanOutcomeDeliveryReportingPeriod struct {
+	Start string `json:"start"`
+	End string `json:"end"`
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7865,7 +7881,7 @@ type ReportPlanOutcomeRequest struct {
 	PurchaseType string `json:"purchase_type,omitempty"` // The type of financial commitment this outcome is for. Determines which budget al
 	Outcome string `json:"outcome"` // Outcome type.
 	SellerResponse any `json:"seller_response,omitempty"` // The seller's full response. Required when outcome is 'completed'.
-	Delivery any `json:"delivery,omitempty"` // Delivery metrics. Required when outcome is 'delivery'.
+	Delivery *ReportPlanOutcomeDelivery `json:"delivery,omitempty"` // Delivery metrics. Required when outcome is 'delivery'.
 	Error any `json:"error,omitempty"` // Error details. Required when outcome is 'failed'.
 	GovernanceContext string `json:"governance_context"` // Opaque governance context from the check_governance response that authorized thi
 	Context any `json:"context,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 25
+python3 generate.py --coverage-max-unreviewed-any 24
 ```
 
-The generator currently reports 191 generated dynamic `any` uses:
+The generator currently reports 190 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 25 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 24 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 25
+python3 generate.py --coverage-max-unreviewed-any 24
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -64,7 +64,6 @@ the new dynamic shape is reviewed in the same PR.
 | `CheckGovernanceResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
-| `ReportPlanOutcomeRequest.Delivery` | `delivery` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `ReportPlanOutcomeRequest.Error` | `error` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `ReportPlanOutcomeResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/report-plan-outcome-response.json` |
 | `ReportPlanOutcomeResponse.PlanSummary` | `plan_summary` | `any` | `inline_object` | `governance/report-plan-outcome-response.json` |
@@ -75,7 +74,7 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 23 unreviewed fallbacks are direct inline
+This is the largest generator gap: 22 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
@@ -83,7 +82,7 @@ detection across generated names.
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets before moving into arrays
 of inline objects. The next direct-object candidates are governance/reporting
-shapes such as `ReportPlanOutcomeRequest.Delivery`.
+shapes such as `ReportPlanOutcomeRequest.Error`.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Generate schema-backed inline types for `ReportPlanOutcomeRequest.delivery`.
- Type `ReportPlanOutcomeRequest.Delivery` as `*ReportPlanOutcomeDelivery`.
- Use pointer numeric fields so explicit zero delivery metrics marshal.
- Lower the unreviewed generated `any` coverage gate from 25 to 24.

## Impact

This is a Go API breaking change for callers that populated `ReportPlanOutcomeRequest.Delivery` with arbitrary values. The generated type exposes the schema-authored fields only; it does not synthesize an `Extra` or `Ext` map for `additionalProperties`.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 24`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`
