### PR TITLE
chore(adcp): expose hand-written inline drift in lint json

### DIFF
--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -868,6 +868,7 @@ def main():
     if args.json:
         out = {
             'drift': reports,
+            'hand_written_inline_drift': hand_written_inline_reports,
             'no_schema_correspondent': no_schema,
             'inline_schema_errors': inline_schema_errors,
             'inline_additional_properties_errors': inline_additional_properties_errors,

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -1,4 +1,8 @@
+import contextlib
+import io
+import json
 from pathlib import Path
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -120,6 +124,43 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             })
 
         self.assertEqual([], reports)
+
+    def test_json_output_exposes_hand_written_inline_drift_separately(self):
+        inline_report = {
+            "type": "InlineShape",
+            "schema": "shape.json#/properties/inline",
+            "missing_in_go": ["message"],
+            "extra_in_go": [],
+            "required_with_omitempty": [],
+        }
+
+        with (
+            mock.patch.object(lint.Path, "exists", return_value=True),
+            mock.patch.object(lint, "parse_go_structs", return_value={}),
+            mock.patch.object(lint, "parse_custom_json_methods", return_value={}),
+            mock.patch.object(lint, "_assert_exempt_subset_known", return_value=None),
+            mock.patch.object(lint, "validate_inline_schema_specs", return_value=[]),
+            mock.patch.object(lint, "validate_inline_additional_properties_policies", return_value=[]),
+            mock.patch.object(lint, "validate_shared_inline_overrides", return_value=[]),
+            mock.patch.object(lint, "validate_union_schema_specs", return_value=[]),
+            mock.patch.object(lint, "validate_custom_wire_fields", return_value=[]),
+            mock.patch.object(lint, "optional_numeric_pointer_reports", return_value=[]),
+            mock.patch.object(
+                lint,
+                "validate_hand_written_inline_schema_specs",
+                return_value=[inline_report],
+            ),
+            mock.patch.object(lint.gen, "KNOWN_TYPES", set()),
+            mock.patch.object(sys, "argv", ["lint.py", "--json"]),
+        ):
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = lint.main()
+
+        self.assertEqual(0, rc)
+        payload = json.loads(out.getvalue())
+        self.assertEqual([inline_report], payload["hand_written_inline_drift"])
+        self.assertIn(inline_report, payload["drift"])
 
 
 class InlineAdditionalPropertiesPolicyLintTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add a dedicated hand_written_inline_drift key to lint.py --json output
- keep existing drift output and strict exit behavior unchanged
- add coverage that the dedicated key is populated while preserving the aggregate drift list

Closes #273

## Validation
- cd adcp/schemas && python3 -m unittest lint_test.HandWrittenInlineSchemaLintTest.test_json_output_exposes_hand_written_inline_drift_separately
- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- cd adcp/schemas && python3 lint.py --json | python3 -c 'import json,sys; data=json.load(sys.stdin); print(sorted(data.keys()))'\n- git diff --check