### PR TITLE
feat(codegen): eliminate unreviewed generated any baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Check generated any coverage
         working-directory: adcp/schemas
-        run: python3 generate.py --coverage-max-unreviewed-any 2
+        run: python3 generate.py --coverage-max-unreviewed-any 0
 
       - name: Check generated code is up to date
         run: |

--- a/adcp/schemas/generate.py
+++ b/adcp/schemas/generate.py
@@ -277,6 +277,7 @@ CORE_SCHEMAS = [
     "core/installment.json",
     "core/special.json",
     "core/talent.json",
+    "content-standards/artifact.json",
     "core/ad-inventory-config.json",
     "core/account-authorization.json",
     "core/committed-metric.json",
@@ -435,6 +436,18 @@ INLINE_SCHEMA_TYPES = OrderedDict([
     (
         "SignalCoverageForecastScope",
         "core/signal-coverage-forecast.json#/properties/scope",
+    ),
+    (
+        "ArtifactWebhookArtifact",
+        "content-standards/artifact-webhook-payload.json#/properties/artifacts/items",
+    ),
+    (
+        "ArtifactMetadata",
+        "content-standards/artifact.json#/properties/metadata",
+    ),
+    (
+        "ArtifactIdentifiers",
+        "content-standards/artifact.json#/properties/identifiers",
     ),
     (
         "AuditObservationDetails",
@@ -1251,6 +1264,9 @@ OPEN_INLINE_SCHEMA_TYPES = frozenset({
     'OptimizationGoalAttributionWindow',
     'ListCreativesSort',
     'ArtifactWebhookPagination',
+    'ArtifactWebhookArtifact',
+    'ArtifactMetadata',
+    'ArtifactIdentifiers',
     'PlannedDeliveryGeo',
     'CreativeBriefMessaging',
     'CreativeBriefCompliance',
@@ -1624,6 +1640,7 @@ INLINE_TYPE_HINTS = {
     ('GetProductsRequest', 'refine'): 'GetProductsRefineItem',
     ('GetProductsResponse', 'refinement_applied'): 'GetProductsRefinementAppliedItem',
     ('ArtifactWebhookPayload', 'pagination'): '*ArtifactWebhookPagination',
+    ('ArtifactWebhookPayload', 'artifacts'): 'ArtifactWebhookArtifact',
     ('RightsConstraint', 'rights_agent'): 'RightsAgentRef',
     ('Product', 'product_card'): '*ProductCard',
     ('Product', 'product_card_detailed'): '*ProductCardDetailed',
@@ -1638,6 +1655,9 @@ INLINE_TYPE_HINTS = {
     ('CreativeAsset', 'provenance'): '*Provenance',
     ('CreativeManifest', 'provenance'): '*Provenance',
     ('Provenance', 'ai_tool'): '*ProvenanceAITool',
+    ('Artifact', 'metadata'): '*ArtifactMetadata',
+    ('Artifact', 'identifiers'): '*ArtifactIdentifiers',
+    ('ComplyTestControllerRequest', 'params'): 'map[string]any',
     ('Provenance', 'declared_by'): '*ProvenanceDeclaredBy',
     ('Provenance', 'c2pa'): '*ProvenanceC2PA',
     ('Provenance', 'disclosure'): '*ProvenanceDisclosure',
@@ -1838,6 +1858,11 @@ INTENTIONAL_ANY_FIELDS = {
     ('GetProductsResponse', 'extensions'): 'response extensions are seller-defined extension payloads',
     ('FilterExclusionDiagnostic', 'values'): 'filter diagnostic values are filter-specific strings or objects',
     ('ComplyTestControllerRequest', 'account'): 'compliance controller account selectors are scenario-specific',
+    ('Artifact', 'assets'): 'artifact assets are a discriminated content union',
+    ('ArtifactMetadata', 'open_graph'): 'Open Graph metadata accepts arbitrary protocol properties',
+    ('ArtifactMetadata', 'twitter_card'): 'Twitter Card metadata accepts arbitrary card properties',
+    ('ArtifactMetadata', 'json_ld'): 'JSON-LD entries are schema.org objects with arbitrary properties',
+    ('ComplyTestControllerRequest', 'params'): 'compliance controller params are scenario-specific and must preserve explicit scalar values',
 }
 
 # Enum schemas

--- a/adcp/schemas/generate_test.py
+++ b/adcp/schemas/generate_test.py
@@ -930,6 +930,21 @@ class InlineObjectGenerationTest(unittest.TestCase):
             "*ArtifactWebhookPagination",
         )
         self.assert_field_type(
+            "content-standards/artifact-webhook-payload.json",
+            "ArtifactWebhookPayload",
+            "artifacts",
+            "[]ArtifactWebhookArtifact",
+        )
+        compliance_request = generate.load_schema("compliance/comply-test-controller-request.json")
+        params_type, params_reason = generate.field_go_type_info(
+            "ComplyTestControllerRequest",
+            "params",
+            compliance_request["properties"]["params"],
+            generate.schema_required_names(compliance_request),
+        )
+        self.assertEqual("map[string]any", params_type)
+        self.assertEqual("inline_type_hint", params_reason)
+        self.assert_field_type(
             "core/performance-feedback.json",
             "PerformanceFeedback",
             "measurement_period",
@@ -1853,9 +1868,12 @@ class InlineObjectGenerationTest(unittest.TestCase):
             for record in generate.any_coverage_report()["records"]
             if not record["allowed"]
         ]
+        self.assertEqual([], records)
 
         self.assertNotIn(("ListCreativesRequest", "sort"), records)
         self.assertNotIn(("ArtifactWebhookPayload", "pagination"), records)
+        self.assertNotIn(("ArtifactWebhookPayload", "artifacts"), records)
+        self.assertNotIn(("ComplyTestControllerRequest", "params"), records)
         self.assertNotIn(("PerformanceFeedback", "measurement_period"), records)
         self.assertNotIn(("PlannedDelivery", "geo"), records)
         self.assertNotIn(("Account", "setup"), records)
@@ -1973,6 +1991,22 @@ class InlineObjectGenerationTest(unittest.TestCase):
                 "MCPWebhookPayload",
                 "result",
                 "core/async-response-data.json is a task-specific response union",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "Artifact",
+                "assets",
+                "artifact assets are a discriminated content union",
+            ),
+            allowed,
+        )
+        self.assertIn(
+            (
+                "ComplyTestControllerRequest",
+                "params",
+                "compliance controller params are scenario-specific and must preserve explicit scalar values",
             ),
             allowed,
         )

--- a/adcp/types_gen.go
+++ b/adcp/types_gen.go
@@ -7047,6 +7047,21 @@ type Talent struct {
 	BrandURL string     `json:"brand_url,omitempty"` // URL to this person's brand.json entry. Enables buyer agents to evaluate the
 }
 
+// Artifact — Content artifact for safety and suitability evaluation. An artifact represents content adjacent to
+type Artifact struct {
+	PropertyRID    string               `json:"property_rid"`               // Stable property identifier from the property catalog. Globally unique across
+	ArtifactID     string               `json:"artifact_id"`                // Identifier for this artifact within the property. The property owner defines
+	VariantID      string               `json:"variant_id,omitempty"`       // Identifies a specific variant of this artifact. Use for A/B tests
+	FormatID       *FormatRef           `json:"format_id,omitempty"`        // Always a structured object {agent_url, id} — never a plain string. Optional
+	URL            string               `json:"url,omitempty"`              // Optional URL for this artifact (web page, podcast feed, video page). Not all
+	PublishedTime  string               `json:"published_time,omitempty"`   // When the artifact was published (ISO 8601 format)
+	LastUpdateTime string               `json:"last_update_time,omitempty"` // When the artifact was last modified (ISO 8601 format)
+	Assets         []any                `json:"assets"`                     // Artifact assets in document flow order - text blocks, images, video, audio
+	Metadata       *ArtifactMetadata    `json:"metadata,omitempty"`         // Rich metadata extracted from the artifact
+	Provenance     *Provenance          `json:"provenance,omitempty"`       // Provenance metadata for this artifact. Serves as the default provenance for
+	Identifiers    *ArtifactIdentifiers `json:"identifiers,omitempty"`      // Platform-specific identifiers for this artifact
+}
+
 // AdInventoryConfig — Break-based ad inventory configuration for an installment. Describes the ad breaks available
 type AdInventoryConfig struct {
 	ExpectedBreaks       int      `json:"expected_breaks"`                   // Number of planned ad breaks in the installment
@@ -7825,6 +7840,32 @@ type SignalCoverageForecastScope struct {
 	Countries     []string   `json:"countries,omitempty"`       // Countries included in the denominator, as ISO 3166-1 alpha-2 codes.
 	LineItemTypes []string   `json:"line_item_types,omitempty"` // Seller or ad-server line item types included in the denominator.
 	DateRange     *DateRange `json:"date_range,omitempty"`      // Historical or planned date window used to compute the denominator.
+}
+
+type ArtifactWebhookArtifact struct {
+	Artifact     Artifact `json:"artifact"`                // The content artifact
+	DeliveredAt  string   `json:"delivered_at"`            // When the impression was delivered (ISO 8601)
+	ImpressionID string   `json:"impression_id,omitempty"` // Optional impression identifier for correlation with delivery reports
+	PackageID    string   `json:"package_id,omitempty"`    // Package within the media buy this artifact relates to
+}
+
+// ArtifactMetadata — Rich metadata extracted from the artifact
+type ArtifactMetadata struct {
+	Canonical   string           `json:"canonical,omitempty"`    // Canonical URL
+	Author      string           `json:"author,omitempty"`       // Artifact author name
+	Keywords    string           `json:"keywords,omitempty"`     // Artifact keywords
+	OpenGraph   map[string]any   `json:"open_graph,omitempty"`   // Open Graph protocol metadata
+	TwitterCard map[string]any   `json:"twitter_card,omitempty"` // Twitter Card metadata
+	JSONLd      []map[string]any `json:"json_ld,omitempty"`      // JSON-LD structured data (schema.org)
+}
+
+// ArtifactIdentifiers — Platform-specific identifiers for this artifact
+type ArtifactIdentifiers struct {
+	ApplePodcastID      string `json:"apple_podcast_id,omitempty"`      // Apple Podcasts ID
+	SpotifyCollectionID string `json:"spotify_collection_id,omitempty"` // Spotify collection ID
+	PodcastGuid         string `json:"podcast_guid,omitempty"`          // Podcast GUID (from RSS feed)
+	YoutubeVideoID      string `json:"youtube_video_id,omitempty"`      // YouTube video ID
+	RssURL              string `json:"rss_url,omitempty"`               // RSS feed URL
 }
 
 // AuditObservationDetails — Audit-safe structured details. Mirrors the safe allowlist keys used for
@@ -9933,13 +9974,13 @@ type ActivateSignalRequest struct {
 
 // ComplyTestControllerRequest — Request payload for the comply_test_controller tool. Triggers seller-side state transitions for
 type ComplyTestControllerRequest struct {
-	AdcpVersion      string `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
-	AdcpMajorVersion int    `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
-	Scenario         string `json:"scenario"`                     // Test scenario to execute. 'list_scenarios' discovers supported scenarios.
-	Params           any    `json:"params,omitempty"`             // Scenario-specific parameters. Required for all scenarios except list_scenarios.
-	Context          any    `json:"context,omitempty"`
-	Ext              any    `json:"ext,omitempty"`
-	Account          any    `json:"account"` // Sandbox account assertion. The runner MUST set sandbox: true on every
+	AdcpVersion      string         `json:"adcp_version,omitempty"`       // Release-precision AdCP version (VERSION.RELEASE, e.g. "3.0", "3.1"
+	AdcpMajorVersion int            `json:"adcp_major_version,omitempty"` // DEPRECATED in favor of adcp_version (release-precision string). Servers MUST
+	Scenario         string         `json:"scenario"`                     // Test scenario to execute. 'list_scenarios' discovers supported scenarios.
+	Params           map[string]any `json:"params,omitempty"`             // Scenario-specific parameters. Required for all scenarios except list_scenarios.
+	Context          any            `json:"context,omitempty"`
+	Ext              any            `json:"ext,omitempty"`
+	Account          any            `json:"account"` // Sandbox account assertion. The runner MUST set sandbox: true on every
 }
 
 // ComplyTestControllerResponse is a discriminated union — use one of the generated variant structs.
@@ -10278,7 +10319,7 @@ type ArtifactWebhookPayload struct {
 	MediaBuyID     string                     `json:"media_buy_id"`         // Media buy identifier these artifacts belong to
 	BatchID        string                     `json:"batch_id"`             // Unique identifier for this batch of artifacts. Use for deduplication and
 	Timestamp      string                     `json:"timestamp"`            // When this batch was generated (ISO 8601)
-	Artifacts      []any                      `json:"artifacts"`            // Content artifacts from delivered impressions
+	Artifacts      []ArtifactWebhookArtifact  `json:"artifacts"`            // Content artifacts from delivered impressions
 	Pagination     *ArtifactWebhookPagination `json:"pagination,omitempty"` // Pagination info when batching large artifact sets
 	Ext            any                        `json:"ext,omitempty"`
 }

--- a/docs/go-generator-baseline.md
+++ b/docs/go-generator-baseline.md
@@ -7,20 +7,20 @@ Command:
 ```bash
 cd adcp/schemas
 python3 generate.py --coverage-summary
-python3 generate.py --coverage-max-unreviewed-any 2
+python3 generate.py --coverage-max-unreviewed-any 0
 ```
 
-The generator currently reports 214 generated dynamic `any` uses:
+The generator currently reports 217 generated dynamic `any` uses:
 
 | Class | Count | Status |
 | --- | ---: | --- |
-| Reviewed intentional `any` | 212 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
-| Unreviewed generated `any` | 2 | CI baseline; every new unreviewed fallback is a regression |
+| Reviewed intentional `any` | 217 | Allowed by `INTENTIONAL_ANY_FIELD_NAMES`, `INTENTIONAL_ANY_FIELDS`, or `AdcpError` handling |
+| Unreviewed generated `any` | 0 | CI baseline; every new unreviewed fallback is a regression |
 
 CI enforces this baseline with:
 
 ```bash
-python3 generate.py --coverage-max-unreviewed-any 2
+python3 generate.py --coverage-max-unreviewed-any 0
 ```
 
 Lower this number whenever a generator improvement removes an unreviewed
@@ -52,25 +52,22 @@ the new dynamic shape is reviewed in the same PR.
 
 ## Unreviewed `any` Baseline
 
-| Surface | JSON field | Go type | Reason | Schema |
-| --- | --- | --- | --- | --- |
-| `ComplyTestControllerRequest.Params` | `params` | `any` | `inline_object` | `compliance/comply-test-controller-request.json` |
-| `ArtifactWebhookPayload.Artifacts` | `artifacts` | `[]any` | `array_item:inline_object` | `content-standards/artifact-webhook-payload.json` |
+There are no unreviewed generated `any` fallbacks. New dynamic fields must be
+typed or reviewed as intentional escape hatches in the same PR that introduces
+them.
 
 ## Work Queues
 
 ### Inline Object Generation
 
-This is the largest generator gap: 2 unreviewed fallbacks are direct inline
-objects or arrays of inline objects. The generator needs stable naming for
+The generator now covers the known schema-owned inline objects. Continued work
+should focus on making inline ownership less manual: stable naming for
 inline schemas, pointer handling for optional inline object fields, and collision
 detection across generated names.
 
-The first reduction passes typed low-risk leaf objects. Continue with inline
-objects that have stable, schema-owned property sets. The remaining inline
-object fallbacks mix genuinely open/controller payloads, inline unions, and
-schema-closed artifacts; keep those classes separate so the generator backlog
-does not turn typed object work into protocol-design work.
+Keep genuinely open/controller payloads, inline unions, and schema-closed
+artifacts separate so the generator backlog does not turn typed object work into
+protocol-design work.
 
 ### Top-Level Unions
 


### PR DESCRIPTION
## Summary
- generate typed artifact webhook rows and the referenced content artifact helper types
- keep compliance controller params as `map[string]any` to preserve scenario-specific JSON and explicit scalar values
- lower generated-any CI baseline from 2 to 0 and refresh the generator baseline docs/tests

## Validation
- cd adcp/schemas && python3 -m unittest discover -p "*_test.py"
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 0
- cd adcp/schemas && python3 generate.py | cmp - ../types_gen.go
- git diff --check
- go test ./...
- cd adcp && go test ./...
- cd reference/seller-agent && go test ./...