### PR TITLE
feat(adcp)!: generate typed response union interfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 8
+        run: python3 generate.py --coverage-max-unreviewed-any 4
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -90,6 +90,17 @@ be populated.
 - `ForcedDirectiveSuccess.Forced` is now `adcp.ForcedDirective` instead of
   `any`. The reference seller now emits directive `message` at the response
   top level, matching the schema, instead of inside `forced`.
+- Top-level response unions are now closed interfaces instead of `any` aliases:
+  `SyncGovernanceResponse`, `CreateMediaBuyResponse`,
+  `ProvidePerformanceFeedbackResponse`, and `ComplyTestControllerResponse`.
+  Use the generated variant structs such as `CreateMediaBuySuccess`,
+  `CreateMediaBuyError`, and `CreateMediaBuySubmitted`. Code that assigned
+  arbitrary `map[string]any` values or custom dynamic wrapper types to these
+  response names should switch to a schema-owned variant or keep the value as
+  caller-owned dynamic JSON outside the generated response interface. Direct
+  `encoding/json` unmarshalling into these interface names is not supported;
+  decode into a concrete variant when the branch is known, or into
+  `json.RawMessage` first when branch selection depends on the payload.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/response_unions_test.go
+++ b/adcp/response_unions_test.go
@@ -1,0 +1,35 @@
+package adcp
+
+var _ SyncGovernanceResponse = SyncGovernanceSuccess{}
+var _ SyncGovernanceResponse = &SyncGovernanceSuccess{}
+var _ SyncGovernanceResponse = SyncGovernanceError{}
+var _ SyncGovernanceResponse = &SyncGovernanceError{}
+
+var _ CreateMediaBuyResponse = CreateMediaBuySuccess{}
+var _ CreateMediaBuyResponse = &CreateMediaBuySuccess{}
+var _ CreateMediaBuyResponse = CreateMediaBuyError{}
+var _ CreateMediaBuyResponse = &CreateMediaBuyError{}
+var _ CreateMediaBuyResponse = CreateMediaBuySubmitted{}
+var _ CreateMediaBuyResponse = &CreateMediaBuySubmitted{}
+
+var _ ProvidePerformanceFeedbackResponse = ProvidePerformanceFeedbackSuccess{}
+var _ ProvidePerformanceFeedbackResponse = &ProvidePerformanceFeedbackSuccess{}
+var _ ProvidePerformanceFeedbackResponse = ProvidePerformanceFeedbackError{}
+var _ ProvidePerformanceFeedbackResponse = &ProvidePerformanceFeedbackError{}
+
+var _ ComplyTestControllerResponse = ListScenariosSuccess{}
+var _ ComplyTestControllerResponse = &ListScenariosSuccess{}
+var _ ComplyTestControllerResponse = StateTransitionSuccess{}
+var _ ComplyTestControllerResponse = &StateTransitionSuccess{}
+var _ ComplyTestControllerResponse = SimulationSuccess{}
+var _ ComplyTestControllerResponse = &SimulationSuccess{}
+var _ ComplyTestControllerResponse = ForcedDirectiveSuccess{}
+var _ ComplyTestControllerResponse = &ForcedDirectiveSuccess{}
+var _ ComplyTestControllerResponse = SeedSuccess{}
+var _ ComplyTestControllerResponse = &SeedSuccess{}
+var _ ComplyTestControllerResponse = ProvenanceAuditObservationsSuccess{}
+var _ ComplyTestControllerResponse = &ProvenanceAuditObservationsSuccess{}
+var _ ComplyTestControllerResponse = UpstreamTrafficSuccess{}
+var _ ComplyTestControllerResponse = &UpstreamTrafficSuccess{}
+var _ ComplyTestControllerResponse = ControllerError{}
+var _ ComplyTestControllerResponse = &ControllerError{}

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -35,7 +35,7 @@ SCHEMA_RESOLUTION_ERRORS = (
 # To remove a type from this list: the hand-written definition in types.go
 # (or inputs.go, etc.) must be deleted first, then the generator will emit
 # the type from its JSON schema. Types remain here when:
-#   - schema is oneOf with union fields (generator produces `type X = any`)
+#   - schema is oneOf with union fields that need hand-written flattening
 #   - type is an inline response-item with no standalone schema file
 #   - generator cannot produce the shape we want (nested inline arrays)
 #   - type has attached methods or helpers
@@ -52,8 +52,8 @@ KNOWN_TYPES = {
     'SignalPricing', 'ActivationKey', 'CatalogResult',
     'EventSourceResult', 'LogEventResult',
     'CheckGovernanceCondition',
-    # oneOf schemas — generator produces `type X = any`; hand-writing flattens
-    # the union into a single struct with all variant fields.
+    # oneOf schemas — hand-writing flattens the union into a single struct with
+    # all variant fields.
     'PricingOption', 'Deployment', 'PublisherPropertySelector',
     'OptimizationGoal',
     'OptimizationGoalCostPerTarget', 'OptimizationGoalThresholdRateTarget',
@@ -2229,13 +2229,13 @@ def auto_ref_schema_paths():
 
 
 def _will_generate_set():
-    """Names (after REF_ALIASES) that this generator run will emit as structs.
+    """Names (after REF_ALIASES) that this generator run will emit.
     Used so `resolve_go_type` can typed-reference a schema-derived type even
     though it hasn't been emitted yet at the moment of the first reference.
     Excludes schemas that will not produce a struct. Core/support oneOf schemas
     with object branches are included because generation flattens their variant
-    fields into one struct; top-level tool oneOf schemas still emit `type X =
-    any` and are not treated as typed refs."""
+    fields into one struct; top-level tool response oneOf schemas are included
+    because generation emits a closed interface plus concrete variants."""
     global _WILL_GENERATE_CACHE
     if _WILL_GENERATE_CACHE is not None:
         return _WILL_GENERATE_CACHE
@@ -2261,6 +2261,10 @@ def _will_generate_set():
             print(f'// Warning: skipped schema {rel}: {e}', file=sys.stderr)
             continue
         if schema.get('type') == 'object' and 'properties' in schema:
+            stem = Path(rel).stem
+            name = REF_ALIASES.get(pascal_case(stem), pascal_case(stem))
+            names.add(name)
+        elif 'oneOf' in schema and is_tool_response_schema(rel):
             stem = Path(rel).stem
             name = REF_ALIASES.get(pascal_case(stem), pascal_case(stem))
             names.add(name)
@@ -2497,6 +2501,61 @@ def schema_to_struct(name, schema):
     desc = safe_comment(schema.get('description', ''), 100)
     doc = f'// {name} — {desc}\n' if desc else ''
     return f'{doc}type {name} struct {{\n' + '\n'.join(fields) + '\n}\n'
+
+def is_tool_response_schema(path):
+    return Path(path).stem.endswith('-response')
+
+def validate_top_level_tool_union(name, schema, schema_path):
+    if not is_tool_response_schema(schema_path):
+        raise ValueError(
+            f'{name} in {schema_path} is a top-level tool oneOf request; '
+            'add explicit request-union generation before emitting it'
+        )
+    return top_level_union_variants(name, schema, schema_path)
+
+def top_level_union_variants(name, schema, schema_path=None):
+    """Return generated variant names for a top-level oneOf schema."""
+    variants = []
+    seen = set()
+    location = f' in {schema_path}' if schema_path else ''
+    for idx, variant in enumerate(schema.get('oneOf', [])):
+        vname = variant.get('title', '')
+        if not vname:
+            raise ValueError(
+                f'{name}{location} oneOf branch {idx} must have a title '
+                'so Go can generate a named variant'
+            )
+        if not has_struct_fields(variant):
+            raise ValueError(
+                f'{name}{location} oneOf branch {idx} ({vname}) must define '
+                'object properties so Go can generate a variant struct'
+            )
+        if vname in seen:
+            raise ValueError(
+                f'{name}{location} oneOf branch {idx} repeats variant {vname}'
+            )
+        seen.add(vname)
+        variants.append(vname)
+    return variants
+
+def union_interface_to_type(name, schema, schema_path=None):
+    """Generate a closed Go interface for a top-level response union."""
+    top_level_union_variants(name, schema, schema_path)
+    marker = f'is{name}'
+    return '\n'.join([
+        f'// {name} is a discriminated union — use one of the generated variant structs.',
+        f'type {name} interface {{',
+        f'\t{marker}()',
+        '}',
+    ]) + '\n'
+
+def union_marker_methods(name, schema, schema_path=None):
+    """Generate marker methods for the variants of a top-level response union."""
+    marker = f'is{name}'
+    lines = []
+    for vname in top_level_union_variants(name, schema, schema_path):
+        lines.append(f'func ({vname}) {marker}() {{}}')
+    return '\n'.join(lines) + '\n'
 
 def scalar_or_array_union_to_type(name, schema):
     """Generate a Go helper for a `scalar or []scalar` JSON union."""
@@ -2796,12 +2855,13 @@ def generated_schema_entries():
             generated.add(name)
 
             if section == 'tool' and 'oneOf' in schema:
+                validate_top_level_tool_union(name, schema, path)
                 yield {
                     'section': section,
                     'name': name,
                     'schema': path,
                     'schema_obj': schema,
-                    'kind': 'alias_any',
+                    'kind': 'union_interface',
                 }
                 for idx, variant in enumerate(schema['oneOf']):
                     vname = variant.get('title', '')
@@ -2842,18 +2902,7 @@ def any_coverage_report():
     """Return a structured report of generated `any` fallbacks."""
     records = []
     for entry in generated_schema_entries():
-        if entry['kind'] == 'alias_any':
-            records.append({
-                'type': entry['name'],
-                'section': entry['section'],
-                'schema': entry['schema'],
-                'field': None,
-                'json': None,
-                'go_type': 'any',
-                'reason': 'top_level_oneOf_alias',
-                'allowed': False,
-                'allowance': None,
-            })
+        if entry['kind'] == 'union_interface':
             continue
 
         schema = entry['schema_obj']
@@ -3065,9 +3114,8 @@ def generate():
 
         # Handle oneOf at top level (like preview-creative-response.json)
         if 'oneOf' in schema:
-            print(f'// {name} is a discriminated union — use the appropriate variant type.')
-            print(f'type {name} = any')
-            print()
+            validate_top_level_tool_union(name, schema, path)
+            print(union_interface_to_type(name, schema, path))
             # Generate each variant
             for variant in schema['oneOf']:
                 vname = variant.get('title', '')
@@ -3075,6 +3123,7 @@ def generate():
                     generated.add(vname)
                     if has_struct_fields(variant):
                         print(schema_to_struct(vname, variant))
+            print(union_marker_methods(name, schema, path))
             continue
 
         if has_struct_fields(schema):

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -593,6 +593,137 @@ class StructGenerationTest(unittest.TestCase):
         )
 
 
+class TopLevelUnionGenerationTest(unittest.TestCase):
+    def test_union_interface_uses_generated_variant_markers(self):
+        schema = {
+            "oneOf": [
+                {
+                    "title": "TestSuccess",
+                    "type": "object",
+                    "properties": {"success": {"type": "boolean"}},
+                },
+                {
+                    "title": "TestError",
+                    "type": "object",
+                    "properties": {"errors": {"type": "array", "items": {}}},
+                },
+            ],
+        }
+
+        interface_src = generate.union_interface_to_type("TestResponse", schema)
+        marker_src = generate.union_marker_methods("TestResponse", schema)
+
+        self.assertIn("type TestResponse interface", interface_src)
+        self.assertIn("\tisTestResponse()", interface_src)
+        self.assertNotIn("type TestResponse = any", interface_src)
+        self.assertIn("func (TestSuccess) isTestResponse() {}", marker_src)
+        self.assertIn("func (TestError) isTestResponse() {}", marker_src)
+
+    def test_union_interface_rejects_unnamed_or_nonstruct_branches(self):
+        with self.assertRaisesRegex(ValueError, "branch 0 must have a title"):
+            generate.union_interface_to_type(
+                "TestResponse",
+                {"oneOf": [{"type": "object", "properties": {"ok": {"type": "boolean"}}}]},
+                "test/test-response.json",
+            )
+
+        with self.assertRaisesRegex(ValueError, "must define object properties"):
+            generate.union_interface_to_type(
+                "TestResponse",
+                {"oneOf": [{"title": "TestSuccess", "type": "string"}]},
+                "test/test-response.json",
+            )
+
+        with self.assertRaisesRegex(ValueError, "repeats variant TestSuccess"):
+            generate.union_interface_to_type(
+                "TestResponse",
+                {
+                    "oneOf": [
+                        {
+                            "title": "TestSuccess",
+                            "type": "object",
+                            "properties": {"ok": {"type": "boolean"}},
+                        },
+                        {
+                            "title": "TestSuccess",
+                            "type": "object",
+                            "properties": {"message": {"type": "string"}},
+                        },
+                    ],
+                },
+                "test/test-response.json",
+            )
+
+    def test_top_level_tool_union_generation_is_response_only(self):
+        schema = {
+            "oneOf": [
+                {
+                    "title": "TestSuccess",
+                    "type": "object",
+                    "properties": {"success": {"type": "boolean"}},
+                },
+            ],
+        }
+
+        self.assertEqual(
+            ["TestSuccess"],
+            generate.validate_top_level_tool_union(
+                "TestResponse",
+                schema,
+                "test/test-response.json",
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "top-level tool oneOf request"):
+            generate.validate_top_level_tool_union(
+                "TestRequest",
+                schema,
+                "test/test-request.json",
+            )
+
+    @unittest.skipUnless(shutil.which("go"), "go command not found")
+    def test_union_interface_runtime_accepts_values_and_pointers(self):
+        schema = {
+            "oneOf": [
+                {
+                    "title": "TestSuccess",
+                    "type": "object",
+                    "properties": {"success": {"type": "boolean"}},
+                },
+                {
+                    "title": "TestError",
+                    "type": "object",
+                    "properties": {"message": {"type": "string"}},
+                },
+            ],
+        }
+        generated = "\n".join([
+            generate.union_interface_to_type("TestResponse", schema),
+            generate.schema_to_struct("TestSuccess", schema["oneOf"][0]),
+            generate.schema_to_struct("TestError", schema["oneOf"][1]),
+            generate.union_marker_methods("TestResponse", schema),
+        ])
+        source = textwrap.dedent(f"""
+            package uniontest
+
+            import "testing"
+
+            {generated}
+
+            func TestUnionInterface(t *testing.T) {{
+                var _ TestResponse = TestSuccess{{}}
+                var _ TestResponse = &TestSuccess{{}}
+                var _ TestResponse = TestError{{}}
+                var _ TestResponse = &TestError{{}}
+            }}
+        """)
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(f"{tmp}/go.mod", "w") as f:
+                f.write("module uniontest\n\ngo 1.22\n")
+            with open(f"{tmp}/union_test.go", "w") as f:
+                f.write(source)
+            subprocess.run(["go", "test", "."], cwd=tmp, check=True)
+
+
 class OptimizationGoalSchemaTest(unittest.TestCase):
     def setUp(self):
         self.schema = generate.load_schema("core/optimization-goal.json")

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -9287,8 +9287,10 @@ type SyncGovernanceRequest struct {
 	Ext              any                      `json:"ext,omitempty"`
 }
 
-// SyncGovernanceResponse is a discriminated union — use the appropriate variant type.
-type SyncGovernanceResponse = any
+// SyncGovernanceResponse is a discriminated union — use one of the generated variant structs.
+type SyncGovernanceResponse interface {
+	isSyncGovernanceResponse()
+}
 
 // SyncGovernanceSuccess — Sync processed — individual accounts may have errors
 type SyncGovernanceSuccess struct {
@@ -9303,6 +9305,9 @@ type SyncGovernanceError struct {
 	Context any         `json:"context,omitempty"`
 	Ext     any         `json:"ext,omitempty"`
 }
+
+func (SyncGovernanceSuccess) isSyncGovernanceResponse() {}
+func (SyncGovernanceError) isSyncGovernanceResponse()   {}
 
 // ListAccountsRequest — Request parameters for listing accounts accessible to the authenticated agent. For
 type ListAccountsRequest struct {
@@ -9418,8 +9423,10 @@ type CreateMediaBuyRequest struct {
 	Ext                    any                     `json:"ext,omitempty"`
 }
 
-// CreateMediaBuyResponse is a discriminated union — use the appropriate variant type.
-type CreateMediaBuyResponse = any
+// CreateMediaBuyResponse is a discriminated union — use one of the generated variant structs.
+type CreateMediaBuyResponse interface {
+	isCreateMediaBuyResponse()
+}
 
 // CreateMediaBuySuccess — Success response - media buy created successfully
 type CreateMediaBuySuccess struct {
@@ -9459,6 +9466,10 @@ type CreateMediaBuySubmitted struct {
 	Context any         `json:"context,omitempty"` // Opaque media-buy-level correlation data echoed unchanged from the
 	Ext     any         `json:"ext,omitempty"`
 }
+
+func (CreateMediaBuySuccess) isCreateMediaBuyResponse()   {}
+func (CreateMediaBuyError) isCreateMediaBuyResponse()     {}
+func (CreateMediaBuySubmitted) isCreateMediaBuyResponse() {}
 
 // UpdateMediaBuyRequest — Request parameters for updating campaign and package settings
 type UpdateMediaBuyRequest struct {
@@ -9672,8 +9683,10 @@ type ProvidePerformanceFeedbackRequest struct {
 	Ext               any            `json:"ext,omitempty"`
 }
 
-// ProvidePerformanceFeedbackResponse is a discriminated union — use the appropriate variant type.
-type ProvidePerformanceFeedbackResponse = any
+// ProvidePerformanceFeedbackResponse is a discriminated union — use one of the generated variant structs.
+type ProvidePerformanceFeedbackResponse interface {
+	isProvidePerformanceFeedbackResponse()
+}
 
 // ProvidePerformanceFeedbackSuccess — Success response - feedback received and processed
 type ProvidePerformanceFeedbackSuccess struct {
@@ -9689,6 +9702,9 @@ type ProvidePerformanceFeedbackError struct {
 	Context any         `json:"context,omitempty"`
 	Ext     any         `json:"ext,omitempty"`
 }
+
+func (ProvidePerformanceFeedbackSuccess) isProvidePerformanceFeedbackResponse() {}
+func (ProvidePerformanceFeedbackError) isProvidePerformanceFeedbackResponse()   {}
 
 // BuildCreativeRequest — Request to transform, generate, or retrieve a creative manifest. Supports three modes: (1)
 type BuildCreativeRequest struct {
@@ -9848,8 +9864,10 @@ type ComplyTestControllerRequest struct {
 	Account          any    `json:"account"` // Sandbox account assertion. The runner MUST set sandbox: true on every
 }
 
-// ComplyTestControllerResponse is a discriminated union — use the appropriate variant type.
-type ComplyTestControllerResponse = any
+// ComplyTestControllerResponse is a discriminated union — use one of the generated variant structs.
+type ComplyTestControllerResponse interface {
+	isComplyTestControllerResponse()
+}
 
 // ListScenariosSuccess — Lists which scenarios this seller's test controller supports
 type ListScenariosSuccess struct {
@@ -9925,6 +9943,15 @@ type ControllerError struct {
 	Context      any     `json:"context,omitempty"`
 	Ext          any     `json:"ext,omitempty"`
 }
+
+func (ListScenariosSuccess) isComplyTestControllerResponse()               {}
+func (StateTransitionSuccess) isComplyTestControllerResponse()             {}
+func (SimulationSuccess) isComplyTestControllerResponse()                  {}
+func (ForcedDirectiveSuccess) isComplyTestControllerResponse()             {}
+func (SeedSuccess) isComplyTestControllerResponse()                        {}
+func (ProvenanceAuditObservationsSuccess) isComplyTestControllerResponse() {}
+func (UpstreamTrafficSuccess) isComplyTestControllerResponse()             {}
+func (ControllerError) isComplyTestControllerResponse()                    {}
 
 // SyncPlansRequest — Push campaign plans to the governance agent. A plan defines the authorized parameters for a
 type SyncPlansRequest struct {

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 8
+python3 generate.py --coverage-max-unreviewed-any 4
 ```
 
-The generator currently reports 219 generated dynamic `any` uses:
+The generator currently reports 215 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 8 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 4 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 8
+python3 generate.py --coverage-max-unreviewed-any 4
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -42,9 +42,9 @@ the new dynamic shape is reviewed in the same PR.
   numeric values follow `encoding/json` and become `float64`.
 - Inline object fallbacks are generator limitations unless the schema explicitly
   models open-ended data.
-- Top-level `oneOf` aliases are generator limitations. They need generated
-  result interfaces, concrete variants, and discriminator-aware marshal/unmarshal
-  helpers.
+- Top-level `oneOf` response schemas are generated as closed Go interfaces with
+  schema-owned concrete variants. Add discriminator-aware marshal/unmarshal
+  helpers only when a caller needs to decode directly into the interface type.
 - Unknown `$ref` fallbacks are generator registry limitations unless the target
   schema is intentionally open.
 - Unspecified schema types are schema limitations first. Resolve them upstream or
@@ -54,13 +54,9 @@ the new dynamic shape is reviewed in the same PR.
 
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
-| `SyncGovernanceResponse` | n/a | `any` | `top_level_oneOf_alias` | `account/sync-governance-response.json` |
 | `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
 | `GetProductsResponse.RefinementApplied` | `refinement_applied` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-response.json` |
-| `CreateMediaBuyResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/create-media-buy-response.json` |
-| `ProvidePerformanceFeedbackResponse` | n/a | `any` | `top_level_oneOf_alias` | `media-buy/provide-performance-feedback-response.json` |
 | `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
-| `ComplyTestControllerResponse` | n/a | `any` | `top_level_oneOf_alias` | `compliance/comply-test-controller-response.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
 ## Work Queues
@@ -80,15 +76,11 @@ does not turn typed object work into protocol-design work.
 
 ### Top-Level Unions
 
-Four response schemas still become `type X = any`:
-
-- `SyncGovernanceResponse`
-- `CreateMediaBuyResponse`
-- `ProvidePerformanceFeedbackResponse`
-- `ComplyTestControllerResponse`
-
-These need a generated union interface and concrete branch types, matching the
-hand-written pattern already used for selected oneOf responses.
+Top-level response `oneOf` schemas now generate closed interfaces and concrete
+branch types instead of `type X = any`. The remaining follow-up is optional
+discriminator-aware unmarshal support for callers that want to decode directly
+into the interface type instead of unmarshalling into a concrete branch or
+`json.RawMessage` first.
 
 ### Unknown References
 
@@ -107,9 +99,10 @@ aggregates, missing metrics, signal targeting, forecast dimensions, provenance
 audit observations, wholesale-feed capability blocks, and the newly named
 inline delivery/reporting helper shapes.
 
-The rc.3 integration reduced unreviewed generated `any` fallbacks from the
-3.0.12 baseline of 15 to 13 while adding the 3.1 protocol surface. The remaining
-items are intentionally tracked as generator work, not schema drift.
+The rc.3 integration and subsequent generator passes reduced unreviewed
+generated `any` fallbacks from the 3.0.12 baseline of 15 to 4 while adding the
+3.1 protocol surface. The remaining items are intentionally tracked as
+generator work, not schema drift.
 
 ### Schema Clarification
 


### PR DESCRIPTION
## Summary
- generate closed marker interfaces for top-level response `oneOf` schemas instead of `type X = any` aliases
- add generator validation so only response unions with named object variants use this path
- lower generated unreviewed `any` coverage from 8 to 4 and document the migration/decode behavior

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 4`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && cmp <(python3 generate.py) ../types_gen.go`\n- `cd adcp && go test ./...`\n- `cd adcp && go test -race -count=1 ./...`\n- `go test ./...`\n- `cd reference/seller-agent && go test ./...`\n- `git diff --check`\n\nRefs #176