### PR TITLE
test(adcp): lock required features boolean bag

### DIFF
--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -942,6 +942,29 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "[]PlanAuditLog",
         )
 
+    def test_required_features_hint_matches_open_boolean_bag_schema(self):
+        filters_schema = generate.load_schema("core/product-filters.json")
+        required_features = filters_schema["properties"]["required_features"]
+        features_path = generate.ref_to_schema_path(required_features["$ref"])
+
+        self.assertEqual("core/media-buy-features.json", features_path)
+
+        features_schema = generate.load_schema(features_path)
+        self.assertEqual("object", features_schema.get("type"))
+        self.assertEqual({"type": "boolean"}, features_schema.get("additionalProperties"))
+        for name, prop in features_schema.get("properties", {}).items():
+            self.assertEqual(
+                "boolean",
+                prop.get("type"),
+                f"media-buy feature {name} must stay boolean",
+            )
+
+        filters_generated = generate.schema_to_struct("ProductFilters", filters_schema)
+        self.assertIn(
+            "RequiredFeatures map[string]bool `json:\"required_features,omitempty\"`",
+            filters_generated,
+        )
+
     def test_inline_object_structs_are_generated_from_schema_pointers(self):
         sort_schema = generate.load_schema_spec(
             "creative/list-creatives-request.json#/properties/sort",


### PR DESCRIPTION
## Summary
- add generator coverage that proves ProductFilters.required_features still references core/media-buy-features.json
- assert media-buy features remain an open object with boolean values before preserving the map[string]bool hint

Closes #280

## Validation
- cd adcp/schemas && python3 -m unittest generate_test.InlineObjectGenerationTest.test_required_features_hint_matches_open_boolean_bag_schema generate_test.InlineObjectGenerationTest.test_inline_object_structs_are_generated_from_schema_pointers
- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- git diff --check