### PR TITLE
feat(adcp)!: type get products refinement items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 4
+        run: python3 generate.py --coverage-max-unreviewed-any 2
 
       - name: Check generated code is up to date
         run: |

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -104,6 +104,12 @@ be populated.
   `CreateMediaBuyResult` remains available as a deprecated alias for
   `CreateMediaBuyResponse`; new handler code should use
   `CreateMediaBuyResponse`.
+- Product refinement arrays are now typed:
+  `GetProductsRequest.Refine` is `[]adcp.GetProductsRefineItem`, and
+  `GetProductsResponse.RefinementApplied` is
+  `[]adcp.GetProductsRefinementAppliedItem` instead of `[]map[string]any`.
+  These are flattened structs for the schema's `scope`-keyed branches; populate
+  the fields that apply to the selected scope.
 - `GetProductsResponse.Incomplete` is now
   `[]adcp.GetProductsIncompleteItem` instead of `[]any`. `EstimatedWait` is
   `*adcp.Duration`; use nil when the seller cannot estimate a retry interval.

--- a/adcp/get_products_refinement_test.go
+++ b/adcp/get_products_refinement_test.go
@@ -1,0 +1,59 @@
+package adcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGetProductsRefinementItemsAreTyped(t *testing.T) {
+	raw := []byte(`{
+		"buying_mode": "refine",
+		"refine": [
+			{"scope": "request", "ask": "more video"},
+			{"scope": "product", "product_id": "prod-1", "action": "include"},
+			{"scope": "proposal", "proposal_id": "prop-1", "action": "finalize"}
+		]
+	}`)
+
+	var req GetProductsRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("unmarshal get products request: %v", err)
+	}
+	if got := len(req.Refine); got != 3 {
+		t.Fatalf("len(req.Refine) = %d, want 3", got)
+	}
+	if req.Refine[1].ProductID != "prod-1" {
+		t.Fatalf("product refinement = %#v", req.Refine[1])
+	}
+	if req.Refine[2].ProposalID != "prop-1" {
+		t.Fatalf("proposal refinement = %#v", req.Refine[2])
+	}
+
+	resp := GetProductsResponse{
+		Status: TaskStatusCompleted,
+		RefinementApplied: []GetProductsRefinementAppliedItem{
+			{Scope: "request", Status: "applied"},
+			{Scope: "product", ProductID: "prod-1", Status: "partial", Notes: "changed format"},
+			{Scope: "proposal", ProposalID: "prop-1", Status: "applied"},
+		},
+	}
+	encoded, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal get products response: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("decode marshaled response: %v", err)
+	}
+	items, ok := decoded["refinement_applied"].([]any)
+	if !ok || len(items) != 3 {
+		t.Fatalf("refinement_applied = %#v, want 3 items", decoded["refinement_applied"])
+	}
+	product, ok := items[1].(map[string]any)
+	if !ok {
+		t.Fatalf("product refinement item = %#v", items[1])
+	}
+	if product["product_id"] != "prod-1" || product["status"] != "partial" {
+		t.Fatalf("product refinement item = %#v", product)
+	}
+}

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -403,6 +403,14 @@ INLINE_SCHEMA_TYPES = OrderedDict([
         "media-buy/get-products-response.json#/properties/filter_diagnostics",
     ),
     (
+        "GetProductsRefineItem",
+        "media-buy/get-products-request.json#/properties/refine/items",
+    ),
+    (
+        "GetProductsRefinementAppliedItem",
+        "media-buy/get-products-response.json#/properties/refinement_applied/items",
+    ),
+    (
         "FilterExclusionDiagnostic",
         "media-buy/get-products-response.json"
         "#/properties/filter_diagnostics/properties/excluded_by/additionalProperties",
@@ -1029,6 +1037,7 @@ INLINE_SCHEMA_TYPES = OrderedDict([
 # helper cannot silently default to data-dropping open-object semantics.
 CLOSED_INLINE_SCHEMA_TYPES = frozenset({
     'MetricQualifier',
+    'RequestedCommittedMetric',
     'ReportingVendorMetric',
     'RequiredVendorMetric',
     'CreativeAcceptedVerifier',
@@ -1096,6 +1105,8 @@ CLOSED_INLINE_SCHEMA_TYPES = frozenset({
     'CollectionRequestPagination',
     'CollectionChangeSummary',
     'PropertyChangeSummary',
+    'GetProductsRefineItem',
+    'GetProductsRefinementAppliedItem',
     'SyncGovernanceAgentResult',
     'ForcedDirective',
     'InstallmentDerivative',
@@ -1113,7 +1124,6 @@ CLOSED_INLINE_SCHEMA_TYPES = frozenset({
 OPEN_INLINE_SCHEMA_TYPES = frozenset({
     'ForecastPointDimension',
     'ReachWindow',
-    'RequestedCommittedMetric',
     'ForecastViewability',
     'CreativeProvenanceRequirements',
     'ProvenanceEmbeddedProvenance',
@@ -1556,6 +1566,8 @@ INLINE_TYPE_HINTS = {
     ('GetCollectionListRequest', 'pagination'): '*CollectionRequestPagination',
     ('CollectionListChangedWebhook', 'change_summary'): '*CollectionChangeSummary',
     ('PropertyListChangedWebhook', 'change_summary'): '*PropertyChangeSummary',
+    ('GetProductsRequest', 'refine'): 'GetProductsRefineItem',
+    ('GetProductsResponse', 'refinement_applied'): 'GetProductsRefinementAppliedItem',
     ('ArtifactWebhookPayload', 'pagination'): '*ArtifactWebhookPagination',
     ('RightsConstraint', 'rights_agent'): 'RightsAgentRef',
     ('Product', 'product_card'): '*ProductCard',

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -367,6 +367,17 @@ def validate_inline_schema_specs():
     return reports
 
 
+def schema_is_closed_inline(schema):
+    if not isinstance(schema, dict):
+        return False
+    if schema.get('additionalProperties') is False:
+        return True
+    branches = schema.get('oneOf') or []
+    if branches:
+        return all(schema_is_closed_inline(branch) for branch in branches)
+    return False
+
+
 def validate_inline_additional_properties_policies():
     """Verify inline helper closure policies match their schemas.
 
@@ -439,11 +450,12 @@ def validate_inline_additional_properties_policies():
             })
             continue
         is_closed = type_name in closed_types
-        if is_closed and schema.get('additionalProperties') is not False:
+        schema_is_closed = schema_is_closed_inline(schema)
+        if is_closed and not schema_is_closed:
             reports.append({
                 'type': type_name,
                 'schema': schema_spec,
-                'error': 'closed inline type schema is not additionalProperties:false',
+                'error': 'closed inline type schema is not closed to additional properties',
                 'remediation': (
                     'if the schema intentionally became open, move the type to '
                     'OPEN_INLINE_SCHEMA_TYPES and review unknown-field dropping; '
@@ -451,11 +463,11 @@ def validate_inline_additional_properties_policies():
                     'a plain struct'
                 ),
             })
-        if not is_closed and schema.get('additionalProperties') is False:
+        if not is_closed and schema_is_closed:
             reports.append({
                 'type': type_name,
                 'schema': schema_spec,
-                'error': 'open inline type schema is additionalProperties:false',
+                'error': 'open inline type schema is closed to additional properties',
                 'remediation': (
                     'move the type to CLOSED_INLINE_SCHEMA_TYPES so future '
                     'schema relaxation is caught, or confirm why this closed '

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -369,10 +369,39 @@ class InlineAdditionalPropertiesPolicyLintTest(unittest.TestCase):
         self.assertEqual("InlineShape", reports[0]["type"])
         self.assertEqual("shape.json#/properties/inline", reports[0]["schema"])
         self.assertEqual(
-            "closed inline type schema is not additionalProperties:false",
+            "closed inline type schema is not closed to additional properties",
             reports[0]["error"],
         )
         self.assertIn("OPEN_INLINE_SCHEMA_TYPES", reports[0]["remediation"])
+
+    def test_closed_inline_type_allows_closed_oneof_branches(self):
+        with (
+            mock.patch.object(lint.Path, "exists", return_value=True),
+            mock.patch.object(lint.gen, "INLINE_SCHEMA_TYPES", {
+                "InlineShape": "shape.json#/properties/inline",
+            }),
+            mock.patch.object(lint.gen, "CLOSED_INLINE_SCHEMA_TYPES", frozenset({
+                "InlineShape",
+            })),
+            mock.patch.object(lint.gen, "OPEN_INLINE_SCHEMA_TYPES", frozenset()),
+            mock.patch.object(lint, "load_schema_spec", return_value={
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {"scope": {"const": "request"}},
+                        "additionalProperties": False,
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"scope": {"const": "product"}},
+                        "additionalProperties": False,
+                    },
+                ],
+            }),
+        ):
+            reports = lint.validate_inline_additional_properties_policies()
+
+        self.assertEqual([], reports)
 
     def test_open_inline_type_fails_when_schema_becomes_closed(self):
         with (
@@ -394,7 +423,7 @@ class InlineAdditionalPropertiesPolicyLintTest(unittest.TestCase):
         self.assertEqual(1, len(reports))
         self.assertEqual("InlineShape", reports[0]["type"])
         self.assertEqual(
-            "open inline type schema is additionalProperties:false",
+            "open inline type schema is closed to additional properties",
             reports[0]["error"],
         )
         self.assertIn("CLOSED_INLINE_SCHEMA_TYPES", reports[0]["remediation"])

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -512,10 +512,10 @@ type GovernanceAgent struct {
 }
 
 type ProductsData struct {
-	Products          []Product        `json:"products"`
-	RefinementApplied []map[string]any `json:"refinement_applied,omitempty"`
-	Sandbox           bool             `json:"sandbox,omitempty"`
-	Context           any              `json:"context,omitempty"`
+	Products          []Product                          `json:"products"`
+	RefinementApplied []GetProductsRefinementAppliedItem `json:"refinement_applied,omitempty"`
+	Sandbox           bool                               `json:"sandbox,omitempty"`
+	Context           any                                `json:"context,omitempty"`
 }
 
 // PricingOption is the flattened union of all variants in pricing-option.json.

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -7724,6 +7724,22 @@ type GetProductsFilterDiagnostics struct {
 	ExcludedBy      map[string]FilterExclusionDiagnostic `json:"excluded_by,omitempty"`      // Per-filter exclusion counts, keyed by the filter property name as it appears
 }
 
+type GetProductsRefineItem struct {
+	Scope      string `json:"scope,omitempty"`       // Change scoped to a specific proposal.
+	Ask        string `json:"ask,omitempty"`         // What the buyer is asking for on this proposal (e.g., 'shift more budget toward
+	ProductID  string `json:"product_id,omitempty"`  // Product ID from a previous get_products response.
+	Action     string `json:"action,omitempty"`      // 'include' (default): return this proposal with updated allocations and
+	ProposalID string `json:"proposal_id,omitempty"` // Proposal ID from a previous get_products response.
+}
+
+type GetProductsRefinementAppliedItem struct {
+	Scope      string `json:"scope,omitempty"`       // Echoes scope 'proposal' from the corresponding refine entry.
+	Status     string `json:"status,omitempty"`      // 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled —
+	Notes      string `json:"notes,omitempty"`       // Seller explanation of what was done, what couldn't be done, or why.
+	ProductID  string `json:"product_id,omitempty"`  // Echoes product_id from the corresponding refine entry.
+	ProposalID string `json:"proposal_id,omitempty"` // Echoes proposal_id from the corresponding refine entry.
+}
+
 type FilterExclusionDiagnostic struct {
 	Count  int    `json:"count"`            // Number of products excluded by this filter, interpreted per the parent
 	Values []any  `json:"values,omitempty"` // Optional list of the specific filter values that contributed to exclusions
@@ -9344,58 +9360,58 @@ type ListAccountsResponse struct {
 
 // GetProductsRequest — Request parameters for discovering or refining advertising products. buying_mode declares the
 type GetProductsRequest struct {
-	AdcpVersion            string             `json:"adcp_version,omitempty"`             // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
-	AdcpMajorVersion       int                `json:"adcp_major_version,omitempty"`       // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
-	BuyingMode             string             `json:"buying_mode"`                        // Declares buyer intent for this request. 'brief': publisher curates product
-	Brief                  string             `json:"brief,omitempty"`                    // Natural language description of campaign requirements. Required when
-	Refine                 []map[string]any   `json:"refine,omitempty"`                   // Array of change requests for iterating on products and proposals from a
-	Brand                  *BrandReference    `json:"brand,omitempty"`                    // Brand reference for product discovery context. Resolved to full brand identity
-	Catalog                *Catalog           `json:"catalog,omitempty"`                  // Catalog of items the buyer wants to promote. The seller matches catalog items
-	Account                *AccountReference  `json:"account,omitempty"`                  // Account for product lookup. Returns products with pricing specific to this
-	PreferredDeliveryTypes []DeliveryType     `json:"preferred_delivery_types,omitempty"` // Delivery types the buyer prefers, in priority order. Unlike
-	Filters                *ProductFilters    `json:"filters,omitempty"`
-	PropertyList           *PropertyListRef   `json:"property_list,omitempty"` // [AdCP 3.0] Reference to an externally managed property list. When provided
-	Fields                 []string           `json:"fields,omitempty"`        // Specific product fields to include in the response. When omitted, all fields
-	TimeBudget             *Duration          `json:"time_budget,omitempty"`   // Maximum time the buyer will commit to this request. The seller returns the
-	Pagination             *PaginationRequest `json:"pagination,omitempty"`
-	IfWholesaleFeedVersion string             `json:"if_wholesale_feed_version,omitempty"` // Opaque wholesale_feed_version token returned by a prior wholesale-mode
-	IfPricingVersion       string             `json:"if_pricing_version,omitempty"`        // Opaque pricing_version token from a prior get_products response. MUST only be
-	Context                any                `json:"context,omitempty"`
-	RequiredPolicies       []string           `json:"required_policies,omitempty"` // Registry policy IDs that the buyer requires to be enforced for products in
-	Ext                    any                `json:"ext,omitempty"`
+	AdcpVersion            string                  `json:"adcp_version,omitempty"`             // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
+	AdcpMajorVersion       int                     `json:"adcp_major_version,omitempty"`       // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
+	BuyingMode             string                  `json:"buying_mode"`                        // Declares buyer intent for this request. 'brief': publisher curates product
+	Brief                  string                  `json:"brief,omitempty"`                    // Natural language description of campaign requirements. Required when
+	Refine                 []GetProductsRefineItem `json:"refine,omitempty"`                   // Array of change requests for iterating on products and proposals from a
+	Brand                  *BrandReference         `json:"brand,omitempty"`                    // Brand reference for product discovery context. Resolved to full brand identity
+	Catalog                *Catalog                `json:"catalog,omitempty"`                  // Catalog of items the buyer wants to promote. The seller matches catalog items
+	Account                *AccountReference       `json:"account,omitempty"`                  // Account for product lookup. Returns products with pricing specific to this
+	PreferredDeliveryTypes []DeliveryType          `json:"preferred_delivery_types,omitempty"` // Delivery types the buyer prefers, in priority order. Unlike
+	Filters                *ProductFilters         `json:"filters,omitempty"`
+	PropertyList           *PropertyListRef        `json:"property_list,omitempty"` // [AdCP 3.0] Reference to an externally managed property list. When provided
+	Fields                 []string                `json:"fields,omitempty"`        // Specific product fields to include in the response. When omitted, all fields
+	TimeBudget             *Duration               `json:"time_budget,omitempty"`   // Maximum time the buyer will commit to this request. The seller returns the
+	Pagination             *PaginationRequest      `json:"pagination,omitempty"`
+	IfWholesaleFeedVersion string                  `json:"if_wholesale_feed_version,omitempty"` // Opaque wholesale_feed_version token returned by a prior wholesale-mode
+	IfPricingVersion       string                  `json:"if_pricing_version,omitempty"`        // Opaque pricing_version token from a prior get_products response. MUST only be
+	Context                any                     `json:"context,omitempty"`
+	RequiredPolicies       []string                `json:"required_policies,omitempty"` // Registry policy IDs that the buyer requires to be enforced for products in
+	Ext                    any                     `json:"ext,omitempty"`
 }
 
 // GetProductsResponse — Response payload for get_products task
 type GetProductsResponse struct {
-	AdcpVersion            string                        `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
-	AdcpMajorVersion       int                           `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
-	ContextID              string                        `json:"context_id,omitempty"`         // Session/conversation identifier for tracking related operations across
-	Context                any                           `json:"context,omitempty"`
-	TaskID                 string                        `json:"task_id,omitempty"`                  // Unique identifier for tracking asynchronous operations. Present when a task
-	Status                 TaskStatus                    `json:"status"`                             // Current task execution state. Indicates whether the task is completed, in
-	Message                string                        `json:"message,omitempty"`                  // Human-readable summary of the task result. Provides natural language
-	Timestamp              string                        `json:"timestamp,omitempty"`                // ISO 8601 timestamp when the response was generated. Useful for debugging
-	Replayed               *bool                         `json:"replayed,omitempty"`                 // Set to true when this response was returned from the idempotency cache rather
-	AdcpError              AdcpError                     `json:"adcp_error,omitempty"`               // Transport-envelope error signal for fatal task failures. Per the two-layer
-	PushNotificationConfig *PushNotificationConfig       `json:"push_notification_config,omitempty"` // Push notification configuration for async task updates (A2A and REST
-	GovernanceContext      string                        `json:"governance_context,omitempty"`       // Governance context token issued by the account's governance agent during
-	Payload                map[string]any                `json:"payload,omitempty"`                  // Conceptual grouping for the task-specific response data defined by individual
-	Products               []Product                     `json:"products,omitempty"`                 // Array of matching products
-	Extensions             map[string]any                `json:"extensions,omitempty"`               // Bundled platform-extension definitions referenced by any product in
-	Proposals              []Proposal                    `json:"proposals,omitempty"`                // Optional array of proposed media plans with budget allocations across
-	Errors                 []AdcpError                   `json:"errors,omitempty"`                   // Task-specific errors and warnings (e.g., product filtering issues)
-	PropertyListApplied    *bool                         `json:"property_list_applied,omitempty"`    // [AdCP 3.0] Indicates whether property_list filtering was applied. True if the
-	CatalogApplied         *bool                         `json:"catalog_applied,omitempty"`          // Whether the seller filtered results based on the provided catalog. True if the
-	RefinementApplied      []map[string]any              `json:"refinement_applied,omitempty"`       // Seller's response to each change request in the refine array, matched by
-	Incomplete             []GetProductsIncompleteItem   `json:"incomplete,omitempty"`               // Declares what the seller could not finish within the buyer's time_budget or
-	FilterDiagnostics      *GetProductsFilterDiagnostics `json:"filter_diagnostics,omitempty"`       // Optional non-fatal diagnostic block describing how the request's `filters`
-	Pagination             *PaginationResponse           `json:"pagination,omitempty"`
-	WholesaleFeedVersion   string                        `json:"wholesale_feed_version,omitempty"` // Opaque token representing the version of the wholesale product feed state used
-	PricingVersion         string                        `json:"pricing_version,omitempty"`        // Opaque token representing the version of the pricing layer, including product
-	CacheScope             string                        `json:"cache_scope,omitempty"`            // Declares whether the wholesale_feed_version and pricing_version on this
-	Unchanged              *bool                         `json:"unchanged,omitempty"`              // Present and `true` ONLY on wholesale-mode responses when the request carried
-	Sandbox                *bool                         `json:"sandbox,omitempty"`                // When true, this response contains simulated data from sandbox mode.
-	Ext                    any                           `json:"ext,omitempty"`
+	AdcpVersion            string                             `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
+	AdcpMajorVersion       int                                `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
+	ContextID              string                             `json:"context_id,omitempty"`         // Session/conversation identifier for tracking related operations across
+	Context                any                                `json:"context,omitempty"`
+	TaskID                 string                             `json:"task_id,omitempty"`                  // Unique identifier for tracking asynchronous operations. Present when a task
+	Status                 TaskStatus                         `json:"status"`                             // Current task execution state. Indicates whether the task is completed, in
+	Message                string                             `json:"message,omitempty"`                  // Human-readable summary of the task result. Provides natural language
+	Timestamp              string                             `json:"timestamp,omitempty"`                // ISO 8601 timestamp when the response was generated. Useful for debugging
+	Replayed               *bool                              `json:"replayed,omitempty"`                 // Set to true when this response was returned from the idempotency cache rather
+	AdcpError              AdcpError                          `json:"adcp_error,omitempty"`               // Transport-envelope error signal for fatal task failures. Per the two-layer
+	PushNotificationConfig *PushNotificationConfig            `json:"push_notification_config,omitempty"` // Push notification configuration for async task updates (A2A and REST
+	GovernanceContext      string                             `json:"governance_context,omitempty"`       // Governance context token issued by the account's governance agent during
+	Payload                map[string]any                     `json:"payload,omitempty"`                  // Conceptual grouping for the task-specific response data defined by individual
+	Products               []Product                          `json:"products,omitempty"`                 // Array of matching products
+	Extensions             map[string]any                     `json:"extensions,omitempty"`               // Bundled platform-extension definitions referenced by any product in
+	Proposals              []Proposal                         `json:"proposals,omitempty"`                // Optional array of proposed media plans with budget allocations across
+	Errors                 []AdcpError                        `json:"errors,omitempty"`                   // Task-specific errors and warnings (e.g., product filtering issues)
+	PropertyListApplied    *bool                              `json:"property_list_applied,omitempty"`    // [AdCP 3.0] Indicates whether property_list filtering was applied. True if the
+	CatalogApplied         *bool                              `json:"catalog_applied,omitempty"`          // Whether the seller filtered results based on the provided catalog. True if the
+	RefinementApplied      []GetProductsRefinementAppliedItem `json:"refinement_applied,omitempty"`       // Seller's response to each change request in the refine array, matched by
+	Incomplete             []GetProductsIncompleteItem        `json:"incomplete,omitempty"`               // Declares what the seller could not finish within the buyer's time_budget or
+	FilterDiagnostics      *GetProductsFilterDiagnostics      `json:"filter_diagnostics,omitempty"`       // Optional non-fatal diagnostic block describing how the request's `filters`
+	Pagination             *PaginationResponse                `json:"pagination,omitempty"`
+	WholesaleFeedVersion   string                             `json:"wholesale_feed_version,omitempty"` // Opaque token representing the version of the wholesale product feed state used
+	PricingVersion         string                             `json:"pricing_version,omitempty"`        // Opaque token representing the version of the pricing layer, including product
+	CacheScope             string                             `json:"cache_scope,omitempty"`            // Declares whether the wholesale_feed_version and pricing_version on this
+	Unchanged              *bool                              `json:"unchanged,omitempty"`              // Present and `true` ONLY on wholesale-mode responses when the request carried
+	Sandbox                *bool                              `json:"sandbox,omitempty"`                // When true, this response contains simulated data from sandbox mode.
+	Ext                    any                                `json:"ext,omitempty"`
 }
 
 // CreateMediaBuyRequest — Request parameters for creating a media buy. Supports two modes: (1) Manual mode - provide

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 4
+python3 generate.py --coverage-max-unreviewed-any 2
 ```
 
-The generator currently reports 215 generated dynamic `any` uses:
+The generator currently reports 213 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
 | Reviewed intentional `any` | 211 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 4 | CI baseline; every new unreviewed fallback is a regression |
+| Unreviewed generated `any` | 2 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 4
+python3 generate.py --coverage-max-unreviewed-any 2
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -54,8 +54,6 @@ the new dynamic shape is reviewed in the same PR.
 
 | Surface | JSON field | Go type | Reason | Schema |
 | --- | --- | --- | --- | --- |
-| `GetProductsRequest.Refine` | `refine` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-request.json` |
-| `GetProductsResponse.RefinementApplied` | `refinement_applied` | `[]map[string]any` | `array_item:freeform_object` | `media-buy/get-products-response.json` |
 | `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
 | `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
 
@@ -100,26 +98,17 @@ audit observations, wholesale-feed capability blocks, and the newly named
 inline delivery/reporting helper shapes.
 
 The rc.3 integration and subsequent generator passes reduced unreviewed
-generated `any` fallbacks from the 3.0.12 baseline of 15 to 4 while adding the
+generated `any` fallbacks from the 3.0.12 baseline of 15 to 2 while adding the
 3.1 protocol surface. The remaining items are intentionally tracked as
 generator work, not schema drift.
 
-### Schema Clarification
-
-One fallback comes from a schema without enough type information:
-
-- `ControllerError.CurrentState`
-
-These should usually be fixed in the protocol schema. A Go-only type override is
-acceptable only when the schema intent is clear and tested.
-
 ### Product Refinement Shapes
 
-`GetProductsRequest.Refine` and `GetProductsResponse.RefinementApplied` are
-currently unreviewed `[]map[string]any` fallbacks because each array item is an
-inline discriminated `oneOf` object. The schema branches are closed and keyed by
-`scope`; this is a generator gap for inline union/discriminator generation, not
-a protocol extension-point decision.
+`GetProductsRequest.Refine` and `GetProductsResponse.RefinementApplied` now use
+generated flattened structs for their inline `scope`-keyed `oneOf` items:
+`GetProductsRefineItem` and `GetProductsRefinementAppliedItem`. These structs
+preserve request-side `encoding/json` decoding while avoiding interface fields
+on tool inputs.
 
 ## Manual Ownership Baseline
 

--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -844,11 +844,13 @@ func main() {
 				}
 				data := &adcp.ProductsData{Products: products}
 				if input.BuyingMode == "refine" && len(input.Refine) > 0 {
-					applied := make([]map[string]any, 0, len(input.Refine))
+					applied := make([]adcp.GetProductsRefinementAppliedItem, 0, len(input.Refine))
 					for _, ref := range input.Refine {
-						item := map[string]any{"scope": ref["scope"], "status": "applied"}
-						if productID, ok := ref["product_id"].(string); ok {
-							item["product_id"] = productID
+						item := adcp.GetProductsRefinementAppliedItem{
+							Scope:      ref.Scope,
+							Status:     "applied",
+							ProductID:  ref.ProductID,
+							ProposalID: ref.ProposalID,
 						}
 						applied = append(applied, item)
 					}


### PR DESCRIPTION
## Summary
- generate flattened structs for get_products refine/refinement_applied scope-keyed item unions
- update ProductsData and the reference seller to use typed refinement-applied items
- lower generated unreviewed `any` coverage from 4 to 2
- teach schema lint that a oneOf wrapper is closed when all object branches are closed

## Validation
- `cd adcp/schemas && python3 -m unittest discover -p '*_test.py'`\n- `cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 2`\n- `cd adcp/schemas && python3 lint.py --strict`\n- `cd adcp/schemas && cmp <(python3 generate.py) ../types_gen.go`\n- `cd adcp && go test ./...`\n- `cd adcp && go test -race -count=1 ./...`\n- `go test ./...`\n- `cd reference/seller-agent && go test ./...`\n- `git diff --check`\n\nRefs #176