### PR TITLE
feat(adcp)!: type forced test controller directives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 9
+        run: python3 generate.py --coverage-max-unreviewed-any 8
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -87,6 +87,9 @@ be populated.
   `PreviewCreativeRequest.Requests` is now
   `[]adcp.PreviewCreativeBatchRequest` instead of `[]any`. Batch request
   `Inputs` also uses `[]adcp.PreviewCreativeInput`.
+- `ForcedDirectiveSuccess.Forced` is now `adcp.ForcedDirective` instead of
+  `any`. The reference seller now emits directive `message` at the response
+  top level, matching the schema, instead of inside `forced`.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -984,6 +984,10 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "creative/preview-creative-request.json#/properties/requests/items",
     ),
     (
+        "ForcedDirective",
+        "compliance/comply-test-controller-response.json#/oneOf/3/properties/forced",
+    ),
+    (
         "ArtifactWebhookPagination",
         "content-standards/artifact-webhook-payload.json#/properties/pagination",
     ),
@@ -1093,6 +1097,7 @@ CLOSED_INLINE_SCHEMA_TYPES = frozenset({
     'CollectionChangeSummary',
     'PropertyChangeSummary',
     'SyncGovernanceAgentResult',
+    'ForcedDirective',
     'InstallmentDerivative',
     'ProductFilterMetro',
     'ProductFilterTrustedMatch',
@@ -1381,6 +1386,7 @@ INLINE_TYPE_HINTS = {
     ('PreviewCreativeRequest', 'inputs'): 'PreviewCreativeInput',
     ('PreviewCreativeRequest', 'requests'): 'PreviewCreativeBatchRequest',
     ('PreviewCreativeBatchRequest', 'inputs'): 'PreviewCreativeInput',
+    ('ForcedDirectiveSuccess', 'forced'): 'ForcedDirective',
     ('SyncPlansRequest', 'plans'): 'Plan',
     ('GetProductsResponse', 'proposals'): 'Proposal',
     ('PackageUpdate', 'keyword_targets_add'): 'KeywordTargetUpdate',

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -890,6 +890,17 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "requests",
             "[]PreviewCreativeBatchRequest",
         )
+        forced_success_schema = generate.load_schema_spec(
+            "compliance/comply-test-controller-response.json#/oneOf/3",
+        )
+        forced_type, reason = generate.field_go_type_info(
+            "ForcedDirectiveSuccess",
+            "forced",
+            generate.schema_properties(forced_success_schema)["forced"],
+            generate.schema_required_names(forced_success_schema),
+        )
+        self.assertEqual("ForcedDirective", forced_type)
+        self.assertIsNone(reason)
         self.assert_field_type(
             "core/signal-targeting.json",
             "SignalTargeting",
@@ -1674,6 +1685,16 @@ class InlineObjectGenerationTest(unittest.TestCase):
             preview_batch_request_generated,
         )
 
+        forced_directive_schema = generate.load_schema_spec(
+            "compliance/comply-test-controller-response.json#/oneOf/3/properties/forced",
+        )
+        forced_directive_generated = generate.schema_to_struct(
+            "ForcedDirective",
+            forced_directive_schema,
+        )
+        self.assertIn("Arm string `json:\"arm\"`", forced_directive_generated)
+        self.assertIn("TaskID string `json:\"task_id,omitempty\"`", forced_directive_generated)
+
         plan_audit_action_schema = generate.load_schema_spec(
             "governance/get-plan-audit-logs-response.json#/properties/plans/items"
             "/properties/governed_actions/items",
@@ -1710,6 +1731,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("SyncGovernanceSuccess", "accounts"), records)
         self.assertNotIn(("PreviewCreativeRequest", "inputs"), records)
         self.assertNotIn(("PreviewCreativeRequest", "requests"), records)
+        self.assertNotIn(("ForcedDirectiveSuccess", "forced"), records)
         self.assertNotIn(("CheckGovernanceRequest", "delivery_metrics"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "seller_response"), records)
         self.assertNotIn(("ReportPlanOutcomeRequest", "delivery"), records)

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -9152,6 +9152,12 @@ type PreviewCreativeBatchRequest struct {
 	ItemLimit        int                    `json:"item_limit,omitempty"`    // Maximum number of catalog items to render in this preview.
 }
 
+// ForcedDirective — Echo of the registered directive. The next create_media_buy call from this sandbox account will
+type ForcedDirective struct {
+	Arm    string `json:"arm"`               // Arm the seller will emit on the next create_media_buy response.
+	TaskID string `json:"task_id,omitempty"` // Echo of the registered task_id. Present only when arm is 'submitted' (the arm
+}
+
 // ArtifactWebhookPagination — Pagination info when batching large artifact sets
 type ArtifactWebhookPagination struct {
 	TotalArtifacts int `json:"total_artifacts,omitempty"` // Total artifacts in the delivery period
@@ -9875,11 +9881,11 @@ type SimulationSuccess struct {
 
 // ForcedDirectiveSuccess — A force_create_media_buy_arm directive was registered. The directive shapes the next
 type ForcedDirectiveSuccess struct {
-	Success bool   `json:"success"`
-	Forced  any    `json:"forced"`            // Echo of the registered directive. The next create_media_buy call from this
-	Message string `json:"message,omitempty"` // Human-readable acknowledgement.
-	Context any    `json:"context,omitempty"`
-	Ext     any    `json:"ext,omitempty"`
+	Success bool            `json:"success"`
+	Forced  ForcedDirective `json:"forced"`            // Echo of the registered directive. The next create_media_buy call from this
+	Message string          `json:"message,omitempty"` // Human-readable acknowledgement.
+	Context any             `json:"context,omitempty"`
+	Ext     any             `json:"ext,omitempty"`
 }
 
 // SeedSuccess — A seed_* scenario successfully pre-populated a fixture in the seller's test state

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 9
+python3 generate.py --coverage-max-unreviewed-any 8
 ```
 
-The generator currently reports 220 generated dynamic `any` uses:
+The generator currently reports 219 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 9 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 8 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 9
+python3 generate.py --coverage-max-unreviewed-any 8
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -61,14 +61,13 @@ the new dynamic shape is reviewed in the same PR.
 | `ProvidePerformanceFeedbackResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/provide-performance-feedback-response.json` |
 | `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
 | `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
-| `ForcedDirectiveSuccess.Forced` | `forced` | `any` | `inline_object` | `compliance/comply-test-controller-response.json#/oneOf/3` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
 
 ### Inline Object Generation
 
-This is the largest generator gap: 3 unreviewed fallbacks are direct inline
+This is the largest generator gap: 2 unreviewed fallbacks are direct inline
 objects or arrays of inline objects. The generator needs stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -650,7 +650,11 @@ func (b *backend) handleCustomScenario(scenario string, params map[string]any) (
 		b.mu.Lock()
 		b.forced = &forceArm{TaskID: taskID, Message: message}
 		b.mu.Unlock()
-		return map[string]any{"success": true, "forced": map[string]any{"arm": arm, "task_id": taskID, "message": message}}, nil
+		return map[string]any{
+			"success": true,
+			"forced":  map[string]any{"arm": arm, "task_id": taskID},
+			"message": message,
+		}, nil
 	default:
 		return nil, &adcp.TestControllerError{Code: "UNKNOWN_SCENARIO", Message: "Unrecognized scenario name"}
 	}

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -621,13 +621,27 @@ func TestCustomScenario_SeedPricingOption(t *testing.T) {
 func TestCustomScenario_ForceCreateMediaBuyArm_Submitted(t *testing.T) {
 	b := newTestBackend()
 
-	_, err := b.handleCustomScenario("force_create_media_buy_arm", map[string]any{
+	result, err := b.handleCustomScenario("force_create_media_buy_arm", map[string]any{
 		"arm":     "submitted",
 		"task_id": "task-abc-123",
 		"message": "processing in async queue",
 	})
 	if err != nil {
 		t.Fatalf("force_create_media_buy_arm: %v", err)
+	}
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("want map result, got %T", result)
+	}
+	forced, ok := resultMap["forced"].(map[string]any)
+	if !ok {
+		t.Fatalf("want forced map, got %T", resultMap["forced"])
+	}
+	if forced["message"] != nil {
+		t.Fatalf("forced.message should not be present: %#v", forced)
+	}
+	if resultMap["message"] != "processing in async queue" {
+		t.Fatalf("want top-level message, got %#v", resultMap["message"])
 	}
 
 	resp, err := b.createMediaBuyResponse(&adcp.CreateMediaBuyRequest{


### PR DESCRIPTION
## Summary
- generate `ForcedDirective` for `ForcedDirectiveSuccess.forced`
- lower generated unreviewed `any` coverage from 9 to 8
- move the reference seller forced-arm `message` to the response top level so `forced` matches the closed schema shape

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 8`\n- `cd adcp && go test ./...`\n- `go test ./...`\n- `cd reference/seller-agent && go test ./...`\n- `git diff --check`\n\nRefs #259