### PR TITLE
feat(adcp)!: type report plan outcome seller response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 10
+        run: python3 generate.py --coverage-max-unreviewed-any 9
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -61,6 +61,12 @@ be populated.
   such as `Spend`, `CPM`, and `Impressions` are pointers so explicit zero values
   still marshal. The schema's open `additionalProperties` allowance is not
   exposed as a synthetic `Extra`/`Ext` map; use the schema-authored fields.
+- `ReportPlanOutcomeRequest.SellerResponse` is now
+  `*adcp.ReportPlanOutcomeSellerResponse` instead of `any`. Optional budget
+  values such as `CommittedBudget` and package `Budget` are pointers so explicit
+  zero values still marshal. The schema's open `additionalProperties` allowance
+  is not exposed as a synthetic `Extra`/`Ext` map; use the schema-authored
+  fields.
 - `ReportPlanOutcomeRequest.Error` is now
   `*adcp.ReportPlanOutcomeError` instead of `any`, with schema-backed `Code`
   and `Message` fields.

--- a/adcp/generated_core_refs_test.go
+++ b/adcp/generated_core_refs_test.go
@@ -1100,6 +1100,52 @@ func TestReportPlanOutcomeDeliveryPreservesExplicitZero(t *testing.T) {
 	}
 }
 
+func TestReportPlanOutcomeSellerResponsePreservesExplicitZero(t *testing.T) {
+	req := ReportPlanOutcomeRequest{
+		PlanID:            "plan-1",
+		IdempotencyKey:    "idem-1",
+		Outcome:           "completed",
+		GovernanceContext: "ctx-1",
+		SellerResponse: Ptr(ReportPlanOutcomeSellerResponse{
+			SellerReference: "mb-1",
+			CommittedBudget: Ptr(0.0),
+			Packages: []ReportPlanOutcomeSellerPackage{{
+				Budget: Ptr(0.0),
+			}},
+		}),
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal report plan outcome request: %v", err)
+	}
+	body := string(raw)
+	for _, want := range []string{
+		`"committed_budget":0`,
+		`"budget":0`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("marshaled report plan outcome missing %s:\n%s", want, body)
+		}
+	}
+
+	var decoded ReportPlanOutcomeRequest
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal report plan outcome request: %v", err)
+	}
+	if decoded.SellerResponse == nil {
+		t.Fatal("seller_response did not round-trip")
+	}
+	if decoded.SellerResponse.CommittedBudget == nil || *decoded.SellerResponse.CommittedBudget != 0 {
+		t.Fatalf("committed_budget = %v, want pointer to 0", decoded.SellerResponse.CommittedBudget)
+	}
+	if len(decoded.SellerResponse.Packages) != 1 ||
+		decoded.SellerResponse.Packages[0].Budget == nil ||
+		*decoded.SellerResponse.Packages[0].Budget != 0 {
+		t.Fatalf("package budget did not round-trip as pointer to 0: %#v", decoded.SellerResponse.Packages)
+	}
+}
+
 func TestReportPlanOutcomeErrorRoundTrip(t *testing.T) {
 	req := ReportPlanOutcomeRequest{
 		PlanID:            "plan-1",

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -608,6 +608,15 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "governance/report-plan-outcome-request.json#/properties/delivery",
     ),
     (
+        "ReportPlanOutcomeSellerResponse",
+        "governance/report-plan-outcome-request.json#/properties/seller_response",
+    ),
+    (
+        "ReportPlanOutcomeSellerPackage",
+        "governance/report-plan-outcome-request.json#/properties/seller_response"
+        "/properties/packages/items",
+    ),
+    (
         "ReportPlanOutcomeDeliveryReportingPeriod",
         "governance/report-plan-outcome-request.json#/properties/delivery"
         "/properties/reporting_period",
@@ -1130,6 +1139,8 @@ OPEN_INLINE_SCHEMA_TYPES = frozenset({
     'DeliveryReportingGeoDimension',
     'DeliveryReportingDimension',
     'ReportPlanOutcomeDelivery',
+    'ReportPlanOutcomeSellerResponse',
+    'ReportPlanOutcomeSellerPackage',
     'CreativeAgentRef',
     'BuildCreativePreviewInput',
     'RightsAgentRef',
@@ -1460,6 +1471,10 @@ INLINE_TYPE_HINTS = {
     ('GovernanceDeliveryMetrics', 'impressions'): '*int',
     ('GovernanceDeliveryMetrics', 'cumulative_impressions'): '*int',
     ('GovernanceDeliveryMetrics', 'audience_distribution'): '*GovernanceAudienceDistribution',
+    ('ReportPlanOutcomeRequest', 'seller_response'): '*ReportPlanOutcomeSellerResponse',
+    ('ReportPlanOutcomeSellerResponse', 'committed_budget'): '*float64',
+    ('ReportPlanOutcomeSellerResponse', 'packages'): 'ReportPlanOutcomeSellerPackage',
+    ('ReportPlanOutcomeSellerPackage', 'budget'): '*float64',
     ('ReportPlanOutcomeRequest', 'delivery'): '*ReportPlanOutcomeDelivery',
     ('ReportPlanOutcomeDelivery', 'reporting_period'): '*ReportPlanOutcomeDeliveryReportingPeriod',
     ('ReportPlanOutcomeDelivery', 'impressions'): '*int',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -911,6 +911,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assert_field_type(
             "governance/report-plan-outcome-request.json",
             "ReportPlanOutcomeRequest",
+            "seller_response",
+            "*ReportPlanOutcomeSellerResponse",
+        )
+        self.assert_field_type(
+            "governance/report-plan-outcome-request.json",
+            "ReportPlanOutcomeRequest",
             "delivery",
             "*ReportPlanOutcomeDelivery",
         )
@@ -1353,6 +1359,36 @@ class InlineObjectGenerationTest(unittest.TestCase):
             outcome_delivery_generated,
         )
 
+        seller_response_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-request.json#/properties/seller_response",
+        )
+        seller_response_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeSellerResponse",
+            seller_response_schema,
+        )
+        self.assertIn(
+            "CommittedBudget *float64 `json:\"committed_budget,omitempty\"`",
+            seller_response_generated,
+        )
+        self.assertIn(
+            "Packages []ReportPlanOutcomeSellerPackage `json:\"packages,omitempty\"`",
+            seller_response_generated,
+        )
+        self.assertIn(
+            "PlannedDelivery *PlannedDelivery `json:\"planned_delivery,omitempty\"`",
+            seller_response_generated,
+        )
+
+        seller_package_schema = generate.load_schema_spec(
+            "governance/report-plan-outcome-request.json#/properties/seller_response"
+            "/properties/packages/items",
+        )
+        seller_package_generated = generate.schema_to_struct(
+            "ReportPlanOutcomeSellerPackage",
+            seller_package_schema,
+        )
+        self.assertIn("Budget *float64 `json:\"budget,omitempty\"`", seller_package_generated)
+
         outcome_reporting_period_schema = generate.load_schema_spec(
             "governance/report-plan-outcome-request.json#/properties/delivery"
             "/properties/reporting_period",
@@ -1675,6 +1711,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("PreviewCreativeRequest", "inputs"), records)
         self.assertNotIn(("PreviewCreativeRequest", "requests"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
+        self.assertNotIn(("ReportPlanOutcomeRequest", "seller_response"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "error"), records)
         self.assertNotIn(("ReportPlanOutcomeResponse", "plan_summary"), records)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -8203,6 +8203,19 @@ type ReportPlanOutcomeDelivery struct {
 	CompletionRate  *float64                                  `json:"completion_rate,omitempty"`  // Video completion rate (0-1).
 }
 
+// ReportPlanOutcomeSellerResponse — The seller's full response. Required when outcome is 'completed'.
+type ReportPlanOutcomeSellerResponse struct {
+	SellerReference  string                           `json:"seller_reference,omitempty"`  // The seller's identifier for the created resource (e.g., media_buy_id
+	CommittedBudget  *float64                         `json:"committed_budget,omitempty"`  // Total budget committed across all confirmed packages. When present, the
+	Packages         []ReportPlanOutcomeSellerPackage `json:"packages,omitempty"`          // Confirmed packages with actual budget and targeting.
+	PlannedDelivery  *PlannedDelivery                 `json:"planned_delivery,omitempty"`  // What the seller said it will deliver. When seller-side governance is not
+	CreativeDeadline string                           `json:"creative_deadline,omitempty"` // ISO 8601 deadline for creative submission.
+}
+
+type ReportPlanOutcomeSellerPackage struct {
+	Budget *float64 `json:"budget,omitempty"`
+}
+
 // ReportPlanOutcomeDeliveryReportingPeriod — Start and end timestamps for the reporting window.
 type ReportPlanOutcomeDeliveryReportingPeriod struct {
 	Start string `json:"start"`
@@ -9977,19 +9990,19 @@ type CheckGovernanceResponse struct {
 
 // ReportPlanOutcomeRequest — Report the outcome of an action to the governance agent. Called by the orchestrator (buyer-side
 type ReportPlanOutcomeRequest struct {
-	AdcpVersion       string                     `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
-	AdcpMajorVersion  int                        `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
-	PlanID            string                     `json:"plan_id"`                      // The plan this outcome is for. The plan uniquely scopes the account and
-	CheckID           string                     `json:"check_id,omitempty"`           // The check_id from check_governance. Links the outcome to the governance check
-	IdempotencyKey    string                     `json:"idempotency_key"`              // Client-generated unique key for this request. Prevents duplicate outcome
-	PurchaseType      PurchaseType               `json:"purchase_type,omitempty"`      // The type of financial commitment this outcome is for. Determines which budget
-	Outcome           OutcomeType                `json:"outcome"`                      // Outcome type.
-	SellerResponse    any                        `json:"seller_response,omitempty"`    // The seller's full response. Required when outcome is 'completed'.
-	Delivery          *ReportPlanOutcomeDelivery `json:"delivery,omitempty"`           // Delivery metrics. Required when outcome is 'delivery'.
-	Error             *ReportPlanOutcomeError    `json:"error,omitempty"`              // Error details. Required when outcome is 'failed'.
-	GovernanceContext string                     `json:"governance_context"`           // Opaque governance context from the check_governance response that authorized
-	Context           any                        `json:"context,omitempty"`
-	Ext               any                        `json:"ext,omitempty"`
+	AdcpVersion       string                           `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
+	AdcpMajorVersion  int                              `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
+	PlanID            string                           `json:"plan_id"`                      // The plan this outcome is for. The plan uniquely scopes the account and
+	CheckID           string                           `json:"check_id,omitempty"`           // The check_id from check_governance. Links the outcome to the governance check
+	IdempotencyKey    string                           `json:"idempotency_key"`              // Client-generated unique key for this request. Prevents duplicate outcome
+	PurchaseType      PurchaseType                     `json:"purchase_type,omitempty"`      // The type of financial commitment this outcome is for. Determines which budget
+	Outcome           OutcomeType                      `json:"outcome"`                      // Outcome type.
+	SellerResponse    *ReportPlanOutcomeSellerResponse `json:"seller_response,omitempty"`    // The seller's full response. Required when outcome is 'completed'.
+	Delivery          *ReportPlanOutcomeDelivery       `json:"delivery,omitempty"`           // Delivery metrics. Required when outcome is 'delivery'.
+	Error             *ReportPlanOutcomeError          `json:"error,omitempty"`              // Error details. Required when outcome is 'failed'.
+	GovernanceContext string                           `json:"governance_context"`           // Opaque governance context from the check_governance response that authorized
+	Context           any                              `json:"context,omitempty"`
+	Ext               any                              `json:"ext,omitempty"`
 }
 
 // ReportPlanOutcomeResponse — Response from reporting an action outcome. Only returned to the orchestrator (buyer-side agent)

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 10
+python3 generate.py --coverage-max-unreviewed-any 9
 ```
 
-The generator currently reports 221 generated dynamic `any` uses:
+The generator currently reports 220 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 10 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 9 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 10
+python3 generate.py --coverage-max-unreviewed-any 9
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -62,14 +62,13 @@ the new dynamic shape is reviewed in the same PR.
 | `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
-| `ReportPlanOutcomeRequest.SellerResponse` | `seller_response` | `any` | `inline_object` | `governance/report-plan-outcome-request.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
 
 ### Inline Object Generation
 
-This is the largest generator gap: 4 unreviewed fallbacks are direct inline
+This is the largest generator gap: 3 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.


### PR DESCRIPTION
## Summary
- generate `ReportPlanOutcomeSellerResponse` and `ReportPlanOutcomeSellerPackage` for `seller_response`
- keep committed budget and package budget pointer-backed so explicit zero values marshal
- lower generated unreviewed `any` coverage from 10 to 9 and document the migration

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 9`\n- `cd adcp && go test ./...`\n- `go test ./...`\n- `git diff --check`\n\nRefs #259