### PR TITLE
feat(adcp)!: type sync plans response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 20
+        run: python3 generate.py --coverage-max-unreviewed-any 19
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -76,6 +76,9 @@ be populated.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.
+- `SyncPlansResponse.Plans` is now `[]adcp.SyncPlansPlan` instead of
+  `[]any`. Nested `Categories` and `ResolvedPolicies` are typed as
+  `[]adcp.SyncPlansPlanCategory` and `[]adcp.SyncPlansResolvedPolicy`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -144,6 +147,7 @@ be populated.
 | `ReportPlanOutcomeResponse.PlanSummary` | `*adcp.ReportPlanOutcomePlanSummary` |
 | `PolicyEntry.Exemplars` | `*adcp.PolicyExemplars` |
 | `GetProductsResponse.Incomplete` | `[]adcp.GetProductsIncompleteItem` |
+| `SyncPlansResponse.Plans` | `[]adcp.SyncPlansPlan` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -255,6 +255,29 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "sync plans response plans",
+			value: SyncPlansResponse{
+				Plans: []SyncPlansPlan{{
+					PlanID:  "plan-1",
+					Status:  "active",
+					Version: 2,
+					Categories: []SyncPlansPlanCategory{{
+						CategoryID: "budget_compliance",
+						Status:     "active",
+					}},
+					ResolvedPolicies: []SyncPlansResolvedPolicy{{
+						PolicyID:    "policy-1",
+						Source:      "explicit",
+						Enforcement: PolicyEnforcementMust,
+						Reason:      "Brand compliance configuration.",
+					}},
+				}},
+			},
+			want: []string{
+				`"plans":[{"plan_id":"plan-1","status":"active","version":2,"categories":[{"category_id":"budget_compliance","status":"active"}],"resolved_policies":[{"policy_id":"policy-1","source":"explicit","enforcement":"must","reason":"Brand compliance configuration."}]}]`,
+			},
+		},
+		{
 			name: "creative format disclosures",
 			value: CreativeFormat{
 				FormatID: FormatRef{AgentURL: "https://seller.example/mcp", ID: "display_300x250"},
@@ -558,6 +581,49 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSyncPlansResponsePlansRoundTrip(t *testing.T) {
+	resp := SyncPlansResponse{
+		Plans: []SyncPlansPlan{{
+			PlanID:  "plan-1",
+			Status:  "active",
+			Version: 2,
+			Categories: []SyncPlansPlanCategory{{
+				CategoryID: "budget_compliance",
+				Status:     "active",
+			}},
+			ResolvedPolicies: []SyncPlansResolvedPolicy{{
+				PolicyID:    "policy-1",
+				Source:      "explicit",
+				Enforcement: PolicyEnforcementMust,
+				Reason:      "Brand compliance configuration.",
+			}},
+		}},
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal sync plans response: %v", err)
+	}
+
+	var decoded SyncPlansResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal sync plans response: %v", err)
+	}
+	if len(decoded.Plans) != 1 {
+		t.Fatalf("plans len = %d, want 1", len(decoded.Plans))
+	}
+	plan := decoded.Plans[0]
+	if plan.PlanID != "plan-1" || plan.Status != "active" || plan.Version != 2 {
+		t.Fatalf("plan did not round-trip: %#v", plan)
+	}
+	if len(plan.Categories) != 1 || plan.Categories[0].CategoryID != "budget_compliance" {
+		t.Fatalf("categories did not round-trip: %#v", plan.Categories)
+	}
+	if len(plan.ResolvedPolicies) != 1 || plan.ResolvedPolicies[0].Enforcement != PolicyEnforcementMust {
+		t.Fatalf("resolved policies did not round-trip: %#v", plan.ResolvedPolicies)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -477,6 +477,18 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "media-buy/get-products-response.json#/properties/incomplete/items",
     ),
     (
+        "SyncPlansPlan",
+        "governance/sync-plans-response.json#/properties/plans/items",
+    ),
+    (
+        "SyncPlansPlanCategory",
+        "governance/sync-plans-response.json#/properties/plans/items/properties/categories/items",
+    ),
+    (
+        "SyncPlansResolvedPolicy",
+        "governance/sync-plans-response.json#/properties/plans/items/properties/resolved_policies/items",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -1021,6 +1033,10 @@ INLINE_TYPE_HINTS = {
     ('PolicyExemplars', 'fail'): 'PolicyExemplar',
     ('GetProductsResponse', 'incomplete'): 'GetProductsIncompleteItem',
     ('GetProductsIncompleteItem', 'estimated_wait'): '*Duration',
+    ('SyncPlansResponse', 'plans'): 'SyncPlansPlan',
+    ('SyncPlansPlan', 'categories'): 'SyncPlansPlanCategory',
+    ('SyncPlansPlan', 'resolved_policies'): 'SyncPlansResolvedPolicy',
+    ('SyncPlansResolvedPolicy', 'enforcement'): 'PolicyEnforcement',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -858,6 +858,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "incomplete",
             "[]GetProductsIncompleteItem",
         )
+        self.assert_field_type(
+            "governance/sync-plans-response.json",
+            "SyncPlansResponse",
+            "plans",
+            "[]SyncPlansPlan",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1219,6 +1225,55 @@ class InlineObjectGenerationTest(unittest.TestCase):
             incomplete_generated,
         )
 
+        sync_plan_schema = generate.load_schema_spec(
+            "governance/sync-plans-response.json#/properties/plans/items",
+        )
+        sync_plan_generated = generate.schema_to_struct(
+            "SyncPlansPlan",
+            sync_plan_schema,
+        )
+        self.assertIn("PlanID string `json:\"plan_id\"`", sync_plan_generated)
+        self.assertIn("Status string `json:\"status\"`", sync_plan_generated)
+        self.assertIn("Version int `json:\"version\"`", sync_plan_generated)
+        self.assertIn(
+            "Categories []SyncPlansPlanCategory `json:\"categories,omitempty\"`",
+            sync_plan_generated,
+        )
+        self.assertIn(
+            "ResolvedPolicies []SyncPlansResolvedPolicy `json:\"resolved_policies,omitempty\"`",
+            sync_plan_generated,
+        )
+
+        sync_plan_category_schema = generate.load_schema_spec(
+            "governance/sync-plans-response.json#/properties/plans/items"
+            "/properties/categories/items",
+        )
+        sync_plan_category_generated = generate.schema_to_struct(
+            "SyncPlansPlanCategory",
+            sync_plan_category_schema,
+        )
+        self.assertIn(
+            "CategoryID string `json:\"category_id\"`",
+            sync_plan_category_generated,
+        )
+        self.assertIn("Status string `json:\"status\"`", sync_plan_category_generated)
+
+        sync_plan_policy_schema = generate.load_schema_spec(
+            "governance/sync-plans-response.json#/properties/plans/items"
+            "/properties/resolved_policies/items",
+        )
+        sync_plan_policy_generated = generate.schema_to_struct(
+            "SyncPlansResolvedPolicy",
+            sync_plan_policy_schema,
+        )
+        self.assertIn("PolicyID string `json:\"policy_id\"`", sync_plan_policy_generated)
+        self.assertIn("Source string `json:\"source\"`", sync_plan_policy_generated)
+        self.assertIn(
+            "Enforcement PolicyEnforcement `json:\"enforcement\"`",
+            sync_plan_policy_generated,
+        )
+        self.assertIn("Reason string `json:\"reason,omitempty\"`", sync_plan_policy_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1247,6 +1302,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ReportPlanOutcomeResponse", "plan_summary"), records)
         self.assertNotIn(("PolicyEntry", "exemplars"), records)
         self.assertNotIn(("GetProductsResponse", "incomplete"), records)
+        self.assertNotIn(("SyncPlansResponse", "plans"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6619,6 +6619,26 @@ type GetProductsIncompleteItem struct {
 	EstimatedWait *Duration `json:"estimated_wait,omitempty"` // How much additional time would resolve this scope. Allows the buyer to decide wh
 }
 
+type SyncPlansPlan struct {
+	PlanID string `json:"plan_id"` // Plan identifier.
+	Status string `json:"status"` // Sync result status. 'active' means sync succeeded; 'error' means sync failed.
+	Version int `json:"version"` // Plan version (increments on each sync).
+	Categories []SyncPlansPlanCategory `json:"categories,omitempty"` // Validation categories active for this plan.
+	ResolvedPolicies []SyncPlansResolvedPolicy `json:"resolved_policies,omitempty"` // Policies the governance agent will enforce for this plan. Includes explicitly re
+}
+
+type SyncPlansPlanCategory struct {
+	CategoryID string `json:"category_id"` // Validation category identifier.
+	Status string `json:"status"` // Whether this category is active for this plan.
+}
+
+type SyncPlansResolvedPolicy struct {
+	PolicyID string `json:"policy_id"` // Registry policy ID.
+	Source string `json:"source"` // How this policy was included. 'explicit': referenced in the brand compliance con
+	Enforcement PolicyEnforcement `json:"enforcement"` // Enforcement level for this policy.
+	Reason string `json:"reason,omitempty"` // Why this policy was included (e.g., 'Matched jurisdiction US and policy category
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7859,7 +7879,7 @@ type SyncPlansRequest struct {
 
 // SyncPlansResponse — Response from syncing campaign plans. Returns status and active validation categories for each plan.
 type SyncPlansResponse struct {
-	Plans []any `json:"plans"` // Status for each synced plan.
+	Plans []SyncPlansPlan `json:"plans"` // Status for each synced plan.
 	Replayed *bool `json:"replayed,omitempty"` // Set to true when this response is a cached replay returned for an idempotency_ke
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 20
+python3 generate.py --coverage-max-unreviewed-any 19
 ```
 
-The generator currently reports 186 generated dynamic `any` uses:
+The generator currently reports 185 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 20 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 19 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 20
+python3 generate.py --coverage-max-unreviewed-any 19
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -58,7 +58,6 @@ the new dynamic shape is reviewed in the same PR.
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ControllerError.CurrentState` | `current_state` | `any` | `unspecified_schema_type` | `compliance/comply-test-controller-response.json#/oneOf/5` |
-| `SyncPlansResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/sync-plans-response.json` |
 | `CheckGovernanceResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
@@ -70,15 +69,14 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 13 unreviewed fallbacks are direct inline
+This is the largest generator gap: 12 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets. The next broad class is
-closed array-item schemas such as `SyncPlansResponse.Plans`,
-`CheckGovernanceResponse.Findings` /
+closed array-item schemas such as `CheckGovernanceResponse.Findings` /
 `Conditions`, and `ReportPlanOutcomeResponse.Findings`. Keep genuinely
 open/controller payloads separate from schema-closed array items so the
 generator backlog does not turn typed object work into protocol-design work.


### PR DESCRIPTION
## Summary

- generate `SyncPlansPlan`, `SyncPlansPlanCategory`, and `SyncPlansResolvedPolicy` from the closed `sync-plans-response.plans[]` schemas
- type `SyncPlansResponse.Plans` as `[]SyncPlansPlan` instead of `[]any`
- keep nested `resolved_policies[].enforcement` on the existing `PolicyEnforcement` alias
- lower the generated unreviewed-`any` CI gate from 20 to 19 and update baseline docs

## DX / schema notes

This is schema-backed closed-object typing. The response plan item requires `plan_id`, `status`, and `version`; nested categories and resolved policies are also closed schema-owned objects.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 19`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert review

- code reviewer: no actionable issues
- docs / DX reviewer: no actionable issues
