### PR TITLE
feat(adcp)!: type preview creative request items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 12
+        run: python3 generate.py --coverage-max-unreviewed-any 10
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -77,6 +77,10 @@ be populated.
   `[]adcp.SyncGovernanceAccountResult` instead of `[]any`.
   `GovernanceAgents` is now `[]adcp.SyncGovernanceAgentResult`; per-account
   `Errors` remains `[]adcp.AdcpError`.
+- `PreviewCreativeRequest.Inputs` is now `[]adcp.PreviewCreativeInput` and
+  `PreviewCreativeRequest.Requests` is now
+  `[]adcp.PreviewCreativeBatchRequest` instead of `[]any`. Batch request
+  `Inputs` also uses `[]adcp.PreviewCreativeInput`.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/inputs_test.go
+++ b/adcp/inputs_test.go
@@ -264,6 +264,31 @@ func TestGeneratedInlineLeafObjectsMarshal(t *testing.T) {
 	assert.Equal(t, "synced", account["status"])
 	assert.Equal(t, map[string]any{"account_id": "acct-1"}, account["account"])
 
+	out, err = json.Marshal(PreviewCreativeRequest{
+		RequestType: "batch",
+		Requests: []PreviewCreativeBatchRequest{{
+			CreativeManifest: CreativeManifest{Assets: map[string]any{}},
+			Inputs: []PreviewCreativeInput{{
+				Name:   "mobile",
+				Macros: map[string]string{"city": "Honolulu"},
+			}},
+			OutputFormat: PreviewOutputFormatURL,
+		}},
+	})
+	require.NoError(t, err)
+	wire = nil
+	require.NoError(t, json.Unmarshal(out, &wire))
+	requests, ok := wire["requests"].([]any)
+	require.True(t, ok)
+	require.Len(t, requests, 1)
+	previewRequest, ok := requests[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "url", previewRequest["output_format"])
+	assert.Equal(t, []any{map[string]any{
+		"name":   "mobile",
+		"macros": map[string]any{"city": "Honolulu"},
+	}}, previewRequest["inputs"])
+
 	out, err = json.Marshal(PerformanceFeedback{
 		FeedbackID: "pf-1",
 		MediaBuyID: "mb-1",

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -967,6 +967,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "creative/list-creatives-request.json#/properties/sort",
     ),
     (
+        "PreviewCreativeInput",
+        "creative/preview-creative-request.json#/properties/inputs/items",
+    ),
+    (
+        "PreviewCreativeBatchRequest",
+        "creative/preview-creative-request.json#/properties/requests/items",
+    ),
+    (
         "ArtifactWebhookPagination",
         "content-standards/artifact-webhook-payload.json#/properties/pagination",
     ),
@@ -1115,6 +1123,8 @@ OPEN_INLINE_SCHEMA_TYPES = frozenset({
     'DeliveryQuartileData',
     'IOAcceptance',
     'ArtifactWebhookConfig',
+    'PreviewCreativeInput',
+    'PreviewCreativeBatchRequest',
     'DeliveryAttributionWindow',
     'DeliveryReportingDimensions',
     'DeliveryReportingGeoDimension',
@@ -1194,6 +1204,11 @@ SHARED_INLINE_OVERRIDES = {
         "#/properties/reporting_dimensions/properties/audience",
         "media-buy/get-media-buy-delivery-request.json"
         "#/properties/reporting_dimensions/properties/placement",
+    ],
+    "PreviewCreativeInput": [
+        "creative/preview-creative-request.json#/properties/inputs/items",
+        "creative/preview-creative-request.json"
+        "#/properties/requests/items/properties/inputs/items",
     ],
 }
 
@@ -1352,6 +1367,9 @@ INLINE_TYPE_HINTS = {
     ('GetSignalsRequest', 'filters'): 'SignalFilters',
     ('GetProductsRequest', 'filters'): '*ProductFilters',
     ('ListCreativesRequest', 'sort'): '*ListCreativesSort',
+    ('PreviewCreativeRequest', 'inputs'): 'PreviewCreativeInput',
+    ('PreviewCreativeRequest', 'requests'): 'PreviewCreativeBatchRequest',
+    ('PreviewCreativeBatchRequest', 'inputs'): 'PreviewCreativeInput',
     ('SyncPlansRequest', 'plans'): 'Plan',
     ('GetProductsResponse', 'proposals'): 'Proposal',
     ('PackageUpdate', 'keyword_targets_add'): 'KeywordTargetUpdate',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -879,6 +879,18 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "[]GeoProximityTarget",
         )
         self.assert_field_type(
+            "creative/preview-creative-request.json",
+            "PreviewCreativeRequest",
+            "inputs",
+            "[]PreviewCreativeInput",
+        )
+        self.assert_field_type(
+            "creative/preview-creative-request.json",
+            "PreviewCreativeRequest",
+            "requests",
+            "[]PreviewCreativeBatchRequest",
+        )
+        self.assert_field_type(
             "core/signal-targeting.json",
             "SignalTargeting",
             "min_value",
@@ -1610,6 +1622,22 @@ class InlineObjectGenerationTest(unittest.TestCase):
             sync_governance_account_generated,
         )
 
+        preview_batch_request_schema = generate.load_schema_spec(
+            "creative/preview-creative-request.json#/properties/requests/items",
+        )
+        preview_batch_request_generated = generate.schema_to_struct(
+            "PreviewCreativeBatchRequest",
+            preview_batch_request_schema,
+        )
+        self.assertIn(
+            "CreativeManifest CreativeManifest `json:\"creative_manifest\"`",
+            preview_batch_request_generated,
+        )
+        self.assertIn(
+            "Inputs []PreviewCreativeInput `json:\"inputs,omitempty\"`",
+            preview_batch_request_generated,
+        )
+
         plan_audit_action_schema = generate.load_schema_spec(
             "governance/get-plan-audit-logs-response.json#/properties/plans/items"
             "/properties/governed_actions/items",
@@ -1644,6 +1672,8 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("ProductFilters", "signal_targeting"), records)
         self.assertNotIn(("Targeting", "geo_proximity"), records)
         self.assertNotIn(("SyncGovernanceSuccess", "accounts"), records)
+        self.assertNotIn(("PreviewCreativeRequest", "inputs"), records)
+        self.assertNotIn(("PreviewCreativeRequest", "requests"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -9123,6 +9123,22 @@ type ListCreativesSort struct {
 	Direction SortDirection     `json:"direction,omitempty"` // Sort direction
 }
 
+type PreviewCreativeInput struct {
+	Name               string            `json:"name"`                          // Human-readable name for this input set (e.g., 'Sunny morning on mobile'
+	Macros             map[string]string `json:"macros,omitempty"`              // Macro values to use for this preview. Supports all universal macros from the
+	ContextDescription string            `json:"context_description,omitempty"` // Natural language description of the context for AI-generated content (e.g.
+}
+
+type PreviewCreativeBatchRequest struct {
+	FormatID         *FormatRef             `json:"format_id,omitempty"`     // Format identifier for rendering the preview. Defaults to
+	CreativeManifest CreativeManifest       `json:"creative_manifest"`       // Complete creative manifest with all required assets.
+	Inputs           []PreviewCreativeInput `json:"inputs,omitempty"`        // Array of input sets for generating multiple preview variants
+	TemplateID       string                 `json:"template_id,omitempty"`   // Specific template ID for custom format rendering
+	Quality          CreativeQuality        `json:"quality,omitempty"`       // Render quality for this preview. Overrides batch-level default.
+	OutputFormat     PreviewOutputFormat    `json:"output_format,omitempty"` // Output format for this preview. Overrides batch-level default.
+	ItemLimit        int                    `json:"item_limit,omitempty"`    // Maximum number of catalog items to render in this preview.
+}
+
 // ArtifactWebhookPagination — Pagination info when batching large artifact sets
 type ArtifactWebhookPagination struct {
 	TotalArtifacts int `json:"total_artifacts,omitempty"` // Total artifacts in the delivery period
@@ -9721,21 +9737,21 @@ type ListCreativesRequest struct {
 
 // PreviewCreativeRequest — Request to generate previews of creative manifests. Uses request_type to select single, batch, or
 type PreviewCreativeRequest struct {
-	AdcpVersion      string              `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
-	AdcpMajorVersion int                 `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
-	RequestType      string              `json:"request_type"`                 // Preview mode. 'single' previews one creative manifest. 'batch' previews
-	CreativeManifest *CreativeManifest   `json:"creative_manifest,omitempty"`  // Complete creative manifest with all required assets for the format. Required
-	FormatID         *FormatRef          `json:"format_id,omitempty"`          // Always a structured object {agent_url, id} — never a plain string. Format
-	Inputs           []any               `json:"inputs,omitempty"`             // Array of input sets for generating multiple preview variants. Each input set
-	TemplateID       string              `json:"template_id,omitempty"`        // Specific template ID for custom format rendering. Used in single mode.
-	Quality          CreativeQuality     `json:"quality,omitempty"`            // Render quality. 'draft' produces fast, lower-fidelity renderings. 'production'
-	OutputFormat     PreviewOutputFormat `json:"output_format,omitempty"`      // Output format. 'url' returns preview_url (iframe-embeddable URL), 'html'
-	ItemLimit        int                 `json:"item_limit,omitempty"`         // Maximum number of catalog items to render per preview variant. Used in single
-	Requests         []any               `json:"requests,omitempty"`           // Array of preview requests (1-50 items). Required when request_type is 'batch'.
-	VariantID        string              `json:"variant_id,omitempty"`         // Platform-assigned variant identifier from get_creative_delivery response.
-	CreativeID       string              `json:"creative_id,omitempty"`        // Creative identifier for context. Used in variant mode.
-	Context          any                 `json:"context,omitempty"`
-	Ext              any                 `json:"ext,omitempty"`
+	AdcpVersion      string                        `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
+	AdcpMajorVersion int                           `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
+	RequestType      string                        `json:"request_type"`                 // Preview mode. 'single' previews one creative manifest. 'batch' previews
+	CreativeManifest *CreativeManifest             `json:"creative_manifest,omitempty"`  // Complete creative manifest with all required assets for the format. Required
+	FormatID         *FormatRef                    `json:"format_id,omitempty"`          // Always a structured object {agent_url, id} — never a plain string. Format
+	Inputs           []PreviewCreativeInput        `json:"inputs,omitempty"`             // Array of input sets for generating multiple preview variants. Each input set
+	TemplateID       string                        `json:"template_id,omitempty"`        // Specific template ID for custom format rendering. Used in single mode.
+	Quality          CreativeQuality               `json:"quality,omitempty"`            // Render quality. 'draft' produces fast, lower-fidelity renderings. 'production'
+	OutputFormat     PreviewOutputFormat           `json:"output_format,omitempty"`      // Output format. 'url' returns preview_url (iframe-embeddable URL), 'html'
+	ItemLimit        int                           `json:"item_limit,omitempty"`         // Maximum number of catalog items to render per preview variant. Used in single
+	Requests         []PreviewCreativeBatchRequest `json:"requests,omitempty"`           // Array of preview requests (1-50 items). Required when request_type is 'batch'.
+	VariantID        string                        `json:"variant_id,omitempty"`         // Platform-assigned variant identifier from get_creative_delivery response.
+	CreativeID       string                        `json:"creative_id,omitempty"`        // Creative identifier for context. Used in variant mode.
+	Context          any                           `json:"context,omitempty"`
+	Ext              any                           `json:"ext,omitempty"`
 }
 
 // GetSignalsRequest — Request parameters for discovering and refining signals. Use signal_spec for natural language

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 12
+python3 generate.py --coverage-max-unreviewed-any 10
 ```
 
-The generator currently reports 223 generated dynamic `any` uses:
+The generator currently reports 221 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 12 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 10 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 12
+python3 generate.py --coverage-max-unreviewed-any 10
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -59,8 +59,6 @@ the new dynamic shape is reviewed in the same PR.
 | `GetProductsResponse.RefinementApplied` | `refinement_applied` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-response.json` |
 | `CreateMediaBuyResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/create-media-buy-response.json` |
 | `ProvidePerformanceFeedbackResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/provide-performance-feedback-response.json` |
-| `PreviewCreativeRequest.Inputs` | `inputs` | `[]any` | `array_item:inline_object` | `creative/preview-creative-request.json` |
-| `PreviewCreativeRequest.Requests` | `requests` | `[]any` | `array_item:inline_object` | `creative/preview-creative-request.json` |
 | `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
@@ -71,7 +69,7 @@ the new dynamic shape is reviewed in the same PR.
 
 ### Inline Object Generation
 
-This is the largest generator gap: 5 unreviewed fallbacks are direct inline
+This is the largest generator gap: 4 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.


### PR DESCRIPTION
## Summary
- generate `PreviewCreativeInput` and `PreviewCreativeBatchRequest` for preview creative request arrays
- reuse `PreviewCreativeInput` for nested batch inputs with a shared inline override
- lower generated unreviewed `any` coverage from 12 to 10 and document the migration

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 10`\n- `cd adcp && go test ./...`\n- `go test ./...`\n- `git diff --check`\n\nRefs #259