### PR TITLE
fix(adcp): harden 3.1 follow-up edges

### DIFF
--- a/adcp/responses.go
+++ b/adcp/responses.go
@@ -12,10 +12,13 @@ import (
 
 // CapabilitiesResponse builds a get_adcp_capabilities response.
 func CapabilitiesResponse(data *CapabilitiesData) (*mcp.CallToolResult, any, error) {
+	out := data
 	if data != nil && data.Status == "" {
-		data.Status = "completed"
+		copy := *data
+		copy.Status = "completed"
+		out = &copy
 	}
-	return buildResult("Agent capabilities retrieved", data), data, nil
+	return buildResult("Agent capabilities retrieved", out), out, nil
 }
 
 // ProductsResponse builds a get_products response.

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -2078,7 +2078,9 @@ def resolve_allof_go_type_info(branches, required=False):
         validation_only = True
         for branch in structural_branches:
             branch_props = set(schema_properties(branch).keys())
-            if not branch_props or not branch_props.issubset(ref_property_names):
+            if not branch_props:
+                continue
+            if not branch_props.issubset(ref_property_names):
                 validation_only = False
                 break
         if validation_only:

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1681,6 +1681,20 @@ class AutoRefDiscoveryTest(unittest.TestCase):
         self.assertEqual("PublisherPropertySelector", go_type)
         self.assertIsNone(reason)
 
+    def test_required_only_allof_branch_resolves_to_ref_type(self):
+        go_type, reason = generate.resolve_go_type_info({
+            "allOf": [
+                {"$ref": "/schemas/test/core/account.json"},
+                {
+                    "type": "object",
+                    "required": ["brand"],
+                },
+            ],
+        })
+
+        self.assertEqual("Account", go_type)
+        self.assertIsNone(reason)
+
     def test_structural_allof_without_named_inline_type_stays_unreviewed(self):
         go_type, reason = generate.resolve_go_type_info({
             "allOf": [

--- a/adcp/seller.go
+++ b/adcp/seller.go
@@ -444,8 +444,14 @@ func stampCreateMediaBuyResult(result CreateMediaBuyResult, sandbox bool, contex
 // supported_protocols value, so collection handlers do not affect this list.
 func detectProtocols(cfg Config) []string {
 	var protocols []string
-	if cfg.GetProducts != nil || cfg.CreateMediaBuy != nil {
+	if cfg.SyncAccounts != nil || cfg.GetProducts != nil || cfg.CreateMediaBuy != nil || cfg.GetMediaBuys != nil || cfg.GetDelivery != nil {
 		protocols = append(protocols, "media_buy")
+	}
+	if cfg.SyncGovernance != nil {
+		protocols = append(protocols, "governance")
+	}
+	if cfg.ListCreativeFormats != nil || cfg.SyncCreatives != nil {
+		protocols = append(protocols, "creative")
 	}
 	if cfg.GetSignals != nil || cfg.ActivateSignal != nil {
 		protocols = append(protocols, "signals")

--- a/adcp/seller_test.go
+++ b/adcp/seller_test.go
@@ -143,6 +143,15 @@ func TestDetectProtocolsEmitsOnlySchemaEnum(t *testing.T) {
 	}
 }
 
+func TestDetectProtocolsCoversRegisteredProtocolHandlers(t *testing.T) {
+	got := detectProtocols(Config{
+		SyncGovernance: func(context.Context, *SyncGovernanceRequest) ([]GovernanceResult, error) { return nil, nil },
+		SyncCreatives:  func(context.Context, *SyncCreativesRequest) ([]CreativeResult, error) { return nil, nil },
+	})
+
+	assert.ElementsMatch(t, []string{"governance", "creative"}, got)
+}
+
 func TestCapabilitiesResponseWireShape(t *testing.T) {
 	// Round-trip through JSON to verify the 3.0 wire shape: adcp.idempotency
 	// must be present as an object (not null), and media_buy blocks survive.
@@ -176,6 +185,20 @@ func TestCapabilitiesResponseWireShape(t *testing.T) {
 	require.True(t, ok)
 	models, _ := mb["supported_pricing_models"].([]any)
 	assert.Equal(t, []any{"cpm"}, models)
+}
+
+func TestCapabilitiesResponseDoesNotMutateInputStatus(t *testing.T) {
+	data := &CapabilitiesData{
+		SupportedProtocols: []string{"media_buy"},
+		ADCP:               &ADCPVersion{MajorVersions: []int{3}},
+	}
+
+	_, out, err := CapabilitiesResponse(data)
+	require.NoError(t, err)
+
+	assert.Empty(t, data.Status)
+	require.IsType(t, &CapabilitiesData{}, out)
+	assert.Equal(t, "completed", out.(*CapabilitiesData).Status)
 }
 
 func TestAttachContext(t *testing.T) {

--- a/adcp/version_test.go
+++ b/adcp/version_test.go
@@ -54,6 +54,7 @@ func TestNegotiateADCPVersion(t *testing.T) {
 		{name: "default highest", want: "3.1", ok: true},
 		{name: "downshift", requestVersion: "3.1", supported: []string{"3.0"}, want: "3.0", ok: true},
 		{name: "pre release uses matching stable", requestVersion: "3.1-rc.3", supported: []string{"3.0", "3.1"}, want: "3.1", ok: true},
+		{name: "ga buyer can use only matching pre release seller", requestVersion: "3.1.0", supported: []string{"3.1-rc.3"}, want: "3.1-rc.3", ok: true},
 		{name: "cross major unsupported", requestVersion: "4.0", ok: false},
 	}
 

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -674,12 +674,16 @@ func updateMediaBuyResult(buy *adcp.MediaBuyData, affected []adcp.Package, conte
 }
 
 func mediaBuyCreateSuccess(buy *adcp.MediaBuyData) *adcp.CreateMediaBuySuccess {
+	var confirmedAt *string
+	if buy.ConfirmedAt != "" {
+		confirmedAt = adcp.Ptr(buy.ConfirmedAt)
+	}
 	return &adcp.CreateMediaBuySuccess{
 		MediaBuyID:       buy.MediaBuyID,
 		Account:          buy.Account,
 		InvoiceRecipient: responseBusinessEntity(buy.InvoiceRecipient),
 		Status:           buy.Status,
-		ConfirmedAt:      adcp.Ptr(buy.ConfirmedAt),
+		ConfirmedAt:      confirmedAt,
 		CreativeDeadline: buy.CreativeDeadline,
 		Revision:         buy.Revision,
 		ValidActions:     buy.ValidActions,

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -108,6 +108,45 @@ func TestCreateMediaBuy_ScrubsWriteOnlyInvoiceRecipientBank(t *testing.T) {
 	}
 }
 
+func TestMediaBuyCreateSuccess_EmitsNullForEmptyConfirmedAt(t *testing.T) {
+	buy := &adcp.MediaBuyData{
+		MediaBuyID: "mb-1",
+		Status:     string(adcp.MediaBuyStatusPendingCreatives),
+	}
+
+	raw, err := json.Marshal(mediaBuyCreateSuccess(buy))
+	if err != nil {
+		t.Fatalf("marshal create success: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal create success: %v", err)
+	}
+	if got, ok := wire["confirmed_at"]; !ok || got != nil {
+		t.Fatalf("empty confirmed_at should emit null, got %#v in %s", got, raw)
+	}
+}
+
+func TestMediaBuyCreateSuccess_IncludesConfirmedAtWhenSet(t *testing.T) {
+	buy := &adcp.MediaBuyData{
+		MediaBuyID:  "mb-1",
+		Status:      string(adcp.MediaBuyStatusActive),
+		ConfirmedAt: "2026-06-01T00:00:00Z",
+	}
+
+	raw, err := json.Marshal(mediaBuyCreateSuccess(buy))
+	if err != nil {
+		t.Fatalf("marshal create success: %v", err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatalf("unmarshal create success: %v", err)
+	}
+	if got := wire["confirmed_at"]; got != buy.ConfirmedAt {
+		t.Fatalf("confirmed_at = %#v, want %q", got, buy.ConfirmedAt)
+	}
+}
+
 // --- pending_creatives → active state transitions ---
 
 func TestPendingCreativesToActive_ViaSyncCreatives(t *testing.T) {

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -503,6 +503,9 @@ func (c Config) Validate() error {
 	if c.ResponseTTL <= 0 {
 		errs = append(errs, errors.New("RESPONSE_TTL must be positive"))
 	}
+	if c.ResponseTTL > time.Duration(maxServeWindowSec)*time.Second {
+		errs = append(errs, fmt.Errorf("RESPONSE_TTL must be <= %ds", maxServeWindowSec))
+	}
 	if len(c.SupportedADCPMajorVersions) == 0 {
 		errs = append(errs, errors.New("SUPPORTED_ADCP_MAJOR_VERSIONS must declare at least one major version"))
 	}

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -139,6 +139,11 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: "RESPONSE_TTL",
 		},
 		{
+			name:    "response ttl exceeds serve window max",
+			mutate:  func(c *Config) { c.ResponseTTL = 301 * time.Second },
+			wantErr: "RESPONSE_TTL must be <= 300s",
+		},
+		{
 			name:    "missing config url",
 			mutate:  func(c *Config) { c.IdentityConfig.URL = "" },
 			wantErr: "CONFIG_SOURCE_URL",

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -32,6 +32,8 @@ type identityHandler struct {
 	logger                     *slog.Logger
 }
 
+const maxServeWindowSec = 300
+
 // IdentityHandlerConfig packages the inputs for NewIdentityHandler.
 type IdentityHandlerConfig struct {
 	Service    *Service
@@ -83,6 +85,14 @@ func NewIdentityHandler(cfg IdentityHandlerConfig) http.Handler {
 		recorder:                   cfg.Recorder,
 		logger:                     cfg.Logger,
 	}
+}
+
+func serveWindowSeconds(ttl time.Duration) int {
+	seconds := int(ttl.Seconds())
+	if seconds > maxServeWindowSec {
+		return maxServeWindowSec
+	}
+	return seconds
 }
 
 func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +152,7 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Type:               tmproto.TypeIdentityMatchResponse,
 			RequestID:          req.RequestID,
 			EligiblePackageIDs: []string{},
-			ServeWindowSec:     int(h.responseTTL.Seconds()),
+			ServeWindowSec:     serveWindowSeconds(h.responseTTL),
 		}) {
 			status = "write_error"
 		}
@@ -161,7 +171,7 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Type:               tmproto.TypeIdentityMatchResponse,
 		RequestID:          result.RequestID,
 		EligiblePackageIDs: eligible,
-		ServeWindowSec:     int(h.responseTTL.Seconds()),
+		ServeWindowSec:     serveWindowSeconds(h.responseTTL),
 	}
 	if h.tmpx != nil && len(eligible) > 0 {
 		tmpxStart := time.Now()

--- a/targeting/identityagent/handler_test.go
+++ b/targeting/identityagent/handler_test.go
@@ -168,6 +168,12 @@ func TestIdentityHandlerUnsupportedMajorVersionIsGenericAndLogged(t *testing.T) 
 	assert.NotContains(t, logErr, "999")
 }
 
+func TestServeWindowSecondsClampsToSchemaMax(t *testing.T) {
+	assert.Equal(t, 299, serveWindowSeconds(299*time.Second))
+	assert.Equal(t, 300, serveWindowSeconds(300*time.Second))
+	assert.Equal(t, 300, serveWindowSeconds(10*time.Minute))
+}
+
 // TestBuildServiceRequest_NoCanonicalizer_PassesThroughUnchanged covers the
 // legacy code path: when the handler has neither a canonicalizer nor a
 // sealer, the request flows to service.Evaluate exactly as received — no


### PR DESCRIPTION
## Summary\n- avoid emitting empty-string confirmed_at from the reference seller; provisional buys now serialize confirmed_at as null per the 3.1 schema\n- clamp and validate TMP identity serve_window_sec at the schema max of 300 seconds\n- make CapabilitiesResponse avoid mutating caller-owned capabilities data\n- extend protocol auto-detection to creative/governance handlers and add rc/GA negotiation coverage\n- cover the validation-only allOf generator edge without changing generated output\n\n## Tracking issues\n- #312 tracks the remaining serve_window_sec router merge semantics decision\n- #313 tracks the minor adcp_major_version sentinel cleanup\n\n## Validation\n- go test ./...\n- cd adcp && go test ./...\n- cd reference/seller-agent && go test ./...\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 13\n- cd adcp && golangci-lint run ./...\n- cd reference/seller-agent && golangci-lint run ./...\n- git diff --check