### PR TITLE
test(adcp): harden plan audit Budget.Committed explicit-zero round-trip

### DIFF
--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -841,12 +841,13 @@ func TestPlanAuditLogsRoundTrip(t *testing.T) {
 	}
 
 	// Contrast: budget.committed explicitly zero must round-trip as "committed":0 inside
-	// the "budget" object, not be omitted. Distinct from PlanAuditGovernedAction.Committed
-	// (a non-pointer float64) whose presence in the output is unrelated.
-	raw2 := []byte(`{"plans":[{"plan_id":"plan-2","plan_version":1,"status":"active","budget":{"authorized":5000,"committed":0},"summary":{}}]}`)
+	// the "budget" object, not be omitted. The governed_actions entry also has "committed":0
+	// (a non-pointer float64) — the scoped assertion on the "budget" object confirms we are
+	// checking PlanAuditBudget.Committed (*float64), not PlanAuditGovernedAction.Committed.
+	raw2 := []byte(`{"plans":[{"plan_id":"plan-2","plan_version":1,"status":"active","budget":{"authorized":5000,"committed":0},"summary":{},"governed_actions":[{"governance_context":"ctx-1","purchase_type":"media_buy","status":"active","committed":0,"check_count":0}]}]}`)
 	var decoded2 GetPlanAuditLogsResponse
-	if err := json.Unmarshal(raw2, &decoded2); err != nil {
-		t.Fatalf("unmarshal plan audit logs with explicit committed zero: %v", err)
+	if err2 := json.Unmarshal(raw2, &decoded2); err2 != nil {
+		t.Fatalf("unmarshal plan audit logs with explicit committed zero: %v", err2)
 	}
 	if len(decoded2.Plans) != 1 {
 		t.Fatalf("plans len = %d, want 1", len(decoded2.Plans))
@@ -855,12 +856,13 @@ func TestPlanAuditLogsRoundTrip(t *testing.T) {
 	if plan2.Budget.Committed == nil || *plan2.Budget.Committed != 0 {
 		t.Fatalf("budget.committed = %#v, want explicit pointer to 0", plan2.Budget.Committed)
 	}
-	encoded2, err := json.Marshal(decoded2)
-	if err != nil {
-		t.Fatalf("marshal plan audit logs with explicit committed zero: %v", err)
+	encoded2, err2 := json.Marshal(decoded2)
+	if err2 != nil {
+		t.Fatalf("marshal plan audit logs with explicit committed zero: %v", err2)
 	}
 	if !strings.Contains(string(encoded2), `"budget":{"authorized":5000,"committed":0}`) {
-		t.Fatalf("explicit Budget.Committed:0 did not round-trip inside budget object (check Budget.Committed is *float64 with omitempty):\n%s", encoded2)
+		t.Fatalf("explicit Budget.Committed:0 did not round-trip inside budget object"+
+			" (Budget.Committed is *float64; nil pointer is omitted, pointer-to-zero is emitted even with omitempty):\n%s", encoded2)
 	}
 }
 

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -839,6 +839,29 @@ func TestPlanAuditLogsRoundTrip(t *testing.T) {
 	if strings.Contains(body, `"committed":null`) {
 		t.Fatalf("plan audit logs unexpectedly marshaled absent budget.committed:\n%s", body)
 	}
+
+	// Contrast: budget.committed explicitly zero must round-trip as "committed":0 inside
+	// the "budget" object, not be omitted. Distinct from PlanAuditGovernedAction.Committed
+	// (a non-pointer float64) whose presence in the output is unrelated.
+	raw2 := []byte(`{"plans":[{"plan_id":"plan-2","plan_version":1,"status":"active","budget":{"authorized":5000,"committed":0},"summary":{}}]}`)
+	var decoded2 GetPlanAuditLogsResponse
+	if err := json.Unmarshal(raw2, &decoded2); err != nil {
+		t.Fatalf("unmarshal plan audit logs with explicit committed zero: %v", err)
+	}
+	if len(decoded2.Plans) != 1 {
+		t.Fatalf("plans len = %d, want 1", len(decoded2.Plans))
+	}
+	plan2 := decoded2.Plans[0]
+	if plan2.Budget.Committed == nil || *plan2.Budget.Committed != 0 {
+		t.Fatalf("budget.committed = %#v, want explicit pointer to 0", plan2.Budget.Committed)
+	}
+	encoded2, err := json.Marshal(decoded2)
+	if err != nil {
+		t.Fatalf("marshal plan audit logs with explicit committed zero: %v", err)
+	}
+	if !strings.Contains(string(encoded2), `"budget":{"authorized":5000,"committed":0}`) {
+		t.Fatalf("explicit Budget.Committed:0 did not round-trip inside budget object (check Budget.Committed is *float64 with omitempty):\n%s", encoded2)
+	}
 }
 
 func TestGovernanceFindingsRoundTrip(t *testing.T) {


### PR DESCRIPTION
Closes #306

Strengthens `TestPlanAuditLogsRoundTrip` with a second fixture case where `Budget.Committed` is explicitly zero. The existing case leaves `budget.committed` absent and only asserts the absent case (`Committed == nil`); the existing `"committed":0` re-marshal check passes via `PlanAuditGovernedAction.Committed` (a non-pointer `float64`), so `PlanAuditBudget.Committed` (`*float64`) zero-value round-trip was previously untested. The new case feeds a fixture with `"budget":{"authorized":5000,"committed":0}` and a governed-actions entry that also carries `"committed":0`, then asserts (1) the pointer is non-nil after unmarshal and (2) `"budget":{"authorized":5000,"committed":0}` appears in the re-marshaled output — a scoped check that cannot be satisfied by the governed-actions field.

## What tested

- `go vet ./...` — clean
- `go test ./... -run TestPlanAuditLogsRoundTrip` — PASS
- `go test ./...` (adcp submodule) — all pass
- `go test ./...` (root module) — all pass

## Pre-PR review

- code-reviewer: approved — no blockers; confirmed `*float64` + `omitempty` zero-value semantics are correct; flagged missing `governed_actions` in fixture (addressed in fixup commit); nit on `err` shadowing (addressed)
- dx-expert: approved — no blockers; nits on `governed_actions:null` leak (addressed by adding explicit entry), comment clarity (addressed), and error-message hint wording (addressed)
- security-reviewer: approved — no blockers; test-only change, no TEE paths touched, no pinhole widening, no metric cardinality or error-sanitization changes

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or request a new first draft PR:** comment `/triage execute`
>   on the source issue only when no triage-managed PR is already
>   open. Triage does not update existing PRs.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WBzJCnaT7zEFovwELGVceo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBzJCnaT7zEFovwELGVceo)_