### PR TITLE
fix(adcp): improve rc4 generated signal docs

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1040,6 +1040,41 @@ INLINE_SCHEMA_TYPES = OrderedDict([
     ),
 ])
 
+INLINE_SCHEMA_DESCRIPTIONS = {
+    'GetSignalsResponseSignal': (
+        'GetSignals response row with listing identity, enrichment, activation, and pricing fields.'
+    ),
+    'SignalCoverageForecastScope': 'Explicit denominator for the coverage forecast.',
+}
+
+FIELD_DESCRIPTION_OVERRIDES = {
+    ('GetAdcpCapabilitiesResponse', 'supported_protocols'): 'AdCP protocols this agent supports.',
+}
+
+ENUM_DESCRIPTION_OVERRIDES = {
+    'ProposalStatus': 'Lifecycle status of a proposal.',
+}
+
+FIELD_DESCRIPTION_FALLBACK_SPECS = {
+    ('GetSignalsResponseSignal', name): f'core/signal-definition.json#/properties/{name}'
+    for name in (
+        'segmentation_criteria',
+        'criteria_url',
+        'data_sources',
+        'methodology',
+        'audience_expansion',
+        'device_expansion',
+        'refresh_cadence',
+        'lookback_window',
+        'onboarder',
+        'countries',
+        'consent_basis',
+        'art9_basis',
+        'modeling',
+        'dts_compliant_version',
+    )
+}
+
 # Inline object helpers generated as plain structs drop unknown properties on
 # unmarshal/remarshal. Closed registrations are only safe while the schema keeps
 # `additionalProperties: false`; open registrations are explicit so a new inline
@@ -1823,6 +1858,25 @@ def safe_comment(text, max_len=80):
         return cutoff[:word_end].rstrip(' ,;:-')
     return cutoff
 
+def field_description(type_name, json_name, prop):
+    """Return the preferred field description, including reviewed fallbacks."""
+    override = FIELD_DESCRIPTION_OVERRIDES.get((type_name, json_name))
+    if override:
+        return override
+    desc = prop.get('description', '')
+    if desc:
+        return desc
+    spec = FIELD_DESCRIPTION_FALLBACK_SPECS.get((type_name, json_name))
+    if not spec:
+        return ''
+    try:
+        fallback = load_schema_spec(spec)
+    except SCHEMA_RESOLUTION_ERRORS:
+        return ''
+    if isinstance(fallback, dict):
+        return fallback.get('description', '')
+    return ''
+
 def deprecated_comment(prop):
     """Return the Go deprecation notice for a deprecated schema property."""
     if not prop.get('deprecated'):
@@ -2522,7 +2576,7 @@ def schema_to_struct(name, schema):
             tag += f',{omit}'
         tag += '"`'
 
-        desc = safe_comment(prop.get('description', ''), 80)
+        desc = safe_comment(field_description(name, json_name, prop), 80)
         comment = f' // {desc}' if desc else ''
 
         deprecated = deprecated_comment(prop)
@@ -2530,7 +2584,10 @@ def schema_to_struct(name, schema):
             fields.append(f'\t// {deprecated}')
         fields.append(f'\t{go_name} {go_type} {tag}{comment}')
 
-    desc = safe_comment(schema.get('description', ''), 100)
+    desc = safe_comment(
+        INLINE_SCHEMA_DESCRIPTIONS.get(name, '') or schema.get('description', ''),
+        100,
+    )
     doc = f'// {name} — {desc}\n' if desc else ''
     return f'{doc}type {name} struct {{\n' + '\n'.join(fields) + '\n}\n'
 
@@ -2717,6 +2774,7 @@ def enum_to_type(name, desc, values):
     lines = []
     members = enum_members(name, values)
 
+    desc = ENUM_DESCRIPTION_OVERRIDES.get(name, desc)
     lines.append(f'// {name} — {safe_comment(desc, 80)}' if desc else f'// {name} enum values')
     lines.append(f'type {name} = string')
     lines.append('const (')

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -101,6 +101,16 @@ class CommentGenerationTest(unittest.TestCase):
 
         self.assertEqual("Line one. Line two. Line three.", comment)
 
+    def test_enum_description_override_avoids_dangling_docs(self):
+        src = generate.enum_to_type(
+            "ProposalStatus",
+            "Lifecycle status of a proposal. This is the per-proposal signal for whether finalization is required before create_media_buy.",
+            ["draft", "committed"],
+        )
+
+        self.assertIn("// ProposalStatus — Lifecycle status of a proposal.", src)
+        self.assertNotIn("whether", src.splitlines()[0])
+
 
 class UnionHelperGenerationTest(unittest.TestCase):
     def setUp(self):
@@ -1878,6 +1888,32 @@ class InlineObjectGenerationTest(unittest.TestCase):
         self.assertNotIn(("GetSignalsResponse", "signals"), records)
         self.assertNotIn(("GetSignalsResponseSignal", "coverage_forecast"), records)
         self.assertNotIn(("SignalCoverageForecast", "scope"), records)
+
+        get_signals = generate.load_schema("signals/get-signals-response.json")
+        go_type, reason = generate.field_go_type_info(
+            "GetSignalsResponse",
+            "signals",
+            get_signals["properties"]["signals"],
+            set(),
+        )
+        self.assertEqual("[]GetSignalsResponseSignal", go_type)
+        self.assertIsNone(reason)
+
+        signal_item = generate.load_schema_spec(
+            "signals/get-signals-response.json#/properties/signals/items",
+        )
+        generated_signal = generate.schema_to_struct(
+            "GetSignalsResponseSignal",
+            signal_item,
+        )
+        self.assertIn(
+            "// GetSignalsResponseSignal — GetSignals response row with listing identity",
+            generated_signal,
+        )
+        self.assertIn(
+            "SegmentationCriteria string `json:\"segmentation_criteria,omitempty\"` // Rules governing inclusion",
+            generated_signal,
+        )
 
         allowed = [
             (record["type"], record["json"], record["allowance"])

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -4568,7 +4568,7 @@ func ParsePropertyType(s string) (PropertyType, error) {
 	return "", fmt.Errorf("unknown PropertyType value")
 }
 
-// ProposalStatus — Lifecycle status of a proposal. This is the per-proposal signal for whether
+// ProposalStatus — Lifecycle status of a proposal.
 type ProposalStatus = string
 
 const (
@@ -7777,6 +7777,7 @@ type GetSignalsIncompleteItem struct {
 	EstimatedWait *Duration `json:"estimated_wait,omitempty"` // How much additional time would resolve this scope. Allows the caller to decide
 }
 
+// GetSignalsResponseSignal — GetSignals response row with listing identity, enrichment, activation, and pricing fields.
 type GetSignalsResponseSignal struct {
 	SignalRef *SignalRef `json:"signal_ref,omitempty"` // Canonical signal reference for discovery, activation, and media-buy targeting.
 	// Deprecated: DEPRECATED.
@@ -7791,24 +7792,24 @@ type GetSignalsResponseSignal struct {
 	RestrictedAttributes []RestrictedAttribute    `json:"restricted_attributes,omitempty"` // Restricted attribute categories this signal touches.
 	PolicyCategories     []string                 `json:"policy_categories,omitempty"`     // Policy categories this signal is sensitive for.
 	Taxonomy             *SignalTaxonomy          `json:"taxonomy,omitempty"`              // Optional taxonomy metadata describing what this signal means in an external
-	SegmentationCriteria string                   `json:"segmentation_criteria,omitempty"`
-	CriteriaURL          string                   `json:"criteria_url,omitempty"`
-	DataSources          []string                 `json:"data_sources,omitempty"`
-	Methodology          string                   `json:"methodology,omitempty"`
-	AudienceExpansion    *bool                    `json:"audience_expansion,omitempty"`
-	DeviceExpansion      *bool                    `json:"device_expansion,omitempty"`
-	RefreshCadence       string                   `json:"refresh_cadence,omitempty"`
-	LookbackWindow       string                   `json:"lookback_window,omitempty"`
-	Onboarder            *SignalOnboarder         `json:"onboarder,omitempty"`
-	Countries            []string                 `json:"countries,omitempty"`
-	ConsentBasis         []ConsentBasis           `json:"consent_basis,omitempty"`
-	Art9Basis            string                   `json:"art9_basis,omitempty"`
-	Modeling             *SignalModeling          `json:"modeling,omitempty"`
-	DataSubjectRights    *SignalDataSubjectRights `json:"data_subject_rights,omitempty"` // Per-signal data-subject-rights routing. This is a contact/routing reference
-	DtsCompliantVersion  string                   `json:"dts_compliant_version,omitempty"`
-	SignalAgentSegmentID string                   `json:"signal_agent_segment_id"` // Opaque signal handle issued by this signal source. Pass this string verbatim
-	SignalType           SignalCatalogType        `json:"signal_type"`             // Commercial/provenance type of signal (marketplace, custom, owned)
-	DataProvider         string                   `json:"data_provider,omitempty"` // Human-readable source name for the signal, when applicable. For
+	SegmentationCriteria string                   `json:"segmentation_criteria,omitempty"` // Rules governing inclusion of identifiers in the segment. Aligns with IAB Data
+	CriteriaURL          string                   `json:"criteria_url,omitempty"`          // Optional URL to a longer-form methodology or criteria document. This is a
+	DataSources          []string                 `json:"data_sources,omitempty"`          // Origin categories of the raw data used to compile the signal, aligned with IAB
+	Methodology          string                   `json:"methodology,omitempty"`           // How the signal's audience membership or attribute was determined. 'modeled'
+	AudienceExpansion    *bool                    `json:"audience_expansion,omitempty"`    // Whether look-alike or similar-audience expansion was used to include
+	DeviceExpansion      *bool                    `json:"device_expansion,omitempty"`      // Whether the signal was expanded deterministically across devices of the same
+	RefreshCadence       string                   `json:"refresh_cadence,omitempty"`       // Cadence at which the signal definition's underlying segment membership is
+	LookbackWindow       string                   `json:"lookback_window,omitempty"`       // Time window in which a qualifying event can occur for inclusion.
+	Onboarder            *SignalOnboarder         `json:"onboarder,omitempty"`             // Onboarder disclosure. Required when data_sources includes an offline_* or
+	Countries            []string                 `json:"countries,omitempty"`             // ISO 3166-1 alpha-2 country codes where the signal is applicable. Sellers must
+	ConsentBasis         []ConsentBasis           `json:"consent_basis,omitempty"`         // Declared GDPR Article 6 lawful basis or consent basis under which this
+	Art9Basis            string                   `json:"art9_basis,omitempty"`            // GDPR Article 9 basis when restricted_attributes is non-empty and the signal is
+	Modeling             *SignalModeling          `json:"modeling,omitempty"`              // Modeling disclosure for modeled data signals. Required when methodology is
+	DataSubjectRights    *SignalDataSubjectRights `json:"data_subject_rights,omitempty"`   // Per-signal data-subject-rights routing. This is a contact/routing reference
+	DtsCompliantVersion  string                   `json:"dts_compliant_version,omitempty"` // IAB Data Transparency Standard version this signal definition self-attests as
+	SignalAgentSegmentID string                   `json:"signal_agent_segment_id"`         // Opaque signal handle issued by this signal source. Pass this string verbatim
+	SignalType           SignalCatalogType        `json:"signal_type"`                     // Commercial/provenance type of signal (marketplace, custom, owned)
+	DataProvider         string                   `json:"data_provider,omitempty"`         // Human-readable source name for the signal, when applicable. For
 	// Deprecated: DEPRECATED for detailed planning.
 	CoveragePercentage float64                 `json:"coverage_percentage,omitempty"` // DEPRECATED for detailed planning. Optional legacy scalar percentage of
 	CoverageForecast   *SignalCoverageForecast `json:"coverage_forecast,omitempty"`   // Optional forecast-shaped signal availability guidance. When present, this is
@@ -7816,7 +7817,7 @@ type GetSignalsResponseSignal struct {
 	PricingOptions     []VendorPricingOption   `json:"pricing_options,omitempty"`     // Pricing options available for this signal when it has an incremental price.
 }
 
-// SignalCoverageForecastScope — Explicit denominator for the coverage forecast. This identifies the inventory, product, account
+// SignalCoverageForecastScope — Explicit denominator for the coverage forecast.
 type SignalCoverageForecastScope struct {
 	Kind          string     `json:"kind"`                      // Denominator family for the coverage forecast.
 	Label         string     `json:"label"`                     // Human-readable denominator label, such as 'network price-priority inventory'.
@@ -9318,7 +9319,7 @@ type GetAdcpCapabilitiesResponse struct {
 	GovernanceContext       string                               `json:"governance_context,omitempty"`        // Governance context token issued by the account's governance agent during
 	Payload                 map[string]any                       `json:"payload,omitempty"`                   // Conceptual grouping for the task-specific response data defined by individual
 	Adcp                    ADCPVersion                          `json:"adcp"`                                // Core AdCP protocol information
-	SupportedProtocols      []string                             `json:"supported_protocols"`                 // AdCP protocols this agent supports. Stable values both (a) declare which tools
+	SupportedProtocols      []string                             `json:"supported_protocols"`                 // AdCP protocols this agent supports.
 	Account                 *AccountCapabilities                 `json:"account,omitempty"`                   // Account management capabilities. Describes how accounts are established, what
 	MediaBuy                *MediaBuyCapabilities                `json:"media_buy,omitempty"`                 // Media-buy protocol capabilities. Expected when media_buy is in
 	Signals                 *SignalsCapabilities                 `json:"signals,omitempty"`                   // Signals protocol capabilities. Only present if signals is in


### PR DESCRIPTION
## Summary

- add reviewed generator doc fallbacks for rc4 get_signals inline response rows
- keep GetSignalsResponse.Signals locked to []GetSignalsResponseSignal with a positive generator test
- avoid dangling generated docs for ProposalStatus and supported_protocols

## Follow-up issues filed

- adcontextprotocol/adcp#5213: clarify GPC posture after gpc_honored removal
- adcontextprotocol/adcp#5214: document requires_proposal migration

## Validation

- cd adcp/schemas && python3 -m unittest discover -p "*_test.py"
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 2
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py | cmp - ../types_gen.go
- cd adcp && go test ./...
- go test ./...
- git diff --check