### PR TITLE
feat(adcp)!: type policy entry exemplars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 22
+        run: python3 generate.py --coverage-max-unreviewed-any 21
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -70,6 +70,9 @@ be populated.
   values still marshal. `ReportPlanOutcomeResponse.CommittedBudget` remains a
   value field because it is a per-outcome delta where an omitted zero is not
   currently distinct from no committed budget.
+- `PolicyEntry.Exemplars` is now `*adcp.PolicyExemplars` instead of `any`.
+  `PolicyExemplars.Pass` and `PolicyExemplars.Fail` are
+  `[]adcp.PolicyExemplar`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -136,6 +139,7 @@ be populated.
 | `ReportPlanOutcomeRequest.Delivery` | `*adcp.ReportPlanOutcomeDelivery` |
 | `ReportPlanOutcomeRequest.Error` | `*adcp.ReportPlanOutcomeError` |
 | `ReportPlanOutcomeResponse.PlanSummary` | `*adcp.ReportPlanOutcomePlanSummary` |
+| `PolicyEntry.Exemplars` | `*adcp.PolicyExemplars` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -508,6 +508,27 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				`"planned_delivery":{"total_budget":1000,"currency":"USD"}`,
 			},
 		},
+		{
+			name: "policy entry exemplars",
+			value: PolicyEntry{
+				PolicyID:    "policy-1",
+				Enforcement: "must",
+				Policy:      "Do not target restricted categories.",
+				Exemplars: &PolicyExemplars{
+					Pass: []PolicyExemplar{{
+						Scenario:    "Age-neutral campaign",
+						Explanation: "No restricted attribute targeting.",
+					}},
+					Fail: []PolicyExemplar{{
+						Scenario:    "Housing ads targeted by age",
+						Explanation: "Age-based housing targeting violates policy.",
+					}},
+				},
+			},
+			want: []string{
+				`"exemplars":{"pass":[{"scenario":"Age-neutral campaign","explanation":"No restricted attribute targeting."}],"fail":[{"scenario":"Housing ads targeted by age","explanation":"Age-based housing targeting violates policy."}]}`,
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -523,6 +544,43 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPolicyEntryExemplarsRoundTrip(t *testing.T) {
+	entry := PolicyEntry{
+		PolicyID:    "policy-1",
+		Enforcement: "must",
+		Policy:      "Do not target restricted categories.",
+		Exemplars: &PolicyExemplars{
+			Pass: []PolicyExemplar{{
+				Scenario:    "Age-neutral campaign",
+				Explanation: "No restricted attribute targeting.",
+			}},
+			Fail: []PolicyExemplar{{
+				Scenario:    "Housing ads targeted by age",
+				Explanation: "Age-based housing targeting violates policy.",
+			}},
+		},
+	}
+
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal policy entry: %v", err)
+	}
+
+	var decoded PolicyEntry
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal policy entry: %v", err)
+	}
+	if decoded.Exemplars == nil {
+		t.Fatal("exemplars did not round-trip")
+	}
+	if len(decoded.Exemplars.Pass) != 1 || decoded.Exemplars.Pass[0].Scenario != "Age-neutral campaign" {
+		t.Fatalf("pass exemplars did not round-trip: %#v", decoded.Exemplars.Pass)
+	}
+	if len(decoded.Exemplars.Fail) != 1 || decoded.Exemplars.Fail[0].Explanation != "Age-based housing targeting violates policy." {
+		t.Fatalf("fail exemplars did not round-trip: %#v", decoded.Exemplars.Fail)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -465,6 +465,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/report-plan-outcome-response.json#/properties/plan_summary",
     ),
     (
+        "PolicyExemplars",
+        "governance/policy-entry.json#/properties/exemplars",
+    ),
+    (
+        "PolicyExemplar",
+        "governance/policy-entry.json#/$defs/exemplar",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -1004,6 +1012,9 @@ INLINE_TYPE_HINTS = {
     ('ReportPlanOutcomeResponse', 'plan_summary'): '*ReportPlanOutcomePlanSummary',
     ('ReportPlanOutcomePlanSummary', 'total_committed'): '*float64',
     ('ReportPlanOutcomePlanSummary', 'budget_remaining'): '*float64',
+    ('PolicyEntry', 'exemplars'): '*PolicyExemplars',
+    ('PolicyExemplars', 'pass'): 'PolicyExemplar',
+    ('PolicyExemplars', 'fail'): 'PolicyExemplar',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -846,6 +846,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "plan_summary",
             "*ReportPlanOutcomePlanSummary",
         )
+        self.assert_field_type(
+            "governance/policy-entry.json",
+            "PolicyEntry",
+            "exemplars",
+            "*PolicyExemplars",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1167,6 +1173,32 @@ class InlineObjectGenerationTest(unittest.TestCase):
             outcome_plan_summary_generated,
         )
 
+        policy_exemplars_schema = generate.load_schema_spec(
+            "governance/policy-entry.json#/properties/exemplars",
+        )
+        policy_exemplars_generated = generate.schema_to_struct(
+            "PolicyExemplars",
+            policy_exemplars_schema,
+        )
+        self.assertIn(
+            "Pass []PolicyExemplar `json:\"pass,omitempty\"`",
+            policy_exemplars_generated,
+        )
+        self.assertIn(
+            "Fail []PolicyExemplar `json:\"fail,omitempty\"`",
+            policy_exemplars_generated,
+        )
+
+        policy_exemplar_schema = generate.load_schema_spec(
+            "governance/policy-entry.json#/$defs/exemplar",
+        )
+        policy_exemplar_generated = generate.schema_to_struct(
+            "PolicyExemplar",
+            policy_exemplar_schema,
+        )
+        self.assertIn("Scenario string `json:\"scenario\"`", policy_exemplar_generated)
+        self.assertIn("Explanation string `json:\"explanation\"`", policy_exemplar_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1193,6 +1225,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)
         self.assertNotIn(("ReportPlanOutcomeResponse", "plan_summary"), records)
+        self.assertNotIn(("PolicyEntry", "exemplars"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -5411,7 +5411,7 @@ type PolicyEntry struct {
 	SourceName string `json:"source_name,omitempty"` // Name of the issuing body (e.g., "UK Food Standards Agency", "US Federal Trade Co
 	Policy string `json:"policy"` // Natural language policy text describing what is required, prohibited, or recomme
 	Guidance string `json:"guidance,omitempty"` // Implementation notes for governance agent developers. Not used in evaluation pro
-	Exemplars any `json:"exemplars,omitempty"` // Calibration examples for governance agents, following the Content Standards patt
+	Exemplars *PolicyExemplars `json:"exemplars,omitempty"` // Calibration examples for governance agents, following the Content Standards patt
 	Ext any `json:"ext,omitempty"`
 }
 
@@ -6600,6 +6600,17 @@ type ReportPlanOutcomeError struct {
 type ReportPlanOutcomePlanSummary struct {
 	TotalCommitted *float64 `json:"total_committed,omitempty"` // Total budget committed across all campaigns in the plan.
 	BudgetRemaining *float64 `json:"budget_remaining,omitempty"` // Authorized budget minus total committed.
+}
+
+// PolicyExemplars — Calibration examples for governance agents, following the Content Standards pattern.
+type PolicyExemplars struct {
+	Pass []PolicyExemplar `json:"pass,omitempty"` // Scenarios that comply with this policy.
+	Fail []PolicyExemplar `json:"fail,omitempty"` // Scenarios that violate this policy.
+}
+
+type PolicyExemplar struct {
+	Scenario string `json:"scenario"` // A concrete scenario describing an advertising action or configuration.
+	Explanation string `json:"explanation"` // Why this scenario passes or fails the policy.
 }
 
 type CreativeAgentRef struct {

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 22
+python3 generate.py --coverage-max-unreviewed-any 21
 ```
 
-The generator currently reports 188 generated dynamic `any` uses:
+The generator currently reports 187 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 22 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 21 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 22
+python3 generate.py --coverage-max-unreviewed-any 21
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -45,7 +45,6 @@ the new dynamic shape is reviewed in the same PR.
 
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
-| `PolicyEntry.Exemplars` | `exemplars` | `any` | `inline_object` | `governance/policy-entry.json` |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
 | `SyncGovernanceSuccess.Accounts` | `accounts` | `[]any` | `array_item:inline_object` | `account/sync-governance-response.json#/oneOf/0` |
 | `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
@@ -72,15 +71,18 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 20 unreviewed fallbacks are direct inline
+This is the largest generator gap: 14 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
-objects that have stable, schema-owned property sets before moving into arrays
-of inline objects. Remaining direct-object candidates now need either local
-`$defs` reference support or an explicit unknown-field preservation decision.
+objects that have stable, schema-owned property sets. The next broad class is
+closed array-item schemas such as `GetProductsResponse.Incomplete`,
+`SyncPlansResponse.Plans`, `CheckGovernanceResponse.Findings` /
+`Conditions`, and `ReportPlanOutcomeResponse.Findings`. Keep genuinely
+open/controller payloads separate from schema-closed array items so the
+generator backlog does not turn typed object work into protocol-design work.
 
 ### Top-Level Unions
 
@@ -112,8 +114,10 @@ acceptable only when the schema intent is clear and tested.
 ### Product Refinement Shapes
 
 `GetProductsRequest.Refine` and `GetProductsResponse.RefinementApplied` are
-currently unreviewed `[]map[string]any` freeform objects. Decide whether these
-are intentional protocol extension points or missing typed refinement schemas.
+currently unreviewed `[]map[string]any` fallbacks because each array item is an
+inline discriminated `oneOf` object. The schema branches are closed and keyed by
+`scope`; this is a generator gap for inline union/discriminator generation, not
+a protocol extension-point decision.
 
 ## Manual Ownership Baseline
 


### PR DESCRIPTION
## Summary

- generate `PolicyExemplars` / `PolicyExemplar` from the AdCP 3.0.12 `policy-entry` schema
- type `PolicyEntry.Exemplars` as `*PolicyExemplars` instead of `any`
- lower the generated unreviewed-`any` CI gate from 22 to 21 and update the generator baseline docs
- document the breaking SDK migration path and add marshal / round-trip coverage

## DX / schema notes

This does not invent a Go-only shape: `exemplars` is a closed schema object with `pass` and `fail` arrays, and each exemplar is the local `$defs/exemplar` object requiring `scenario` and `explanation`.

The baseline doc now calls out the next generator backlog more precisely: closed inline array-item schemas are separate from open/controller payloads, and product refinement is an inline discriminated-union generator gap rather than a protocol extension question.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 21`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert review

- code reviewer: no actionable issues
- docs / DX reviewer: flagged baseline-doc wording; addressed in this PR
