### PR TITLE
chore(adcp): clarify webhook result any allowance

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1517,7 +1517,7 @@ INTENTIONAL_ANY_FIELDS = {
     ('Catalog', 'items'): 'inline catalog item schema depends on catalog type',
     ('CatalogFieldMapping', 'value'): 'catalog static literal values can be strings, numbers, booleans, arrays, or objects',
     ('CatalogFieldMapping', 'default'): 'catalog fallback literal values can be strings, numbers, booleans, arrays, or objects',
-    ('MCPWebhookPayload', 'result'): 'async webhook result is a task-specific response union',
+    ('MCPWebhookPayload', 'result'): 'core/async-response-data.json is a task-specific response union',
     ('ProductFilterGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('GeoProximityGeometry', 'coordinates'): 'GeoJSON coordinates are shape-dependent for Polygon/MultiPolygon',
     ('SimulationSuccess', 'simulated'): 'test-controller simulation payload is scenario-specific',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1564,7 +1564,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
             (
                 "MCPWebhookPayload",
                 "result",
-                "async webhook result is a task-specific response union",
+                "core/async-response-data.json is a task-specific response union",
             ),
             allowed,
         )


### PR DESCRIPTION
## Summary
- update the MCPWebhookPayload.result intentional-any rationale to name core/async-response-data.json
- keep the generator coverage assertion in sync so the allowance remains searchable and retireable

Closes #285

## Validation
- cd adcp/schemas && python3 -m unittest generate_test.InlineObjectGenerationTest
- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 999\n- git diff --check