### PR TITLE
feat(adcp)!: enforce optional scalar pointer policy

### DIFF
--- a/adcp/generated_capabilities_test.go
+++ b/adcp/generated_capabilities_test.go
@@ -30,6 +30,17 @@ func TestGeneratedCapabilitiesResponseUsesTypedBlocks(t *testing.T) {
 		RequestSigning: &RequestSigningCapabilities{
 			Supported: true,
 		},
+		WebhookSigning: &WebhookSigningCapabilities{
+			Supported:          true,
+			LegacyHMACFallback: Bool(false),
+		},
+		Identity: &IdentityCapabilities{
+			PerPrincipalKeyIsolation: Bool(false),
+			CompromiseNotification: &IdentityCompromiseNotification{
+				Emits:   Bool(false),
+				Accepts: Bool(false),
+			},
+		},
 	}
 
 	raw, err := json.Marshal(resp)
@@ -43,6 +54,9 @@ func TestGeneratedCapabilitiesResponseUsesTypedBlocks(t *testing.T) {
 		`"axe_integrations":["https://legacy.example/axe"]`,
 		`"aggregation_window_days":7`,
 		`"request_signing":{"supported":true}`,
+		`"legacy_hmac_fallback":false`,
+		`"per_principal_key_isolation":false`,
+		`"compromise_notification":{"emits":false,"accepts":false}`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("marshaled capabilities missing %s:\n%s", want, body)
@@ -61,5 +75,75 @@ func TestGeneratedCapabilitiesResponseUsesTypedBlocks(t *testing.T) {
 	}
 	if decoded.Governance == nil || decoded.Governance.AggregationWindowDays != 7 {
 		t.Fatalf("governance block did not round-trip: %#v", decoded.Governance)
+	}
+	if decoded.WebhookSigning == nil ||
+		decoded.WebhookSigning.LegacyHMACFallback == nil ||
+		*decoded.WebhookSigning.LegacyHMACFallback {
+		t.Fatalf("webhook signing false pointer did not round-trip: %#v", decoded.WebhookSigning)
+	}
+	if decoded.Identity == nil ||
+		decoded.Identity.PerPrincipalKeyIsolation == nil ||
+		*decoded.Identity.PerPrincipalKeyIsolation ||
+		decoded.Identity.CompromiseNotification == nil ||
+		decoded.Identity.CompromiseNotification.Emits == nil ||
+		*decoded.Identity.CompromiseNotification.Emits ||
+		decoded.Identity.CompromiseNotification.Accepts == nil ||
+		*decoded.Identity.CompromiseNotification.Accepts {
+		t.Fatalf("identity false pointers did not round-trip: %#v", decoded.Identity)
+	}
+}
+
+func TestDeploymentOptionalBoolPreservesFalse(t *testing.T) {
+	deployment := Deployment{
+		Type:   "agent",
+		IsLive: Bool(false),
+	}
+
+	raw, err := json.Marshal(deployment)
+	if err != nil {
+		t.Fatalf("marshal deployment: %v", err)
+	}
+	if !strings.Contains(string(raw), `"is_live":false`) {
+		t.Fatalf("marshaled deployment dropped false is_live:\n%s", raw)
+	}
+
+	var decoded Deployment
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal deployment: %v", err)
+	}
+	if decoded.IsLive == nil || *decoded.IsLive {
+		t.Fatalf("deployment false pointer did not round-trip: %#v", decoded)
+	}
+
+	raw, err = json.Marshal(Deployment{Type: "agent"})
+	if err != nil {
+		t.Fatalf("marshal deployment without is_live: %v", err)
+	}
+	if strings.Contains(string(raw), `"is_live"`) {
+		t.Fatalf("marshaled deployment emitted absent is_live:\n%s", raw)
+	}
+}
+
+func TestMeasurementWindowOptionalBoolPreservesFalse(t *testing.T) {
+	window := MeasurementWindow{
+		WindowID:         "broadcast-q1",
+		DurationDays:     7,
+		IsGuaranteeBasis: Bool(false),
+	}
+
+	raw, err := json.Marshal(window)
+	if err != nil {
+		t.Fatalf("marshal measurement window: %v", err)
+	}
+	if !strings.Contains(string(raw), `"is_guarantee_basis":false`) {
+		t.Fatalf("marshaled measurement window dropped false is_guarantee_basis:\n%s", raw)
+	}
+
+	var decoded MeasurementWindow
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal measurement window: %v", err)
+	}
+	if decoded.IsGuaranteeBasis == nil || *decoded.IsGuaranteeBasis {
+		t.Fatalf("measurement window false pointer did not round-trip: %#v", decoded)
 	}
 }

--- a/adcp/schemas/lint.py
+++ b/adcp/schemas/lint.py
@@ -801,6 +801,72 @@ def optional_numeric_pointer_candidate(json_name, prop, required_set):
     )
 
 
+def optional_bool_pointer_candidate(json_name, prop, required_set):
+    """Return True when an optional boolean must preserve explicit false."""
+    if json_name in required_set:
+        return False
+    return prop.get('type') == 'boolean'
+
+
+def optional_bool_pointer_reports(go_structs):
+    """Find optional boolean fields that need pointers to preserve false."""
+    reports = []
+
+    for entry in gen.generated_schema_entries():
+        if entry['kind'] != 'struct':
+            continue
+        props = gen.schema_properties(entry['schema_obj'])
+        required_set = gen.schema_required_names(entry['schema_obj'])
+        for json_name, prop in props.items():
+            if not isinstance(prop, dict):
+                continue
+            if not optional_bool_pointer_candidate(json_name, prop, required_set):
+                continue
+            go_type, _ = gen.field_go_type_info(
+                entry['name'], json_name, prop, required_set,
+            )
+            # Generated optional booleans should already be pointers; this branch
+            # catches generator regressions before they reach types_gen.go.
+            if go_type == 'bool':
+                reports.append({
+                    'owner': 'generated',
+                    'type': entry['name'],
+                    'schema': entry['schema'],
+                    'json': json_name,
+                    'go_type': go_type,
+                    'description': prop.get('description', ''),
+                })
+
+    for type_name, go_fields in sorted(go_structs.items()):
+        schema_spec = resolve_schema_spec(type_name)
+        if schema_spec is None:
+            continue
+        try:
+            schema = load_schema_spec(schema_spec)
+        except SCHEMA_RESOLUTION_ERRORS:
+            continue
+        props = gen.schema_properties(schema)
+        required_set = gen.schema_required_names(schema)
+        fields_by_json = {tag: go_type for _, go_type, tag, _ in go_fields}
+        for json_name, prop in props.items():
+            if not isinstance(prop, dict):
+                continue
+            if not optional_bool_pointer_candidate(json_name, prop, required_set):
+                continue
+            go_type = fields_by_json.get(json_name)
+            if go_type == 'bool':
+                reports.append({
+                    'owner': 'hand-written',
+                    'type': type_name,
+                    'schema': schema_spec,
+                    'json': json_name,
+                    'go_type': go_type,
+                    'description': prop.get('description', ''),
+                })
+
+    return reports
+
+
 def optional_numeric_pointer_reports(go_structs):
     """Find optional numeric fields that need pointers to preserve omission."""
     reports = []
@@ -992,6 +1058,7 @@ def main():
         go_structs,
         custom_json_methods,
     )
+    optional_bool_reports = optional_bool_pointer_reports(go_structs)
     optional_numeric_reports = optional_numeric_pointer_reports(go_structs)
     hand_written_inline_schema_divergence = validate_hand_written_inline_schema_divergence()
     hand_written_inline_reports = validate_hand_written_inline_schema_specs(go_structs)
@@ -1025,6 +1092,7 @@ def main():
             'cross_type_inline_errors': cross_type_inline_errors,
             'union_schema_errors': union_schema_errors,
             'custom_wire_field_errors': custom_wire_field_errors,
+            'optional_bool_pointer': optional_bool_reports,
             'optional_numeric_pointer': optional_numeric_reports,
         }
         print(json.dumps(out, indent=2))
@@ -1136,6 +1204,18 @@ def main():
                 if r.get('missing_methods'):
                     print(f'    missing methods: {", ".join(r["missing_methods"])}')
             print()
+        if optional_bool_reports:
+            print(
+                'Optional boolean pointer issues in '
+                f'{len(optional_bool_reports)} field(s):'
+            )
+            for r in optional_bool_reports:
+                print()
+                print(f'  {r["type"]}.{r["json"]}  ({r["schema"]})')
+                print(f'    owner:   {r["owner"]}')
+                print(f'    Go type: {r["go_type"]}')
+                print('    fix:     use *bool so explicit false survives omitempty')
+            print()
         if optional_numeric_reports:
             print(
                 'Optional numeric pointer issues in '
@@ -1179,6 +1259,7 @@ def main():
         or bool(hand_written_inline_schema_divergence)
         or bool(union_schema_errors)
         or bool(custom_wire_field_errors)
+        or bool(optional_bool_reports)
         or bool(reports)
         or bool(optional_numeric_reports)
         or (args.strict and bool(no_schema))

--- a/adcp/schemas/lint_test.py
+++ b/adcp/schemas/lint_test.py
@@ -298,6 +298,7 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             mock.patch.object(lint, "validate_cross_type_inline_hints", return_value=[]),
             mock.patch.object(lint, "validate_union_schema_specs", return_value=[]),
             mock.patch.object(lint, "validate_custom_wire_fields", return_value=[]),
+            mock.patch.object(lint, "optional_bool_pointer_reports", return_value=[]),
             mock.patch.object(lint, "optional_numeric_pointer_reports", return_value=[]),
             mock.patch.object(
                 lint,
@@ -324,6 +325,7 @@ class HandWrittenInlineSchemaLintTest(unittest.TestCase):
             payload["hand_written_inline_schema_divergence"],
         )
         self.assertIn(inline_report, payload["drift"])
+        self.assertEqual([], payload["optional_bool_pointer"])
 
 
 class InlineAdditionalPropertiesPolicyLintTest(unittest.TestCase):
@@ -550,6 +552,83 @@ class OptionalNumericPointerLintTest(unittest.TestCase):
             {"type": "number", "exclusiveMinimum": 0, "description": "Minimum view duration."},
             set(),
         ))
+
+    def test_optional_bool_pointer_candidate(self):
+        self.assertTrue(lint.optional_bool_pointer_candidate(
+            "emits",
+            {"type": "boolean", "default": False},
+            set(),
+        ))
+        self.assertFalse(lint.optional_bool_pointer_candidate(
+            "supported",
+            {"type": "boolean"},
+            {"supported"},
+        ))
+        self.assertFalse(lint.optional_bool_pointer_candidate(
+            "count",
+            {"type": "integer"},
+            set(),
+        ))
+
+    def test_optional_bool_lint_catches_hand_written_bool_omitempty(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "emits": {"type": "boolean", "default": False},
+                "supported": {"type": "boolean"},
+            },
+            "required": ["supported"],
+        }
+
+        with (
+            mock.patch.object(lint.gen, "generated_schema_entries", return_value=[]),
+            mock.patch.object(lint, "resolve_schema_spec", return_value="shape.json"),
+            mock.patch.object(lint, "load_schema_spec", return_value=schema),
+        ):
+            reports = lint.optional_bool_pointer_reports({
+                "Shape": [
+                    ("Emits", "bool", "emits", True),
+                    ("Supported", "bool", "supported", False),
+                ],
+            })
+
+        self.assertEqual([("Shape", "emits")], [
+            (r["type"], r["json"]) for r in reports
+        ])
+
+    def test_optional_bool_lint_catches_generated_bool_omitempty(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "emits": {"type": "boolean", "default": False},
+                "supported": {"type": "boolean"},
+            },
+            "required": ["supported"],
+        }
+        entry = {
+            "kind": "struct",
+            "name": "GeneratedShape",
+            "schema": "generated-shape.json",
+            "schema_obj": schema,
+        }
+
+        def field_go_type_info(type_name, json_name, prop, required_set):
+            return ("bool", None)
+
+        with (
+            mock.patch.object(lint.gen, "generated_schema_entries", return_value=[entry]),
+            mock.patch.object(lint.gen, "field_go_type_info", side_effect=field_go_type_info),
+            mock.patch.object(lint, "resolve_schema_spec", return_value=None),
+        ):
+            reports = lint.optional_bool_pointer_reports({})
+
+        self.assertEqual([("GeneratedShape", "emits")], [
+            (r["type"], r["json"]) for r in reports
+        ])
+
+    def test_optional_bool_lint_current_schema_is_clean(self):
+        reports = lint.optional_bool_pointer_reports(lint.parse_go_structs())
+        self.assertEqual([], reports)
 
     def test_optional_numeric_lint_catches_current_schema_candidates(self):
         reports = lint.optional_numeric_pointer_reports(lint.parse_go_structs())

--- a/adcp/types.go
+++ b/adcp/types.go
@@ -398,7 +398,7 @@ type WebhookSigningCapabilities struct {
 	Supported          bool     `json:"supported"`
 	Profile            string   `json:"profile,omitempty"`
 	Algorithms         []string `json:"algorithms,omitempty"`
-	LegacyHMACFallback bool     `json:"legacy_hmac_fallback,omitempty"`
+	LegacyHMACFallback *bool    `json:"legacy_hmac_fallback,omitempty"`
 }
 
 // IdentityCapabilities declares operator identity posture — key-scoping and
@@ -406,7 +406,7 @@ type WebhookSigningCapabilities struct {
 // them to reason about blast radius and revocation latency at onboarding.
 type IdentityCapabilities struct {
 	BrandJSONURL             string                          `json:"brand_json_url,omitempty"`
-	PerPrincipalKeyIsolation bool                            `json:"per_principal_key_isolation,omitempty"`
+	PerPrincipalKeyIsolation *bool                           `json:"per_principal_key_isolation,omitempty"`
 	KeyOrigins               *IdentityKeyOrigins             `json:"key_origins,omitempty"`
 	CompromiseNotification   *IdentityCompromiseNotification `json:"compromise_notification,omitempty"`
 }
@@ -435,8 +435,8 @@ type IdentityKeyOrigins struct {
 // subscribes to the identity.compromise_notification webhook event on key
 // revocation due to known or suspected compromise.
 type IdentityCompromiseNotification struct {
-	Emits   bool `json:"emits,omitempty"`
-	Accepts bool `json:"accepts,omitempty"`
+	Emits   *bool `json:"emits,omitempty"`
+	Accepts *bool `json:"accepts,omitempty"`
 }
 
 // ComplianceTestingCapabilities declares supported comply_test_controller
@@ -1219,7 +1219,7 @@ type Deployment struct {
 	Platform                           string         `json:"platform,omitempty"`
 	AgentURL                           string         `json:"agent_url,omitempty"`
 	Account                            string         `json:"account,omitempty"`
-	IsLive                             bool           `json:"is_live"`
+	IsLive                             *bool          `json:"is_live,omitempty"`
 	ActivationKey                      *ActivationKey `json:"activation_key,omitempty"`
 	DeployedAt                         string         `json:"deployed_at,omitempty"`
 	EstimatedActivationDurationMinutes int            `json:"estimated_activation_duration_minutes,omitempty"`
@@ -1422,7 +1422,7 @@ type MeasurementWindow struct {
 	Description              string `json:"description,omitempty"`
 	DurationDays             int    `json:"duration_days"`
 	ExpectedAvailabilityDays int    `json:"expected_availability_days,omitempty"`
-	IsGuaranteeBasis         bool   `json:"is_guarantee_basis,omitempty"`
+	IsGuaranteeBasis         *bool  `json:"is_guarantee_basis,omitempty"`
 }
 
 // PerformanceStandard defines a rate threshold for a performance metric.

--- a/docs/sdk-typing-policy.md
+++ b/docs/sdk-typing-policy.md
@@ -78,6 +78,11 @@ Migration rule:
 - Avoid sweeping pointer changes across all generated response fields in one
   PR. Change request-side fields first, with round-trip tests, because those
   affect emitted wire payloads and MCP input schemas.
+- `adcp/schemas/lint.py --strict` enforces optional boolean pointers and flags
+  optional numeric pointer candidates when omission and explicit zero appear
+  semantically distinct. Numeric exceptions require a documented
+  `OPTIONAL_NUMERIC_SCALAR_OK` waiver in `adcp/schemas/lint.py`. Boolean
+  exceptions have no waiver; file an upstream schema clarification first.
 
 ## Enum Policy
 


### PR DESCRIPTION
## Summary
- add strict-lint enforcement for optional boolean fields so explicit `false` is not lost or emitted accidentally
- convert remaining hand-written optional bool capability/deployment/window fields to `*bool`
- add false round-trip coverage for capability, deployment, and measurement-window booleans
- document lint enforcement in the SDK typing policy

## Source compatibility
This narrows several public Go fields from `bool` to `*bool`. Go callers constructing these structs will need to use `adcp.Bool(false)` / `adcp.Bool(true)`.

Most affected fields already used `omitempty`; `Deployment.IsLive` is the exception. Before this PR, the zero-value struct emitted `"is_live":false`; after this PR, a nil `IsLive` omits the field and callers must set `IsLive: adcp.Bool(false)` to emit explicit false. This matches the schema optionality but should be called out in release notes.

`Deployment` is used by the AdCP signal activation/get-signals surface. I found no signed TMP envelope or JCS canonicalization path containing `Deployment` in this repo (`tmproto`, router signing, and TMP client surfaces are separate), so the `is_live` omission change should not affect TMP signature verification.

Release policy for generated/typed narrowings is tracked in #341. This PR is marked `feat(adcp)!` because it changes exported Go field types.

Closes #178.

## Validation
- cd adcp/schemas && python3 -m unittest discover -p "*_test.py"
- cd adcp/schemas && python3 lint.py --strict
- cd adcp/schemas && python3 generate.py --coverage-max-unreviewed-any 0
- cd adcp/schemas && python3 generate.py | cmp - ../types_gen.go
- git diff --check
- go test ./...
- cd adcp && go test ./...
- cd reference/seller-agent && go test ./...