### PR TITLE
feat(adcp)!: type report plan outcome error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 24
+        run: python3 generate.py --coverage-max-unreviewed-any 23
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -61,6 +61,9 @@ be populated.
   such as `Spend`, `CPM`, and `Impressions` are pointers so explicit zero values
   still marshal. The schema's open `additionalProperties` allowance is not
   exposed as a synthetic `Extra`/`Ext` map; use the schema-authored fields.
+- `ReportPlanOutcomeRequest.Error` is now
+  `*adcp.ReportPlanOutcomeError` instead of `any`, with schema-backed `Code`
+  and `Message` fields.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -125,6 +128,7 @@ be populated.
 | `Targeting.GeoProximity` | `[]adcp.GeoProximityTarget` |
 | `CheckGovernanceRequest.DeliveryMetrics` | `*adcp.GovernanceDeliveryMetrics` |
 | `ReportPlanOutcomeRequest.Delivery` | `*adcp.ReportPlanOutcomeDelivery` |
+| `ReportPlanOutcomeRequest.Error` | `*adcp.ReportPlanOutcomeError` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -586,6 +586,43 @@ func TestReportPlanOutcomeDeliveryPreservesExplicitZero(t *testing.T) {
 	}
 }
 
+func TestReportPlanOutcomeErrorRoundTrip(t *testing.T) {
+	req := ReportPlanOutcomeRequest{
+		PlanID:            "plan-1",
+		IdempotencyKey:    "idem-1",
+		Outcome:           "failed",
+		GovernanceContext: "ctx-1",
+		Error: &ReportPlanOutcomeError{
+			Code:    "seller_timeout",
+			Message: "seller timed out",
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal report plan outcome request: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"error":{"code":"seller_timeout","message":"seller timed out"}`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("marshaled report plan outcome missing %s:\n%s", want, body)
+		}
+	}
+
+	var decoded ReportPlanOutcomeRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal report plan outcome request: %v", err)
+	}
+	if decoded.Error == nil {
+		t.Fatal("error did not round-trip")
+	}
+	if decoded.Error.Code != "seller_timeout" || decoded.Error.Message != "seller timed out" {
+		t.Fatalf("error = %#v, want seller timeout", decoded.Error)
+	}
+}
+
 func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
 	if got := NewMediaBuyStatusFilter(); got != nil {
 		t.Fatalf("empty status filter constructor returned %#v, want nil", got)

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -457,6 +457,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "/properties/reporting_period",
     ),
     (
+        "ReportPlanOutcomeError",
+        "governance/report-plan-outcome-request.json#/properties/error",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -992,6 +996,7 @@ INLINE_TYPE_HINTS = {
     ('ReportPlanOutcomeDelivery', 'cpm'): '*float64',
     ('ReportPlanOutcomeDelivery', 'viewability_rate'): '*float64',
     ('ReportPlanOutcomeDelivery', 'completion_rate'): '*float64',
+    ('ReportPlanOutcomeRequest', 'error'): '*ReportPlanOutcomeError',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -834,6 +834,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "delivery",
             "*ReportPlanOutcomeDelivery",
         )
+        self.assert_field_type(
+            "governance/report-plan-outcome-request.json",
+            "ReportPlanOutcomeRequest",
+            "error",
+            "*ReportPlanOutcomeError",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1129,6 +1135,16 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Start string `json:\"start\"`", outcome_reporting_period_generated)
         self.assertIn("End string `json:\"end\"`", outcome_reporting_period_generated)
 
+        outcome_error_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-request.json#/properties/error",
+        )
+        outcome_error_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeError",
+            outcome_error_schema,
+        )
+        self.assertIn("Code string `json:\"code,omitempty\"`", outcome_error_generated)
+        self.assertIn("Message string `json:\"message,omitempty\"`", outcome_error_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1153,6 +1169,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("Targeting", "geo_proximity"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
+        self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6590,6 +6590,12 @@ type ReportPlanOutcomeDeliveryReportingPeriod struct {
 	End string `json:"end"`
 }
 
+// ReportPlanOutcomeError — Error details. Required when outcome is 'failed'.
+type ReportPlanOutcomeError struct {
+	Code string `json:"code,omitempty"` // Error code from the seller.
+	Message string `json:"message,omitempty"` // Human-readable error description.
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7882,7 +7888,7 @@ type ReportPlanOutcomeRequest struct {
 	Outcome string `json:"outcome"` // Outcome type.
 	SellerResponse any `json:"seller_response,omitempty"` // The seller's full response. Required when outcome is 'completed'.
 	Delivery *ReportPlanOutcomeDelivery `json:"delivery,omitempty"` // Delivery metrics. Required when outcome is 'delivery'.
-	Error any `json:"error,omitempty"` // Error details. Required when outcome is 'failed'.
+	Error *ReportPlanOutcomeError `json:"error,omitempty"` // Error details. Required when outcome is 'failed'.
 	GovernanceContext string `json:"governance_context"` // Opaque governance context from the check_governance response that authorized thi
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 24
+python3 generate.py --coverage-max-unreviewed-any 23
 ```
 
-The generator currently reports 190 generated dynamic `any` uses:
+The generator currently reports 189 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 24 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 23 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 24
+python3 generate.py --coverage-max-unreviewed-any 23
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -64,7 +64,6 @@ the new dynamic shape is reviewed in the same PR.
 | `CheckGovernanceResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
-| `ReportPlanOutcomeRequest.Error` | `error` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `ReportPlanOutcomeResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/report-plan-outcome-response.json` |
 | `ReportPlanOutcomeResponse.PlanSummary` | `plan_summary` | `any` | `inline_object` | `governance/report-plan-outcome-response.json` |
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
@@ -74,7 +73,7 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 22 unreviewed fallbacks are direct inline
+This is the largest generator gap: 21 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
@@ -82,7 +81,7 @@ detection across generated names.
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets before moving into arrays
 of inline objects. The next direct-object candidates are governance/reporting
-shapes such as `ReportPlanOutcomeRequest.Error`.
+shapes such as `ReportPlanOutcomeResponse.PlanSummary`.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Generate a schema-backed inline type for `ReportPlanOutcomeRequest.error`.
- Type `ReportPlanOutcomeRequest.Error` as `*ReportPlanOutcomeError`.
- Add a JSON round-trip test for the typed error payload.
- Lower the unreviewed generated `any` coverage gate from 24 to 23.

## Impact

This is a Go API breaking change for callers that populated `ReportPlanOutcomeRequest.Error` with arbitrary values. The wire shape remains schema-faithful with `code` and `message` fields.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 23`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`
