### PR TITLE
feat(adcp)!: type governance conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 17
+        run: python3 generate.py --coverage-max-unreviewed-any 16
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -87,6 +87,18 @@ be populated.
   structured payloads. `CheckGovernanceFinding.Confidence` is `*float64`; use
   nil when confidence is absent, and use a pointer only when intentionally
   sending a schema-valid confidence value, including `adcp.Ptr(0.0)`.
+- `CheckGovernanceResponse.Conditions` is now
+  `[]adcp.CheckGovernanceCondition` instead of `[]any`.
+  `CheckGovernanceCondition.RequiredValue` remains `any` because a governance
+  condition can require different JSON value types. Treat decoded values as
+  generic JSON data (`nil`, `bool`, `string`, `float64`, `[]any`, or
+  `map[string]any`) or decode them into caller-owned types before use; numeric
+  values decode as `float64`. Use `HasRequiredValue` to distinguish an absent
+  advisory `required_value` from an explicit one, because `RequiredValue == nil`
+  can mean either absent or explicit JSON `null`. When constructing responses,
+  set `HasRequiredValue: true` whenever `required_value` should be present on
+  the wire. To send `required_value: null`, set `HasRequiredValue: true` and
+  leave `RequiredValue` nil.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -158,6 +170,7 @@ be populated.
 | `SyncPlansResponse.Plans` | `[]adcp.SyncPlansPlan` |
 | `CheckGovernanceResponse.Findings` | `[]adcp.CheckGovernanceFinding` |
 | `ReportPlanOutcomeResponse.Findings` | `[]adcp.ReportPlanOutcomeFinding` |
+| `CheckGovernanceResponse.Conditions` | `[]adcp.CheckGovernanceCondition` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -300,6 +300,24 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "governance conditions",
+			value: CheckGovernanceResponse{
+				CheckID:     "check-1",
+				Status:      "conditions",
+				PlanID:      "plan-1",
+				Explanation: "Approval requires a smaller budget.",
+				Conditions: []CheckGovernanceCondition{{
+					Field:            "planned_delivery.total_budget",
+					RequiredValue:    5000,
+					HasRequiredValue: true,
+					Reason:           "Budget exceeds approved plan.",
+				}},
+			},
+			want: []string{
+				`"conditions":[{"field":"planned_delivery.total_budget","required_value":5000,"reason":"Budget exceeds approved plan."}]`,
+			},
+		},
+		{
 			name: "report plan outcome findings",
 			value: ReportPlanOutcomeResponse{
 				OutcomeID: "outcome-1",
@@ -619,6 +637,87 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckGovernanceConditionsRoundTrip(t *testing.T) {
+	resp := CheckGovernanceResponse{
+		CheckID:     "check-1",
+		Status:      "conditions",
+		PlanID:      "plan-1",
+		Explanation: "Approval requires a smaller budget.",
+		Conditions: []CheckGovernanceCondition{{
+			Field:            "planned_delivery.total_budget",
+			RequiredValue:    5000,
+			HasRequiredValue: true,
+			Reason:           "Budget exceeds approved plan.",
+		}},
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal check governance response: %v", err)
+	}
+	var decoded CheckGovernanceResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal check governance response: %v", err)
+	}
+	if len(decoded.Conditions) != 1 {
+		t.Fatalf("conditions len = %d, want 1", len(decoded.Conditions))
+	}
+	condition := decoded.Conditions[0]
+	if condition.Field != "planned_delivery.total_budget" || condition.Reason != "Budget exceeds approved plan." {
+		t.Fatalf("condition did not round-trip: %#v", condition)
+	}
+	if condition.RequiredValue != float64(5000) {
+		t.Fatalf("required_value = %#v, want 5000", condition.RequiredValue)
+	}
+	if !condition.HasRequiredValue {
+		t.Fatal("HasRequiredValue = false, want true")
+	}
+
+	raw = []byte(`{"check_id":"check-1","status":"conditions","conditions":[{"field":"planned_delivery.total_budget","required_value":null,"reason":"Unset budget."}]}`)
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal explicit null condition: %v", err)
+	}
+	condition = decoded.Conditions[0]
+	if !condition.HasRequiredValue {
+		t.Fatal("explicit null HasRequiredValue = false, want true")
+	}
+	if condition.RequiredValue != nil {
+		t.Fatalf("explicit null required_value = %#v, want nil", condition.RequiredValue)
+	}
+	raw, err = json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("marshal explicit null condition: %v", err)
+	}
+	if !strings.Contains(string(raw), `"required_value":null`) {
+		t.Fatalf("explicit null condition did not re-marshal required_value:null:\n%s", raw)
+	}
+
+	raw = []byte(`{"check_id":"check-1","status":"conditions","conditions":[{"field":"planned_delivery.total_budget","reason":"Review budget."}]}`)
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal advisory condition: %v", err)
+	}
+	condition = decoded.Conditions[0]
+	if condition.HasRequiredValue {
+		t.Fatal("advisory HasRequiredValue = true, want false")
+	}
+	raw, err = json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("marshal advisory condition: %v", err)
+	}
+	if strings.Contains(string(raw), `"required_value"`) {
+		t.Fatalf("advisory condition unexpectedly marshaled required_value:\n%s", raw)
+	}
+
+	resp.Conditions[0].HasRequiredValue = false
+	raw, err = json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal condition without presence bit: %v", err)
+	}
+	if strings.Contains(string(raw), `"required_value"`) {
+		t.Fatalf("condition without presence bit unexpectedly marshaled required_value:\n%s", raw)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -48,6 +48,7 @@ KNOWN_TYPES = {
     'Preview', 'PreviewRender', 'BuildCreativeResult', 'SignalID',
     'SignalPricing', 'ActivationKey', 'CatalogResult',
     'EventSourceResult', 'LogEventResult',
+    'CheckGovernanceCondition',
     # oneOf schemas — generator produces `type X = any`; hand-writing flattens
     # the union into a single struct with all variant fields.
     'PricingOption', 'Deployment', 'PublisherPropertySelector',
@@ -911,6 +912,9 @@ HAND_WRITTEN_INLINE_SCHEMA_SPECS = {
         'bundled/media-buy/create-media-buy-response.json#/oneOf/0/properties/account/properties/setup',
         'bundled/media-buy/get-media-buys-response.json#/properties/media_buys/items/properties/account/properties/setup',
     ],
+    'CheckGovernanceCondition': [
+        'governance/check-governance-response.json#/properties/conditions/items',
+    ],
 }
 
 # Map schema-derived Go names to the preferred Go name. Applied both when
@@ -1050,6 +1054,7 @@ INLINE_TYPE_HINTS = {
     ('CheckGovernanceFinding', 'confidence'): '*float64',
     ('ReportPlanOutcomeResponse', 'findings'): 'ReportPlanOutcomeFinding',
     ('ReportPlanOutcomeFinding', 'severity'): 'EscalationSeverity',
+    ('CheckGovernanceResponse', 'conditions'): 'CheckGovernanceCondition',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -876,6 +876,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "findings",
             "[]ReportPlanOutcomeFinding",
         )
+        self.assert_field_type(
+            "governance/check-governance-response.json",
+            "CheckGovernanceResponse",
+            "conditions",
+            "[]CheckGovernanceCondition",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1354,6 +1360,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("SyncPlansResponse", "plans"), records)
         self.assertNotIn(("CheckGovernanceResponse", "findings"), records)
         self.assertNotIn(("ReportPlanOutcomeResponse", "findings"), records)
+        self.assertNotIn(("CheckGovernanceResponse", "conditions"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -42,6 +42,12 @@ GO_SOURCE_FILES = [
     ADCP_DIR / 'seller.go',
 ]
 
+# Wire-visible JSON properties implemented by custom MarshalJSON/UnmarshalJSON
+# rather than direct struct tags.
+CUSTOM_WIRE_FIELDS = {
+    'CheckGovernanceCondition': {'required_value'},
+}
+
 # Types we deliberately do not diff against a named schema file:
 #   - oneOf union flatteners (Go can't express oneOf natively)
 #   - error/helper types that carry no schema
@@ -81,6 +87,7 @@ EXEMPT = {
     'SyncCreativeAssignment', 'DeliveryTotals', 'DeliveryData',
     'ReportingPeriod', 'PreviewResult', 'Preview',
     'PreviewRender', 'BuildCreativeResult', 'ProductsData',
+    'CheckGovernanceCondition',
     # collection response wrappers — responses with embedded payload
     'CreateCollectionListResponse', 'GetCollectionListResponse',
     'UpdateCollectionListResponse', 'DeleteCollectionListResponse',
@@ -602,6 +609,7 @@ def diff_type(type_name, go_fields, schema_spec):
     if not schema_props:
         return None
     go_tags = {tag for _, _, tag, _ in go_fields}
+    go_tags.update(CUSTOM_WIRE_FIELDS.get(type_name, set()))
     # A required field marked `omitempty` in Go is silently dropped from the
     # wire when the zero value is present — a distinct failure mode from
     # missing/extra fields, worth flagging separately so the fix is obvious.

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -9,6 +9,13 @@ ACCOUNT_SETUP_SCHEMA_PATHS_EXIST = all(
     (lint.SCRIPT_DIR / spec.split("#", 1)[0]).exists()
     for spec in ACCOUNT_SETUP_SCHEMA_SPECS
 )
+CHECK_GOVERNANCE_CONDITION_SCHEMA_SPECS = (
+    lint.gen.HAND_WRITTEN_INLINE_SCHEMA_SPECS["CheckGovernanceCondition"]
+)
+CHECK_GOVERNANCE_CONDITION_SCHEMA_PATHS_EXIST = all(
+    (lint.SCRIPT_DIR / spec.split("#", 1)[0]).exists()
+    for spec in CHECK_GOVERNANCE_CONDITION_SCHEMA_SPECS
+)
 
 
 class SharedInlineOverrideLintTest(unittest.TestCase):
@@ -48,6 +55,15 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
 
         self.assertEqual([], [r for r in reports if r["type"] == "AccountSetup"])
 
+    @unittest.skipUnless(
+        CHECK_GOVERNANCE_CONDITION_SCHEMA_PATHS_EXIST,
+        "check governance condition schema is not present",
+    )
+    def test_current_check_governance_condition_shape_is_drift_checked(self):
+        reports = lint.validate_hand_written_inline_schema_specs(lint.parse_go_structs())
+
+        self.assertEqual([], [r for r in reports if r["type"] == "CheckGovernanceCondition"])
+
     def test_hand_written_inline_schema_reports_required_omitempty(self):
         schema_spec = "missing/schema.json#/properties/setup"
         specs = {
@@ -73,6 +89,35 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
         self.assertEqual(1, len(reports))
         self.assertEqual("InlineShape", reports[0]["type"])
         self.assertEqual(["message"], reports[0]["required_with_omitempty"])
+
+    def test_custom_wire_fields_count_as_present_for_drift(self):
+        schema_spec = "missing/schema.json#/properties/condition"
+        specs = {
+            "InlineShape": [schema_spec],
+        }
+        schema = {
+            "properties": {
+                "field": {"type": "string"},
+                "required_value": {},
+                "reason": {"type": "string"},
+            },
+            "required": ["field", "reason"],
+        }
+
+        with (
+            mock.patch.object(lint.Path, "exists", return_value=True),
+            mock.patch.object(lint.gen, "HAND_WRITTEN_INLINE_SCHEMA_SPECS", specs),
+            mock.patch.object(lint, "CUSTOM_WIRE_FIELDS", {"InlineShape": {"required_value"}}),
+            mock.patch.object(lint, "load_schema_spec", return_value=schema),
+        ):
+            reports = lint.validate_hand_written_inline_schema_specs({
+                "InlineShape": [
+                    ("Field", "string", "field", False),
+                    ("Reason", "string", "reason", False),
+                ],
+            })
+
+        self.assertEqual([], reports)
 
 
 class OptionalNumericPointerLintTest(unittest.TestCase):

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -230,6 +230,67 @@ type GovernanceFeature struct {
 	MethodologyURL string        `json:"methodology_url,omitempty"`
 }
 
+// CheckGovernanceCondition is a typed condition item returned by
+// check_governance. RequiredValue is intentionally dynamic because a condition
+// can require any JSON literal or object. HasRequiredValue distinguishes an
+// absent advisory value from an explicit required_value, including JSON null.
+type CheckGovernanceCondition struct {
+	Field string `json:"field"`
+	// RequiredValue is emitted only when HasRequiredValue is true. Decode
+	// numeric JSON values as float64, following encoding/json's any behavior.
+	RequiredValue any `json:"-"`
+	// HasRequiredValue distinguishes absent required_value from explicit
+	// required_value, including JSON null. Set it true whenever RequiredValue
+	// should be present on the wire.
+	HasRequiredValue bool   `json:"-"`
+	Reason           string `json:"reason"`
+}
+
+type checkGovernanceConditionJSON struct {
+	Field         string           `json:"field"`
+	RequiredValue *json.RawMessage `json:"required_value,omitempty"`
+	Reason        string           `json:"reason"`
+}
+
+func (c CheckGovernanceCondition) MarshalJSON() ([]byte, error) {
+	var requiredValue *json.RawMessage
+	if c.HasRequiredValue {
+		rawBytes, err := json.Marshal(c.RequiredValue)
+		if err != nil {
+			return nil, err
+		}
+		raw := json.RawMessage(rawBytes)
+		requiredValue = &raw
+	}
+	return json.Marshal(checkGovernanceConditionJSON{
+		Field:         c.Field,
+		RequiredValue: requiredValue,
+		Reason:        c.Reason,
+	})
+}
+
+func (c *CheckGovernanceCondition) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var decoded checkGovernanceConditionJSON
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	c.Field = decoded.Field
+	c.Reason = decoded.Reason
+	c.RequiredValue = nil
+	c.HasRequiredValue = false
+	if requiredValue, ok := raw["required_value"]; ok {
+		c.HasRequiredValue = true
+		if err := json.Unmarshal(requiredValue, &c.RequiredValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type FeatureRange struct {
 	Min float64 `json:"min"`
 	Max float64 `json:"max"`

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -7928,7 +7928,7 @@ type CheckGovernanceResponse struct {
 	PlanID string `json:"plan_id"` // Echoed from request.
 	Explanation string `json:"explanation"` // Human-readable explanation of the governance decision.
 	Findings []CheckGovernanceFinding `json:"findings,omitempty"` // Specific issues found during the governance check. Present when status is 'denie
-	Conditions []any `json:"conditions,omitempty"` // Present when status is 'conditions'. Specific adjustments the caller must make.
+	Conditions []CheckGovernanceCondition `json:"conditions,omitempty"` // Present when status is 'conditions'. Specific adjustments the caller must make.
 	ExpiresAt string `json:"expires_at,omitempty"` // When this approval expires. Present when status is 'approved' or 'conditions'. T
 	NextCheck string `json:"next_check,omitempty"` // When the seller should next call check_governance with delivery metrics. Present
 	CategoriesEvaluated []string `json:"categories_evaluated,omitempty"` // Governance categories evaluated during this check.

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 17
+python3 generate.py --coverage-max-unreviewed-any 16
 ```
 
-The generator currently reports 185 generated dynamic `any` uses:
+The generator currently reports 184 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 168 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 17 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 16 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 17
+python3 generate.py --coverage-max-unreviewed-any 16
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -34,6 +34,12 @@ the new dynamic shape is reviewed in the same PR.
 - Governance finding details are intentional dynamic escape hatches:
   `CheckGovernanceFinding.Details` and `ReportPlanOutcomeFinding.Details` stay
   `map[string]any` because their structured payloads are category-specific.
+- `CheckGovernanceCondition.RequiredValue` stays `any` because a governance
+  condition can require different JSON value types. The type is hand-written so
+  `HasRequiredValue` preserves the difference between an absent advisory value
+  and an explicit `required_value`, including JSON `null`. Callers must set
+  `HasRequiredValue` when constructing any present `required_value`; decoded
+  numeric values follow `encoding/json` and become `float64`.
 - Inline object fallbacks are generator limitations unless the schema explicitly
   models open-ended data.
 - Top-level `oneOf` aliases are generator limitations. They need generated
@@ -61,7 +67,6 @@ the new dynamic shape is reviewed in the same PR.
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ControllerError.CurrentState` | `current_state` | `any` | `unspecified_schema_type` | `compliance/comply-test-controller-response.json#/oneOf/5` |
-| `CheckGovernanceResponse.Conditions` | `conditions` | `[]any` | `array_item:inline_object` | `governance/check-governance-response.json` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
@@ -70,17 +75,16 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 10 unreviewed fallbacks are direct inline
+This is the largest generator gap: 9 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
 objects that have stable, schema-owned property sets. The next broad class is
-closed array-item schemas such as `CheckGovernanceResponse.Conditions` and
-`GetPlanAuditLogsResponse.Plans`. Keep genuinely open/controller payloads
-separate from schema-closed array items so the generator backlog does not turn
-typed object work into protocol-design work.
+closed array-item schemas such as `GetPlanAuditLogsResponse.Plans`. Keep
+genuinely open/controller payloads separate from schema-closed array items so
+the generator backlog does not turn typed object work into protocol-design work.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Type `CheckGovernanceResponse.Conditions` as `[]CheckGovernanceCondition` instead of `[]any`.
- Add a hand-written `CheckGovernanceCondition` that keeps `required_value` dynamic while preserving presence, including explicit JSON `null`.
- Keep the generator/linter honest with a typed inline hint, drift checking for the hand-written inline schema, and a lower generated-any CI baseline.

## Impact

This is a breaking Go SDK type change for callers that read or write `CheckGovernanceResponse.Conditions`. Callers now get structured condition items. `RequiredValue` remains `any` because the schema allows arbitrary JSON values; callers must inspect or set `HasRequiredValue` to distinguish absent advisory values from explicit `required_value` values.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 16`
- `cd adcp/schemas && tmp=$(mktemp); python3 generate.py > "$tmp"; diff -u ../types_gen.go "$tmp"; rm "$tmp"`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert Review

- DX review requested clearer write-side docs for `HasRequiredValue`; folded into GoDoc, `MIGRATING.md`, baseline docs, and tests.
- Code review requested preserving drift checks for the hand-written inline shape; folded in via `HAND_WRITTEN_INLINE_SCHEMA_SPECS` and custom wire-field lint support.
