### PR TITLE
test(adcp): guard generated signal doc fallbacks

### DIFF
--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -1861,13 +1861,13 @@ def safe_comment(text, max_len=80):
 def field_description(type_name, json_name, prop):
     """Return the preferred field description, including reviewed fallbacks."""
     override = FIELD_DESCRIPTION_OVERRIDES.get((type_name, json_name))
-    if override:
+    if override is not None:
         return override
     desc = prop.get('description', '')
     if desc:
         return desc
     spec = FIELD_DESCRIPTION_FALLBACK_SPECS.get((type_name, json_name))
-    if not spec:
+    if spec is None:
         return ''
     try:
         fallback = load_schema_spec(spec)
@@ -2774,6 +2774,7 @@ def enum_to_type(name, desc, values):
     lines = []
     members = enum_members(name, values)
 
+    # Enum overrides are total replacements for schema docs that truncate poorly.
     desc = ENUM_DESCRIPTION_OVERRIDES.get(name, desc)
     lines.append(f'// {name} — {safe_comment(desc, 80)}' if desc else f'// {name} enum values')
     lines.append(f'type {name} = string')

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -1914,7 +1914,6 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "SegmentationCriteria string `json:\"segmentation_criteria,omitempty\"` // Rules governing inclusion",
             generated_signal,
         )
-
         allowed = [
             (record["type"], record["json"], record["allowance"])
             for record in generate.any_coverage_report()["records"]
@@ -1928,6 +1927,7 @@ class InlineObjectGenerationTest(unittest.TestCase):
             ),
             allowed,
         )
+
         self.assertIn(
             (
                 "CheckGovernanceFinding",
@@ -1976,6 +1976,15 @@ class InlineObjectGenerationTest(unittest.TestCase):
             ),
             allowed,
         )
+
+    def test_field_description_fallback_specs_resolve(self):
+        for (type_name, json_name), spec in generate.FIELD_DESCRIPTION_FALLBACK_SPECS.items():
+            with self.subTest(type_name=type_name, json_name=json_name):
+                self.assertNotIn((type_name, json_name), generate.FIELD_DESCRIPTION_OVERRIDES)
+                fallback = generate.load_schema_spec(spec)
+                self.assertIsInstance(fallback, dict)
+                self.assertTrue(fallback.get("description"))
+                self.assertTrue(generate.field_description(type_name, json_name, {}))
 
 
 class AutoRefDiscoveryTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add guard coverage for every generated signal doc fallback spec
- preserve explicit empty field-description overrides by checking `is not None`
- document that enum description overrides are total replacements

## Validation
- cd adcp/schemas && python3 -m unittest discover -p "*_test.py"
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 2
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py | cmp - ../types_gen.go
- git diff --check