### PR TITLE
feat(adcp): alias create media buy result to response union

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -101,6 +101,9 @@ be populated.
   `encoding/json` unmarshalling into these interface names is not supported;
   decode into a concrete variant when the branch is known, or into
   `json.RawMessage` first when branch selection depends on the payload.
+  `CreateMediaBuyResult` remains available as a deprecated alias for
+  `CreateMediaBuyResponse`; new handler code should use
+  `CreateMediaBuyResponse`.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/responses.go
+++ b/adcp/responses.go
@@ -26,17 +26,13 @@ func ProductsResponse(data *ProductsData) (*mcp.CallToolResult, any, error) {
 	return buildResult(fmt.Sprintf("Found %d products", len(data.Products)), data), data, nil
 }
 
-// CreateMediaBuyResult is implemented by generated create_media_buy response variants.
-type CreateMediaBuyResult interface {
-	createMediaBuyResult()
-}
-
-func (*CreateMediaBuySuccess) createMediaBuyResult()   {}
-func (*CreateMediaBuyError) createMediaBuyResult()     {}
-func (*CreateMediaBuySubmitted) createMediaBuyResult() {}
+// CreateMediaBuyResult is an alias for the generated create_media_buy response union.
+//
+// Deprecated: use CreateMediaBuyResponse.
+type CreateMediaBuyResult = CreateMediaBuyResponse
 
 // MediaBuyResponse builds a create_media_buy response.
-func MediaBuyResponse(data CreateMediaBuyResult) (*mcp.CallToolResult, any, error) {
+func MediaBuyResponse(data CreateMediaBuyResponse) (*mcp.CallToolResult, any, error) {
 	if data == nil {
 		return Errorf("INVALID_REQUEST", ErrorOptions{Message: "media buy response is required"})
 	}
@@ -44,10 +40,16 @@ func MediaBuyResponse(data CreateMediaBuyResult) (*mcp.CallToolResult, any, erro
 	switch v := data.(type) {
 	case *CreateMediaBuySuccess:
 		return createMediaBuySuccessResponse(v)
+	case CreateMediaBuySuccess:
+		return createMediaBuySuccessResponse(&v)
 	case *CreateMediaBuyError:
 		return createMediaBuyErrorResponse(v)
+	case CreateMediaBuyError:
+		return createMediaBuyErrorResponse(&v)
 	case *CreateMediaBuySubmitted:
 		return createMediaBuySubmittedResponse(v)
+	case CreateMediaBuySubmitted:
+		return createMediaBuySubmittedResponse(&v)
 	default:
 		return Errorf("INVALID_REQUEST", ErrorOptions{
 			Message:    "create_media_buy response must be a generated create_media_buy response variant",

--- a/adcp/responses_test.go
+++ b/adcp/responses_test.go
@@ -44,6 +44,37 @@ func TestMediaBuyResponseSubmittedUsesTypedTaskFields(t *testing.T) {
 	assert.IsType(t, &CreateMediaBuySubmitted{}, out)
 }
 
+func TestMediaBuyResponseAcceptsValueVariants(t *testing.T) {
+	var alias CreateMediaBuyResult = CreateMediaBuySuccess{
+		MediaBuyID: "mb-1",
+		Packages:   []Package{{PackageID: "pkg-1"}},
+	}
+	result, out, err := MediaBuyResponse(alias)
+	require.NoError(t, err)
+
+	wire, ok := result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "mb-1", wire["media_buy_id"])
+	assert.IsType(t, &CreateMediaBuySuccess{}, out)
+
+	result, out, err = MediaBuyResponse(CreateMediaBuySubmitted{TaskID: "task-1"})
+	require.NoError(t, err)
+	wire, ok = result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "submitted", wire["status"])
+	assert.IsType(t, &CreateMediaBuySubmitted{}, out)
+
+	result, out, err = MediaBuyResponse(CreateMediaBuyError{
+		Errors: []AdcpError{{"code": "INVALID_REQUEST", "message": "bad request"}},
+	})
+	require.NoError(t, err)
+	wire, ok = result.StructuredContent.(map[string]any)
+	require.True(t, ok)
+	assert.True(t, result.IsError)
+	assert.Contains(t, wire, "errors")
+	assert.IsType(t, &CreateMediaBuyError{}, out)
+}
+
 func TestMediaBuyResponseSubmittedRequiresTaskID(t *testing.T) {
 	result, out, err := MediaBuyResponse(&CreateMediaBuySubmitted{Status: "submitted"})
 	require.NoError(t, err)

--- a/adcp/seller.go
+++ b/adcp/seller.go
@@ -32,7 +32,7 @@ import (
 //	    GetProducts: func(ctx context.Context, acct any, req *adcp.GetProductsRequest) (*adcp.ProductsData, error) {
 //	        return &adcp.ProductsData{Products: catalog.Query(req.Brief)}, nil
 //	    },
-//	    CreateMediaBuy: func(ctx context.Context, acct any, req *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
+//	    CreateMediaBuy: func(ctx context.Context, acct any, req *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResponse, error) {
 //	        return oms.BookCampaign(req)
 //	    },
 //	})
@@ -127,7 +127,7 @@ func Register(server *mcp.Server, cfg Config) {
 					result, out, e := errorToResult(err)
 					return attachContext(result, input.Context), out, e
 				}
-				stampCreateMediaBuyResult(buy, sandbox, input.Context)
+				buy = stampCreateMediaBuyResult(buy, sandbox, input.Context)
 				result, out, err := MediaBuyResponse(buy)
 				return attachContext(result, input.Context), out, err
 			})
@@ -347,7 +347,7 @@ type Config struct {
 	SyncAccounts   func(ctx context.Context, req *SyncAccountsRequest) ([]AccountResult, error)
 	SyncGovernance func(ctx context.Context, req *SyncGovernanceRequest) ([]GovernanceResult, error)
 	GetProducts    func(ctx context.Context, acct any, req *GetProductsRequest) (*ProductsData, error)
-	CreateMediaBuy func(ctx context.Context, acct any, req *CreateMediaBuyRequest) (CreateMediaBuyResult, error)
+	CreateMediaBuy func(ctx context.Context, acct any, req *CreateMediaBuyRequest) (CreateMediaBuyResponse, error)
 	GetMediaBuys   func(ctx context.Context, acct any, req *GetMediaBuysRequest) (*GetMediaBuysResponse, error)
 	GetDelivery    func(ctx context.Context, acct any, req *GetMediaBuyDeliveryRequest) (*DeliveryData, error)
 
@@ -423,18 +423,34 @@ func resolveAccount(ctx context.Context, resolver func(context.Context, AccountR
 	return acct, nil
 }
 
-func stampCreateMediaBuyResult(result CreateMediaBuyResult, sandbox bool, context any) {
+func stampCreateMediaBuyResult(result CreateMediaBuyResponse, sandbox bool, context any) CreateMediaBuyResponse {
 	switch v := result.(type) {
 	case *CreateMediaBuySuccess:
 		if v.Sandbox == nil {
 			v.Sandbox = Bool(sandbox)
 		}
 		v.Context = context
+		return v
+	case CreateMediaBuySuccess:
+		if v.Sandbox == nil {
+			v.Sandbox = Bool(sandbox)
+		}
+		v.Context = context
+		return v
 	case *CreateMediaBuySubmitted:
 		v.Context = context
+		return v
+	case CreateMediaBuySubmitted:
+		v.Context = context
+		return v
 	case *CreateMediaBuyError:
 		v.Context = context
+		return v
+	case CreateMediaBuyError:
+		v.Context = context
+		return v
 	}
+	return result
 }
 
 // detectProtocols returns supported_protocols values inferred from the

--- a/adcp/seller_test.go
+++ b/adcp/seller_test.go
@@ -385,8 +385,24 @@ func TestRegisteredCreateMediaBuyStampsVariants(t *testing.T) {
 	t.Run("success stamps sandbox and context", func(t *testing.T) {
 		result := callRegisteredTool(t, baseTestConfig(Config{
 			Sandbox: true,
-			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
 				return &CreateMediaBuySuccess{
+					MediaBuyID: "mb-1",
+					Packages:   []Package{},
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.Equal(t, ctxValue, wire["context"])
+		assert.Equal(t, true, wire["sandbox"])
+	})
+
+	t.Run("success value stamps sandbox and context", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			Sandbox: true,
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
+				return CreateMediaBuySuccess{
 					MediaBuyID: "mb-1",
 					Packages:   []Package{},
 				}, nil
@@ -401,7 +417,7 @@ func TestRegisteredCreateMediaBuyStampsVariants(t *testing.T) {
 	t.Run("success preserves explicit sandbox", func(t *testing.T) {
 		result := callRegisteredTool(t, baseTestConfig(Config{
 			Sandbox: true,
-			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
 				return &CreateMediaBuySuccess{
 					MediaBuyID: "mb-1",
 					Packages:   []Package{},
@@ -417,7 +433,7 @@ func TestRegisteredCreateMediaBuyStampsVariants(t *testing.T) {
 
 	t.Run("submitted stamps context", func(t *testing.T) {
 		result := callRegisteredTool(t, baseTestConfig(Config{
-			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
 				return &CreateMediaBuySubmitted{
 					TaskID: "task-1",
 				}, nil
@@ -431,8 +447,22 @@ func TestRegisteredCreateMediaBuyStampsVariants(t *testing.T) {
 
 	t.Run("schema error stamps context", func(t *testing.T) {
 		result := callRegisteredTool(t, baseTestConfig(Config{
-			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResult, error) {
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
 				return &CreateMediaBuyError{
+					Errors: []AdcpError{{"code": "INVALID_REQUEST", "message": "bad request"}},
+				}, nil
+			},
+		}), "create_media_buy", args)
+
+		wire := structuredContentMap(t, result)
+		assert.True(t, result.IsError)
+		assert.Equal(t, ctxValue, wire["context"])
+	})
+
+	t.Run("schema error value stamps context", func(t *testing.T) {
+		result := callRegisteredTool(t, baseTestConfig(Config{
+			CreateMediaBuy: func(context.Context, any, *CreateMediaBuyRequest) (CreateMediaBuyResponse, error) {
+				return CreateMediaBuyError{
 					Errors: []AdcpError{{"code": "INVALID_REQUEST", "message": "bad request"}},
 				}, nil
 			},

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -394,7 +394,7 @@ func (b *backend) createMediaBuy(input *adcp.CreateMediaBuyRequest) (*adcp.Media
 	return buy, nil
 }
 
-func (b *backend) createMediaBuyResponse(input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
+func (b *backend) createMediaBuyResponse(input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResponse, error) {
 	b.mu.Lock()
 	if b.forced != nil {
 		forced := b.forced
@@ -856,7 +856,7 @@ func main() {
 				}
 				return data, nil
 			},
-			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResult, error) {
+			CreateMediaBuy: func(_ context.Context, _ any, input *adcp.CreateMediaBuyRequest) (adcp.CreateMediaBuyResponse, error) {
 				return b.createMediaBuyResponse(input)
 			},
 			GetMediaBuys: func(_ context.Context, _ any, input *adcp.GetMediaBuysRequest) (*adcp.GetMediaBuysResponse, error) {


### PR DESCRIPTION
## Summary
- make `CreateMediaBuyResult` a deprecated alias of the generated `CreateMediaBuyResponse` union
- update seller config/reference seller signatures to use the canonical generated response union
- accept value variants in `MediaBuyResponse` and stamp value responses in registered seller handlers

## Validation
- `cd adcp && go test ./...`
- `cd adcp && go test -race -count=1 ./...`
- `go test ./...`
- `cd reference/seller-agent && go test ./...`
- `git diff --check`

Closes #334