### PR TITLE
feat(adcp)!: type sync governance account results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 13
+        run: python3 generate.py --coverage-max-unreviewed-any 12
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -73,6 +73,10 @@ be populated.
 - `PolicyEntry.Exemplars` is now `*adcp.PolicyExemplars` instead of `any`.
   `PolicyExemplars.Pass` and `PolicyExemplars.Fail` are
   `[]adcp.PolicyExemplar`.
+- `SyncGovernanceSuccess.Accounts` is now
+  `[]adcp.SyncGovernanceAccountResult` instead of `[]any`.
+  `GovernanceAgents` is now `[]adcp.SyncGovernanceAgentResult`; per-account
+  `Errors` remains `[]adcp.AdcpError`.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -244,6 +244,26 @@ func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
 		"total_batches":   float64(3),
 	}, wire["pagination"])
 
+	out, err = json.Marshal(SyncGovernanceSuccess{
+		Accounts: []SyncGovernanceAccountResult{{
+			Account: AccountReference{AccountID: "acct-1"},
+			Status:  "synced",
+			GovernanceAgents: []SyncGovernanceAgentResult{{
+				URL: "https://governance.example.com",
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	accounts, ok := wire["accounts"].([]any)
+	require.True(t, ok)
+	require.Len(t, accounts, 1)
+	account, ok := accounts[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "synced", account["status"])
+	assert.Equal(t, map[string]any{"account_id": "acct-1"}, account["account"])
+
 	out, err = json.Marshal(PerformanceFeedback{
 		FeedbackID: "pf-1",
 		MediaBuyID: "mb-1",

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -565,6 +565,15 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "media-buy/create-media-buy-request.json#/properties/artifact_webhook",
     ),
     (
+        "SyncGovernanceAccountResult",
+        "account/sync-governance-response.json#/oneOf/0/properties/accounts/items",
+    ),
+    (
+        "SyncGovernanceAgentResult",
+        "account/sync-governance-response.json#/oneOf/0/properties/accounts/items"
+        "/properties/governance_agents/items",
+    ),
+    (
         "DeliveryAttributionWindow",
         "media-buy/get-media-buy-delivery-request.json#/properties/attribution_window",
     ),
@@ -1066,6 +1075,7 @@ CLOSED_INLINE_SCHEMA_TYPES = frozenset({
     'CollectionRequestPagination',
     'CollectionChangeSummary',
     'PropertyChangeSummary',
+    'SyncGovernanceAgentResult',
     'InstallmentDerivative',
     'ProductFilterMetro',
     'ProductFilterTrustedMatch',
@@ -1098,6 +1108,7 @@ OPEN_INLINE_SCHEMA_TYPES = frozenset({
     'PackageDelivery',
     'ProductDeliveryMeasurement',
     'ProductCatalogMatch',
+    'SyncGovernanceAccountResult',
     'AccountCreditLimit',
     'GeoProximityTarget',
     'CreativeFormatAccessibility',
@@ -1497,6 +1508,8 @@ INLINE_TYPE_HINTS = {
     ('PlanAuditFinding', 'severity'): 'EscalationSeverity',
     ('PlanAuditFinding', 'confidence'): '*float64',
     ('PlanAuditGovernedAction', 'purchase_type'): 'PurchaseType',
+    ('SyncGovernanceSuccess', 'accounts'): 'SyncGovernanceAccountResult',
+    ('SyncGovernanceAccountResult', 'governance_agents'): 'SyncGovernanceAgentResult',
     ('ListCreativeFormatsResponse', 'creative_agents'): 'CreativeAgentRef',
     ('BuildCreativeRequest', 'preview_inputs'): 'BuildCreativePreviewInput',
     ('GetMediaBuysRequest', 'status_filter'): '*MediaBuyStatusFilter',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1578,6 +1578,38 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertIn("Severity EscalationSeverity `json:\"severity\"`", plan_audit_finding_generated)
         self.assertIn("Confidence *float64 `json:\"confidence,omitempty\"`", plan_audit_finding_generated)
 
+        sync_governance_success_schema = generate.load_schema_spec(
+            "account/sync-governance-response.json#/oneOf/0",
+        )
+        sync_governance_accounts_type, reason = generate.field_go_type_info(
+            "SyncGovernanceSuccess",
+            "accounts",
+            generate.schema_properties(sync_governance_success_schema)["accounts"],
+            generate.schema_required_names(sync_governance_success_schema),
+        )
+        self.assertEqual("[]SyncGovernanceAccountResult", sync_governance_accounts_type)
+        self.assertIsNone(reason)
+
+        sync_governance_account_schema = generate.load_schema_spec(
+            "account/sync-governance-response.json#/oneOf/0/properties/accounts/items",
+        )
+        sync_governance_account_generated = generate.schema_to_struct(
+            "SyncGovernanceAccountResult",
+            sync_governance_account_schema,
+        )
+        self.assertIn(
+            "Account AccountReference `json:\"account\"`",
+            sync_governance_account_generated,
+        )
+        self.assertIn(
+            "GovernanceAgents []SyncGovernanceAgentResult `json:\"governance_agents,omitempty\"`",
+            sync_governance_account_generated,
+        )
+        self.assertIn(
+            "Errors []AdcpError `json:\"errors,omitempty\"`",
+            sync_governance_account_generated,
+        )
+
         plan_audit_action_schema = generate.load_schema_spec(
             "governance/get-plan-audit-logs-response.json#/properties/plans/items"
             "/properties/governed_actions/items",
@@ -1611,6 +1643,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ProductFilters", "required_features"), records)
         self.assertNotIn(("ProductFilters", "signal_targeting"), records)
         self.assertNotIn(("Targeting", "geo_proximity"), records)
+        self.assertNotIn(("SyncGovernanceSuccess", "accounts"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -8125,6 +8125,17 @@ type ArtifactWebhookConfig struct {
 	SamplingRate   *float64                    `json:"sampling_rate,omitempty"`   // Fraction of impressions to include (0-1). 1.0 = all impressions, 0.1 = 10%
 }
 
+type SyncGovernanceAccountResult struct {
+	Account          AccountReference            `json:"account"`                     // Account reference, echoed from request
+	Status           string                      `json:"status"`                      // Sync result. synced: governance agents persisted. failed: could not complete
+	GovernanceAgents []SyncGovernanceAgentResult `json:"governance_agents,omitempty"` // Governance agent now synced on this account. Reflects the persisted state
+	Errors           []AdcpError                 `json:"errors,omitempty"`            // Per-account errors (only present when status is 'failed')
+}
+
+type SyncGovernanceAgentResult struct {
+	URL string `json:"url"` // Governance agent endpoint URL.
+}
+
 // DeliveryAttributionWindow — Attribution window to apply for conversion metrics. When provided, the seller returns conversion
 type DeliveryAttributionWindow struct {
 	PostClick *Duration        `json:"post_click,omitempty"` // Post-click attribution window to apply.
@@ -9246,9 +9257,9 @@ type SyncGovernanceResponse = any
 
 // SyncGovernanceSuccess — Sync processed — individual accounts may have errors
 type SyncGovernanceSuccess struct {
-	Accounts []any `json:"accounts"` // Per-account sync results
-	Context  any   `json:"context,omitempty"`
-	Ext      any   `json:"ext,omitempty"`
+	Accounts []SyncGovernanceAccountResult `json:"accounts"` // Per-account sync results
+	Context  any                           `json:"context,omitempty"`
+	Ext      any                           `json:"ext,omitempty"`
 }
 
 // SyncGovernanceError — Operation failed completely, no accounts were processed

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 13
+python3 generate.py --coverage-max-unreviewed-any 12
 ```
 
 The generator currently reports 223 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 210 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 13 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 12 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 13
+python3 generate.py --coverage-max-unreviewed-any 12
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -55,7 +55,6 @@ the new dynamic shape is reviewed in the same PR.
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
 | `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
-| `SyncGovernanceSuccess.Accounts` | `accounts` | `[]any` | `array_item:inline_object` | `account/sync-governance-response.json#/oneOf/0` |
 | `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
 | `GetProductsResponse.RefinementApplied` | `refinement_applied` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-response.json` |
 | `CreateMediaBuyResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/create-media-buy-response.json` |
@@ -72,7 +71,7 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 6 unreviewed fallbacks are direct inline
+This is the largest generator gap: 5 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.


### PR DESCRIPTION
## Summary
- generate `SyncGovernanceAccountResult` and `SyncGovernanceAgentResult` for `SyncGovernanceSuccess.accounts`
- keep the account result registered as an explicitly open inline helper and the nested agent result as closed
- lower generated unreviewed `any` coverage from 13 to 12 and document the migration

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 12`\n- `cd adcp && go test ./...`\n- `go test ./...`\n- `git diff --check`\n\nRefs #259