### PR TITLE
feat(adcp)!: type get products incomplete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 21
+        run: python3 generate.py --coverage-max-unreviewed-any 20
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -73,6 +73,9 @@ be populated.
 - `PolicyEntry.Exemplars` is now `*adcp.PolicyExemplars` instead of `any`.
   `PolicyExemplars.Pass` and `PolicyExemplars.Fail` are
   `[]adcp.PolicyExemplar`.
+- `GetProductsResponse.Incomplete` is now
+  `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
+  `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -140,6 +143,7 @@ be populated.
 | `ReportPlanOutcomeRequest.Error` | `*adcp.ReportPlanOutcomeError` |
 | `ReportPlanOutcomeResponse.PlanSummary` | `*adcp.ReportPlanOutcomePlanSummary` |
 | `PolicyEntry.Exemplars` | `*adcp.PolicyExemplars` |
+| `GetProductsResponse.Incomplete` | `[]adcp.GetProductsIncompleteItem` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -241,6 +241,20 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "get products incomplete",
+			value: GetProductsResponse{
+				Products: []Product{},
+				Incomplete: []GetProductsIncompleteItem{{
+					Scope:         "forecast",
+					Description:   "Forecast is still running.",
+					EstimatedWait: Ptr(Duration{Interval: 2, Unit: "minutes"}),
+				}},
+			},
+			want: []string{
+				`"incomplete":[{"scope":"forecast","description":"Forecast is still running.","estimated_wait":{"interval":2,"unit":"minutes"}}]`,
+			},
+		},
+		{
 			name: "creative format disclosures",
 			value: CreativeFormat{
 				FormatID: FormatRef{AgentURL: "https://seller.example/mcp", ID: "display_300x250"},
@@ -544,6 +558,37 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetProductsIncompleteRoundTrip(t *testing.T) {
+	resp := GetProductsResponse{
+		Products: []Product{},
+		Incomplete: []GetProductsIncompleteItem{{
+			Scope:         "forecast",
+			Description:   "Forecast is still running.",
+			EstimatedWait: Ptr(Duration{Interval: 2, Unit: "minutes"}),
+		}},
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal get products response: %v", err)
+	}
+
+	var decoded GetProductsResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal get products response: %v", err)
+	}
+	if len(decoded.Incomplete) != 1 {
+		t.Fatalf("incomplete len = %d, want 1", len(decoded.Incomplete))
+	}
+	item := decoded.Incomplete[0]
+	if item.Scope != "forecast" || item.Description != "Forecast is still running." {
+		t.Fatalf("incomplete item did not round-trip: %#v", item)
+	}
+	if item.EstimatedWait == nil || item.EstimatedWait.Interval != 2 || item.EstimatedWait.Unit != "minutes" {
+		t.Fatalf("estimated_wait did not round-trip: %#v", item.EstimatedWait)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -473,6 +473,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/policy-entry.json#/$defs/exemplar",
     ),
     (
+        "GetProductsIncompleteItem",
+        "media-buy/get-products-response.json#/properties/incomplete/items",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -1015,6 +1019,8 @@ INLINE_TYPE_HINTS = {
     ('PolicyEntry', 'exemplars'): '*PolicyExemplars',
     ('PolicyExemplars', 'pass'): 'PolicyExemplar',
     ('PolicyExemplars', 'fail'): 'PolicyExemplar',
+    ('GetProductsResponse', 'incomplete'): 'GetProductsIncompleteItem',
+    ('GetProductsIncompleteItem', 'estimated_wait'): '*Duration',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -852,6 +852,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "exemplars",
             "*PolicyExemplars",
         )
+        self.assert_field_type(
+            "media-buy/get-products-response.json",
+            "GetProductsResponse",
+            "incomplete",
+            "[]GetProductsIncompleteItem",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1199,6 +1205,20 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Scenario string `json:\"scenario\"`", policy_exemplar_generated)
         self.assertIn("Explanation string `json:\"explanation\"`", policy_exemplar_generated)
 
+        incomplete_schema = generate.load_schema_spec(
+            "media-buy/get-products-response.json#/properties/incomplete/items",
+        )
+        incomplete_generated = generate.schema_to_struct(
+            "GetProductsIncompleteItem",
+            incomplete_schema,
+        )
+        self.assertIn("Scope string `json:\"scope\"`", incomplete_generated)
+        self.assertIn("Description string `json:\"description\"`", incomplete_generated)
+        self.assertIn(
+            "EstimatedWait *Duration `json:\"estimated_wait,omitempty\"`",
+            incomplete_generated,
+        )
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1226,6 +1246,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)
         self.assertNotIn(("ReportPlanOutcomeResponse", "plan_summary"), records)
         self.assertNotIn(("PolicyEntry", "exemplars"), records)
+        self.assertNotIn(("GetProductsResponse", "incomplete"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6613,6 +6613,12 @@ type PolicyExemplar struct {
 	Explanation string `json:"explanation"` // Why this scenario passes or fails the policy.
 }
 
+type GetProductsIncompleteItem struct {
+	Scope string `json:"scope"` // 'products': not all inventory sources were searched. 'pricing': products returne
+	Description string `json:"description"` // Human-readable explanation of what is missing and why.
+	EstimatedWait *Duration `json:"estimated_wait,omitempty"` // How much additional time would resolve this scope. Allows the buyer to decide wh
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7414,7 +7420,7 @@ type GetProductsResponse struct {
 	PropertyListApplied *bool `json:"property_list_applied,omitempty"` // [AdCP 3.0] Indicates whether property_list filtering was applied. True if the ag
 	CatalogApplied *bool `json:"catalog_applied,omitempty"` // Whether the seller filtered results based on the provided catalog. True if the s
 	RefinementApplied []map[string]any `json:"refinement_applied,omitempty"` // Seller's response to each change request in the refine array, matched by positio
-	Incomplete []any `json:"incomplete,omitempty"` // Declares what the seller could not finish within the buyer's time_budget or due
+	Incomplete []GetProductsIncompleteItem `json:"incomplete,omitempty"` // Declares what the seller could not finish within the buyer's time_budget or due
 	Pagination *PaginationResponse `json:"pagination,omitempty"`
 	Sandbox *bool `json:"sandbox,omitempty"` // When true, this response contains simulated data from sandbox mode.
 	Context any `json:"context,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 21
+python3 generate.py --coverage-max-unreviewed-any 20
 ```
 
-The generator currently reports 187 generated dynamic `any` uses:
+The generator currently reports 186 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 21 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 20 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 21
+python3 generate.py --coverage-max-unreviewed-any 20
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -49,7 +49,6 @@ the new dynamic shape is reviewed in the same PR.
 | `SyncGovernanceSuccess.Accounts` | `accounts` | `[]any` | `array_item:inline_object` | `account/sync-governance-response.json#/oneOf/0` |
 | `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
 | `GetProductsResponse.RefinementApplied` | `refinement_applied` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-response.json` |
-| `GetProductsResponse.Incomplete` | `incomplete` | `[]any` | `array_item:inline_object` | `media-buy/get-products-response.json` |
 | `CreateMediaBuyResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/create-media-buy-response.json` |
 | `ProvidePerformanceFeedbackResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/provide-performance-feedback-response.json` |
 | `PreviewCreativeRequest.Inputs` | `inputs` | `[]any` | `array_item:inline_object` | `creative/preview-creative-request.json` |
@@ -71,15 +70,15 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 14 unreviewed fallbacks are direct inline
+This is the largest generator gap: 13 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets. The next broad class is
-closed array-item schemas such as `GetProductsResponse.Incomplete`,
-`SyncPlansResponse.Plans`, `CheckGovernanceResponse.Findings` /
+closed array-item schemas such as `SyncPlansResponse.Plans`,
+`CheckGovernanceResponse.Findings` /
 `Conditions`, and `ReportPlanOutcomeResponse.Findings`. Keep genuinely
 open/controller payloads separate from schema-closed array items so the
 generator backlog does not turn typed object work into protocol-design work.


### PR DESCRIPTION
## Summary

- generate `GetProductsIncompleteItem` from the closed `get-products-response.incomplete[]` schema
- type `GetProductsResponse.Incomplete` as `[]GetProductsIncompleteItem` instead of `[]any`
- type nested `estimated_wait` as `*Duration`
- lower the generated unreviewed-`any` CI gate from 21 to 20 and update the baseline docs

## DX / schema notes

This is schema-backed, not an invented Go shape. The upstream item schema is closed and requires `scope` and `description`; `estimated_wait` is the existing AdCP duration ref and remains optional.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 20`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert review

- code reviewer: no actionable issues
- docs / DX reviewer: no actionable issues
