### PR TITLE
feat(adcp)!: type plan audit logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 16
+        run: python3 generate.py --coverage-max-unreviewed-any 15
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -99,6 +99,15 @@ be populated.
   set `HasRequiredValue: true` whenever `required_value` should be present on
   the wire. To send `required_value: null`, set `HasRequiredValue: true` and
   leave `RequiredValue` nil.
+- `GetPlanAuditLogsResponse.Plans` is now `[]adcp.PlanAuditLog` instead of
+  `[]any`. Nested audit-log shapes are also typed, including
+  `PlanAuditBudget`, `PlanAuditSummary`, `PlanAuditEntry`,
+  `PlanAuditFinding`, and `PlanAuditGovernedAction`. Optional numeric counters
+  and metrics across the audit log use pointers so absent values are not
+  re-emitted as zero. Use `adcp.Ptr(0)` for explicit zero integer counters
+  such as `ChecksPerformed` and `Statuses.Approved`, and `adcp.Ptr(0.0)` or
+  `adcp.Float64(0)` for explicit zero float metrics such as `Budget.Authorized`
+  and `PlanAuditEntry.CommittedBudget`.
 - Optional numeric fields where explicit zero is meaningful are now pointers:
   `PricingOption.FixedPrice`, `AudienceSelector.MinValue`,
   `AudienceSelector.MaxValue`, `ForecastPoint.Budget`,
@@ -171,6 +180,7 @@ be populated.
 | `CheckGovernanceResponse.Findings` | `[]adcp.CheckGovernanceFinding` |
 | `ReportPlanOutcomeResponse.Findings` | `[]adcp.ReportPlanOutcomeFinding` |
 | `CheckGovernanceResponse.Conditions` | `[]adcp.CheckGovernanceCondition` |
+| `GetPlanAuditLogsResponse.Plans` | `[]adcp.PlanAuditLog` |
 | `Targeting.FrequencyCap` | `*adcp.FrequencyCap` |
 | `Targeting.DaypartTargets` | `[]adcp.DaypartTarget` |
 | `Catalog.FeedFieldMappings` | `[]adcp.CatalogFieldMapping` |

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -318,6 +318,81 @@ func TestGeneratedCoreRefsAcrossSurfacesMarshalTypedFields(t *testing.T) {
 			},
 		},
 		{
+			name: "plan audit logs",
+			value: GetPlanAuditLogsResponse{
+				Plans: []PlanAuditLog{{
+					PlanID:      "plan-1",
+					PlanVersion: 2,
+					Status:      "active",
+					Budget: PlanAuditBudget{
+						Authorized:     Ptr(10000.0),
+						Committed:      Ptr(2500.0),
+						Remaining:      Ptr(7500.0),
+						UtilizationPct: Ptr(25.0),
+					},
+					ChannelAllocation: map[string]PlanAuditChannelAllocation{
+						"ctv": {Committed: Ptr(1500.0), Pct: Ptr(60.0)},
+					},
+					Summary: PlanAuditSummary{
+						ChecksPerformed:  Ptr(3),
+						OutcomesReported: Ptr(1),
+						Statuses: &PlanAuditStatusCounts{
+							Approved:   Ptr(2),
+							Conditions: Ptr(1),
+						},
+						FindingsCount: Ptr(1),
+						Escalations: []PlanAuditEscalation{{
+							CheckID:    "check-2",
+							Reason:     "budget threshold",
+							Resolution: "approved_by_human",
+							ResolvedAt: "2026-05-28T12:00:00Z",
+						}},
+						DriftMetrics: &PlanAuditDriftMetrics{
+							EscalationRate:      Ptr(0.33),
+							EscalationRateTrend: "stable",
+							AutoApprovalRate:    Ptr(0.67),
+							Thresholds: &PlanAuditDriftThresholds{
+								EscalationRateMax: Ptr(0.5),
+							},
+						},
+					},
+					Entries: []PlanAuditEntry{{
+						ID:           "entry-1",
+						Type:         "check",
+						Timestamp:    "2026-05-28T11:00:00Z",
+						Tool:         "check_governance",
+						Status:       Ptr(GovernanceDecisionApproved),
+						Mode:         Ptr(GovernanceModeAudit),
+						PurchaseType: Ptr(PurchaseTypeMediaBuy),
+						Findings: []PlanAuditFinding{{
+							CategoryID:  "budget_compliance",
+							PolicyID:    "policy-1",
+							Severity:    EscalationSeverityWarning,
+							Explanation: "Near budget limit.",
+							Confidence:  Ptr(0.75),
+						}},
+					}},
+					GovernedActions: []PlanAuditGovernedAction{{
+						GovernanceContext: "ctx-1",
+						PurchaseType:      PurchaseTypeMediaBuy,
+						Status:            "active",
+						Committed:         2500,
+						CheckCount:        3,
+						SellerReference:   "mb-1",
+					}},
+				}},
+			},
+			want: []string{
+				`"plans":[{"plan_id":"plan-1","plan_version":2,"status":"active","budget":{"authorized":10000,"committed":2500,"remaining":7500,"utilization_pct":25}`,
+				`"channel_allocation":{"ctv":{"committed":1500,"pct":60}}`,
+				`"summary":{"checks_performed":3,"outcomes_reported":1,"statuses":{"approved":2,"conditions":1},"findings_count":1`,
+				`"escalations":[{"check_id":"check-2","reason":"budget threshold","resolution":"approved_by_human","resolved_at":"2026-05-28T12:00:00Z"}]`,
+				`"drift_metrics":{"escalation_rate":0.33,"escalation_rate_trend":"stable","auto_approval_rate":0.67,"thresholds":{"escalation_rate_max":0.5}}`,
+				`"entries":[{"id":"entry-1","type":"check","timestamp":"2026-05-28T11:00:00Z","tool":"check_governance","status":"approved","mode":"audit","findings":[{"category_id":"budget_compliance","policy_id":"policy-1","severity":"warning","explanation":"Near budget limit.","confidence":0.75}],"purchase_type":"media_buy"}]`,
+				`"governed_actions":[{"governance_context":"ctx-1","purchase_type":"media_buy","status":"active","committed":2500,"check_count":3,"seller_reference":"mb-1"}]`,
+			},
+		},
+		{
 			name: "report plan outcome findings",
 			value: ReportPlanOutcomeResponse{
 				OutcomeID: "outcome-1",
@@ -718,6 +793,51 @@ func TestCheckGovernanceConditionsRoundTrip(t *testing.T) {
 	}
 	if strings.Contains(string(raw), `"required_value"`) {
 		t.Fatalf("condition without presence bit unexpectedly marshaled required_value:\n%s", raw)
+	}
+}
+
+func TestPlanAuditLogsRoundTrip(t *testing.T) {
+	raw := []byte(`{"plans":[{"plan_id":"plan-1","plan_version":1,"status":"active","budget":{"authorized":0},"summary":{"checks_performed":0},"governed_actions":[{"governance_context":"ctx-1","purchase_type":"media_buy","status":"active","committed":0,"check_count":0}],"entries":[{"id":"entry-1","type":"outcome","timestamp":"2026-05-28T11:00:00Z","outcome":"completed","committed_budget":0}]}]}`)
+
+	var decoded GetPlanAuditLogsResponse
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal plan audit logs: %v", err)
+	}
+	if len(decoded.Plans) != 1 {
+		t.Fatalf("plans len = %d, want 1", len(decoded.Plans))
+	}
+	plan := decoded.Plans[0]
+	if plan.Budget.Authorized == nil || *plan.Budget.Authorized != 0 {
+		t.Fatalf("budget.authorized = %#v, want explicit 0", plan.Budget.Authorized)
+	}
+	if plan.Budget.Committed != nil {
+		t.Fatalf("budget.committed = %#v, want absent", plan.Budget.Committed)
+	}
+	if plan.Summary.ChecksPerformed == nil || *plan.Summary.ChecksPerformed != 0 {
+		t.Fatalf("summary.checks_performed = %#v, want explicit 0", plan.Summary.ChecksPerformed)
+	}
+	if len(plan.Entries) != 1 || plan.Entries[0].CommittedBudget == nil || *plan.Entries[0].CommittedBudget != 0 {
+		t.Fatalf("entry committed_budget did not preserve explicit zero: %#v", plan.Entries)
+	}
+
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("marshal plan audit logs: %v", err)
+	}
+	body := string(encoded)
+	for _, want := range []string{
+		`"authorized":0`,
+		`"checks_performed":0`,
+		`"committed_budget":0`,
+		`"committed":0`,
+		`"check_count":0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("plan audit logs missing %s:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, `"committed":null`) {
+		t.Fatalf("plan audit logs unexpectedly marshaled absent budget.committed:\n%s", body)
 	}
 }
 

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -498,6 +498,60 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/report-plan-outcome-response.json#/properties/findings/items",
     ),
     (
+        "PlanAuditLog",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items",
+    ),
+    (
+        "PlanAuditBudget",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/budget",
+    ),
+    (
+        "PlanAuditChannelAllocation",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/channel_allocation/additionalProperties",
+    ),
+    (
+        "PlanAuditSummary",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/summary",
+    ),
+    (
+        "PlanAuditStatusCounts",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/summary/properties/statuses",
+    ),
+    (
+        "PlanAuditEscalation",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/summary/properties/escalations/items",
+    ),
+    (
+        "PlanAuditDriftMetrics",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/summary/properties/drift_metrics",
+    ),
+    (
+        "PlanAuditDriftThresholds",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/summary/properties/drift_metrics/properties/thresholds",
+    ),
+    (
+        "PlanAuditEntry",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/entries/items",
+    ),
+    (
+        "PlanAuditFinding",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/entries/items/properties/findings/items",
+    ),
+    (
+        "PlanAuditGovernedAction",
+        "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+        "/properties/governed_actions/items",
+    ),
+    (
         "CreativeAgentRef",
         "media-buy/list-creative-formats-response.json#/properties/creative_agents/items",
     ),
@@ -1055,6 +1109,46 @@ INLINE_TYPE_HINTS = {
     ('ReportPlanOutcomeResponse', 'findings'): 'ReportPlanOutcomeFinding',
     ('ReportPlanOutcomeFinding', 'severity'): 'EscalationSeverity',
     ('CheckGovernanceResponse', 'conditions'): 'CheckGovernanceCondition',
+    ('GetPlanAuditLogsResponse', 'plans'): 'PlanAuditLog',
+    ('PlanAuditLog', 'budget'): 'PlanAuditBudget',
+    ('PlanAuditLog', 'channel_allocation'): 'map[string]PlanAuditChannelAllocation',
+    ('PlanAuditLog', 'summary'): 'PlanAuditSummary',
+    ('PlanAuditLog', 'entries'): 'PlanAuditEntry',
+    ('PlanAuditLog', 'governed_actions'): 'PlanAuditGovernedAction',
+    ('PlanAuditBudget', 'authorized'): '*float64',
+    ('PlanAuditBudget', 'committed'): '*float64',
+    ('PlanAuditBudget', 'remaining'): '*float64',
+    ('PlanAuditBudget', 'utilization_pct'): '*float64',
+    ('PlanAuditChannelAllocation', 'committed'): '*float64',
+    ('PlanAuditChannelAllocation', 'pct'): '*float64',
+    ('PlanAuditSummary', 'checks_performed'): '*int',
+    ('PlanAuditSummary', 'outcomes_reported'): '*int',
+    ('PlanAuditSummary', 'statuses'): '*PlanAuditStatusCounts',
+    ('PlanAuditSummary', 'findings_count'): '*int',
+    ('PlanAuditSummary', 'escalations'): 'PlanAuditEscalation',
+    ('PlanAuditSummary', 'drift_metrics'): '*PlanAuditDriftMetrics',
+    ('PlanAuditStatusCounts', 'approved'): '*int',
+    ('PlanAuditStatusCounts', 'denied'): '*int',
+    ('PlanAuditStatusCounts', 'conditions'): '*int',
+    ('PlanAuditStatusCounts', 'human_reviewed'): '*int',
+    ('PlanAuditDriftMetrics', 'escalation_rate'): '*float64',
+    ('PlanAuditDriftMetrics', 'auto_approval_rate'): '*float64',
+    ('PlanAuditDriftMetrics', 'human_override_rate'): '*float64',
+    ('PlanAuditDriftMetrics', 'mean_confidence'): '*float64',
+    ('PlanAuditDriftMetrics', 'thresholds'): '*PlanAuditDriftThresholds',
+    ('PlanAuditDriftThresholds', 'escalation_rate_max'): '*float64',
+    ('PlanAuditDriftThresholds', 'escalation_rate_min'): '*float64',
+    ('PlanAuditDriftThresholds', 'auto_approval_rate_max'): '*float64',
+    ('PlanAuditDriftThresholds', 'human_override_rate_max'): '*float64',
+    ('PlanAuditEntry', 'status'): 'GovernanceDecision',
+    ('PlanAuditEntry', 'mode'): 'GovernanceMode',
+    ('PlanAuditEntry', 'findings'): 'PlanAuditFinding',
+    ('PlanAuditEntry', 'outcome'): 'OutcomeType',
+    ('PlanAuditEntry', 'committed_budget'): '*float64',
+    ('PlanAuditEntry', 'purchase_type'): 'PurchaseType',
+    ('PlanAuditFinding', 'severity'): 'EscalationSeverity',
+    ('PlanAuditFinding', 'confidence'): '*float64',
+    ('PlanAuditGovernedAction', 'purchase_type'): 'PurchaseType',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -882,6 +882,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "conditions",
             "[]CheckGovernanceCondition",
         )
+        self.assert_field_type(
+            "governance/get-plan-audit-logs-response.json",
+            "GetPlanAuditLogsResponse",
+            "plans",
+            "[]PlanAuditLog",
+        )
 
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
@@ -1329,6 +1335,91 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Explanation string `json:\"explanation\"`", outcome_finding_generated)
         self.assertIn("Details map[string]any `json:\"details,omitempty\"`", outcome_finding_generated)
 
+        plan_audit_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items",
+        )
+        plan_audit_generated = generate.schema_to_struct(
+            "PlanAuditLog",
+            plan_audit_schema,
+        )
+        self.assertIn("PlanID string `json:\"plan_id\"`", plan_audit_generated)
+        self.assertIn("PlanVersion int `json:\"plan_version\"`", plan_audit_generated)
+        self.assertIn("Budget PlanAuditBudget `json:\"budget\"`", plan_audit_generated)
+        self.assertIn(
+            "ChannelAllocation map[string]PlanAuditChannelAllocation `json:\"channel_allocation,omitempty\"`",
+            plan_audit_generated,
+        )
+        self.assertIn("Summary PlanAuditSummary `json:\"summary\"`", plan_audit_generated)
+        self.assertIn(
+            "Entries []PlanAuditEntry `json:\"entries,omitempty\"`",
+            plan_audit_generated,
+        )
+        self.assertIn(
+            "GovernedActions []PlanAuditGovernedAction `json:\"governed_actions\"`",
+            plan_audit_generated,
+        )
+
+        plan_audit_budget_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+            "/properties/budget",
+        )
+        plan_audit_budget_generated = generate.schema_to_struct(
+            "PlanAuditBudget",
+            plan_audit_budget_schema,
+        )
+        self.assertIn("Authorized *float64 `json:\"authorized,omitempty\"`", plan_audit_budget_generated)
+        self.assertIn("Committed *float64 `json:\"committed,omitempty\"`", plan_audit_budget_generated)
+
+        plan_audit_summary_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+            "/properties/summary",
+        )
+        plan_audit_summary_generated = generate.schema_to_struct(
+            "PlanAuditSummary",
+            plan_audit_summary_schema,
+        )
+        self.assertIn("ChecksPerformed *int `json:\"checks_performed,omitempty\"`", plan_audit_summary_generated)
+        self.assertIn("Statuses *PlanAuditStatusCounts `json:\"statuses,omitempty\"`", plan_audit_summary_generated)
+        self.assertIn("Escalations []PlanAuditEscalation `json:\"escalations,omitempty\"`", plan_audit_summary_generated)
+        self.assertIn("DriftMetrics *PlanAuditDriftMetrics `json:\"drift_metrics,omitempty\"`", plan_audit_summary_generated)
+
+        plan_audit_entry_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+            "/properties/entries/items",
+        )
+        plan_audit_entry_generated = generate.schema_to_struct(
+            "PlanAuditEntry",
+            plan_audit_entry_schema,
+        )
+        self.assertIn("Status *GovernanceDecision `json:\"status,omitempty\"`", plan_audit_entry_generated)
+        self.assertIn("Mode *GovernanceMode `json:\"mode,omitempty\"`", plan_audit_entry_generated)
+        self.assertIn("Findings []PlanAuditFinding `json:\"findings,omitempty\"`", plan_audit_entry_generated)
+        self.assertIn("Outcome *OutcomeType `json:\"outcome,omitempty\"`", plan_audit_entry_generated)
+        self.assertIn("CommittedBudget *float64 `json:\"committed_budget,omitempty\"`", plan_audit_entry_generated)
+        self.assertIn("PurchaseType *PurchaseType `json:\"purchase_type,omitempty\"`", plan_audit_entry_generated)
+
+        plan_audit_finding_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+            "/properties/entries/items/properties/findings/items",
+        )
+        plan_audit_finding_generated = generate.schema_to_struct(
+            "PlanAuditFinding",
+            plan_audit_finding_schema,
+        )
+        self.assertIn("Severity EscalationSeverity `json:\"severity\"`", plan_audit_finding_generated)
+        self.assertIn("Confidence *float64 `json:\"confidence,omitempty\"`", plan_audit_finding_generated)
+
+        plan_audit_action_schema = generate.load_schema_spec(
+            "governance/get-plan-audit-logs-response.json#/properties/plans/items"
+            "/properties/governed_actions/items",
+        )
+        plan_audit_action_generated = generate.schema_to_struct(
+            "PlanAuditGovernedAction",
+            plan_audit_action_schema,
+        )
+        self.assertIn("PurchaseType PurchaseType `json:\"purchase_type\"`", plan_audit_action_generated)
+        self.assertIn("Committed float64 `json:\"committed\"`", plan_audit_action_generated)
+
     def test_typed_inline_objects_leave_unreviewed_any_coverage(self):
         records = [
             (record["type"], record["json"])
@@ -1361,6 +1452,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("CheckGovernanceResponse", "findings"), records)
         self.assertNotIn(("ReportPlanOutcomeResponse", "findings"), records)
         self.assertNotIn(("CheckGovernanceResponse", "conditions"), records)
+        self.assertNotIn(("GetPlanAuditLogsResponse", "plans"), records)
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -6657,6 +6657,112 @@ type ReportPlanOutcomeFinding struct {
 	Details map[string]any `json:"details,omitempty"` // Structured details for programmatic consumption.
 }
 
+type PlanAuditLog struct {
+	PlanID string `json:"plan_id"` // Plan identifier.
+	PlanVersion int `json:"plan_version"` // Current plan version.
+	Status string `json:"status"` // Plan lifecycle status.
+	Budget PlanAuditBudget `json:"budget"` // Budget state.
+	ChannelAllocation map[string]PlanAuditChannelAllocation `json:"channel_allocation,omitempty"` // Current channel mix. Keyed by channel ID.
+	Summary PlanAuditSummary `json:"summary"` // Aggregate validation and outcome statistics.
+	Entries []PlanAuditEntry `json:"entries,omitempty"` // Ordered audit trail. Only present when include_entries is true.
+	GovernedActions []PlanAuditGovernedAction `json:"governed_actions"` // Per-action breakdown grouped by governance context.
+}
+
+// PlanAuditBudget — Budget state.
+type PlanAuditBudget struct {
+	Authorized *float64 `json:"authorized,omitempty"` // Total authorized budget from the plan.
+	Committed *float64 `json:"committed,omitempty"` // Total budget committed from confirmed outcomes.
+	Remaining *float64 `json:"remaining,omitempty"` // Authorized minus committed.
+	UtilizationPct *float64 `json:"utilization_pct,omitempty"` // Committed as a percentage of authorized.
+}
+
+type PlanAuditChannelAllocation struct {
+	Committed *float64 `json:"committed,omitempty"` // Budget committed to this channel.
+	Pct *float64 `json:"pct,omitempty"` // Channel's share of the authorized total budget.
+}
+
+// PlanAuditSummary — Aggregate validation and outcome statistics.
+type PlanAuditSummary struct {
+	ChecksPerformed *int `json:"checks_performed,omitempty"` // Total governance checks performed.
+	OutcomesReported *int `json:"outcomes_reported,omitempty"` // Total outcomes reported.
+	Statuses *PlanAuditStatusCounts `json:"statuses,omitempty"` // Count of each governance check status.
+	FindingsCount *int `json:"findings_count,omitempty"` // Total findings across all checks and outcomes.
+	Escalations []PlanAuditEscalation `json:"escalations,omitempty"` // All escalations and their resolutions.
+	DriftMetrics *PlanAuditDriftMetrics `json:"drift_metrics,omitempty"` // Aggregate governance metrics for detecting oversight drift. A declining escalati
+}
+
+// PlanAuditStatusCounts — Count of each governance check status.
+type PlanAuditStatusCounts struct {
+	Approved *int `json:"approved,omitempty"`
+	Denied *int `json:"denied,omitempty"`
+	Conditions *int `json:"conditions,omitempty"`
+	HumanReviewed *int `json:"human_reviewed,omitempty"` // Supplementary count of checks that went through internal human review. These che
+}
+
+type PlanAuditEscalation struct {
+	CheckID string `json:"check_id"` // The escalated governance check.
+	Reason string `json:"reason"` // Why it was escalated.
+	Resolution string `json:"resolution,omitempty"` // How it was resolved (e.g., 'approved_by_human', 'rejected_by_human').
+	ResolvedAt string `json:"resolved_at,omitempty"` // ISO 8601 resolution timestamp.
+}
+
+// PlanAuditDriftMetrics — Aggregate governance metrics for detecting oversight drift. A declining escalation rate may indicate
+type PlanAuditDriftMetrics struct {
+	EscalationRate *float64 `json:"escalation_rate,omitempty"` // Fraction of checks that resulted in escalation.
+	EscalationRateTrend string `json:"escalation_rate_trend,omitempty"` // Direction of escalation rate over the plan's lifetime.
+	AutoApprovalRate *float64 `json:"auto_approval_rate,omitempty"` // Fraction of checks approved without human intervention.
+	HumanOverrideRate *float64 `json:"human_override_rate,omitempty"` // Fraction of escalations where the human overrode the governance agent's recommen
+	MeanConfidence *float64 `json:"mean_confidence,omitempty"` // Average confidence score across all findings. Present when findings include conf
+	Thresholds *PlanAuditDriftThresholds `json:"thresholds,omitempty"` // Organization-defined thresholds for drift metrics. When a metric crosses its thr
+}
+
+// PlanAuditDriftThresholds — Organization-defined thresholds for drift metrics. When a metric crosses its threshold, the governan
+type PlanAuditDriftThresholds struct {
+	EscalationRateMax *float64 `json:"escalation_rate_max,omitempty"` // Maximum acceptable escalation rate. A rate above this suggests policy miscalibra
+	EscalationRateMin *float64 `json:"escalation_rate_min,omitempty"` // Minimum acceptable escalation rate. A rate below this may indicate eroding overs
+	AutoApprovalRateMax *float64 `json:"auto_approval_rate_max,omitempty"` // Maximum acceptable auto-approval rate.
+	HumanOverrideRateMax *float64 `json:"human_override_rate_max,omitempty"` // Maximum acceptable human override rate. A high rate suggests the governance agen
+}
+
+type PlanAuditEntry struct {
+	ID string `json:"id"` // Entry identifier.
+	Type string `json:"type"` // Entry type.
+	Timestamp string `json:"timestamp"` // ISO 8601 timestamp.
+	PlanID string `json:"plan_id,omitempty"` // Plan this entry belongs to. Present when querying multiple plans or a portfolio.
+	Caller string `json:"caller,omitempty"` // URL of the agent that made the request. Resolved from the credentials used on th
+	Tool string `json:"tool,omitempty"` // The AdCP tool (present for check entries).
+	Status *GovernanceDecision `json:"status,omitempty"` // Governance check status (present for check entries).
+	CheckType string `json:"check_type,omitempty"` // Whether the check was an intent check (orchestrator) or execution check (seller)
+	Mode *GovernanceMode `json:"mode,omitempty"` // Governance mode active at the moment this specific check was evaluated. Governan
+	Explanation string `json:"explanation,omitempty"` // Human-readable explanation of the governance decision (present for check entries
+	PoliciesEvaluated []string `json:"policies_evaluated,omitempty"` // Policy IDs evaluated during this check. Includes registry policy IDs (resolved v
+	CategoriesEvaluated []string `json:"categories_evaluated,omitempty"` // Governance categories evaluated (e.g., 'budget_authority', 'regulatory_complianc
+	Findings []PlanAuditFinding `json:"findings,omitempty"` // Findings from this check or outcome. Same structure as check_governance response
+	Outcome *OutcomeType `json:"outcome,omitempty"` // Outcome type (present for outcome entries).
+	CommittedBudget *float64 `json:"committed_budget,omitempty"` // Budget committed (present for completed outcome entries).
+	GovernanceContext string `json:"governance_context,omitempty"` // Governance context for this entry (present for check and outcome entries).
+	PlanHash string `json:"plan_hash,omitempty"` // Audit-layer binding to the plan revision this attestation was evaluated over — b
+	PurchaseType *PurchaseType `json:"purchase_type,omitempty"` // Purchase type for this entry.
+	OutcomeStatus string `json:"outcome_status,omitempty"` // Outcome status (present for outcome entries).
+}
+
+type PlanAuditFinding struct {
+	CategoryID string `json:"category_id"`
+	PolicyID string `json:"policy_id,omitempty"`
+	Severity EscalationSeverity `json:"severity"`
+	Explanation string `json:"explanation"`
+	Confidence *float64 `json:"confidence,omitempty"`
+}
+
+type PlanAuditGovernedAction struct {
+	GovernanceContext string `json:"governance_context"` // Governance context correlating this action's lifecycle.
+	PurchaseType PurchaseType `json:"purchase_type"` // Type of financial commitment.
+	Status string `json:"status"` // Action status.
+	Committed float64 `json:"committed"` // Budget committed for this action.
+	CheckCount int `json:"check_count"` // Number of governance checks performed for this action.
+	SellerReference string `json:"seller_reference,omitempty"` // The seller's identifier for the resource (e.g., media_buy_id, rights_grant_id).
+}
+
 type CreativeAgentRef struct {
 	AgentURL string `json:"agent_url"` // Base URL for the creative agent (e.g., 'https://reference.adcp.org', 'https://dc
 	AgentName string `json:"agent_name,omitempty"` // Human-readable name for the creative agent
@@ -7981,7 +8087,7 @@ type GetPlanAuditLogsRequest struct {
 
 // GetPlanAuditLogsResponse — Governance state and audit trail for one or more plans.
 type GetPlanAuditLogsResponse struct {
-	Plans []any `json:"plans"` // Audit data for each requested plan.
+	Plans []PlanAuditLog `json:"plans"` // Audit data for each requested plan.
 	Context any `json:"context,omitempty"`
 	Ext any `json:"ext,omitempty"`
 }

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 16
+python3 generate.py --coverage-max-unreviewed-any 15
 ```
 
-The generator currently reports 184 generated dynamic `any` uses:
+The generator currently reports 183 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 168 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 16 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 15 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 16
+python3 generate.py --coverage-max-unreviewed-any 15
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -68,23 +68,22 @@ the new dynamic shape is reviewed in the same PR.
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ControllerError.CurrentState` | `current_state` | `any` | `unspecified_schema_type` | `compliance/comply-test-controller-response.json#/oneOf/5` |
 | `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
-| `GetPlanAuditLogsResponse.Plans` | `plans` | `[]any` | `array_item:inline_object` | `governance/get-plan-audit-logs-response.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
 
 ### Inline Object Generation
 
-This is the largest generator gap: 9 unreviewed fallbacks are direct inline
+This is the largest generator gap: 8 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
 The first reduction passes typed low-risk leaf objects. Continue with inline
-objects that have stable, schema-owned property sets. The next broad class is
-closed array-item schemas such as `GetPlanAuditLogsResponse.Plans`. Keep
-genuinely open/controller payloads separate from schema-closed array items so
-the generator backlog does not turn typed object work into protocol-design work.
+objects that have stable, schema-owned property sets. The remaining inline
+object fallbacks mix genuinely open/controller payloads, inline unions, and
+schema-closed artifacts; keep those classes separate so the generator backlog
+does not turn typed object work into protocol-design work.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary

- Type `GetPlanAuditLogsResponse.Plans` as `[]PlanAuditLog` instead of `[]any`.
- Register the nested schema-owned audit log shapes, including budget, channel allocation, summary/status counts, escalations, drift metrics, entries, findings, and governed actions.
- Preserve explicit-zero semantics for optional audit counters and metrics with pointer fields.
- Lower the generated-any CI baseline from 16 to 15.

## Impact

This is a breaking Go SDK type change for callers that read or write `GetPlanAuditLogsResponse.Plans`. Callers now get typed audit log data instead of decoding through `[]any` and `map[string]any`.

Optional numeric values across audit logs use pointers where omission and explicit zero are distinct. For example, use `adcp.Ptr(0)` for integer counters such as `ChecksPerformed`, and `adcp.Ptr(0.0)` or `adcp.Float64(0)` for float metrics such as `Budget.Authorized` or `PlanAuditEntry.CommittedBudget`.

## Validation

- `cd adcp/schemas && python3 -m unittest generate_test.py lint_test.py`
- `cd adcp/schemas && python3 lint.py --strict`
- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 15`
- `cd adcp/schemas && tmp=$(mktemp); python3 generate.py > "$tmp"; diff -u ../types_gen.go "$tmp"; rm "$tmp"`
- `go test ./...`
- `cd adcp && go test .`
- `cd reference/seller-agent && go test ./...`
- `cd cmd/router && go test ./...`
- `cd targeting/prommetrics && go test ./...`
- `cd reference/context-agent && go test ./...`
- `cd e2e && go test ./...`
- `git diff --check`

## Expert Review

- Code review found no blockers.
- DX review asked for broader pointer guidance in `MIGRATING.md`; folded in before commit.
