### PR TITLE
feat(adcp): validate flattened signal unions

### DIFF
--- a/adcp/validation.go
+++ b/adcp/validation.go
@@ -50,6 +50,20 @@ func ValidateOptimizationGoal(goal OptimizationGoal, opts ...ValidationOption) [
 	return goal.Validate(opts...)
 }
 
+// ValidateSignalTargeting checks required fields and branch-specific fields for
+// SignalTargeting's flattened value_type oneOf representation. Unknown
+// value_type values are allowed unless WithStrictEnums is supplied.
+func ValidateSignalTargeting(targeting SignalTargeting, opts ...ValidationOption) []ValidationIssue {
+	return targeting.Validate(opts...)
+}
+
+// ValidateAudienceSelector checks required fields and branch-specific fields
+// for AudienceSelector's flattened type/value_type oneOf representation.
+// Unknown discriminator values are allowed unless WithStrictEnums is supplied.
+func ValidateAudienceSelector(selector AudienceSelector, opts ...ValidationOption) []ValidationIssue {
+	return selector.Validate(opts...)
+}
+
 // Validate checks required fields and current-schema invariants that Go zero
 // values cannot express. Call it before submitting package requests or updates
 // that include optimization_goals. OptimizationGoal is a flattened Go
@@ -80,6 +94,66 @@ func (g OptimizationGoal) Validate(opts ...ValidationOption) []ValidationIssue {
 			Code:    "INVALID_VALUE",
 			Message: "priority must be at least 1 when set",
 		})
+	}
+
+	return issues
+}
+
+// Validate checks SignalTargeting's current-schema oneOf invariants. It is
+// intentionally opt-in and forward-compatible: unknown value_type values are
+// ignored unless WithStrictEnums is supplied.
+func (t SignalTargeting) Validate(opts ...ValidationOption) []ValidationIssue {
+	cfg := newValidationConfig(opts)
+	return validateSignalTargetingFields(
+		t.ValueType,
+		t.SignalRef,
+		t.SignalID,
+		t.Value,
+		t.Values,
+		t.MinValue,
+		t.MaxValue,
+		"",
+		cfg,
+	)
+}
+
+// Validate checks AudienceSelector's current-schema oneOf invariants. It is
+// intentionally opt-in and forward-compatible: unknown type/value_type values
+// are ignored unless WithStrictEnums is supplied.
+func (s AudienceSelector) Validate(opts ...ValidationOption) []ValidationIssue {
+	cfg := newValidationConfig(opts)
+	var issues []ValidationIssue
+
+	switch s.Type {
+	case "":
+		issues = appendRequired(issues, "type")
+	case "signal":
+		issues = append(issues, validateSignalTargetingFields(
+			s.ValueType,
+			s.SignalRef,
+			s.SignalID,
+			s.Value,
+			s.Values,
+			s.MinValue,
+			s.MaxValue,
+			"",
+			cfg,
+		)...)
+	case "description":
+		if s.Description == "" {
+			issues = appendRequired(issues, "description")
+		}
+		issues = appendUnsupportedIfSet(issues, "signal_ref", s.SignalRef != nil)
+		issues = appendUnsupportedIfSet(issues, "signal_id", s.SignalID != nil)
+		issues = appendUnsupportedIfSet(issues, "value_type", s.ValueType != "")
+		issues = appendUnsupportedIfSet(issues, "value", s.Value != nil)
+		issues = appendUnsupportedIfSet(issues, "values", len(s.Values) > 0)
+		issues = appendUnsupportedIfSet(issues, "min_value", s.MinValue != nil)
+		issues = appendUnsupportedIfSet(issues, "max_value", s.MaxValue != nil)
+	default:
+		if cfg.strictEnums {
+			issues = appendUnknownVariant(issues, "type")
+		}
 	}
 
 	return issues
@@ -139,6 +213,61 @@ func validateEventOptimizationGoal(g OptimizationGoal, cfg validationConfig) []V
 	}
 	if g.AttributionWindow != nil {
 		issues = append(issues, g.AttributionWindow.validate("attribution_window", cfg)...)
+	}
+
+	return issues
+}
+
+func validateSignalTargetingFields(
+	valueType string,
+	signalRef *SignalRef,
+	signalID *SignalID,
+	value *bool,
+	values []string,
+	minValue *float64,
+	maxValue *float64,
+	path string,
+	cfg validationConfig,
+) []ValidationIssue {
+	var issues []ValidationIssue
+
+	if signalRef == nil && signalID == nil {
+		issues = appendRequired(issues, validationPath(path, "signal_ref"))
+	}
+	if valueType == "" {
+		issues = appendRequired(issues, validationPath(path, "value_type"))
+		return issues
+	}
+
+	switch valueType {
+	case "binary":
+		if value == nil {
+			issues = appendRequired(issues, validationPath(path, "value"))
+		}
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "values"), len(values) > 0)
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "min_value"), minValue != nil)
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "max_value"), maxValue != nil)
+	case "categorical":
+		if len(values) == 0 {
+			issues = appendRequired(issues, validationPath(path, "values"))
+		}
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "value"), value != nil)
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "min_value"), minValue != nil)
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "max_value"), maxValue != nil)
+	case "numeric":
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "value"), value != nil)
+		issues = appendUnsupportedIfSet(issues, validationPath(path, "values"), len(values) > 0)
+		if minValue != nil && maxValue != nil && *minValue > *maxValue {
+			issues = append(issues, ValidationIssue{
+				Field:   validationPath(path, "max_value"),
+				Code:    "INVALID_VALUE",
+				Message: "max_value must be greater than or equal to min_value",
+			})
+		}
+	default:
+		if cfg.strictEnums && !IsKnownSignalValueType(SignalValueType(valueType)) {
+			issues = appendUnknownVariant(issues, validationPath(path, "value_type"))
+		}
 	}
 
 	return issues
@@ -379,6 +508,24 @@ func appendUnknownVariant(issues []ValidationIssue, field string) []ValidationIs
 		Code:    "UNKNOWN_VARIANT",
 		Message: "value is not a current schema variant",
 	})
+}
+
+func appendUnsupportedIfSet(issues []ValidationIssue, field string, set bool) []ValidationIssue {
+	if !set {
+		return issues
+	}
+	return append(issues, ValidationIssue{
+		Field:   field,
+		Code:    "UNSUPPORTED_FIELD",
+		Message: "field is not supported for this schema variant",
+	})
+}
+
+func validationPath(prefix, field string) string {
+	if prefix == "" {
+		return field
+	}
+	return prefix + "." + field
 }
 
 func isKnownDurationUnit(v string) bool {

--- a/adcp/validation_test.go
+++ b/adcp/validation_test.go
@@ -362,3 +362,138 @@ func TestValidateOptimizationGoal_NumericRules(t *testing.T) {
 		t.Fatalf("Validate missing target_frequency.max issue: %#v", issues)
 	}
 }
+
+func TestValidateSignalTargeting_ValidBinary(t *testing.T) {
+	targeting := SignalTargeting{
+		SignalRef: &SignalRef{Scope: "product", SignalID: "auto_intenders"},
+		ValueType: "binary",
+		Value:     Ptr(true),
+	}
+
+	if issues := ValidateSignalTargeting(targeting, WithStrictEnums()); len(issues) != 0 {
+		t.Fatalf("ValidateSignalTargeting issues = %#v, want none", issues)
+	}
+}
+
+func TestValidateSignalTargeting_BranchSpecificFields(t *testing.T) {
+	targeting := SignalTargeting{
+		SignalRef: &SignalRef{Scope: "product", SignalID: "segment"},
+		ValueType: "categorical",
+		Value:     Ptr(true),
+		MinValue:  Ptr(1.0),
+	}
+
+	issues := targeting.Validate()
+	for _, want := range []struct {
+		field string
+		code  string
+	}{
+		{"values", "REQUIRED_FIELD"},
+		{"value", "UNSUPPORTED_FIELD"},
+		{"min_value", "UNSUPPORTED_FIELD"},
+	} {
+		if !hasValidationIssue(issues, want.field, want.code) {
+			t.Fatalf("Validate missing issue %s/%s in %#v", want.field, want.code, issues)
+		}
+	}
+}
+
+func TestValidateSignalTargeting_NumericRange(t *testing.T) {
+	targeting := SignalTargeting{
+		SignalID:  &SignalID{Source: "data_provider", ID: "score"},
+		ValueType: "numeric",
+		MinValue:  Ptr(10.0),
+		MaxValue:  Ptr(5.0),
+	}
+
+	issues := targeting.Validate()
+	if !hasValidationIssue(issues, "max_value", "INVALID_VALUE") {
+		t.Fatalf("Validate missing numeric range issue: %#v", issues)
+	}
+}
+
+func TestValidateSignalTargeting_StrictEnumsAreOptIn(t *testing.T) {
+	targeting := SignalTargeting{
+		SignalRef: &SignalRef{Scope: "product", SignalID: "future"},
+		ValueType: "future_type",
+	}
+
+	if issues := targeting.Validate(); hasValidationIssue(issues, "value_type", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate reported strict variant issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := targeting.Validate(WithStrictEnums()); !hasValidationIssue(issues, "value_type", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate missing strict variant issue: %#v", issues)
+	}
+}
+
+func TestValidateSignalTargeting_RequiresSignalReference(t *testing.T) {
+	targeting := SignalTargeting{
+		ValueType: "binary",
+		Value:     Ptr(false),
+	}
+
+	if issues := targeting.Validate(); !hasValidationIssue(issues, "signal_ref", "REQUIRED_FIELD") {
+		t.Fatalf("Validate missing signal_ref requirement: %#v", issues)
+	}
+}
+
+func TestValidateAudienceSelector_ValidDescription(t *testing.T) {
+	selector := AudienceSelector{
+		Type:        "description",
+		Description: "likely EV buyers",
+		Category:    "behavioral",
+	}
+
+	if issues := ValidateAudienceSelector(selector, WithStrictEnums()); len(issues) != 0 {
+		t.Fatalf("ValidateAudienceSelector issues = %#v, want none", issues)
+	}
+}
+
+func TestValidateAudienceSelector_SignalDelegatesValueTypeRules(t *testing.T) {
+	selector := AudienceSelector{
+		Type:      "signal",
+		SignalRef: &SignalRef{Scope: "product", SignalID: "age_band"},
+		ValueType: "numeric",
+		Values:    []string{"18-34"},
+	}
+
+	issues := selector.Validate()
+	if !hasValidationIssue(issues, "values", "UNSUPPORTED_FIELD") {
+		t.Fatalf("Validate missing signal branch values issue: %#v", issues)
+	}
+}
+
+func TestValidateAudienceSelector_DescriptionBranchSpecificFields(t *testing.T) {
+	selector := AudienceSelector{
+		Type:      "description",
+		SignalRef: &SignalRef{Scope: "product", SignalID: "segment"},
+		ValueType: "binary",
+		Value:     Ptr(true),
+	}
+
+	issues := selector.Validate()
+	for _, want := range []struct {
+		field string
+		code  string
+	}{
+		{"description", "REQUIRED_FIELD"},
+		{"signal_ref", "UNSUPPORTED_FIELD"},
+		{"value_type", "UNSUPPORTED_FIELD"},
+		{"value", "UNSUPPORTED_FIELD"},
+	} {
+		if !hasValidationIssue(issues, want.field, want.code) {
+			t.Fatalf("Validate missing issue %s/%s in %#v", want.field, want.code, issues)
+		}
+	}
+}
+
+func TestValidateAudienceSelector_StrictEnumsAreOptIn(t *testing.T) {
+	selector := AudienceSelector{Type: "future_selector"}
+
+	if issues := selector.Validate(); hasValidationIssue(issues, "type", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate reported strict variant issue without WithStrictEnums: %#v", issues)
+	}
+	if issues := selector.Validate(WithStrictEnums()); !hasValidationIssue(issues, "type", "UNKNOWN_VARIANT") {
+		t.Fatalf("Validate missing strict variant issue: %#v", issues)
+	}
+}


### PR DESCRIPTION
## Summary
- add opt-in Validate helpers for SignalTargeting and AudienceSelector flattened oneOf shapes
- enforce current branch-required fields and branch-specific field mismatches when callers explicitly validate
- keep future discriminator values forward-compatible by default; WithStrictEnums reports unknown variants

Closes #278

## Validation
- cd adcp && go test ./...
- go test ./...
- git diff --check