### PR TITLE
feat(adcp): detect hand-written inline schema divergence

### DIFF
--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -527,6 +527,58 @@ def validate_hand_written_inline_schema_specs(go_structs):
     return reports
 
 
+def validate_hand_written_inline_schema_divergence():
+    """Report schema-side drift among pointers sharing one hand-written type."""
+    reports = []
+    for type_name, schema_specs in gen.HAND_WRITTEN_INLINE_SCHEMA_SPECS.items():
+        loaded = []
+        error_count = len(reports)
+        for schema_spec in schema_specs:
+            path_part = schema_spec.split('#', 1)[0]
+            schema_path = SCRIPT_DIR / path_part
+            if not schema_path.exists():
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'schema not found: {schema_path}',
+                })
+                continue
+            try:
+                schema = load_schema_spec(schema_spec)
+            except SCHEMA_RESOLUTION_ERRORS as e:
+                reports.append({
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'error': f'could not resolve schema pointer: {e}',
+                })
+                continue
+            loaded.append((
+                schema_spec,
+                schema_property_set(schema),
+                schema_required_set(schema),
+            ))
+        if len(reports) != error_count or len(loaded) != len(schema_specs):
+            continue
+        if len(loaded) < 2:
+            continue
+
+        anchor_spec, anchor_props, anchor_required = loaded[0]
+        for schema_spec, props, required in loaded[1:]:
+            if props == anchor_props and required == anchor_required:
+                continue
+            reports.append({
+                'type': type_name,
+                'schema': schema_spec,
+                'anchor_schema': anchor_spec,
+                'missing': sorted(anchor_props - props),
+                'extra': sorted(props - anchor_props),
+                'required_missing': sorted(anchor_required - required),
+                'required_extra': sorted(required - anchor_required),
+                'error': 'hand-written inline schema shape differs',
+            })
+    return reports
+
+
 def validate_union_schema_specs():
     """Smoke-test generated union schema pointers and shared-helper equivalence."""
     reports = []
@@ -846,6 +898,7 @@ def main():
         custom_json_methods,
     )
     optional_numeric_reports = optional_numeric_pointer_reports(go_structs)
+    hand_written_inline_schema_divergence = validate_hand_written_inline_schema_divergence()
     hand_written_inline_reports = validate_hand_written_inline_schema_specs(go_structs)
     reports.extend(hand_written_inline_reports)
 
@@ -869,6 +922,7 @@ def main():
         out = {
             'drift': reports,
             'hand_written_inline_drift': hand_written_inline_reports,
+            'hand_written_inline_schema_divergence': hand_written_inline_schema_divergence,
             'no_schema_correspondent': no_schema,
             'inline_schema_errors': inline_schema_errors,
             'inline_additional_properties_errors': inline_additional_properties_errors,
@@ -908,6 +962,31 @@ def main():
                     print(f'    missing: {", ".join(r["missing"])}')
                 if r.get('extra'):
                     print(f'    extra:   {", ".join(r["extra"])}')
+            print()
+        if hand_written_inline_schema_divergence:
+            print(
+                'Hand-written inline schema divergence in '
+                f'{len(hand_written_inline_schema_divergence)} type(s):'
+            )
+            for r in hand_written_inline_schema_divergence:
+                print()
+                print(f'  {r["type"]}  ({r.get("schema", "?")})')
+                print(f'    anchor: {r.get("anchor_schema", "?")}')
+                print(f'    error:  {r["error"]}')
+                if r.get('missing'):
+                    print(f'    missing: {", ".join(r["missing"])}')
+                if r.get('extra'):
+                    print(f'    extra:   {", ".join(r["extra"])}')
+                if r.get('required_missing'):
+                    print(
+                        '    required missing: '
+                        f'{", ".join(r["required_missing"])}'
+                    )
+                if r.get('required_extra'):
+                    print(
+                        '    required extra:   '
+                        f'{", ".join(r["required_extra"])}'
+                    )
             print()
         if union_schema_errors:
             print(f'Union schema pointer errors in {len(union_schema_errors)} type(s):')
@@ -968,6 +1047,7 @@ def main():
         bool(inline_schema_errors)
         or bool(inline_additional_properties_errors)
         or bool(shared_inline_errors)
+        or bool(hand_written_inline_schema_divergence)
         or bool(union_schema_errors)
         or bool(custom_wire_field_errors)
         or bool(reports)

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -55,6 +55,47 @@ class SharedInlineOverrideLintTest(unittest.TestCase):
 
 
 class HandWrittenInlineSchemaLintTest(unittest.TestCase):
+    def test_schema_divergence_reports_property_and_required_drift(self):
+        specs = {
+            "InlineShape": [
+                "shape.json#/properties/first",
+                "shape.json#/properties/second",
+            ],
+        }
+
+        def load_schema_spec(spec):
+            if spec.endswith("/first"):
+                return {
+                    "properties": {
+                        "message": {"type": "string"},
+                        "url": {"type": "string"},
+                    },
+                    "required": ["message"],
+                }
+            return {
+                "properties": {
+                    "message": {"type": "string"},
+                    "expires_at": {"type": "string"},
+                },
+                "required": ["message", "expires_at"],
+            }
+
+        with (
+            mock.patch.object(lint.Path, "exists", return_value=True),
+            mock.patch.object(lint.gen, "HAND_WRITTEN_INLINE_SCHEMA_SPECS", specs),
+            mock.patch.object(lint, "load_schema_spec", side_effect=load_schema_spec),
+        ):
+            reports = lint.validate_hand_written_inline_schema_divergence()
+
+        self.assertEqual(1, len(reports))
+        self.assertEqual("InlineShape", reports[0]["type"])
+        self.assertEqual("shape.json#/properties/second", reports[0]["schema"])
+        self.assertEqual("shape.json#/properties/first", reports[0]["anchor_schema"])
+        self.assertEqual(["url"], reports[0]["missing"])
+        self.assertEqual(["expires_at"], reports[0]["extra"])
+        self.assertEqual([], reports[0]["required_missing"])
+        self.assertEqual(["expires_at"], reports[0]["required_extra"])
+
     @unittest.skipUnless(ACCOUNT_SETUP_SCHEMA_PATHS_EXIST, "account setup schemas are not present")
     def test_current_account_setup_shape_is_drift_checked(self):
         reports = lint.validate_hand_written_inline_schema_specs(lint.parse_go_structs())
@@ -133,6 +174,16 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             "extra_in_go": [],
             "required_with_omitempty": [],
         }
+        schema_divergence_report = {
+            "type": "InlineShape",
+            "schema": "shape.json#/properties/second",
+            "anchor_schema": "shape.json#/properties/first",
+            "missing": ["url"],
+            "extra": [],
+            "required_missing": [],
+            "required_extra": [],
+            "error": "hand-written inline schema shape differs",
+        }
 
         with (
             mock.patch.object(lint.Path, "exists", return_value=True),
@@ -145,6 +196,11 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             mock.patch.object(lint, "validate_union_schema_specs", return_value=[]),
             mock.patch.object(lint, "validate_custom_wire_fields", return_value=[]),
             mock.patch.object(lint, "optional_numeric_pointer_reports", return_value=[]),
+            mock.patch.object(
+                lint,
+                "validate_hand_written_inline_schema_divergence",
+                return_value=[schema_divergence_report],
+            ),
             mock.patch.object(
                 lint,
                 "validate_hand_written_inline_schema_specs",
@@ -160,6 +216,10 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
         self.assertEqual(0, rc)
         payload = json.loads(out.getvalue())
         self.assertEqual([inline_report], payload["hand_written_inline_drift"])
+        self.assertEqual(
+            [schema_divergence_report],
+            payload["hand_written_inline_schema_divergence"],
+        )
         self.assertIn(inline_report, payload["drift"])
 
 


### PR DESCRIPTION
## Summary
- add a sibling lint check for schema-side divergence across HAND_WRITTEN_INLINE_SCHEMA_SPECS pointers
- report divergence separately in human output and lint.py --json while preserving existing Go drift reporting
- fail strict lint when shared hand-written inline schema shapes disagree

Closes #272

## Validation
- cd adcp/schemas && python3 -m unittest lint_test.HandWrittenInlineSchemaLintTest
- cd adcp/schemas && python3 lint.py --json | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["hand_written_inline_schema_divergence"])'\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- git diff --check