### PR TITLE
feat(adcp)!: type report plan outcome summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 23
+        run: python3 generate.py --coverage-max-unreviewed-any 22
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -64,6 +64,12 @@ be populated.
 - `ReportPlanOutcomeRequest.Error` is now
   `*adcp.ReportPlanOutcomeError` instead of `any`, with schema-backed `Code`
   and `Message` fields.
+- `ReportPlanOutcomeResponse.PlanSummary` is now
+  `*adcp.ReportPlanOutcomePlanSummary` instead of `any`. Its optional budget
+  values, `TotalCommitted` and `BudgetRemaining`, are pointers so explicit zero
+  values still marshal. `ReportPlanOutcomeResponse.CommittedBudget` remains a
+  value field because it is a per-outcome delta where an omitted zero is not
+  currently distinct from no committed budget.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -129,6 +135,7 @@ be populated.
 | `CheckGovernanceRequest.DeliveryMetrics` | `*adcp.GovernanceDeliveryMetrics` |
 | `ReportPlanOutcomeRequest.Delivery` | `*adcp.ReportPlanOutcomeDelivery` |
 | `ReportPlanOutcomeRequest.Error` | `*adcp.ReportPlanOutcomeError` |
+| `ReportPlanOutcomeResponse.PlanSummary` | `*adcp.ReportPlanOutcomePlanSummary` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -623,6 +623,53 @@ func TestReportPlanOutcomeErrorRoundTrip(t *testing.T) {
 	}
 }
 
+func TestReportPlanOutcomePlanSummaryPreservesExplicitZero(t *testing.T) {
+	empty, err := json.Marshal(ReportPlanOutcomePlanSummary{})
+	if err != nil {
+		t.Fatalf("marshal empty report plan outcome plan summary: %v", err)
+	}
+	if string(empty) != "{}" {
+		t.Fatalf("empty plan summary = %s, want {}", empty)
+	}
+
+	resp := ReportPlanOutcomeResponse{
+		OutcomeID: "outcome-1",
+		Status:    "accepted",
+		PlanSummary: &ReportPlanOutcomePlanSummary{
+			TotalCommitted:  Ptr(0.0),
+			BudgetRemaining: Ptr(0.0),
+		},
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal report plan outcome response: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"total_committed":0`,
+		`"budget_remaining":0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("marshaled report plan outcome response missing %s:\n%s", want, body)
+		}
+	}
+
+	var decoded ReportPlanOutcomeResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal report plan outcome response: %v", err)
+	}
+	if decoded.PlanSummary == nil {
+		t.Fatal("plan_summary did not round-trip")
+	}
+	if decoded.PlanSummary.TotalCommitted == nil || *decoded.PlanSummary.TotalCommitted != 0 {
+		t.Fatalf("total_committed = %v, want pointer to 0", decoded.PlanSummary.TotalCommitted)
+	}
+	if decoded.PlanSummary.BudgetRemaining == nil || *decoded.PlanSummary.BudgetRemaining != 0 {
+		t.Fatalf("budget_remaining = %v, want pointer to 0", decoded.PlanSummary.BudgetRemaining)
+	}
+}
+
 func TestGeneratedMediaBuyStatusFilterUnmarshalScalarAndArray(t *testing.T) {
 	if got := NewMediaBuyStatusFilter(); got != nil {
 		t.Fatalf("empty status filter constructor returned %#v, want nil", got)

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -461,6 +461,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/report-plan-outcome-request.json#/properties/error",
     ),
     (
+        "ReportPlanOutcomePlanSummary",
+        "governance/report-plan-outcome-response.json#/properties/plan_summary",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -997,6 +1001,9 @@ INLINE_TYPE_HINTS = {
     ('ReportPlanOutcomeDelivery', 'viewability_rate'): '*float64',
     ('ReportPlanOutcomeDelivery', 'completion_rate'): '*float64',
     ('ReportPlanOutcomeRequest', 'error'): '*ReportPlanOutcomeError',
+    ('ReportPlanOutcomeResponse', 'plan_summary'): '*ReportPlanOutcomePlanSummary',
+    ('ReportPlanOutcomePlanSummary', 'total_committed'): '*float64',
+    ('ReportPlanOutcomePlanSummary', 'budget_remaining'): '*float64',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -840,6 +840,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "error",
             "*ReportPlanOutcomeError",
         )
+        self.assert_field_type(
+            "governance/report-plan-outcome-response.json",
+            "ReportPlanOutcomeResponse",
+            "plan_summary",
+            "*ReportPlanOutcomePlanSummary",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1145,6 +1151,22 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Code string `json:\"code,omitempty\"`", outcome_error_generated)
         self.assertIn("Message string `json:\"message,omitempty\"`", outcome_error_generated)
 
+        outcome_plan_summary_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-response.json#/properties/plan_summary",
+        )
+        outcome_plan_summary_generated = generate.schema_to_struct(
+            "ReportPlanOutcomePlanSummary",
+            outcome_plan_summary_schema,
+        )
+        self.assertIn(
+            "TotalCommitted *float64 `json:\"total_committed,omitempty\"`",
+            outcome_plan_summary_generated,
+        )
+        self.assertIn(
+            "BudgetRemaining *float64 `json:\"budget_remaining,omitempty\"`",
+            outcome_plan_summary_generated,
+        )
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1170,6 +1192,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)
+        self.assertNotIn(("ReportPlanOutcomeResponse", "plan_summary"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6596,6 +6596,12 @@ type ReportPlanOutcomeError struct {
 	Message string `json:"message,omitempty"` // Human-readable error description.
 }
 
+// ReportPlanOutcomePlanSummary — Updated plan budget state. Present for 'completed' and 'failed' outcomes.
+type ReportPlanOutcomePlanSummary struct {
+	TotalCommitted *float64 `json:"total_committed,omitempty"` // Total budget committed across all campaigns in the plan.
+	BudgetRemaining *float64 `json:"budget_remaining,omitempty"` // Authorized budget minus total committed.
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7900,7 +7906,7 @@ type ReportPlanOutcomeResponse struct {
 	Status string `json:"status"` // 'accepted' means state updated with no issues. 'findings' means issues were dete
 	CommittedBudget float64 `json:"committed_budget,omitempty"` // Budget committed from this outcome. Present for 'completed' and 'failed' outcome
 	Findings []any `json:"findings,omitempty"` // Issues detected. Present only when status is 'findings'.
-	PlanSummary any `json:"plan_summary,omitempty"` // Updated plan budget state. Present for 'completed' and 'failed' outcomes.
+	PlanSummary *ReportPlanOutcomePlanSummary `json:"plan_summary,omitempty"` // Updated plan budget state. Present for 'completed' and 'failed' outcomes.
 	Replayed *bool `json:"replayed,omitempty"` // Set to true when this response is a cached replay returned for an idempotency_ke
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 23
+python3 generate.py --coverage-max-unreviewed-any 22
 ```
 
-The generator currently reports 189 generated dynamic `any` uses:
+The generator currently reports 188 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 23 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 22 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 23
+python3 generate.py --coverage-max-unreviewed-any 22
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -65,7 +65,6 @@ the new dynamic shape is reviewed in the same PR.
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `ReportPlanOutcomeResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/report-plan-outcome-response.json` |
-| `ReportPlanOutcomeResponse.PlanSummary` | `plan_summary` | `any` | `inline_object` | `governance/report-plan-outcome-response.json` |
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
@@ -73,15 +72,15 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 21 unreviewed fallbacks are direct inline
+This is the largest generator gap: 20 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets before moving into arrays
-of inline objects. The next direct-object candidates are governance/reporting
-shapes such as `ReportPlanOutcomeResponse.PlanSummary`.
+of inline objects. Remaining direct-object candidates now need either local
+`$defs` reference support or an explicit unknown-field preservation decision.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Generate a schema-backed inline type for `ReportPlanOutcomeResponse.plan_summary`.
- Type `ReportPlanOutcomeResponse.PlanSummary` as `*ReportPlanOutcomePlanSummary`.
- Use pointer budget fields so explicit zero totals marshal.
- Lower the unreviewed generated `any` coverage gate from 23 to 22.

## Impact

This is a Go API breaking change for callers that read or populated `ReportPlanOutcomeResponse.PlanSummary` as arbitrary data. The wire shape remains schema-faithful.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 22`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`
