### PR TITLE
fix(adcp): clarify version and serve window edges

### DIFF
--- a/adcp/version.go
+++ b/adcp/version.go
@@ -66,13 +66,27 @@ func MajorFromADCPVersion(version string) (int, bool) {
 // selected for 3.x backward compatibility. If neither is present, the highest
 // supported release is selected.
 func NegotiateADCPVersion(requestedVersion string, requestedMajor int, supported []string) (string, bool) {
+	return negotiateADCPVersion(adcpVersionRequest{
+		version:       requestedVersion,
+		major:         requestedMajor,
+		majorProvided: requestedMajor != 0,
+	}, supported)
+}
+
+type adcpVersionRequest struct {
+	version       string
+	major         int
+	majorProvided bool
+}
+
+func negotiateADCPVersion(request adcpVersionRequest, supported []string) (string, bool) {
 	supportedReleases := parseSupportedADCPReleases(supported)
 	if len(supportedReleases) == 0 {
 		supportedReleases = parseSupportedADCPReleases(SupportedADCPVersions())
 	}
 
-	if strings.TrimSpace(requestedVersion) != "" {
-		requested, ok := parseADCPRelease(requestedVersion)
+	if strings.TrimSpace(request.version) != "" {
+		requested, ok := parseADCPRelease(request.version)
 		if !ok {
 			return "", false
 		}
@@ -84,8 +98,11 @@ func NegotiateADCPVersion(requestedVersion string, requestedMajor int, supported
 		return highestSupportedADCPRelease(supportedReleases, requested.major, &requested)
 	}
 
-	if requestedMajor != 0 {
-		return highestSupportedADCPRelease(supportedReleases, requestedMajor, nil)
+	if request.majorProvided {
+		if request.major < 1 {
+			return "", false
+		}
+		return highestSupportedADCPRelease(supportedReleases, request.major, nil)
 	}
 
 	return highestSupportedADCPRelease(supportedReleases, 0, nil)

--- a/adcp/version_test.go
+++ b/adcp/version_test.go
@@ -67,6 +67,29 @@ func TestNegotiateADCPVersion(t *testing.T) {
 	}
 }
 
+func TestNegotiateADCPVersionMajorPresence(t *testing.T) {
+	tests := []struct {
+		name string
+		req  adcpVersionRequest
+		want string
+		ok   bool
+	}{
+		{name: "omitted major defaults highest", req: adcpVersionRequest{}, want: "3.1", ok: true},
+		{name: "explicit zero major is invalid", req: adcpVersionRequest{major: 0, majorProvided: true}, ok: false},
+		{name: "negative major is invalid", req: adcpVersionRequest{major: -1, majorProvided: true}, ok: false},
+		{name: "unsupported positive major is invalid", req: adcpVersionRequest{major: 4, majorProvided: true}, ok: false},
+		{name: "supported major selects highest matching release", req: adcpVersionRequest{major: 3, majorProvided: true}, want: "3.1", ok: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := negotiateADCPVersion(tt.req, nil)
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGeneratedRequestsDecode30And31VersionEnvelopes(t *testing.T) {
 	var products GetProductsRequest
 	require.NoError(t, json.Unmarshal([]byte(`{

--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -84,7 +84,7 @@ AgenticAdvertising.org ◄── Registry Syncer (outbound HTTPS polling)
 5. Each identity agent verifies the signature, then evaluates: campaign freq cap → package freq cap → audience → intent score, returns TMPX token
 6. Router merges eligible package lists (union — packages are provider-specific)
 7. Router collects TMPX tokens into `tmpx_providers` map keyed by provider ID
-8. Response to publisher: eligible package ID list + TTL + provider-keyed TMPX tokens
+8. Response to publisher: eligible package ID list + `serve_window_sec` + provider-keyed TMPX tokens
 
 ### Exposure Tracking (TMPX)
 

--- a/router/router.go
+++ b/router/router.go
@@ -429,18 +429,19 @@ func mergeContextResponses(requestID string, responses []*tmproto.ContextMatchRe
 // mergeIdentityResponses combines eligibility from multiple providers.
 // Packages are provider-specific — duplicates across providers are a config error.
 // Merge is union: a package listed by any provider is eligible.
-// TTL: minimum across providers. TMPX: collected per provider ID.
+// Serve window: minimum across providers so the merged response preserves the
+// most restrictive buyer throttle. TMPX: collected per provider ID.
 func mergeIdentityResponses(requestID string, providerIDs []string, responses []*tmproto.IdentityMatchResponse) *tmproto.IdentityMatchResponse {
 	eligibleSet := make(map[string]struct{})
-	minTTL := -1
+	minServeWindowSec := -1
 	var tmpx string
 
 	for _, resp := range responses {
 		if resp.Tmpx != "" {
 			tmpx = resp.Tmpx
 		}
-		if minTTL < 0 || resp.ServeWindowSec < minTTL {
-			minTTL = resp.ServeWindowSec
+		if minServeWindowSec < 0 || resp.ServeWindowSec < minServeWindowSec {
+			minServeWindowSec = resp.ServeWindowSec
 		}
 		for _, pkgID := range resp.EligiblePackageIDs {
 			eligibleSet[pkgID] = struct{}{}
@@ -453,15 +454,15 @@ func mergeIdentityResponses(requestID string, providerIDs []string, responses []
 	}
 	sort.Strings(eligible)
 
-	if minTTL < 0 {
-		minTTL = 0
+	if minServeWindowSec < 0 {
+		minServeWindowSec = 0
 	}
 
 	merged := &tmproto.IdentityMatchResponse{
 		Type:               tmproto.TypeIdentityMatchResponse,
 		RequestID:          requestID,
 		EligiblePackageIDs: eligible,
-		ServeWindowSec:     minTTL,
+		ServeWindowSec:     minServeWindowSec,
 		Tmpx:               tmpx,
 	}
 	return merged

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -150,7 +150,8 @@ func TestMergeIdentityResponses(t *testing.T) {
 	assert.True(t, eligible["pkg-3"], "pkg-3 should be eligible (listed by its provider)")
 	assert.Len(t, merged.EligiblePackageIDs, 3)
 
-	// TTL is the minimum across providers.
+	// Serve window is the minimum across providers so the merged response keeps
+	// the most restrictive buyer throttle.
 	assert.Equal(t, 300, merged.ServeWindowSec)
 }
 
@@ -497,6 +498,16 @@ func TestMergeIdentityResponses_Eligibility(t *testing.T) {
 
 	require.Len(t, merged.EligiblePackageIDs, 3)
 	assert.Equal(t, 300, merged.ServeWindowSec)
+}
+
+func TestMergeIdentityResponses_UsesMostRestrictiveServeWindow(t *testing.T) {
+	merged := mergeIdentityResponses("test", []string{"acme", "nova"}, []*tmproto.IdentityMatchResponse{
+		{EligiblePackageIDs: []string{"pkg-1"}, ServeWindowSec: 120},
+		{EligiblePackageIDs: []string{"pkg-2"}, ServeWindowSec: 45},
+		{EligiblePackageIDs: []string{"pkg-3"}, ServeWindowSec: 300},
+	})
+
+	assert.Equal(t, 45, merged.ServeWindowSec)
 }
 
 func TestRouterTimeout_ProviderExcluded(t *testing.T) {


### PR DESCRIPTION
## Summary\n- make AdCP version negotiation carry requested major presence internally, so explicit invalid majors can be tested separately from omitted majors\n- keep router identity response merging conservative by using the smallest serve_window_sec, but rename the code/docs away from stale TTL terminology\n- add regression coverage for explicit invalid majors and most-restrictive serve-window merging\n\n## Issues\nCloses #312\nCloses #313\n\n## Validation\n- go test ./...\n- cd adcp && go test ./...\n- cd adcp && golangci-lint run ./...\n- golangci-lint run ./...\n- git diff --check