### PR TITLE
feat(adcp): validate cross-type inline hints

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1186,6 +1186,13 @@ SHARED_INLINE_OVERRIDES = {
     ],
 }
 
+# Inline hints that deliberately reuse an existing generated type for a sibling
+# inline schema. lint.py verifies the source inline schema and target type keep
+# the same field and requiredness shape.
+CROSS_TYPE_INLINE_HINTS = {
+    ('PerformanceFeedback', 'measurement_period'): 'DatetimeRange',
+}
+
 # Named enum helpers generated from inline JSON Schema pointers. These cover
 # important SDK validation values that are not standalone enum schema files.
 INLINE_ENUM_TYPES = OrderedDict([

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -509,6 +509,88 @@ def validate_shared_inline_overrides():
     return reports
 
 
+def validate_cross_type_inline_hints():
+    """Verify inline hints that reuse another type stay schema-equivalent."""
+    reports = []
+    entries = {
+        entry['name']: entry
+        for entry in gen.generated_schema_entries()
+        if entry['kind'] == 'struct'
+    }
+    for hint_key, target_type in gen.CROSS_TYPE_INLINE_HINTS.items():
+        source_type, json_name = hint_key
+        actual_hint = gen.INLINE_TYPE_HINTS.get(hint_key)
+        base_actual_hint = (
+            actual_hint[1:]
+            if actual_hint and actual_hint.startswith('*')
+            else actual_hint
+        )
+        if base_actual_hint != target_type:
+            reports.append({
+                'type': source_type,
+                'json': json_name,
+                'target_type': target_type,
+                'actual_hint': actual_hint,
+                'error': 'cross-type inline hint does not match INLINE_TYPE_HINTS',
+            })
+            continue
+
+        source_entry = entries.get(source_type)
+        target_entry = entries.get(target_type)
+        if source_entry is None:
+            reports.append({
+                'type': source_type,
+                'json': json_name,
+                'target_type': target_type,
+                'error': 'cross-type inline hint source type not generated',
+            })
+            continue
+        if target_entry is None:
+            reports.append({
+                'type': source_type,
+                'json': json_name,
+                'target_type': target_type,
+                'schema': source_entry['schema'],
+                'error': 'cross-type inline hint target type not generated',
+            })
+            continue
+
+        source_props = gen.schema_properties(source_entry['schema_obj'])
+        prop = source_props.get(json_name)
+        if not isinstance(prop, dict):
+            reports.append({
+                'type': source_type,
+                'json': json_name,
+                'target_type': target_type,
+                'schema': source_entry['schema'],
+                'target_schema': target_entry['schema'],
+                'error': 'cross-type inline hint source field not found',
+            })
+            continue
+        if prop.get('type') == 'array' and isinstance(prop.get('items'), dict):
+            prop = prop['items']
+
+        source_shape = schema_property_set(prop)
+        target_shape = schema_property_set(target_entry['schema_obj'])
+        source_required = schema_required_set(prop)
+        target_required = schema_required_set(target_entry['schema_obj'])
+        if source_shape == target_shape and source_required == target_required:
+            continue
+        reports.append({
+            'type': source_type,
+            'json': json_name,
+            'target_type': target_type,
+            'schema': source_entry['schema'],
+            'target_schema': target_entry['schema'],
+            'missing': sorted(target_shape - source_shape),
+            'extra': sorted(source_shape - target_shape),
+            'required_missing': sorted(target_required - source_required),
+            'required_extra': sorted(source_required - target_required),
+            'error': 'cross-type inline hint schema shape differs',
+        })
+    return reports
+
+
 def validate_hand_written_inline_schema_specs(go_structs):
     """Diff hand-written inline structs against their owning schema pointers."""
     reports = []
@@ -892,6 +974,7 @@ def main():
     inline_schema_errors = validate_inline_schema_specs()
     inline_additional_properties_errors = validate_inline_additional_properties_policies()
     shared_inline_errors = validate_shared_inline_overrides()
+    cross_type_inline_errors = validate_cross_type_inline_hints()
     union_schema_errors = validate_union_schema_specs()
     custom_wire_field_errors = validate_custom_wire_fields(
         go_structs,
@@ -927,6 +1010,7 @@ def main():
             'inline_schema_errors': inline_schema_errors,
             'inline_additional_properties_errors': inline_additional_properties_errors,
             'shared_inline_errors': shared_inline_errors,
+            'cross_type_inline_errors': cross_type_inline_errors,
             'union_schema_errors': union_schema_errors,
             'custom_wire_field_errors': custom_wire_field_errors,
             'optional_numeric_pointer': optional_numeric_reports,
@@ -962,6 +1046,38 @@ def main():
                     print(f'    missing: {", ".join(r["missing"])}')
                 if r.get('extra'):
                     print(f'    extra:   {", ".join(r["extra"])}')
+            print()
+        if cross_type_inline_errors:
+            print(
+                'Cross-type inline hint errors in '
+                f'{len(cross_type_inline_errors)} type(s):'
+            )
+            for r in cross_type_inline_errors:
+                print()
+                print(
+                    f'  {r["type"]}.{r.get("json", "?")}  '
+                    f'({r.get("schema", "?")})'
+                )
+                print(f'    target: {r.get("target_type", "?")}')
+                if r.get('target_schema'):
+                    print(f'    target schema: {r["target_schema"]}')
+                print(f'    error:  {r["error"]}')
+                if r.get('actual_hint') is not None:
+                    print(f'    actual hint: {r["actual_hint"]}')
+                if r.get('missing'):
+                    print(f'    missing: {", ".join(r["missing"])}')
+                if r.get('extra'):
+                    print(f'    extra:   {", ".join(r["extra"])}')
+                if r.get('required_missing'):
+                    print(
+                        '    required missing: '
+                        f'{", ".join(r["required_missing"])}'
+                    )
+                if r.get('required_extra'):
+                    print(
+                        '    required extra:   '
+                        f'{", ".join(r["required_extra"])}'
+                    )
             print()
         if hand_written_inline_schema_divergence:
             print(
@@ -1047,6 +1163,7 @@ def main():
         bool(inline_schema_errors)
         or bool(inline_additional_properties_errors)
         or bool(shared_inline_errors)
+        or bool(cross_type_inline_errors)
         or bool(hand_written_inline_schema_divergence)
         or bool(union_schema_errors)
         or bool(custom_wire_field_errors)

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -54,6 +54,75 @@ class SharedInlineOverrideLintTest(unittest.TestCase):
         self.assertEqual([], reports[0]["missing"])
 
 
+class CrossTypeInlineHintLintTest(unittest.TestCase):
+    def test_performance_feedback_measurement_period_hint_is_registered(self):
+        hint_key = ("PerformanceFeedback", "measurement_period")
+
+        self.assertEqual("DatetimeRange", lint.gen.CROSS_TYPE_INLINE_HINTS[hint_key])
+        self.assertEqual("DatetimeRange", lint.gen.INLINE_TYPE_HINTS[hint_key])
+
+    def test_cross_type_inline_hint_reports_shape_drift(self):
+        entries = [
+            {
+                "kind": "struct",
+                "name": "SourceShape",
+                "schema": "source.json",
+                "schema_obj": {
+                    "properties": {
+                        "period": {
+                            "type": "object",
+                            "properties": {
+                                "start": {},
+                                "timezone": {},
+                            },
+                            "required": ["start", "timezone"],
+                        },
+                    },
+                },
+            },
+            {
+                "kind": "struct",
+                "name": "TargetShape",
+                "schema": "target.json",
+                "schema_obj": {
+                    "properties": {
+                        "start": {},
+                        "end": {},
+                    },
+                    "required": ["start", "end"],
+                },
+            },
+        ]
+
+        with (
+            mock.patch.object(
+                lint.gen,
+                "CROSS_TYPE_INLINE_HINTS",
+                {("SourceShape", "period"): "TargetShape"},
+            ),
+            mock.patch.object(
+                lint.gen,
+                "INLINE_TYPE_HINTS",
+                {("SourceShape", "period"): "TargetShape"},
+            ),
+            mock.patch.object(
+                lint.gen,
+                "generated_schema_entries",
+                return_value=iter(entries),
+            ),
+        ):
+            reports = lint.validate_cross_type_inline_hints()
+
+        self.assertEqual(1, len(reports))
+        self.assertEqual("SourceShape", reports[0]["type"])
+        self.assertEqual("period", reports[0]["json"])
+        self.assertEqual("TargetShape", reports[0]["target_type"])
+        self.assertEqual(["end"], reports[0]["missing"])
+        self.assertEqual(["timezone"], reports[0]["extra"])
+        self.assertEqual(["end"], reports[0]["required_missing"])
+        self.assertEqual(["timezone"], reports[0]["required_extra"])
+
+
 class HandWrittenInlineSchemaLintTest(unittest.TestCase):
     def test_account_setup_inline_schema_registration_is_pinned_without_schemas(self):
         self.assertEqual(
@@ -226,6 +295,7 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             mock.patch.object(lint, "validate_inline_schema_specs", return_value=[]),
             mock.patch.object(lint, "validate_inline_additional_properties_policies", return_value=[]),
             mock.patch.object(lint, "validate_shared_inline_overrides", return_value=[]),
+            mock.patch.object(lint, "validate_cross_type_inline_hints", return_value=[]),
             mock.patch.object(lint, "validate_union_schema_specs", return_value=[]),
             mock.patch.object(lint, "validate_custom_wire_fields", return_value=[]),
             mock.patch.object(lint, "optional_numeric_pointer_reports", return_value=[]),


### PR DESCRIPTION
## Summary
- add CROSS_TYPE_INLINE_HINTS metadata for inline hints that deliberately reuse existing generated types
- make strict lint compare source inline field schemas against target type schemas by field set and requiredness
- cover PerformanceFeedback.measurement_period -> DatetimeRange and add synthetic drift tests

Closes #264

## Validation
- cd adcp/schemas && python3 -m unittest lint_test.CrossTypeInlineHintLintTest
- cd adcp/schemas && python3 lint.py --json | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data["cross_type_inline_errors"])'\n- cd adcp/schemas && python3 -m unittest discover -p '*_test.py'\n- cd adcp/schemas && python3 lint.py --strict\n- git diff --check