### PR TITLE
feat(adcp)!: type governance findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 19
+        run: python3 generate.py --coverage-max-unreviewed-any 17
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -79,6 +79,14 @@ be populated.
 - `SyncPlansResponse.Plans` is now `[]adcp.SyncPlansPlan` instead of
   `[]any`. Nested `Categories` and `ResolvedPolicies` are typed as
   `[]adcp.SyncPlansPlanCategory` and `[]adcp.SyncPlansResolvedPolicy`.
+- Governance findings are now typed:
+  `CheckGovernanceResponse.Findings` is `[]adcp.CheckGovernanceFinding`, and
+  `ReportPlanOutcomeResponse.Findings` is `[]adcp.ReportPlanOutcomeFinding`.
+  `CheckGovernanceFinding.Details` and `ReportPlanOutcomeFinding.Details`
+  remain `map[string]any` because finding details are category-specific
+  structured payloads. `CheckGovernanceFinding.Confidence` is `*float64`; use
+  nil when confidence is absent and `adcp.Ptr(0.0)` when explicit zero is
+  meaningful.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -148,6 +156,8 @@ be populated.
 | `PolicyEntry.Exemplars` | `*adcp.PolicyExemplars` |
 | `GetProductsResponse.Incomplete` | `[]adcp.GetProductsIncompleteItem` |
 | `SyncPlansResponse.Plans` | `[]adcp.SyncPlansPlan` |
+| `CheckGovernanceResponse.Findings` | `[]adcp.CheckGovernanceFinding` |
+| `ReportPlanOutcomeResponse.Findings` | `[]adcp.ReportPlanOutcomeFinding` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -85,8 +85,8 @@ be populated.
   `CheckGovernanceFinding.Details` and `ReportPlanOutcomeFinding.Details`
   remain `map[string]any` because finding details are category-specific
   structured payloads. `CheckGovernanceFinding.Confidence` is `*float64`; use
-  nil when confidence is absent and `adcp.Ptr(0.0)` when explicit zero is
-  meaningful.
+  nil when confidence is absent, and use a pointer only when intentionally
+  sending a schema-valid confidence value, including `adcp.Ptr(0.0)`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -278,6 +278,44 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "governance findings",
+			value: CheckGovernanceResponse{
+				CheckID:     "check-1",
+				Status:      "denied",
+				PlanID:      "plan-1",
+				Explanation: "Policy violation detected.",
+				Findings: []CheckGovernanceFinding{{
+					CategoryID:        "regulatory_compliance",
+					PolicyID:          "policy-1",
+					SourcePlanID:      "plan-1",
+					Severity:          EscalationSeverityWarning,
+					Explanation:       "Audience includes a restricted category.",
+					Details:           map[string]any{"field": "targeting.age"},
+					Confidence:        Ptr(0.0),
+					UncertaintyReason: "Segment overlap is partial.",
+				}},
+			},
+			want: []string{
+				`"findings":[{"category_id":"regulatory_compliance","policy_id":"policy-1","source_plan_id":"plan-1","severity":"warning","explanation":"Audience includes a restricted category.","details":{"field":"targeting.age"},"confidence":0,"uncertainty_reason":"Segment overlap is partial."}]`,
+			},
+		},
+		{
+			name: "report plan outcome findings",
+			value: ReportPlanOutcomeResponse{
+				OutcomeID: "outcome-1",
+				Status:    "findings",
+				Findings: []ReportPlanOutcomeFinding{{
+					CategoryID:  "budget_compliance",
+					Severity:    EscalationSeverityCritical,
+					Explanation: "Budget exceeded.",
+					Details:     map[string]any{"overage": 125.5},
+				}},
+			},
+			want: []string{
+				`"findings":[{"category_id":"budget_compliance","severity":"critical","explanation":"Budget exceeded.","details":{"overage":125.5}}]`,
+			},
+		},
+		{
 			name: "creative format disclosures",
 			value: CreativeFormat{
 				FormatID: FormatRef{AgentURL: "https://seller.example/mcp", ID: "display_300x250"},
@@ -581,6 +619,76 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGovernanceFindingsRoundTrip(t *testing.T) {
+	checkResp := CheckGovernanceResponse{
+		CheckID:     "check-1",
+		Status:      "denied",
+		PlanID:      "plan-1",
+		Explanation: "Policy violation detected.",
+		Findings: []CheckGovernanceFinding{{
+			CategoryID:        "regulatory_compliance",
+			PolicyID:          "policy-1",
+			SourcePlanID:      "plan-1",
+			Severity:          EscalationSeverityWarning,
+			Explanation:       "Audience includes a restricted category.",
+			Details:           map[string]any{"field": "targeting.age"},
+			Confidence:        Ptr(0.0),
+			UncertaintyReason: "Segment overlap is partial.",
+		}},
+	}
+
+	raw, err := json.Marshal(checkResp)
+	if err != nil {
+		t.Fatalf("marshal check governance response: %v", err)
+	}
+	var decodedCheck CheckGovernanceResponse
+	if err := json.Unmarshal(raw, &decodedCheck); err != nil {
+		t.Fatalf("unmarshal check governance response: %v", err)
+	}
+	if len(decodedCheck.Findings) != 1 {
+		t.Fatalf("check findings len = %d, want 1", len(decodedCheck.Findings))
+	}
+	checkFinding := decodedCheck.Findings[0]
+	if checkFinding.Severity != EscalationSeverityWarning || checkFinding.PolicyID != "policy-1" {
+		t.Fatalf("check finding did not round-trip: %#v", checkFinding)
+	}
+	if checkFinding.Confidence == nil || *checkFinding.Confidence != 0 {
+		t.Fatalf("confidence = %v, want pointer to 0", checkFinding.Confidence)
+	}
+	if checkFinding.Details["field"] != "targeting.age" {
+		t.Fatalf("details did not round-trip: %#v", checkFinding.Details)
+	}
+
+	outcomeResp := ReportPlanOutcomeResponse{
+		OutcomeID: "outcome-1",
+		Status:    "findings",
+		Findings: []ReportPlanOutcomeFinding{{
+			CategoryID:  "budget_compliance",
+			Severity:    EscalationSeverityCritical,
+			Explanation: "Budget exceeded.",
+			Details:     map[string]any{"overage": 125.5},
+		}},
+	}
+	raw, err = json.Marshal(outcomeResp)
+	if err != nil {
+		t.Fatalf("marshal report plan outcome response: %v", err)
+	}
+	var decodedOutcome ReportPlanOutcomeResponse
+	if err := json.Unmarshal(raw, &decodedOutcome); err != nil {
+		t.Fatalf("unmarshal report plan outcome response: %v", err)
+	}
+	if len(decodedOutcome.Findings) != 1 {
+		t.Fatalf("outcome findings len = %d, want 1", len(decodedOutcome.Findings))
+	}
+	outcomeFinding := decodedOutcome.Findings[0]
+	if outcomeFinding.Severity != EscalationSeverityCritical || outcomeFinding.CategoryID != "budget_compliance" {
+		t.Fatalf("outcome finding did not round-trip: %#v", outcomeFinding)
+	}
+	if outcomeFinding.Details["overage"] != 125.5 {
+		t.Fatalf("outcome details did not round-trip: %#v", outcomeFinding.Details)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -489,6 +489,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/sync-plans-response.json#/properties/plans/items/properties/resolved_policies/items",
     ),
     (
+        "CheckGovernanceFinding",
+        "governance/check-governance-response.json#/properties/findings/items",
+    ),
+    (
+        "ReportPlanOutcomeFinding",
+        "governance/report-plan-outcome-response.json#/properties/findings/items",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -1037,6 +1045,11 @@ INLINE_TYPE_HINTS = {
     ('SyncPlansPlan', 'categories'): 'SyncPlansPlanCategory',
     ('SyncPlansPlan', 'resolved_policies'): 'SyncPlansResolvedPolicy',
     ('SyncPlansResolvedPolicy', 'enforcement'): 'PolicyEnforcement',
+    ('CheckGovernanceResponse', 'findings'): 'CheckGovernanceFinding',
+    ('CheckGovernanceFinding', 'severity'): 'EscalationSeverity',
+    ('CheckGovernanceFinding', 'confidence'): '*float64',
+    ('ReportPlanOutcomeResponse', 'findings'): 'ReportPlanOutcomeFinding',
+    ('ReportPlanOutcomeFinding', 'severity'): 'EscalationSeverity',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',
@@ -1197,6 +1210,8 @@ INTENTIONAL_ANY_FIELDS = {
     ('SimulationSuccess', 'simulated'): 'test-controller simulation payload is scenario-specific',
     ('SimulationSuccess', 'cumulative'): 'test-controller cumulative state is scenario-specific',
     ('CheckGovernanceRequest', 'payload'): 'governance can evaluate different protocol payloads',
+    ('CheckGovernanceFinding', 'details'): 'governance finding details are structured but category-specific',
+    ('ReportPlanOutcomeFinding', 'details'): 'outcome finding details are structured but category-specific',
 }
 
 # Enum schemas

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -864,6 +864,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "plans",
             "[]SyncPlansPlan",
         )
+        self.assert_field_type(
+            "governance/check-governance-response.json",
+            "CheckGovernanceResponse",
+            "findings",
+            "[]CheckGovernanceFinding",
+        )
+        self.assert_field_type(
+            "governance/report-plan-outcome-response.json",
+            "ReportPlanOutcomeResponse",
+            "findings",
+            "[]ReportPlanOutcomeFinding",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1274,6 +1286,43 @@ class InlineObjectGenerationTest(unittest.TestCase):
         )
         self.assertIn("Reason string `json:\"reason,omitempty\"`", sync_plan_policy_generated)
 
+        check_finding_schema = generate.load_schema_spec(
+            "governance/check-governance-response.json#/properties/findings/items",
+        )
+        check_finding_generated = generate.schema_to_struct(
+            "CheckGovernanceFinding",
+            check_finding_schema,
+        )
+        self.assertIn("CategoryID string `json:\"category_id\"`", check_finding_generated)
+        self.assertIn("PolicyID string `json:\"policy_id,omitempty\"`", check_finding_generated)
+        self.assertIn("SourcePlanID string `json:\"source_plan_id,omitempty\"`", check_finding_generated)
+        self.assertIn(
+            "Severity EscalationSeverity `json:\"severity\"`",
+            check_finding_generated,
+        )
+        self.assertIn("Explanation string `json:\"explanation\"`", check_finding_generated)
+        self.assertIn("Details map[string]any `json:\"details,omitempty\"`", check_finding_generated)
+        self.assertIn("Confidence *float64 `json:\"confidence,omitempty\"`", check_finding_generated)
+        self.assertIn(
+            "UncertaintyReason string `json:\"uncertainty_reason,omitempty\"`",
+            check_finding_generated,
+        )
+
+        outcome_finding_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-response.json#/properties/findings/items",
+        )
+        outcome_finding_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeFinding",
+            outcome_finding_schema,
+        )
+        self.assertIn("CategoryID string `json:\"category_id\"`", outcome_finding_generated)
+        self.assertIn(
+            "Severity EscalationSeverity `json:\"severity\"`",
+            outcome_finding_generated,
+        )
+        self.assertIn("Explanation string `json:\"explanation\"`", outcome_finding_generated)
+        self.assertIn("Details map[string]any `json:\"details,omitempty\"`", outcome_finding_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1303,6 +1352,8 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("PolicyEntry", "exemplars"), records)
         self.assertNotIn(("GetProductsResponse", "incomplete"), records)
         self.assertNotIn(("SyncPlansResponse", "plans"), records)
+        self.assertNotIn(("CheckGovernanceResponse", "findings"), records)
+        self.assertNotIn(("ReportPlanOutcomeResponse", "findings"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])
@@ -1314,6 +1365,22 @@ class InlineObjectGenerationTest(unittest.TestCase):
                 "ProductFilterGeometry",
                 "coordinates",
                 "GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "CheckGovernanceFinding",
+                "details",
+                "governance finding details are structured but category-specific",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "ReportPlanOutcomeFinding",
+                "details",
+                "outcome finding details are structured but category-specific",
             ),
             allowed,
         )

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6639,6 +6639,24 @@ type SyncPlansResolvedPolicy struct {
 	Reason string `json:"reason,omitempty"` // Why this policy was included (e.g., 'Matched jurisdiction US and policy category
 }
 
+type CheckGovernanceFinding struct {
+	CategoryID string `json:"category_id"` // Validation category that flagged the issue (e.g., 'budget_compliance', 'regulato
+	PolicyID string `json:"policy_id,omitempty"` // ID of the policy that triggered this finding. May reference a registry policy (w
+	SourcePlanID string `json:"source_plan_id,omitempty"` // For portfolio or aggregated evaluations where findings draw on bespoke policies
+	Severity EscalationSeverity `json:"severity"`
+	Explanation string `json:"explanation"` // Human-readable description of the issue.
+	Details map[string]any `json:"details,omitempty"` // Structured details for programmatic consumption.
+	Confidence *float64 `json:"confidence,omitempty"` // Confidence score (0-1) in this finding. Distinguishes 'this definitely violates
+	UncertaintyReason string `json:"uncertainty_reason,omitempty"` // Explanation of why confidence is below 1.0 (e.g., 'Targeting includes regions th
+}
+
+type ReportPlanOutcomeFinding struct {
+	CategoryID string `json:"category_id"` // Which validation category flagged the issue.
+	Severity EscalationSeverity `json:"severity"` // Finding severity.
+	Explanation string `json:"explanation"` // Human-readable description of the issue.
+	Details map[string]any `json:"details,omitempty"` // Structured details for programmatic consumption.
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7909,7 +7927,7 @@ type CheckGovernanceResponse struct {
 	Status string `json:"status"`
 	PlanID string `json:"plan_id"` // Echoed from request.
 	Explanation string `json:"explanation"` // Human-readable explanation of the governance decision.
-	Findings []any `json:"findings,omitempty"` // Specific issues found during the governance check. Present when status is 'denie
+	Findings []CheckGovernanceFinding `json:"findings,omitempty"` // Specific issues found during the governance check. Present when status is 'denie
 	Conditions []any `json:"conditions,omitempty"` // Present when status is 'conditions'. Specific adjustments the caller must make.
 	ExpiresAt string `json:"expires_at,omitempty"` // When this approval expires. Present when status is 'approved' or 'conditions'. T
 	NextCheck string `json:"next_check,omitempty"` // When the seller should next call check_governance with delivery metrics. Present
@@ -7942,7 +7960,7 @@ type ReportPlanOutcomeResponse struct {
 	OutcomeID string `json:"outcome_id"` // Unique identifier for this outcome record.
 	Status string `json:"status"` // 'accepted' means state updated with no issues. 'findings' means issues were dete
 	CommittedBudget float64 `json:"committed_budget,omitempty"` // Budget committed from this outcome. Present for 'completed' and 'failed' outcome
-	Findings []any `json:"findings,omitempty"` // Issues detected. Present only when status is 'findings'.
+	Findings []ReportPlanOutcomeFinding `json:"findings,omitempty"` // Issues detected. Present only when status is 'findings'.
 	PlanSummary *ReportPlanOutcomePlanSummary `json:"plan_summary,omitempty"` // Updated plan budget state. Present for 'completed' and 'failed' outcomes.
 	Replayed *bool `json:"replayed,omitempty"` // Set to true when this response is a cached replay returned for an idempotency_ke
 	Context any `json:"context,omitempty"`

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 19
+python3 generate.py --coverage-max-unreviewed-any 17
 ```
 
 The generator currently reports 185 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 166 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 19 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 168 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 17 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 19
+python3 generate.py --coverage-max-unreviewed-any 17
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -31,6 +31,9 @@ the new dynamic shape is reviewed in the same PR.
 
 - `context`, `ext`, seller-defined creative assets, format manifests, event
   payloads, and AdCP error payloads are intentional dynamic escape hatches.
+- Governance finding details are intentional dynamic escape hatches:
+  `CheckGovernanceFinding.Details` and `ReportPlanOutcomeFinding.Details` stay
+  `map[string]any` because their structured payloads are category-specific.
 - Inline object fallbacks are generator limitations unless the schema explicitly
   models open-ended data.
 - Top-level `oneOf` aliases are generator limitations. They need generated
@@ -58,10 +61,8 @@ the new dynamic shape is reviewed in the same PR.
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ControllerError.CurrentState` | `current_state` | `any` | `unspecified_schema_type` | `compliance/comply-test-controller-response.json#/oneOf/5` |
-| `CheckGovernanceResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
-| `ReportPlanOutcomeResponse.Findings` | `findings` | `[]any` | `array_item:inline_object` | `governance/report-plan-outcome-response.json` |
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
@@ -69,17 +70,17 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 12 unreviewed fallbacks are direct inline
+This is the largest generator gap: 10 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets. The next broad class is
-closed array-item schemas such as `CheckGovernanceResponse.Findings` /
-`Conditions`, and `ReportPlanOutcomeResponse.Findings`. Keep genuinely
-open/controller payloads separate from schema-closed array items so the
-generator backlog does not turn typed object work into protocol-design work.
+closed array-item schemas such as `CheckGovernanceResponse.Conditions` and
+`GetPlanAuditLogsResponse.Plans`. Keep genuinely open/controller payloads
+separate from schema-closed array items so the generator backlog does not turn
+typed object work into protocol-design work.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- generate `CheckGovernanceFinding` and `ReportPlanOutcomeFinding` from closed governance finding item schemas
- type `CheckGovernanceResponse.Findings` and `ReportPlanOutcomeResponse.Findings` instead of leaving them as `[]any`
- keep `Details` as reviewed `map[string]any` because finding details are category-specific structured payloads
- make `CheckGovernanceFinding.Confidence` `*float64` so absent and explicit `0` remain distinct
- lower the generated unreviewed-`any` CI gate from 19 to 17 and update baseline docs

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 17`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert review

- code reviewer: no actionable issues
- docs / DX reviewer: requested migration/baseline detail for `Details` and `Confidence`; addressed before opening
