### PR TITLE
feat(targeting)!: union ContextSignals.Topics; scope topic keys by taxonomy

### DIFF
--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -13,11 +13,15 @@ import (
 	"github.com/adcontextprotocol/adcp-go/router"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmpclient"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// e2eTaxonomy is the taxonomy fixture used across the end-to-end stack.
+var e2eTaxonomy = topicstore.Taxonomy{Source: "e2e", ID: 1}
 
 // testStack holds all components for an integration test.
 type testStack struct {
@@ -32,12 +36,15 @@ func setupStack(t *testing.T) *testStack {
 
 	store := targeting.NewMockStore()
 
-	store.SetAdd("topics:package:pkg-food", "food.cooking", "food.recipes")
-	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
-	store.SetAdd("topics:package:pkg-tech", "technology.gadgets", "technology.reviews")
-	store.SetAdd("topics:artifact:article:cpu-review", "technology.reviews", "technology.hardware")
+	ctx := context.Background()
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-food", []string{"food.cooking", "food.recipes"}))
+	require.NoError(t, writer.SetArtifactTopics(ctx, e2eTaxonomy, "article:pasta", []string{"food.cooking", "food.italian"}))
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-tech", []string{"technology.gadgets", "technology.reviews"}))
+	require.NoError(t, writer.SetArtifactTopics(ctx, e2eTaxonomy, "article:cpu-review", []string{"technology.reviews", "technology.hardware"}))
 
-	store.SetAdd("url:blocklist:pkg-family", targeting.HashURL("article:adult-content"))
+	require.NoError(t, store.SetAdd(ctx, "url:blocklist:pkg-family", targeting.HashURL("article:adult-content")))
 
 	contextEngine := targeting.NewContextEngine(targeting.ContextEngineConfig{
 		ProviderID: "integration-context",
@@ -50,6 +57,7 @@ func setupStack(t *testing.T) *testStack {
 			{PackageID: "pkg-tech", TopicTargets: true, EmitSegments: []string{"technology"}},
 			{PackageID: "pkg-family", URLBlocklist: true},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{e2eTaxonomy},
 	})
 
 	audSvc := audience.New(audience.NewMockStore())
@@ -280,11 +288,14 @@ func TestIntegration_PropertyBitmapFilter(t *testing.T) {
 
 func TestIntegration_Mediation(t *testing.T) {
 	store := targeting.NewMockStore()
+	ctx := context.Background()
 
-	store.SetAdd("topics:package:pkg-olive-oil", "food.cooking", "food.ingredients")
-	store.SetAdd("topics:package:pkg-cookware", "food.cooking", "food.kitchen")
-	store.SetAdd("topics:package:pkg-wine", "food.cooking", "food.beverage")
-	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-olive-oil", []string{"food.cooking", "food.ingredients"}))
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-cookware", []string{"food.cooking", "food.kitchen"}))
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-wine", []string{"food.cooking", "food.beverage"}))
+	require.NoError(t, writer.SetArtifactTopics(ctx, e2eTaxonomy, "article:pasta", []string{"food.cooking", "food.italian"}))
 
 	audSvc := audience.New(audience.NewMockStore())
 	require.NoError(t, audSvc.Upsert(context.Background(), audience.AudienceUpsert{
@@ -337,6 +348,7 @@ func TestIntegration_Mediation(t *testing.T) {
 				EmitSegments: []string{"food", "beverage"},
 			},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{e2eTaxonomy},
 	})
 
 	cookingFans := &targeting.SegmentRule{AnyOf: []string{"cooking_fans"}}
@@ -443,9 +455,12 @@ func TestIntegration_Mediation(t *testing.T) {
 
 func TestIntegration_MultiDealMediation(t *testing.T) {
 	store := targeting.NewMockStore()
+	ctx := context.Background()
 
-	store.SetAdd("topics:package:pkg-premium-food", "food.cooking", "food.recipes")
-	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetPackageTopics(ctx, e2eTaxonomy, "pkg-premium-food", []string{"food.cooking", "food.recipes"}))
+	require.NoError(t, writer.SetArtifactTopics(ctx, e2eTaxonomy, "article:pasta", []string{"food.cooking", "food.italian"}))
 
 	marshalBrand := func(name, domain string) json.RawMessage {
 		b, _ := json.Marshal(map[string]string{"name": name, "advertiser_domain": domain})
@@ -480,6 +495,7 @@ func TestIntegration_MultiDealMediation(t *testing.T) {
 				},
 			},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{e2eTaxonomy},
 	})
 
 	identityEngine := targeting.NewIdentityEngine(targeting.IdentityEngineConfig{})

--- a/e2e/sizes_test.go
+++ b/e2e/sizes_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -162,15 +163,16 @@ func TestMeasure_TargetingScale(t *testing.T) {
 	t.Log("")
 	store := targeting.NewMockStore()
 
+	ctx := context.Background()
 	for _, n := range []int{100, 1000, 10_000, 100_000} {
 		key := fmt.Sprintf("set:seg-%d", n)
 		for i := range n {
-			store.SetAdd(key, fmt.Sprintf("token-hash-%d", i))
+			_ = store.SetAdd(ctx, key, fmt.Sprintf("token-hash-%d", i))
 		}
 		start := time.Now()
 		const lookups = 100_000
 		for i := range lookups {
-			store.SetIsMember(nil, key, fmt.Sprintf("token-hash-%d", i%n))
+			_, _ = store.SetIsMember(ctx, key, fmt.Sprintf("token-hash-%d", i%n))
 		}
 		elapsed := time.Since(start)
 		t.Logf("  %6d members: %v per lookup", n, elapsed/lookups)

--- a/reference/context-agent/bench_test.go
+++ b/reference/context-agent/bench_test.go
@@ -135,7 +135,6 @@ func BenchmarkValkeyLookup(b *testing.B) {
 		_ = store.SetAdd(ctx, "url:blocklist:pkg-1", targeting.HashURL(fmt.Sprintf("article:content-%d", i)))
 	}
 
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		urlHash := targeting.HashURL(fmt.Sprintf("article:content-%d", i%20000))

--- a/reference/context-agent/bench_test.go
+++ b/reference/context-agent/bench_test.go
@@ -13,8 +13,11 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+var benchTaxonomy = topicstore.Taxonomy{Source: "bench", ID: 1}
 
 // BenchmarkBitmapCheck tests the string-set bitmap Contains() with 50K properties, targeting 1K.
 func BenchmarkBitmapCheck(b *testing.B) {
@@ -57,8 +60,17 @@ func BenchmarkSignatureVerify(b *testing.B) {
 // BenchmarkFullPipeline tests complete context evaluation with bitmap + topic match.
 func BenchmarkFullPipeline(b *testing.B) {
 	store := targeting.NewMockStore()
-	store.SetAdd("topics:package:pkg-food", "food.cooking", "food.baking", "food.italian")
-	store.SetAdd("topics:artifact:article:pasta-recipe", "food.cooking", "food.italian")
+	ctx := context.Background()
+	writer, err := topicstore.NewWriter(store)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := writer.SetPackageTopics(ctx, benchTaxonomy, "pkg-food", []string{"food.cooking", "food.baking", "food.italian"}); err != nil {
+		b.Fatal(err)
+	}
+	if err := writer.SetArtifactTopics(ctx, benchTaxonomy, "article:pasta-recipe", []string{"food.cooking", "food.italian"}); err != nil {
+		b.Fatal(err)
+	}
 
 	bm := NewSetBitmap()
 	for i := 1; i <= 1000; i++ {
@@ -75,6 +87,7 @@ func BenchmarkFullPipeline(b *testing.B) {
 			{PackageID: "pkg-food", TopicTargets: true, URLBlocklist: true},
 			{PackageID: "pkg-tech", TopicTargets: true},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{benchTaxonomy},
 	})
 
 	req := &tmproto.ContextMatchRequest{
@@ -84,7 +97,6 @@ func BenchmarkFullPipeline(b *testing.B) {
 		PackageIDs:   []string{"pkg-food", "pkg-tech"},
 	}
 
-	ctx := context.Background()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = engine.EvaluateContext(ctx, req)
@@ -118,11 +130,12 @@ func BenchmarkRegistryLoad(b *testing.B) {
 // BenchmarkValkeyLookup tests URL pattern check using mock store.
 func BenchmarkValkeyLookup(b *testing.B) {
 	store := targeting.NewMockStore()
+	ctx := context.Background()
 	for i := range 10000 {
-		store.SetAdd("url:blocklist:pkg-1", targeting.HashURL(fmt.Sprintf("article:content-%d", i)))
+		_ = store.SetAdd(ctx, "url:blocklist:pkg-1", targeting.HashURL(fmt.Sprintf("article:content-%d", i)))
 	}
 
-	ctx := context.Background()
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		urlHash := targeting.HashURL(fmt.Sprintf("article:content-%d", i%20000))

--- a/reference/context-agent/cmd/context-agent/main.go
+++ b/reference/context-agent/cmd/context-agent/main.go
@@ -15,8 +15,14 @@ import (
 	contextagent "github.com/adcontextprotocol/adcp-go/reference/context-agent"
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/prommetrics"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+// referenceTaxonomy is the demo taxonomy the reference agent seeds with. A
+// real deployment configures its accepted taxonomies via env / flag and
+// matches the writers that populate its Valkey instance.
+var referenceTaxonomy = topicstore.Taxonomy{Source: "reference", ID: 1}
 
 var version = "dev"
 
@@ -65,8 +71,20 @@ func main() {
 
 	// Seed sample data in mock store.
 	store := targeting.NewMockStore()
-	store.SetAdd("topics:package:pkg-display-0041", "food.cooking", "food.recipes", "lifestyle.home")
-	store.SetAdd("topics:package:pkg-native-0078", "technology.gadgets", "technology.reviews")
+	seedCtx := context.Background()
+	writer, wErr := topicstore.NewWriter(store)
+	if wErr != nil {
+		slog.Error("topicstore writer init failed", "error", wErr)
+		os.Exit(1)
+	}
+	if err := writer.SetPackageTopics(seedCtx, referenceTaxonomy, "pkg-display-0041", []string{"food.cooking", "food.recipes", "lifestyle.home"}); err != nil {
+		slog.Error("seed package topics failed", "error", err)
+		os.Exit(1)
+	}
+	if err := writer.SetPackageTopics(seedCtx, referenceTaxonomy, "pkg-native-0078", []string{"technology.gadgets", "technology.reviews"}); err != nil {
+		slog.Error("seed package topics failed", "error", err)
+		os.Exit(1)
+	}
 
 	engine := targeting.NewContextEngine(targeting.ContextEngineConfig{
 		ProviderID: "reference-context-agent",
@@ -79,6 +97,7 @@ func main() {
 			{PackageID: "pkg-display-0041", TopicTargets: true, EmitSegments: []string{"food", "lifestyle"}},
 			{PackageID: "pkg-native-0078", TopicTargets: true, URLBlocklist: true, EmitSegments: []string{"technology"}},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{referenceTaxonomy},
 	})
 
 	keystoreCtx, keystoreCancel := context.WithCancel(context.Background())

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -14,6 +14,7 @@ package targeting
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
@@ -36,9 +37,14 @@ type ContextEngine struct {
 	// trusts. A publisher's ContextSignals.Topics are unioned into the
 	// engine's topic set only when (TaxonomySource, TaxonomyID) is in this
 	// list; Valkey topic lookups happen once per accepted taxonomy per
-	// artifact. Empty disables topic targeting entirely.
+	// artifact. Empty disables topic targeting: every TopicTargets package
+	// fails the topic check rather than passing through vacuously, so a
+	// deployment cannot accidentally match on unscoped data.
+	//
+	// acceptedSet is the map form of acceptedTaxonomies for O(1) lookup;
+	// the slice keeps the iteration order callers configured.
 	acceptedTaxonomies []topicstore.Taxonomy
-	acceptedTaxonomy   map[topicstore.Taxonomy]struct{}
+	acceptedSet        map[topicstore.Taxonomy]struct{}
 
 	metrics Metrics
 }
@@ -53,16 +59,25 @@ type ContextEngineConfig struct {
 
 	// AcceptedTaxonomies enumerates the topic taxonomies this deployment
 	// trusts on inbound ContextSignals and consults on Valkey artifact /
-	// package topic lookups. Empty disables topic targeting (every
-	// TopicTargets package falls through as non-matching, which is the
-	// fail-closed shape — misconfigured deployments cannot accidentally
-	// match on stale, unscoped topic data).
+	// package topic lookups. Empty disables topic targeting: every
+	// TopicTargets package fails the topic check (fail-closed) — a
+	// deployment that wants topic targeting MUST declare at least one
+	// accepted taxonomy.
+	//
+	// A publisher who sends ContextSignals.Topics with an empty
+	// TaxonomySource gets a Taxonomy{Source: ""} key that
+	// Taxonomy.Validate rejects and that no deployment can configure as
+	// accepted. Those topics are silently dropped; deployments that need
+	// to honor untagged topics must agree out-of-band with publishers on
+	// a default Source value to send.
 	AcceptedTaxonomies []topicstore.Taxonomy
 
 	Metrics Metrics // nil = noop
 }
 
-// NewContextEngine creates a context-match engine.
+// NewContextEngine creates a context-match engine. The caller's
+// cfg.AcceptedTaxonomies slice is copied so post-construction mutation
+// cannot reach into engine state.
 func NewContextEngine(cfg ContextEngineConfig) *ContextEngine {
 	pkgMap := make(map[string]PackageConfig, len(cfg.Packages))
 	for _, p := range cfg.Packages {
@@ -72,9 +87,11 @@ func NewContextEngine(cfg ContextEngineConfig) *ContextEngine {
 	if metrics == nil {
 		metrics = noopMetrics{}
 	}
-	accepted := make(map[topicstore.Taxonomy]struct{}, len(cfg.AcceptedTaxonomies))
-	for _, t := range cfg.AcceptedTaxonomies {
-		accepted[t] = struct{}{}
+	acceptedSlice := make([]topicstore.Taxonomy, len(cfg.AcceptedTaxonomies))
+	copy(acceptedSlice, cfg.AcceptedTaxonomies)
+	acceptedSet := make(map[topicstore.Taxonomy]struct{}, len(acceptedSlice))
+	for _, t := range acceptedSlice {
+		acceptedSet[t] = struct{}{}
 	}
 	return &ContextEngine{
 		providerID:         cfg.ProviderID,
@@ -82,15 +99,15 @@ func NewContextEngine(cfg ContextEngineConfig) *ContextEngine {
 		properties:         cfg.Properties,
 		packages:           pkgMap,
 		dynamicPackages:    cfg.DynamicPackages,
-		acceptedTaxonomies: cfg.AcceptedTaxonomies,
-		acceptedTaxonomy:   accepted,
+		acceptedTaxonomies: acceptedSlice,
+		acceptedSet:        acceptedSet,
 		metrics:            metrics,
 	}
 }
 
 // acceptsTaxonomy reports whether tax is configured as accepted.
 func (e *ContextEngine) acceptsTaxonomy(tax topicstore.Taxonomy) bool {
-	_, ok := e.acceptedTaxonomy[tax]
+	_, ok := e.acceptedSet[tax]
 	return ok
 }
 
@@ -108,6 +125,23 @@ func (e *ContextEngine) publisherTopics(req *tmproto.ContextMatchRequest) []stri
 		return nil
 	}
 	return topicstore.NamespaceTopics(tax, cs.Topics)
+}
+
+// publisherTopicsByTaxonomy returns ContextSignals.Topics grouped by the
+// declared taxonomy when that taxonomy is in the accepted set. Returns
+// nil when no usable publisher topics are present. The non-resolved
+// engine path uses this to perform an in-memory join against each
+// candidate package's stored topic set per accepted taxonomy.
+func (e *ContextEngine) publisherTopicsByTaxonomy(req *tmproto.ContextMatchRequest) map[topicstore.Taxonomy][]string {
+	cs := req.ContextSignals
+	if cs == nil || len(cs.Topics) == 0 {
+		return nil
+	}
+	tax := topicstore.Taxonomy{Source: cs.TaxonomySource, ID: cs.TaxonomyID}
+	if !e.acceptsTaxonomy(tax) {
+		return nil
+	}
+	return map[topicstore.Taxonomy][]string{tax: cs.Topics}
 }
 
 // IdentityEngine evaluates identity-match requests. It reads pre-resolved
@@ -184,6 +218,9 @@ func (e *ContextEngine) EvaluateContext(ctx context.Context, req *tmproto.Contex
 	e.metrics.Latency(ctx, StageSuppression, time.Since(suppressionStart))
 
 	artifactRefs := extractArtifactRefURLs(req)
+	pubTopicsByTax := e.publisherTopicsByTaxonomy(req)
+	cs := req.ContextSignals
+	haveTopicSource := len(artifactRefs) > 0 || (cs != nil && len(cs.Topics) > 0)
 
 	var dynCtxConfigs map[string]*PackageContextConfig
 	if e.dynamicPackages {
@@ -250,13 +287,23 @@ func (e *ContextEngine) EvaluateContext(ctx context.Context, req *tmproto.Contex
 		}
 
 		if topicTargets {
-			matched, err := e.checkTopicMatch(ctx, artifactRefs, pkgID)
-			if err != nil {
-				e.metrics.StoreError(ctx, StageTopicMatch, err)
-			} else if !matched {
+			if len(e.acceptedTaxonomies) == 0 {
 				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
 				continue
 			}
+			if haveTopicSource {
+				matched, err := e.checkTopicMatch(ctx, artifactRefs, pubTopicsByTax, pkgID)
+				if err != nil {
+					e.metrics.StoreError(ctx, StageTopicMatch, err)
+				} else if !matched {
+					e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
+					continue
+				}
+			}
+			// haveTopicSource == false: the publisher disclosed no
+			// topics at all (no artifact_refs, no ContextSignals.Topics)
+			// — the package passes the topic check vacuously, matching
+			// the resolved path.
 		}
 
 		e.metrics.ContextEvaluated(ctx, "", true)
@@ -288,6 +335,13 @@ func (e *ContextEngine) EvaluateContext(ctx context.Context, req *tmproto.Contex
 // engine's accepted set. When publisher-provided topics already activate
 // every topic-targeted package in the request, the per-artifact Valkey
 // SMEMBERS lookups are skipped entirely.
+//
+// Errors from per-(artifact, taxonomy) SMEMBERS lookups are recorded via
+// StoreError + structured log and the loop continues to the next
+// taxonomy; the affected taxonomy effectively under-matches for the
+// request while the rest still evaluate. There is no overall "stop on
+// first error" — a partial Valkey outage degrades match coverage rather
+// than failing the whole request.
 func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *ResolvedPackages, req *tmproto.ContextMatchRequest) (*ContextResult, error) {
 	evalStart := time.Now()
 	rid := req.PropertyRID
@@ -323,11 +377,21 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 	topicCandidates := resolved.TopicCandidates(artifactTopics)
 	needArtifactLookup := len(artifactRefs) > 0 && !publisherCoversTopicTargets(req.PackageIDs, resolved, topicCandidates)
 	if needArtifactLookup {
+		// Fail-closed per (artifact, taxonomy): a Valkey hiccup for one
+		// taxonomy under-matches that taxonomy but does not poison the
+		// rest of the eval. StageTopicMatch error metric + structured
+		// log so on-call can correlate underrmatch incidents to
+		// upstream errors.
 		for _, artifact := range artifactRefs {
 			for _, tax := range e.acceptedTaxonomies {
 				topics, err := e.store.SetMembers(ctx, topicstore.ArtifactKey(tax, artifact))
 				if err != nil {
 					e.metrics.StoreError(ctx, StageTopicMatch, err)
+					slog.Warn("topicstore: artifact-topic lookup failed; under-matching this taxonomy",
+						"request_id", req.RequestID,
+						"artifact", artifact,
+						"taxonomy", tax.String(),
+						"error", err)
 					continue
 				}
 				for _, t := range topics {
@@ -360,17 +424,31 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 		}
 
 		if cfg.TopicTargets {
-			// A topic source is anything the publisher could have given
-			// us topics through: artifact refs (we look them up) or
-			// ContextSignals.Topics on the request (we union them). If
-			// the publisher *attempted* either path — even with a
-			// taxonomy the engine doesn't accept — the package must
-			// match a real topic candidate; falling through would mean
-			// a misconfigured publisher gets free activations on every
-			// topic-targeted package, which is the opposite of what
-			// TopicTargets is for. Only the pure no-input case (no
-			// artifacts, no ContextSignals.Topics at all) preserves the
-			// legacy vacuous-match shape.
+			// Topic-source matrix the gate below enforces:
+			//
+			//   AcceptedTax | artifact_refs | cs.Topics | outcome
+			//   ------------+---------------+-----------+----------
+			//   empty       | (any)         | (any)     | fail-closed
+			//   non-empty   | none          | none      | vacuous pass
+			//   non-empty   | none          | rogue-tax | fail (only
+			//                                            source was
+			//                                            rejected)
+			//   non-empty   | none          | accepted  | match required
+			//   non-empty   | present       | (any)     | match required
+			//                                            (rogue cs.Topics
+			//                                            silently ignored;
+			//                                            artifact lookups
+			//                                            still run)
+			//
+			// The fail-on-rogue-only-source case is what prevents a
+			// publisher from earning free activations by mis-declaring
+			// their taxonomy on an otherwise empty request — they
+			// supplied a topic source the engine couldn't use, so the
+			// package's required-match contract stays in force.
+			if len(e.acceptedTaxonomies) == 0 {
+				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
+				continue
+			}
 			cs := req.ContextSignals
 			haveTopicSource := len(artifactRefs) > 0 || (cs != nil && len(cs.Topics) > 0)
 			if haveTopicSource {
@@ -556,15 +634,44 @@ func (e *ContextEngine) checkURLFilter(ctx context.Context, artifacts []string, 
 	return false, nil
 }
 
-// checkTopicMatch checks if artifacts have topic overlap with a package in
-// any accepted taxonomy. Returns true (vacuously) when neither artifacts
-// nor accepted taxonomies are configured — matching the resolved path's
-// no-topic-source semantics. ContextSignals.Topics is not honored here;
-// embedders that want publisher-topic union must use EvaluateContextResolved.
-func (e *ContextEngine) checkTopicMatch(ctx context.Context, artifacts []string, pkgID string) (bool, error) {
-	if len(artifacts) == 0 || len(e.acceptedTaxonomies) == 0 {
-		return true, nil
+// checkTopicMatch returns true when at least one accepted taxonomy yields
+// a topic overlap between (publisher topics ∪ artifact topics) and the
+// package's stored topic set. Callers must verify upstream that there is
+// at least one topic source (artifact refs or accepted ContextSignals
+// topics) before calling — when both sources are empty, the caller should
+// treat the topic check as vacuously passing rather than invoking this
+// helper, which would otherwise return false.
+//
+// pubTopicsByTax may be nil when the request had no usable publisher
+// topics; in that case only the artifact branch runs.
+func (e *ContextEngine) checkTopicMatch(ctx context.Context, artifacts []string, pubTopicsByTax map[topicstore.Taxonomy][]string, pkgID string) (bool, error) {
+	if len(e.acceptedTaxonomies) == 0 {
+		return false, nil
 	}
+
+	// Publisher-topic branch: one SMEMBERS per (taxonomy carrying
+	// publisher topics) and an in-memory join. Short-circuits as soon as
+	// any taxonomy produces overlap.
+	for tax, pubTopics := range pubTopicsByTax {
+		pkgTopics, err := e.store.SetMembers(ctx, topicstore.PackageKey(tax, pkgID))
+		if err != nil {
+			return false, err
+		}
+		if len(pkgTopics) == 0 {
+			continue
+		}
+		pkgSet := make(map[string]struct{}, len(pkgTopics))
+		for _, t := range pkgTopics {
+			pkgSet[t] = struct{}{}
+		}
+		for _, t := range pubTopics {
+			if _, ok := pkgSet[t]; ok {
+				return true, nil
+			}
+		}
+	}
+
+	// Artifact-topic branch: one SINTER per (artifact, taxonomy).
 	for _, artifact := range artifacts {
 		for _, tax := range e.acceptedTaxonomies {
 			intersection, err := e.store.SetIntersect(ctx,

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -31,6 +32,14 @@ type ContextEngine struct {
 	packages        map[string]PackageConfig
 	dynamicPackages bool
 
+	// acceptedTaxonomies enumerates the topic taxonomies this deployment
+	// trusts. A publisher's ContextSignals.Topics are unioned into the
+	// engine's topic set only when (TaxonomySource, TaxonomyID) is in this
+	// list; Valkey topic lookups happen once per accepted taxonomy per
+	// artifact. Empty disables topic targeting entirely.
+	acceptedTaxonomies []topicstore.Taxonomy
+	acceptedTaxonomy   map[topicstore.Taxonomy]struct{}
+
 	metrics Metrics
 }
 
@@ -40,8 +49,17 @@ type ContextEngineConfig struct {
 	Store           ContextStore
 	Properties      PropertyList
 	Packages        []PackageConfig
-	DynamicPackages bool    // When true, load package configs from Store at eval time.
-	Metrics         Metrics // nil = noop
+	DynamicPackages bool // When true, load package configs from Store at eval time.
+
+	// AcceptedTaxonomies enumerates the topic taxonomies this deployment
+	// trusts on inbound ContextSignals and consults on Valkey artifact /
+	// package topic lookups. Empty disables topic targeting (every
+	// TopicTargets package falls through as non-matching, which is the
+	// fail-closed shape — misconfigured deployments cannot accidentally
+	// match on stale, unscoped topic data).
+	AcceptedTaxonomies []topicstore.Taxonomy
+
+	Metrics Metrics // nil = noop
 }
 
 // NewContextEngine creates a context-match engine.
@@ -54,14 +72,42 @@ func NewContextEngine(cfg ContextEngineConfig) *ContextEngine {
 	if metrics == nil {
 		metrics = noopMetrics{}
 	}
-	return &ContextEngine{
-		providerID:      cfg.ProviderID,
-		store:           cfg.Store,
-		properties:      cfg.Properties,
-		packages:        pkgMap,
-		dynamicPackages: cfg.DynamicPackages,
-		metrics:         metrics,
+	accepted := make(map[topicstore.Taxonomy]struct{}, len(cfg.AcceptedTaxonomies))
+	for _, t := range cfg.AcceptedTaxonomies {
+		accepted[t] = struct{}{}
 	}
+	return &ContextEngine{
+		providerID:         cfg.ProviderID,
+		store:              cfg.Store,
+		properties:         cfg.Properties,
+		packages:           pkgMap,
+		dynamicPackages:    cfg.DynamicPackages,
+		acceptedTaxonomies: cfg.AcceptedTaxonomies,
+		acceptedTaxonomy:   accepted,
+		metrics:            metrics,
+	}
+}
+
+// acceptsTaxonomy reports whether tax is configured as accepted.
+func (e *ContextEngine) acceptsTaxonomy(tax topicstore.Taxonomy) bool {
+	_, ok := e.acceptedTaxonomy[tax]
+	return ok
+}
+
+// publisherTopics returns the namespaced topic strings derived from
+// req.ContextSignals when its declared taxonomy is in the engine's
+// accepted set. Returns nil when ContextSignals is absent, has no topics,
+// or declares a taxonomy the engine does not trust.
+func (e *ContextEngine) publisherTopics(req *tmproto.ContextMatchRequest) []string {
+	cs := req.ContextSignals
+	if cs == nil || len(cs.Topics) == 0 {
+		return nil
+	}
+	tax := topicstore.Taxonomy{Source: cs.TaxonomySource, ID: cs.TaxonomyID}
+	if !e.acceptsTaxonomy(tax) {
+		return nil
+	}
+	return topicstore.NamespaceTopics(tax, cs.Topics)
 }
 
 // IdentityEngine evaluates identity-match requests. It reads pre-resolved
@@ -233,6 +279,15 @@ func (e *ContextEngine) EvaluateContext(ctx context.Context, req *tmproto.Contex
 // EvaluateContextResolved evaluates context using pre-built indexes.
 // Minimal Store calls: only suppression checks and artifact→topic resolution.
 // All targeting lookups (property, topic, URL) are in-memory.
+//
+// Topic resolution is taxonomy-scoped: the engine namespaces every topic id
+// by its (TaxonomySource, TaxonomyID) before joining against TopicIndex, so
+// the id "632" under IAB Content Taxonomy 3.0 never cross-matches with the
+// same string under a different taxonomy. ContextSignals.Topics is unioned
+// into the artifact-topic set when its declared taxonomy is in the
+// engine's accepted set. When publisher-provided topics already activate
+// every topic-targeted package in the request, the per-artifact Valkey
+// SMEMBERS lookups are skipped entirely.
 func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *ResolvedPackages, req *tmproto.ContextMatchRequest) (*ContextResult, error) {
 	evalStart := time.Now()
 	rid := req.PropertyRID
@@ -252,22 +307,41 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 
 	artifactRefs := extractArtifactRefURLs(req)
 
-	var artifactTopics []string
-	for _, artifact := range artifactRefs {
-		topics, err := e.store.SetMembers(ctx, "topics:artifact:"+artifact)
-		if err != nil {
-			e.metrics.StoreError(ctx, StageTopicMatch, err)
-		} else {
-			artifactTopics = append(artifactTopics, topics...)
+	// Seed artifact topics from publisher-provided ContextSignals when the
+	// declared taxonomy is accepted. These count as topics for every
+	// artifact in the request (the publisher classifies the placement, not
+	// a per-ref view) and are also the only topic input for the
+	// no-artifact / ephemeral-content case.
+	pubTopics := e.publisherTopics(req)
+	artifactTopics := make([]string, 0, len(pubTopics))
+	artifactTopics = append(artifactTopics, pubTopics...)
+
+	// Short-circuit: skip the Valkey SMEMBERS round-trips entirely when
+	// publisher topics already produce a candidate hit for every
+	// TopicTargets package in the request. The fallback path runs when at
+	// least one such package still lacks a candidate.
+	topicCandidates := resolved.TopicCandidates(artifactTopics)
+	needArtifactLookup := len(artifactRefs) > 0 && !publisherCoversTopicTargets(req.PackageIDs, resolved, topicCandidates)
+	if needArtifactLookup {
+		for _, artifact := range artifactRefs {
+			for _, tax := range e.acceptedTaxonomies {
+				topics, err := e.store.SetMembers(ctx, topicstore.ArtifactKey(tax, artifact))
+				if err != nil {
+					e.metrics.StoreError(ctx, StageTopicMatch, err)
+					continue
+				}
+				for _, t := range topics {
+					artifactTopics = append(artifactTopics, topicstore.NamespaceTopic(tax, t))
+				}
+			}
 		}
+		topicCandidates = resolved.TopicCandidates(artifactTopics)
 	}
 
 	var artifactHashes []string
 	for _, artifact := range artifactRefs {
 		artifactHashes = append(artifactHashes, HashURL(artifact))
 	}
-
-	topicCandidates := resolved.TopicCandidates(artifactTopics)
 
 	var offers []tmproto.Offer
 	var segments []string
@@ -285,14 +359,25 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 			}
 		}
 
-		if cfg.TopicTargets && len(artifactRefs) > 0 {
-			if len(topicCandidates) == 0 {
-				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
-				continue
-			}
-			if _, ok := topicCandidates[pkgID]; !ok {
-				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
-				continue
+		if cfg.TopicTargets {
+			// A topic source is anything the publisher could have given
+			// us topics through: artifact refs (we look them up) or
+			// ContextSignals.Topics on the request (we union them). If
+			// the publisher *attempted* either path — even with a
+			// taxonomy the engine doesn't accept — the package must
+			// match a real topic candidate; falling through would mean
+			// a misconfigured publisher gets free activations on every
+			// topic-targeted package, which is the opposite of what
+			// TopicTargets is for. Only the pure no-input case (no
+			// artifacts, no ContextSignals.Topics at all) preserves the
+			// legacy vacuous-match shape.
+			cs := req.ContextSignals
+			haveTopicSource := len(artifactRefs) > 0 || (cs != nil && len(cs.Topics) > 0)
+			if haveTopicSource {
+				if _, ok := topicCandidates[pkgID]; !ok {
+					e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
+					continue
+				}
 			}
 		}
 
@@ -471,21 +556,48 @@ func (e *ContextEngine) checkURLFilter(ctx context.Context, artifacts []string, 
 	return false, nil
 }
 
-// checkTopicMatch checks if artifacts have topic overlap with a package.
+// checkTopicMatch checks if artifacts have topic overlap with a package in
+// any accepted taxonomy. Returns true (vacuously) when neither artifacts
+// nor accepted taxonomies are configured — matching the resolved path's
+// no-topic-source semantics. ContextSignals.Topics is not honored here;
+// embedders that want publisher-topic union must use EvaluateContextResolved.
 func (e *ContextEngine) checkTopicMatch(ctx context.Context, artifacts []string, pkgID string) (bool, error) {
-	if len(artifacts) == 0 {
+	if len(artifacts) == 0 || len(e.acceptedTaxonomies) == 0 {
 		return true, nil
 	}
 	for _, artifact := range artifacts {
-		intersection, err := e.store.SetIntersect(ctx, "topics:package:"+pkgID, "topics:artifact:"+artifact)
-		if err != nil {
-			return false, err
-		}
-		if len(intersection) > 0 {
-			return true, nil
+		for _, tax := range e.acceptedTaxonomies {
+			intersection, err := e.store.SetIntersect(ctx,
+				topicstore.PackageKey(tax, pkgID),
+				topicstore.ArtifactKey(tax, artifact))
+			if err != nil {
+				return false, err
+			}
+			if len(intersection) > 0 {
+				return true, nil
+			}
 		}
 	}
 	return false, nil
+}
+
+// publisherCoversTopicTargets reports whether topicCandidates (built from
+// publisher-provided topics alone) already places every TopicTargets
+// package in pkgIDs into the candidate set. When true, the engine can
+// skip per-artifact Valkey SMEMBERS lookups: union semantics guarantee
+// that adding artifact topics can only grow the candidate set, never
+// remove a package that publisher topics already satisfied.
+func publisherCoversTopicTargets(pkgIDs []string, resolved *ResolvedPackages, candidates map[string]struct{}) bool {
+	for _, pkgID := range pkgIDs {
+		cfg := resolved.ContextConfigs[pkgID]
+		if cfg == nil || !cfg.TopicTargets {
+			continue
+		}
+		if _, ok := candidates[pkgID]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // buildOffers returns one or more Offers for an activated package.

--- a/targeting/engine.go
+++ b/targeting/engine.go
@@ -132,6 +132,13 @@ func (e *ContextEngine) publisherTopics(req *tmproto.ContextMatchRequest) []stri
 // nil when no usable publisher topics are present. The non-resolved
 // engine path uses this to perform an in-memory join against each
 // candidate package's stored topic set per accepted taxonomy.
+//
+// The TMP wire today carries exactly one (TaxonomySource, TaxonomyID)
+// pair per ContextSignals, so the returned map has at most one entry.
+// The map shape is forward-compat for a future spec extension that
+// would let a publisher disclose topics under multiple taxonomies in a
+// single request; downstream callers handle multi-entry input without
+// further changes.
 func (e *ContextEngine) publisherTopicsByTaxonomy(req *tmproto.ContextMatchRequest) map[topicstore.Taxonomy][]string {
 	cs := req.ContextSignals
 	if cs == nil || len(cs.Topics) == 0 {
@@ -288,7 +295,7 @@ func (e *ContextEngine) EvaluateContext(ctx context.Context, req *tmproto.Contex
 
 		if topicTargets {
 			if len(e.acceptedTaxonomies) == 0 {
-				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
+				e.metrics.ContextEvaluated(ctx, StageTopicNoTaxonomy, false)
 				continue
 			}
 			if haveTopicSource {
@@ -380,14 +387,14 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 		// Fail-closed per (artifact, taxonomy): a Valkey hiccup for one
 		// taxonomy under-matches that taxonomy but does not poison the
 		// rest of the eval. StageTopicMatch error metric + structured
-		// log so on-call can correlate underrmatch incidents to
+		// log so on-call can correlate under-match incidents to
 		// upstream errors.
 		for _, artifact := range artifactRefs {
 			for _, tax := range e.acceptedTaxonomies {
 				topics, err := e.store.SetMembers(ctx, topicstore.ArtifactKey(tax, artifact))
 				if err != nil {
 					e.metrics.StoreError(ctx, StageTopicMatch, err)
-					slog.Warn("topicstore: artifact-topic lookup failed; under-matching this taxonomy",
+					slog.Warn("topicstore: artifact-topic lookup failed; under-match for this taxonomy",
 						"request_id", req.RequestID,
 						"artifact", artifact,
 						"taxonomy", tax.String(),
@@ -446,7 +453,7 @@ func (e *ContextEngine) EvaluateContextResolved(ctx context.Context, resolved *R
 			// supplied a topic source the engine couldn't use, so the
 			// package's required-match contract stays in force.
 			if len(e.acceptedTaxonomies) == 0 {
-				e.metrics.ContextEvaluated(ctx, StageTopicMatch, false)
+				e.metrics.ContextEvaluated(ctx, StageTopicNoTaxonomy, false)
 				continue
 			}
 			cs := req.ContextSignals

--- a/targeting/engine_context_signals_test.go
+++ b/targeting/engine_context_signals_test.go
@@ -395,6 +395,39 @@ func TestContext_NonResolvedPath_PublisherTopicsHonored(t *testing.T) {
 	assert.Len(t, resp.Offers, 1, "non-resolved path must honor ContextSignals.Topics for accepted taxonomies")
 }
 
+// TestContext_NonResolvedPath_RogueOnlySource_FailsClosed pins the
+// fail-closed shape on the non-resolved path when the publisher's
+// ContextSignals.Topics is the only topic source AND its taxonomy is
+// not accepted. The package's TopicTargets contract requires a real
+// match; the rogue-declared topics are dropped and no Valkey data is
+// reachable, so the package must not activate.
+func TestContext_NonResolvedPath_RogueOnlySource_FailsClosed(t *testing.T) {
+	accepted := topicstore.Taxonomy{Source: "iab", ID: 7}
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		Packages:           []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		AcceptedTaxonomies: []topicstore.Taxonomy{accepted},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "rogue",
+			TaxonomyID:     99,
+			Topics:         []string{"anything"},
+		},
+	}
+
+	resp, err := engine.EvaluateContext(context.Background(), req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Offers, "non-resolved path must fail-closed when rogue ContextSignals is the only topic source")
+}
+
 // TestContext_NonResolvedPath_EmptyAcceptedTaxonomies_FailsClosed mirrors
 // the resolved-path fail-closed test for the non-resolved engine path.
 func TestContext_NonResolvedPath_EmptyAcceptedTaxonomies_FailsClosed(t *testing.T) {

--- a/targeting/engine_context_signals_test.go
+++ b/targeting/engine_context_signals_test.go
@@ -2,6 +2,7 @@ package targeting
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -21,23 +22,10 @@ type countingStore struct {
 }
 
 func (c *countingStore) SetMembers(ctx context.Context, key string) ([]string, error) {
-	if c.prefix == "" || containsSubstring(key, c.prefix) {
+	if c.prefix == "" || strings.Contains(key, c.prefix) {
 		c.hits.Add(1)
 	}
 	return c.ContextStore.SetMembers(ctx, key)
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(sub) <= len(s) && (s == sub || indexOf(s, sub) >= 0)
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
 }
 
 // resolvedFromConfigs builds a minimal ResolvedPackages whose ContextConfigs
@@ -261,7 +249,11 @@ func TestContextResolved_MultiTaxonomyIsolation(t *testing.T) {
 	assert.Equal(t, "pkg-food", resp.Offers[0].PackageID, "only the IAB-side package should activate")
 }
 
-func TestContextResolved_NoTopicTargetsBypassesUnion(t *testing.T) {
+// TestContextResolved_ShortCircuitsWhenOnlyPackageIsNonTopicTargets
+// verifies the short-circuit fires when the request asks about a package
+// that has no TopicTargets rule — `publisherCoversTopicTargets` returns
+// true vacuously and no artifact-topic lookups happen.
+func TestContextResolved_ShortCircuitsWhenOnlyPackageIsNonTopicTargets(t *testing.T) {
 	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
 	base := NewMockStore()
 	store := &countingStore{ContextStore: base, prefix: "topics:artifact:"}
@@ -293,5 +285,154 @@ func TestContextResolved_NoTopicTargetsBypassesUnion(t *testing.T) {
 	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
 	require.NoError(t, err)
 	assert.Len(t, resp.Offers, 1)
-	assert.Equal(t, int32(0), store.hits.Load(), "non-TopicTargets package must not trigger artifact-topic Valkey lookups")
+	assert.Equal(t, int32(0), store.hits.Load(), "no TopicTargets package in the request → no artifact-topic Valkey lookups")
+}
+
+// TestContextResolved_EmptyAcceptedTaxonomies_FailsClosed pins the
+// fail-closed semantic the ContextEngineConfig doc promises. A package
+// configured with TopicTargets must NOT activate if the deployment
+// declares no accepted taxonomies — even when there's no topic input on
+// the request that would normally trigger the vacuous-pass path.
+func TestContextResolved_EmptyAcceptedTaxonomies_FailsClosed(t *testing.T) {
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID: "test",
+		Store:      store,
+		Properties: PropertyList{Global: NewMapBitmap("1")},
+		// AcceptedTaxonomies intentionally empty.
+	})
+	resolved := &ResolvedPackages{
+		ContextConfigs: map[string]*PackageContextConfig{
+			"pkg-food": {PackageID: "pkg-food", TopicTargets: true},
+		},
+	}
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food"},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Offers, "TopicTargets package must fail-closed when no taxonomies are configured")
+}
+
+// TestContextResolved_RogueTaxonomyPlusRealArtifact verifies the subtle
+// case where the publisher mis-declared a taxonomy on ContextSignals AND
+// also sent legitimate artifact refs whose stored topics match. The rogue
+// ContextSignals.Topics is silently dropped (not in accepted set), but
+// the artifact lookup still runs under the accepted taxonomy and the
+// package activates from artifact-side data alone.
+func TestContextResolved_RogueTaxonomyPlusRealArtifact(t *testing.T) {
+	accepted := topicstore.Taxonomy{Source: "iab", ID: 7}
+	base := NewMockStore()
+	w, err := topicstore.NewWriter(base)
+	require.NoError(t, err)
+	require.NoError(t, w.SetArtifactTopics(context.Background(), accepted, "article:pasta", []string{"632"}))
+
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              base,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{accepted},
+	})
+	resolved := resolvedFromConfigs(accepted, map[string][]string{
+		"pkg-food": {"632"},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:pasta"}},
+		PackageIDs:   []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "rogue",
+			TaxonomyID:     99,
+			Topics:         []string{"anything"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 1, "rogue ContextSignals must not poison legitimate artifact-side match")
+}
+
+// TestContext_NonResolvedPath_PublisherTopicsHonored covers item 3 from
+// review: the non-resolved EvaluateContext path must consume
+// ContextSignals.Topics when the declared taxonomy is accepted, in
+// addition to the artifact-side SetIntersect path. Without artifact refs
+// in the request, only publisher topics drive the match.
+func TestContext_NonResolvedPath_PublisherTopicsHonored(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	store := NewMockStore()
+	ctx := context.Background()
+	w, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, w.SetPackageTopics(ctx, tax, "pkg-food", []string{"632", "640"}))
+
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		Packages:           []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContext(ctx, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 1, "non-resolved path must honor ContextSignals.Topics for accepted taxonomies")
+}
+
+// TestContext_NonResolvedPath_EmptyAcceptedTaxonomies_FailsClosed mirrors
+// the resolved-path fail-closed test for the non-resolved engine path.
+func TestContext_NonResolvedPath_EmptyAcceptedTaxonomies_FailsClosed(t *testing.T) {
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID: "test",
+		Store:      store,
+		Properties: PropertyList{Global: NewMapBitmap("1")},
+		Packages:   []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		// AcceptedTaxonomies intentionally empty.
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:x"}},
+		PackageIDs:   []string{"pkg-food"},
+	}
+
+	resp, err := engine.EvaluateContext(context.Background(), req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Offers, "TopicTargets package must fail-closed when no taxonomies are configured on the non-resolved path")
+}
+
+// TestContext_NewContextEngine_DefensiveCopiesAcceptedTaxonomies makes
+// sure the slice the caller passes in cannot be mutated post-construction
+// to silently change engine behavior.
+func TestContext_NewContextEngine_DefensiveCopiesAcceptedTaxonomies(t *testing.T) {
+	caller := []topicstore.Taxonomy{{Source: "iab", ID: 7}}
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              NewMockStore(),
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: caller,
+	})
+	caller[0] = topicstore.Taxonomy{Source: "rogue", ID: 99}
+
+	assert.True(t, engine.acceptsTaxonomy(topicstore.Taxonomy{Source: "iab", ID: 7}),
+		"engine must keep its own copy; post-construction mutation must not reach in")
+	assert.False(t, engine.acceptsTaxonomy(topicstore.Taxonomy{Source: "rogue", ID: 99}))
 }

--- a/targeting/engine_context_signals_test.go
+++ b/targeting/engine_context_signals_test.go
@@ -1,0 +1,297 @@
+package targeting
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingStore wraps a ContextStore and counts SetMembers calls keyed on a
+// substring of the looked-up key. Used to assert which Valkey paths the
+// engine traverses for a given request shape.
+type countingStore struct {
+	ContextStore
+	prefix string
+	hits   atomic.Int32
+}
+
+func (c *countingStore) SetMembers(ctx context.Context, key string) ([]string, error) {
+	if c.prefix == "" || containsSubstring(key, c.prefix) {
+		c.hits.Add(1)
+	}
+	return c.ContextStore.SetMembers(ctx, key)
+}
+
+func containsSubstring(s, sub string) bool {
+	return len(sub) <= len(s) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// resolvedFromConfigs builds a minimal ResolvedPackages whose ContextConfigs
+// the engine reads to decide TopicTargets, and whose TopicIndex maps the
+// taxonomy-namespaced topics to their packages. Tests use it to drive the
+// resolved path with a hand-built fixture.
+func resolvedFromConfigs(tax topicstore.Taxonomy, pkgs map[string][]string) *ResolvedPackages {
+	resolved := &ResolvedPackages{
+		ContextConfigs: make(map[string]*PackageContextConfig, len(pkgs)),
+		TopicIndex:     make(map[string][]string),
+	}
+	for pkgID, topics := range pkgs {
+		resolved.ContextConfigs[pkgID] = &PackageContextConfig{PackageID: pkgID, TopicTargets: true}
+		for _, t := range topics {
+			ns := topicstore.NamespaceTopic(tax, t)
+			resolved.TopicIndex[ns] = append(resolved.TopicIndex[ns], pkgID)
+		}
+	}
+	return resolved
+}
+
+func TestContextResolved_PublisherTopicsUnion(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+	resolved := resolvedFromConfigs(tax, map[string][]string{
+		"pkg-food": {"632"},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:pasta"}},
+		PackageIDs:   []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 1, "publisher topic should match pkg-food without any Valkey artifact-topic data")
+}
+
+func TestContextResolved_PublisherTopicsRejectedForUnacceptedTaxonomy(t *testing.T) {
+	accepted := topicstore.Taxonomy{Source: "iab", ID: 7}
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{accepted},
+	})
+	resolved := resolvedFromConfigs(accepted, map[string][]string{
+		"pkg-food": {"632"},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "rogue",
+			TaxonomyID:     99,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Offers, "publisher topics from an unaccepted taxonomy must be ignored")
+}
+
+func TestContextResolved_ShortCircuitsValkeyWhenPublisherCoversAllPackages(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	base := NewMockStore()
+	store := &countingStore{ContextStore: base, prefix: "topics:artifact:"}
+
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+	resolved := resolvedFromConfigs(tax, map[string][]string{
+		"pkg-food": {"632"},
+		"pkg-tech": {"640"},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:x"}},
+		PackageIDs:   []string{"pkg-food", "pkg-tech"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632", "640"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 2, "both packages should activate from publisher topics alone")
+	assert.Equal(t, int32(0), store.hits.Load(), "no Valkey artifact-topic lookups when publisher topics cover every TopicTargets package")
+}
+
+func TestContextResolved_FallsBackToValkeyWhenPublisherTopicsIncomplete(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	base := NewMockStore()
+	writer, err := topicstore.NewWriter(base)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetArtifactTopics(context.Background(), tax, "article:x", []string{"640"}))
+
+	store := &countingStore{ContextStore: base, prefix: "topics:artifact:"}
+
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+	resolved := resolvedFromConfigs(tax, map[string][]string{
+		"pkg-food": {"632"}, // publisher covers this one
+		"pkg-tech": {"640"}, // needs Valkey to discover
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:x"}},
+		PackageIDs:   []string{"pkg-food", "pkg-tech"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 2, "both packages activate after union of publisher + Valkey topics")
+	assert.Greater(t, store.hits.Load(), int32(0), "Valkey must be consulted when publisher topics don't cover every package")
+}
+
+func TestContextResolved_NoArtifactsButPublisherTopicsActivate(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	store := NewMockStore()
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+	resolved := resolvedFromConfigs(tax, map[string][]string{
+		"pkg-food": {"632"},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 1, "ephemeral content (no artifact refs) must still match via publisher topics")
+}
+
+func TestContextResolved_MultiTaxonomyIsolation(t *testing.T) {
+	iab := topicstore.Taxonomy{Source: "iab", ID: 7}
+	custom := topicstore.Taxonomy{Source: "custom", ID: 1}
+	base := NewMockStore()
+
+	// pkg-food targets topic "632" under IAB; pkg-tech targets "632" under
+	// custom. The two should not cross-match.
+	resolved := &ResolvedPackages{
+		ContextConfigs: map[string]*PackageContextConfig{
+			"pkg-food": {PackageID: "pkg-food", TopicTargets: true},
+			"pkg-tech": {PackageID: "pkg-tech", TopicTargets: true},
+		},
+		TopicIndex: map[string][]string{
+			topicstore.NamespaceTopic(iab, "632"):    {"pkg-food"},
+			topicstore.NamespaceTopic(custom, "632"): {"pkg-tech"},
+		},
+	}
+
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              base,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{iab, custom},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:   "r",
+		PropertyRID: "1",
+		PackageIDs:  []string{"pkg-food", "pkg-tech"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"632"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Offers, 1)
+	assert.Equal(t, "pkg-food", resp.Offers[0].PackageID, "only the IAB-side package should activate")
+}
+
+func TestContextResolved_NoTopicTargetsBypassesUnion(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	base := NewMockStore()
+	store := &countingStore{ContextStore: base, prefix: "topics:artifact:"}
+
+	resolved := &ResolvedPackages{
+		ContextConfigs: map[string]*PackageContextConfig{
+			"pkg-nontopic": {PackageID: "pkg-nontopic", TopicTargets: false},
+		},
+	}
+	engine := NewContextEngine(ContextEngineConfig{
+		ProviderID:         "test",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{tax},
+	})
+
+	req := &tmproto.ContextMatchRequest{
+		RequestID:    "r",
+		PropertyRID:  "1",
+		ArtifactRefs: []tmproto.ArtifactRef{{Type: tmproto.ArtifactRefTypeURL, Value: "article:x"}},
+		PackageIDs:   []string{"pkg-nontopic"},
+		ContextSignals: &tmproto.ContextSignals{
+			TaxonomySource: "iab",
+			TaxonomyID:     7,
+			Topics:         []string{"anything"},
+		},
+	}
+
+	resp, err := engine.EvaluateContextResolved(context.Background(), resolved, req)
+	require.NoError(t, err)
+	assert.Len(t, resp.Offers, 1)
+	assert.Equal(t, int32(0), store.hits.Load(), "non-TopicTargets package must not trigger artifact-topic Valkey lookups")
+}

--- a/targeting/engine_test.go
+++ b/targeting/engine_test.go
@@ -6,10 +6,35 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testTaxonomy is the taxonomy fixture used across context-engine tests.
+// Chosen to be distinct from any real taxonomy so cross-contamination from
+// production data would be obvious; the engine treats Source/ID as opaque
+// regardless of the value.
+var testTaxonomy = topicstore.Taxonomy{Source: "test", ID: 1}
+
+// seedPackageTopics is a small helper that pushes a package's targeted
+// topics into store under testTaxonomy. Cuts the noise on every test that
+// would otherwise repeat the writer construction boilerplate.
+func seedPackageTopics(t *testing.T, store *MockStore, pkgID string, topics ...string) {
+	t.Helper()
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetPackageTopics(context.Background(), testTaxonomy, pkgID, topics))
+}
+
+// seedArtifactTopics is the artifact-side twin of seedPackageTopics.
+func seedArtifactTopics(t *testing.T, store *MockStore, ref string, topics ...string) {
+	t.Helper()
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetArtifactTopics(context.Background(), testTaxonomy, ref, topics))
+}
 
 func setupContextEngine(t *testing.T) (*ContextEngine, *MockStore) {
 	t.Helper()
@@ -137,14 +162,15 @@ func TestContext_PerPackageTargeting(t *testing.T) {
 
 func TestContext_TopicMatch(t *testing.T) {
 	store := NewMockStore()
-	store.SetAdd("topics:package:pkg-food", "food.cooking", "food.baking")
-	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
+	seedPackageTopics(t, store, "pkg-food", "food.cooking", "food.baking")
+	seedArtifactTopics(t, store, "article:pasta", "food.cooking", "food.italian")
 
 	engine := NewContextEngine(ContextEngineConfig{
-		ProviderID: "test-provider",
-		Store:      store,
-		Properties: PropertyList{Global: NewMapBitmap("10")},
-		Packages:   []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		ProviderID:         "test-provider",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("10")},
+		Packages:           []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		AcceptedTaxonomies: []topicstore.Taxonomy{testTaxonomy},
 	})
 
 	resp, err := engine.EvaluateContext(context.Background(), &tmproto.ContextMatchRequest{
@@ -159,14 +185,15 @@ func TestContext_TopicMatch(t *testing.T) {
 
 func TestContext_TopicMiss(t *testing.T) {
 	store := NewMockStore()
-	store.SetAdd("topics:package:pkg-food", "food.cooking")
-	store.SetAdd("topics:artifact:article:cpu", "technology.hardware")
+	seedPackageTopics(t, store, "pkg-food", "food.cooking")
+	seedArtifactTopics(t, store, "article:cpu", "technology.hardware")
 
 	engine := NewContextEngine(ContextEngineConfig{
-		ProviderID: "test-provider",
-		Store:      store,
-		Properties: PropertyList{Global: NewMapBitmap("10")},
-		Packages:   []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		ProviderID:         "test-provider",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("10")},
+		Packages:           []PackageConfig{{PackageID: "pkg-food", TopicTargets: true}},
+		AcceptedTaxonomies: []topicstore.Taxonomy{testTaxonomy},
 	})
 
 	resp, err := engine.EvaluateContext(context.Background(), &tmproto.ContextMatchRequest{
@@ -182,7 +209,7 @@ func TestContext_TopicMiss(t *testing.T) {
 func TestContext_URLBlocklist(t *testing.T) {
 	store := NewMockStore()
 	blockedHash := HashURL("article:controversial")
-	store.SetAdd("url:blocklist:pkg-family", blockedHash)
+	require.NoError(t, store.SetAdd(context.Background(), "url:blocklist:pkg-family", blockedHash))
 
 	engine := NewContextEngine(ContextEngineConfig{
 		ProviderID: "test-provider",
@@ -204,7 +231,7 @@ func TestContext_URLBlocklist(t *testing.T) {
 func TestContext_URLAllowlist(t *testing.T) {
 	store := NewMockStore()
 	allowedHash := HashURL("article:safe-content")
-	store.SetAdd("url:allowlist:pkg-premium", allowedHash)
+	require.NoError(t, store.SetAdd(context.Background(), "url:allowlist:pkg-premium", allowedHash))
 
 	engine := NewContextEngine(ContextEngineConfig{
 		ProviderID: "test-provider",
@@ -234,9 +261,9 @@ func TestContext_URLAllowlist(t *testing.T) {
 
 func TestContext_MultiplePackages_MixedResults(t *testing.T) {
 	store := NewMockStore()
-	store.SetAdd("topics:package:pkg-food", "food.cooking")
-	store.SetAdd("topics:package:pkg-tech", "technology.reviews")
-	store.SetAdd("topics:artifact:article:pasta", "food.cooking", "food.italian")
+	seedPackageTopics(t, store, "pkg-food", "food.cooking")
+	seedPackageTopics(t, store, "pkg-tech", "technology.reviews")
+	seedArtifactTopics(t, store, "article:pasta", "food.cooking", "food.italian")
 
 	engine := NewContextEngine(ContextEngineConfig{
 		ProviderID: "test-provider",
@@ -246,6 +273,7 @@ func TestContext_MultiplePackages_MixedResults(t *testing.T) {
 			{PackageID: "pkg-food", TopicTargets: true},
 			{PackageID: "pkg-tech", TopicTargets: true},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{testTaxonomy},
 	})
 
 	resp, err := engine.EvaluateContext(context.Background(), &tmproto.ContextMatchRequest{

--- a/targeting/entity.go
+++ b/targeting/entity.go
@@ -22,9 +22,9 @@ type PackageConfig struct {
 
 	// Context dimensions (evaluated during EvaluateContext).
 	PropertyList Bitmap // Per-package property bitmap. Nil = all properties pass.
-	URLBlocklist bool   // If true, check "url:blocklist:{pkg}" in Store.
-	URLAllowlist bool   // If true, check "url:allowlist:{pkg}" in Store.
-	TopicTargets bool   // If true, check "topics:package:{pkg}" in Store.
+	URLBlocklist bool   // If true, the engine consults the package's URL blocklist set.
+	URLAllowlist bool   // If true, the engine consults the package's URL allowlist set.
+	TopicTargets bool   // If true, the engine consults the package's targeted topic set under each accepted taxonomy (see topicstore).
 
 	// Identity dimensions are served by the in-memory
 	// identityconfig.Service, keyed by (seller_agent_url, package_id).

--- a/targeting/glidestore/integration_test.go
+++ b/targeting/glidestore/integration_test.go
@@ -20,8 +20,11 @@ import (
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+var integrationTaxonomy = topicstore.Taxonomy{Source: "integration", ID: 1}
 
 // startValkey9 spins up a Valkey 9 container and returns a connected glide client.
 // Skips the test when Docker isn't available locally.
@@ -273,9 +276,9 @@ func TestIntegration_Engine_EvaluateContext_AgainstRealValkey(t *testing.T) {
 	client, store := startValkey9(t)
 	ctx := context.Background()
 
-	_, err := client.SAdd(ctx, "topics:package:pkg-food", []string{"food.cooking", "food.recipes"})
+	_, err := client.SAdd(ctx, topicstore.PackageKey(integrationTaxonomy, "pkg-food"), []string{"food.cooking", "food.recipes"})
 	require.NoError(t, err)
-	_, err = client.SAdd(ctx, "topics:artifact:article:pasta", []string{"food.cooking", "food.italian"})
+	_, err = client.SAdd(ctx, topicstore.ArtifactKey(integrationTaxonomy, "article:pasta"), []string{"food.cooking", "food.italian"})
 	require.NoError(t, err)
 	_, err = client.SAdd(ctx, "url:blocklist:pkg-family", []string{targeting.HashURL("article:adult-content")})
 	require.NoError(t, err)
@@ -288,6 +291,7 @@ func TestIntegration_Engine_EvaluateContext_AgainstRealValkey(t *testing.T) {
 			{PackageID: "pkg-food", TopicTargets: true},
 			{PackageID: "pkg-family", URLBlocklist: true},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{integrationTaxonomy},
 	})
 
 	t.Run("TopicMatch", func(t *testing.T) {

--- a/targeting/glidestore/store.go
+++ b/targeting/glidestore/store.go
@@ -293,6 +293,46 @@ func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Durati
 	return err
 }
 
+// SetAdd executes SADD for the given key+members. Returns ErrReadOnly when
+// the store is a shadow replica. Empty member lists are a no-op.
+func (s *Store) SetAdd(ctx context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	_, err := s.client.SAdd(ctx, key, members)
+	return err
+}
+
+// SetRemove executes SREM for the given key+members. Returns ErrReadOnly
+// when the store is a shadow replica. Empty member lists are a no-op.
+// Missing keys and members are silently treated as no-ops by Valkey.
+func (s *Store) SetRemove(ctx context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	_, err := s.client.SRem(ctx, key, members)
+	return err
+}
+
+// Del executes DEL for the supplied keys. Returns ErrReadOnly when the
+// store is a shadow replica. Empty key lists are a no-op.
+func (s *Store) Del(ctx context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	_, err := s.client.Del(ctx, keys)
+	return err
+}
+
 // --- fcap.Store ---
 
 func (s *Store) SetFields(ctx context.Context, key string, fields map[string]string, expireAt time.Time) error {

--- a/targeting/metrics.go
+++ b/targeting/metrics.go
@@ -6,13 +6,20 @@ import (
 )
 
 // Evaluation stage constants.
+//
+// StageTopicNoTaxonomy is emitted instead of StageTopicMatch when a
+// TopicTargets package is short-circuited because the engine has no
+// accepted taxonomies configured. The separate label lets on-call
+// distinguish a configuration drop (no taxonomies declared) from a
+// genuine miss (taxonomy declared, no matching topic) in dashboards.
 const (
-	StagePropertyBitmap = "property_bitmap"
-	StageSuppression    = "suppression"
-	StageSignature      = "signature"
-	StageURLFilter      = "url_filter"
-	StageTopicMatch     = "topic_match"
-	StageAudience       = "audience"
+	StagePropertyBitmap  = "property_bitmap"
+	StageSuppression     = "suppression"
+	StageSignature       = "signature"
+	StageURLFilter       = "url_filter"
+	StageTopicMatch      = "topic_match"
+	StageTopicNoTaxonomy = "topic_no_taxonomy"
+	StageAudience        = "audience"
 )
 
 // Metrics receives instrumentation callbacks from the targeting engine.

--- a/targeting/mock_store.go
+++ b/targeting/mock_store.go
@@ -35,8 +35,14 @@ func NewMockStore() *MockStore {
 	}
 }
 
-// SetAdd adds members to a set. Test helper, not part of Store interface.
-func (m *MockStore) SetAdd(key string, members ...string) {
+// SetAdd adds members to a set, creating the key if it does not exist.
+// Satisfies targeting.ContextStore. The unused ctx and unconditional nil
+// return keep the in-memory mock signature-compatible with the Valkey
+// implementations.
+func (m *MockStore) SetAdd(_ context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	s, ok := m.sets[key]
@@ -47,6 +53,43 @@ func (m *MockStore) SetAdd(key string, members ...string) {
 	for _, member := range members {
 		s[member] = struct{}{}
 	}
+	return nil
+}
+
+// SetRemove removes members from a set. Missing members are silently
+// skipped. Satisfies targeting.ContextStore.
+func (m *MockStore) SetRemove(_ context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sets[key]
+	if !ok {
+		return nil
+	}
+	for _, member := range members {
+		delete(s, member)
+	}
+	if len(s) == 0 {
+		delete(m.sets, key)
+	}
+	return nil
+}
+
+// Del deletes one or more keys from both the set and string spaces.
+// Missing keys are silently skipped. Satisfies targeting.ContextStore.
+func (m *MockStore) Del(_ context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, k := range keys {
+		delete(m.sets, k)
+		delete(m.strings, k)
+	}
+	return nil
 }
 
 // SetMediaBuy stores a media buy and adds it to the seller's set. Test helper.

--- a/targeting/mock_store_test.go
+++ b/targeting/mock_store_test.go
@@ -13,8 +13,8 @@ func TestMockStore_SetOperations(t *testing.T) {
 	ctx := context.Background()
 	s := NewMockStore()
 
-	s.SetAdd("colors", "red", "green", "blue")
-	s.SetAdd("warm", "red", "orange", "yellow")
+	require.NoError(t, s.SetAdd(ctx, "colors", "red", "green", "blue"))
+	require.NoError(t, s.SetAdd(ctx, "warm", "red", "orange", "yellow"))
 
 	t.Run("IsMember", func(t *testing.T) {
 		ok, err := s.SetIsMember(ctx, "colors", "red")
@@ -39,7 +39,7 @@ func TestMockStore_SetOperations(t *testing.T) {
 	})
 
 	t.Run("Intersect_NoOverlap", func(t *testing.T) {
-		s.SetAdd("cold", "blue", "purple")
+		require.NoError(t, s.SetAdd(ctx, "cold", "blue", "purple"))
 		result, err := s.SetIntersect(ctx, "warm", "cold")
 		require.NoError(t, err)
 		assert.Empty(t, result)

--- a/targeting/redisstore/integration_test.go
+++ b/targeting/redisstore/integration_test.go
@@ -18,8 +18,11 @@ import (
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+var integrationTaxonomy = topicstore.Taxonomy{Source: "integration", ID: 1}
 
 // startValkey9 spins up a Valkey 9 container and returns a connected go-redis client.
 // Skips the test when Docker isn't available locally.
@@ -266,9 +269,9 @@ func TestIntegration_Engine_EvaluateContext_AgainstRealValkey(t *testing.T) {
 	client, store := startValkey9(t)
 	ctx := context.Background()
 
-	_, err := client.SAdd(ctx, "topics:package:pkg-food", "food.cooking", "food.recipes").Result()
+	_, err := client.SAdd(ctx, topicstore.PackageKey(integrationTaxonomy, "pkg-food"), "food.cooking", "food.recipes").Result()
 	require.NoError(t, err)
-	_, err = client.SAdd(ctx, "topics:artifact:article:pasta", "food.cooking", "food.italian").Result()
+	_, err = client.SAdd(ctx, topicstore.ArtifactKey(integrationTaxonomy, "article:pasta"), "food.cooking", "food.italian").Result()
 	require.NoError(t, err)
 	_, err = client.SAdd(ctx, "url:blocklist:pkg-family", targeting.HashURL("article:adult-content")).Result()
 	require.NoError(t, err)
@@ -281,6 +284,7 @@ func TestIntegration_Engine_EvaluateContext_AgainstRealValkey(t *testing.T) {
 			{PackageID: "pkg-food", TopicTargets: true},
 			{PackageID: "pkg-family", URLBlocklist: true},
 		},
+		AcceptedTaxonomies: []topicstore.Taxonomy{integrationTaxonomy},
 	})
 
 	t.Run("TopicMatch", func(t *testing.T) {

--- a/targeting/redisstore/store.go
+++ b/targeting/redisstore/store.go
@@ -357,6 +357,53 @@ func (s *Store) MGet(ctx context.Context, keys ...string) ([]string, error) {
 	return out, nil
 }
 
+// SetAdd executes SADD for the given key+members. Returns ErrReadOnly when
+// the store is a shadow replica. Empty member lists are a no-op.
+func (s *Store) SetAdd(ctx context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	args := make([]any, len(members))
+	for i, m := range members {
+		args[i] = m
+	}
+	return s.client.SAdd(ctx, key, args...).Err()
+}
+
+// SetRemove executes SREM for the given key+members. Returns ErrReadOnly
+// when the store is a shadow replica. Empty member lists are a no-op.
+// Missing keys and members are silently treated as no-ops by Valkey.
+func (s *Store) SetRemove(ctx context.Context, key string, members ...string) error {
+	if len(members) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	args := make([]any, len(members))
+	for i, m := range members {
+		args[i] = m
+	}
+	return s.client.SRem(ctx, key, args...).Err()
+}
+
+// Del executes DEL for the supplied keys. Returns ErrReadOnly when the
+// store is a shadow replica. Empty key lists are a no-op. In cluster mode
+// every key must hash to the same slot; callers either co-locate via
+// `{hashtag}` or call Del once per key.
+func (s *Store) Del(ctx context.Context, keys ...string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	if s.shadow() {
+		return ErrReadOnly
+	}
+	return mapCrossSlotErr(s.client.Del(ctx, keys...).Err())
+}
+
 func (s *Store) MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error {
 	if len(kvs) == 0 {
 		return nil

--- a/targeting/resolved.go
+++ b/targeting/resolved.go
@@ -14,7 +14,7 @@ type ResolvedPackages struct {
 
 	// Context indexes (zero Store calls at eval time).
 	PropertyIndex     map[string][]string            // propertyRID → packageIDs
-	TopicIndex        map[string][]string            // topic → packageIDs
+	TopicIndex        map[string][]string            // topicstore.NamespaceTopic(tax,topic) → packageIDs
 	URLBlocklistIndex map[string][]string            // urlHash → packageIDs that block it
 	URLAllowlists     map[string]map[string]struct{} // pkgID → set of allowed urlHashes
 

--- a/targeting/resolver.go
+++ b/targeting/resolver.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
@@ -99,10 +100,18 @@ func ResolvePackages(ctx context.Context, store ContextStore, sellerID, property
 // This is the cacheable entry point — call once, cache the result, use for
 // many requests. Loads all configs and builds all indexes.
 //
+// taxonomies enumerates the topic taxonomies this deployment accepts. The
+// resolver fetches `topics:package:{src}:{id}:{pkg}` once per (package,
+// taxonomy) and stores the results in TopicIndex keyed by the namespaced
+// form `topicstore.NamespaceTopic(tax, topic)` so artifact-topic lookups
+// can join against it without per-taxonomy index lookups at eval time. An
+// empty taxonomies slice means topic-targeting data is not loaded — every
+// TopicTargets package will be skipped by the engine.
+//
 // Identity configs are no longer loaded here; callers wanting identity gating
 // populate ResolvedPackages.IdentityConfigs from the identityconfig.Service
 // keyed by (seller_agent_url, package_id).
-func Resolve(ctx context.Context, store ContextStore, sellerID, propertyID, country string, now time.Time) (*ResolvedPackages, error) {
+func Resolve(ctx context.Context, store ContextStore, sellerID, propertyID, country string, taxonomies []topicstore.Taxonomy, now time.Time) (*ResolvedPackages, error) {
 	pkgs, err := ResolvePackages(ctx, store, sellerID, propertyID, country, now)
 	if err != nil {
 		return nil, err
@@ -133,9 +142,12 @@ func Resolve(ctx context.Context, store ContextStore, sellerID, propertyID, coun
 			}
 		}
 
-		topics, _ := store.SetMembers(ctx, "topics:package:"+pkgID)
-		for _, topic := range topics {
-			topicIdx[topic] = append(topicIdx[topic], pkgID)
+		for _, tax := range taxonomies {
+			topics, _ := store.SetMembers(ctx, topicstore.PackageKey(tax, pkgID))
+			for _, topic := range topics {
+				ns := topicstore.NamespaceTopic(tax, topic)
+				topicIdx[ns] = append(topicIdx[ns], pkgID)
+			}
 		}
 
 		if cc := ctxConfigs[pkgID]; cc != nil && cc.URLBlocklist {

--- a/targeting/resolver.go
+++ b/targeting/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -108,6 +109,13 @@ func ResolvePackages(ctx context.Context, store ContextStore, sellerID, property
 // empty taxonomies slice means topic-targeting data is not loaded — every
 // TopicTargets package will be skipped by the engine.
 //
+// Errors from per-(package, taxonomy) topic loads, URL-blocklist loads,
+// and URL-allowlist loads are recorded via structured log but do not fail
+// the resolve. The affected slice of the in-memory index will be missing
+// the corresponding entries until the cache is refreshed — a fail-closed
+// partial degradation rather than a hard error that would block every
+// request against the cached ResolvedPackages.
+//
 // Identity configs are no longer loaded here; callers wanting identity gating
 // populate ResolvedPackages.IdentityConfigs from the identityconfig.Service
 // keyed by (seller_agent_url, package_id).
@@ -143,7 +151,14 @@ func Resolve(ctx context.Context, store ContextStore, sellerID, propertyID, coun
 		}
 
 		for _, tax := range taxonomies {
-			topics, _ := store.SetMembers(ctx, topicstore.PackageKey(tax, pkgID))
+			topics, err := store.SetMembers(ctx, topicstore.PackageKey(tax, pkgID))
+			if err != nil {
+				slog.Warn("topicstore: package-topic load failed; under-indexing this taxonomy",
+					"package_id", pkgID,
+					"taxonomy", tax.String(),
+					"error", err)
+				continue
+			}
 			for _, topic := range topics {
 				ns := topicstore.NamespaceTopic(tax, topic)
 				topicIdx[ns] = append(topicIdx[ns], pkgID)
@@ -151,14 +166,22 @@ func Resolve(ctx context.Context, store ContextStore, sellerID, propertyID, coun
 		}
 
 		if cc := ctxConfigs[pkgID]; cc != nil && cc.URLBlocklist {
-			blocked, _ := store.SetMembers(ctx, "url:blocklist:"+pkgID)
+			blocked, err := store.SetMembers(ctx, "url:blocklist:"+pkgID)
+			if err != nil {
+				slog.Warn("targeting: url-blocklist load failed; under-indexing this package",
+					"package_id", pkgID, "error", err)
+			}
 			for _, hash := range blocked {
 				urlBlockIdx[hash] = append(urlBlockIdx[hash], pkgID)
 			}
 		}
 
 		if cc := ctxConfigs[pkgID]; cc != nil && cc.URLAllowlist {
-			allowed, _ := store.SetMembers(ctx, "url:allowlist:"+pkgID)
+			allowed, err := store.SetMembers(ctx, "url:allowlist:"+pkgID)
+			if err != nil {
+				slog.Warn("targeting: url-allowlist load failed; allowlist not applied for this package",
+					"package_id", pkgID, "error", err)
+			}
 			if len(allowed) > 0 {
 				set := make(map[string]struct{}, len(allowed))
 				for _, hash := range allowed {

--- a/targeting/resolver_test.go
+++ b/targeting/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -171,13 +172,16 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	})
 
 	// Topic data.
-	store.SetAdd("topics:package:pkg-food", "food.cooking", "food.recipes")
-	store.SetAdd("topics:package:pkg-tech", "tech.gadgets", "tech.reviews")
+	tax := topicstore.Taxonomy{Source: "test", ID: 1}
+	writer, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	require.NoError(t, writer.SetPackageTopics(context.Background(), tax, "pkg-food", []string{"food.cooking", "food.recipes"}))
+	require.NoError(t, writer.SetPackageTopics(context.Background(), tax, "pkg-tech", []string{"tech.gadgets", "tech.reviews"}))
 
 	// URL blocklist.
-	store.SetAdd("url:blocklist:pkg-food", HashURL("article:bad"))
+	require.NoError(t, store.SetAdd(context.Background(), "url:blocklist:pkg-food", HashURL("article:bad")))
 
-	resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)
+	resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", []topicstore.Taxonomy{tax}, now)
 	require.NoError(t, err)
 
 	// Check packages resolved.
@@ -189,11 +193,11 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	require.Len(t, resolved.PropertyIndex["4"], 1)
 	assert.Equal(t, "pkg-tech", resolved.PropertyIndex["4"][0])
 
-	// TopicIndex.
-	require.Len(t, resolved.TopicIndex["food.cooking"], 1)
-	assert.Equal(t, "pkg-food", resolved.TopicIndex["food.cooking"][0])
-	require.Len(t, resolved.TopicIndex["tech.gadgets"], 1)
-	assert.Equal(t, "pkg-tech", resolved.TopicIndex["tech.gadgets"][0])
+	// TopicIndex: namespaced under the taxonomy used at resolve time.
+	require.Len(t, resolved.TopicIndex[topicstore.NamespaceTopic(tax, "food.cooking")], 1)
+	assert.Equal(t, "pkg-food", resolved.TopicIndex[topicstore.NamespaceTopic(tax, "food.cooking")][0])
+	require.Len(t, resolved.TopicIndex[topicstore.NamespaceTopic(tax, "tech.gadgets")], 1)
+	assert.Equal(t, "pkg-tech", resolved.TopicIndex[topicstore.NamespaceTopic(tax, "tech.gadgets")][0])
 
 	// URLBlocklistIndex.
 	badHash := HashURL("article:bad")
@@ -207,7 +211,10 @@ func TestResolve_BuildsIndexes(t *testing.T) {
 	assert.True(t, resolved.IsURLBlocked("pkg-food", badHash))
 	assert.False(t, resolved.IsURLBlocked("pkg-tech", badHash))
 
-	candidates := resolved.TopicCandidates([]string{"food.cooking", "tech.gadgets"})
+	candidates := resolved.TopicCandidates([]string{
+		topicstore.NamespaceTopic(tax, "food.cooking"),
+		topicstore.NamespaceTopic(tax, "tech.gadgets"),
+	})
 	assert.Len(t, candidates, 2)
 }
 

--- a/targeting/scale_test.go
+++ b/targeting/scale_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+var scaleTaxonomy = topicstore.Taxonomy{Source: "scale", ID: 1}
 
 // TestScale_PropertyBitmap measures property bitmap lookup at increasing scale.
 func TestScale_PropertyBitmap(t *testing.T) {
@@ -54,17 +57,20 @@ func TestScale_TopicSetSize(t *testing.T) {
 
 	for _, n := range []int{10, 100, 1_000, 10_000} {
 		store := NewMockStore()
+		ctx := context.Background()
 
+		pkgKey := topicstore.PackageKey(scaleTaxonomy, "pkg-1")
 		for i := range n {
-			store.SetAdd("topics:package:pkg-1", fmt.Sprintf("topic-%d", i))
+			_ = store.SetAdd(ctx, pkgKey, fmt.Sprintf("topic-%d", i))
 		}
-		store.SetAdd("topics:artifact:article:test", fmt.Sprintf("topic-%d", n-1))
+		_ = store.SetAdd(ctx, topicstore.ArtifactKey(scaleTaxonomy, "article:test"), fmt.Sprintf("topic-%d", n-1))
 
 		engine := NewContextEngine(ContextEngineConfig{
-			ProviderID: "bench",
-			Store:      store,
-			Properties: PropertyList{Global: NewMapBitmap("1")},
-			Packages:   []PackageConfig{{PackageID: "pkg-1", TopicTargets: true}},
+			ProviderID:         "bench",
+			Store:              store,
+			Properties:         PropertyList{Global: NewMapBitmap("1")},
+			Packages:           []PackageConfig{{PackageID: "pkg-1", TopicTargets: true}},
+			AcceptedTaxonomies: []topicstore.Taxonomy{scaleTaxonomy},
 		})
 
 		req := &tmproto.ContextMatchRequest{
@@ -94,8 +100,9 @@ func TestScale_URLBlocklistSize(t *testing.T) {
 	for _, n := range []int{100, 1_000, 10_000, 100_000} {
 		store := NewMockStore()
 
+		ctx := context.Background()
 		for i := range n {
-			store.SetAdd("url:blocklist:pkg-1", HashURL(fmt.Sprintf("article:blocked-%d", i)))
+			_ = store.SetAdd(ctx, "url:blocklist:pkg-1", HashURL(fmt.Sprintf("article:blocked-%d", i)))
 		}
 
 		engine := NewContextEngine(ContextEngineConfig{
@@ -131,6 +138,7 @@ func TestScale_DynamicVsStatic(t *testing.T) {
 
 	for _, numPkgs := range []int{1, 10, 50, 100, 500} {
 		store := NewMockStore()
+		ctx := context.Background()
 
 		var staticPkgs []PackageConfig
 		var pkgIDs []string
@@ -138,26 +146,28 @@ func TestScale_DynamicVsStatic(t *testing.T) {
 			pkgID := fmt.Sprintf("pkg-%d", i)
 			staticPkgs = append(staticPkgs, PackageConfig{PackageID: pkgID, TopicTargets: true})
 			pkgIDs = append(pkgIDs, pkgID)
-			store.SetAdd(fmt.Sprintf("topics:package:%s", pkgID), "food.cooking")
+			_ = store.SetAdd(ctx, topicstore.PackageKey(scaleTaxonomy, pkgID), "food.cooking")
 			store.SetPackageContextConfig(pkgID, PackageContextConfig{
 				PackageID:    pkgID,
 				TopicTargets: true,
 			})
 		}
-		store.SetAdd("topics:artifact:article:food", "food.cooking")
+		_ = store.SetAdd(ctx, topicstore.ArtifactKey(scaleTaxonomy, "article:food"), "food.cooking")
 
 		staticEngine := NewContextEngine(ContextEngineConfig{
-			ProviderID: "bench",
-			Store:      store,
-			Properties: PropertyList{Global: NewMapBitmap("1")},
-			Packages:   staticPkgs,
+			ProviderID:         "bench",
+			Store:              store,
+			Properties:         PropertyList{Global: NewMapBitmap("1")},
+			Packages:           staticPkgs,
+			AcceptedTaxonomies: []topicstore.Taxonomy{scaleTaxonomy},
 		})
 
 		dynamicEngine := NewContextEngine(ContextEngineConfig{
-			ProviderID:      "bench",
-			Store:           store,
-			Properties:      PropertyList{Global: NewMapBitmap("1")},
-			DynamicPackages: true,
+			ProviderID:         "bench",
+			Store:              store,
+			Properties:         PropertyList{Global: NewMapBitmap("1")},
+			DynamicPackages:    true,
+			AcceptedTaxonomies: []topicstore.Taxonomy{scaleTaxonomy},
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
@@ -234,6 +244,7 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 
 	for _, numPkgs := range []int{10, 50, 100, 500} {
 		store := NewMockStore()
+		ctx := context.Background()
 		now := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
 
 		var mbPkgs []MediaBuyPackage
@@ -243,7 +254,7 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 			mbPkgs = append(mbPkgs, MediaBuyPackage{PackageID: pkgID, MediaBuyID: "mb-1"})
 			pkgIDs = append(pkgIDs, pkgID)
 
-			store.SetAdd("topics:package:"+pkgID, "food.cooking")
+			_ = store.SetAdd(ctx, topicstore.PackageKey(scaleTaxonomy, pkgID), "food.cooking")
 			store.SetPackageContextConfig(pkgID, PackageContextConfig{
 				PackageID:    pkgID,
 				TopicTargets: true,
@@ -256,18 +267,19 @@ func TestScale_ResolvedVsDynamic(t *testing.T) {
 			Countries: []string{"US"}, PropertyIDs: []string{"pub-1"},
 			Packages: mbPkgs,
 		})
-		store.SetAdd("topics:artifact:article:food", "food.cooking")
+		_ = store.SetAdd(ctx, topicstore.ArtifactKey(scaleTaxonomy, "article:food"), "food.cooking")
 
-		resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)
+		resolved, err := Resolve(ctx, store, "seller-1", "pub-1", "US", []topicstore.Taxonomy{scaleTaxonomy}, now)
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		engine := NewContextEngine(ContextEngineConfig{
-			ProviderID:      "bench",
-			Store:           store,
-			Properties:      PropertyList{Global: NewMapBitmap("1")},
-			DynamicPackages: true,
+			ProviderID:         "bench",
+			Store:              store,
+			Properties:         PropertyList{Global: NewMapBitmap("1")},
+			DynamicPackages:    true,
+			AcceptedTaxonomies: []topicstore.Taxonomy{scaleTaxonomy},
 		})
 
 		ctxReq := &tmproto.ContextMatchRequest{
@@ -306,6 +318,7 @@ func TestScale_PackagesPerRequest(t *testing.T) {
 
 	for _, numPkgs := range []int{1, 5, 10, 25, 50} {
 		store := NewMockStore()
+		ctx := context.Background()
 
 		var pkgs []PackageConfig
 		var pkgIDs []string
@@ -314,17 +327,18 @@ func TestScale_PackagesPerRequest(t *testing.T) {
 			pkgID := fmt.Sprintf("pkg-%d", i)
 			pkgs = append(pkgs, PackageConfig{PackageID: pkgID, TopicTargets: true})
 			pkgIDs = append(pkgIDs, pkgID)
-			store.SetAdd(fmt.Sprintf("topics:package:%s", pkgID), "food.cooking")
+			_ = store.SetAdd(ctx, topicstore.PackageKey(scaleTaxonomy, pkgID), "food.cooking")
 			idCfg := PackageIdentityConfig{}
 			idConfigs[pkgID] = &idCfg
 		}
-		store.SetAdd("topics:artifact:article:food", "food.cooking")
+		_ = store.SetAdd(ctx, topicstore.ArtifactKey(scaleTaxonomy, "article:food"), "food.cooking")
 
 		ctxEngine := NewContextEngine(ContextEngineConfig{
-			ProviderID: "bench",
-			Store:      store,
-			Properties: PropertyList{Global: NewMapBitmap("1")},
-			Packages:   pkgs,
+			ProviderID:         "bench",
+			Store:              store,
+			Properties:         PropertyList{Global: NewMapBitmap("1")},
+			Packages:           pkgs,
+			AcceptedTaxonomies: []topicstore.Taxonomy{scaleTaxonomy},
 		})
 		idEngine := NewIdentityEngine(IdentityEngineConfig{})
 

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -5,8 +5,11 @@ import (
 	"time"
 )
 
-// ContextStore is the storage backend the ContextEngine reads and writes.
-// Implementations wrap Valkey or an in-memory mock.
+// ContextStore is the read surface the ContextEngine consults at evaluation
+// time. Write primitives for the targeting topic data (set-element add /
+// remove / key delete) are not on this interface — they live on
+// targeting/topicstore so writers depend on a smaller surface than the
+// engine.
 type ContextStore interface {
 	// SetIsMember checks if member is in the set at key.
 	SetIsMember(ctx context.Context, key, member string) (bool, error)
@@ -33,16 +36,4 @@ type ContextStore interface {
 	// With a non-zero TTL, atomicity is implementation-defined; callers must not
 	// assume that all keys land together.
 	MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error
-
-	// SetAdd adds members to the set at key, creating the key if it does
-	// not exist. Empty member lists are a no-op.
-	SetAdd(ctx context.Context, key string, members ...string) error
-
-	// SetRemove removes members from the set at key. Missing members are
-	// silently skipped. Empty member lists are a no-op.
-	SetRemove(ctx context.Context, key string, members ...string) error
-
-	// Del deletes one or more keys. Missing keys are silently skipped.
-	// Empty key lists are a no-op.
-	Del(ctx context.Context, keys ...string) error
 }

--- a/targeting/store.go
+++ b/targeting/store.go
@@ -33,4 +33,16 @@ type ContextStore interface {
 	// With a non-zero TTL, atomicity is implementation-defined; callers must not
 	// assume that all keys land together.
 	MSet(ctx context.Context, kvs map[string]string, ttl time.Duration) error
+
+	// SetAdd adds members to the set at key, creating the key if it does
+	// not exist. Empty member lists are a no-op.
+	SetAdd(ctx context.Context, key string, members ...string) error
+
+	// SetRemove removes members from the set at key. Missing members are
+	// silently skipped. Empty member lists are a no-op.
+	SetRemove(ctx context.Context, key string, members ...string) error
+
+	// Del deletes one or more keys. Missing keys are silently skipped.
+	// Empty key lists are a no-op.
+	Del(ctx context.Context, keys ...string) error
 }

--- a/targeting/system_test.go
+++ b/targeting/system_test.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+var systemTaxonomy = topicstore.Taxonomy{Source: "system", ID: 1}
 
 // TestSystem_EndToEnd runs a realistic scenario at scale and reports
 // a complete breakdown of latency, memory, Store calls, and throughput
@@ -59,6 +62,7 @@ func TestSystem_EndToEnd(t *testing.T) {
 		segments[i] = fmt.Sprintf("seg-%d", i)
 	}
 
+	ctx := context.Background()
 	for i, pkgID := range allPkgIDs {
 		store.SetPackageContextConfig(pkgID, PackageContextConfig{
 			PackageID:    pkgID,
@@ -70,11 +74,11 @@ func TestSystem_EndToEnd(t *testing.T) {
 		})
 
 		for tp := range topicsPerPkg {
-			store.SetAdd("topics:package:"+pkgID, fmt.Sprintf("topic-%d", (i*3+tp)%50))
+			_ = store.SetAdd(ctx, topicstore.PackageKey(systemTaxonomy, pkgID), fmt.Sprintf("topic-%d", (i*3+tp)%50))
 		}
 
 		for bl := range blocklistPerPkg {
-			store.SetAdd("url:blocklist:"+pkgID, HashURL(fmt.Sprintf("blocked-%d-%d", i, bl)))
+			_ = store.SetAdd(ctx, "url:blocklist:"+pkgID, HashURL(fmt.Sprintf("blocked-%d-%d", i, bl)))
 		}
 
 	}
@@ -96,14 +100,14 @@ func TestSystem_EndToEnd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store.SetAdd("topics:artifact:article:food", "topic-0", "topic-1", "topic-2")
+	_ = store.SetAdd(ctx, topicstore.ArtifactKey(systemTaxonomy, "article:food"), "topic-0", "topic-1", "topic-2")
 
 	var m1, m2 runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&m1)
 
 	resolveStart := time.Now()
-	resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", now)
+	resolved, err := Resolve(context.Background(), store, "seller-1", "pub-1", "US", []topicstore.Taxonomy{systemTaxonomy}, now)
 	resolveTime := time.Since(resolveStart)
 	if err != nil {
 		t.Fatal(err)
@@ -127,23 +131,26 @@ func TestSystem_EndToEnd(t *testing.T) {
 	}
 
 	staticEngine := NewContextEngine(ContextEngineConfig{
-		ProviderID: "bench",
-		Store:      store,
-		Properties: PropertyList{Global: NewMapBitmap("1")},
-		Packages:   staticPkgs,
+		ProviderID:         "bench",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		Packages:           staticPkgs,
+		AcceptedTaxonomies: []topicstore.Taxonomy{systemTaxonomy},
 	})
 
 	dynamicEngine := NewContextEngine(ContextEngineConfig{
-		ProviderID:      "bench",
-		Store:           store,
-		Properties:      PropertyList{Global: NewMapBitmap("1")},
-		DynamicPackages: true,
+		ProviderID:         "bench",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		DynamicPackages:    true,
+		AcceptedTaxonomies: []topicstore.Taxonomy{systemTaxonomy},
 	})
 
 	resolvedCtxEngine := NewContextEngine(ContextEngineConfig{
-		ProviderID: "bench",
-		Store:      store,
-		Properties: PropertyList{Global: NewMapBitmap("1")},
+		ProviderID:         "bench",
+		Store:              store,
+		Properties:         PropertyList{Global: NewMapBitmap("1")},
+		AcceptedTaxonomies: []topicstore.Taxonomy{systemTaxonomy},
 	})
 	identityEngine := NewIdentityEngine(IdentityEngineConfig{
 		Audience: audSvc,

--- a/targeting/topicstore/topicstore.go
+++ b/targeting/topicstore/topicstore.go
@@ -1,0 +1,299 @@
+// Package topicstore wraps targeting.ContextStore with taxonomy-aware key
+// construction for content topics. Topics in TMP are taxonomy-scoped: the
+// topic id "632" means "Food & Drink" under IAB Content Taxonomy 3.0 but
+// something different under a publisher's custom taxonomy. Without taxonomy
+// in the storage key, cross-taxonomy collisions would silently produce wrong
+// matches.
+//
+// Two surfaces:
+//
+//   - Writer: classifier pipelines (artifact-topic side) and media-buy /
+//     governance pipelines (package-topic side) import the Writer and call
+//     it with a Taxonomy + the topic ids. They do not assemble Valkey keys
+//     themselves — the key shape lives in this package.
+//   - Reader: the context engine and the resolver use the Reader to look up
+//     topics for an artifact or a package, and to compute the
+//     artifact ∩ package intersection. The engine also uses NamespaceTopic
+//     to convert raw topic ids into the taxonomy-qualified form the
+//     in-memory ResolvedPackages.TopicIndex is keyed on.
+package topicstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Taxonomy identifies a topic taxonomy. Source is the publishing
+// organization (e.g., "iab"); ID is the version within that source (e.g., 7
+// for IAB Content Taxonomy 3.0). The pair (Source, ID) uniquely identifies
+// the namespace topic strings live in.
+//
+// On the TMP wire this corresponds to ContextSignals.TaxonomySource +
+// ContextSignals.TaxonomyID; the spec is taxonomy-agnostic so any
+// (source, id) pair the deployment configures as accepted is valid.
+type Taxonomy struct {
+	Source string
+	ID     int
+}
+
+// Validate returns an error if the taxonomy cannot be safely serialized
+// into a Valkey key. Empty Source or characters that would break key
+// parsing (colons, slashes, whitespace) are rejected.
+func (t Taxonomy) Validate() error {
+	if t.Source == "" {
+		return errors.New("topicstore: taxonomy.source must be non-empty")
+	}
+	if t.ID < 0 {
+		return errors.New("topicstore: taxonomy.id must be non-negative")
+	}
+	if strings.ContainsAny(t.Source, ":\n\r\t /\\") {
+		return fmt.Errorf("topicstore: taxonomy.source %q contains invalid characters", t.Source)
+	}
+	return nil
+}
+
+// String returns the canonical "source:id" form used as the key namespace
+// segment and as the prefix on namespaced topic strings in the in-memory
+// TopicIndex.
+func (t Taxonomy) String() string {
+	return t.Source + ":" + strconv.Itoa(t.ID)
+}
+
+// ArtifactKey returns the Valkey key holding the set of topic ids for the
+// given artifact under taxonomy tax.
+func ArtifactKey(tax Taxonomy, ref string) string {
+	return "topics:artifact:" + tax.String() + ":" + ref
+}
+
+// PackageKey returns the Valkey key holding the set of topic ids a package
+// targets under taxonomy tax.
+func PackageKey(tax Taxonomy, pkgID string) string {
+	return "topics:package:" + tax.String() + ":" + pkgID
+}
+
+// NamespaceTopic returns the taxonomy-qualified topic string used by the
+// engine and ResolvedPackages.TopicIndex. Two topics with the same raw id
+// but different taxonomies serialize to distinct namespaced strings.
+func NamespaceTopic(tax Taxonomy, topic string) string {
+	return tax.String() + ":" + topic
+}
+
+// NamespaceTopics applies NamespaceTopic to every topic in the slice. The
+// returned slice has the same length and order; allocates exactly one
+// underlying array.
+func NamespaceTopics(tax Taxonomy, topics []string) []string {
+	if len(topics) == 0 {
+		return nil
+	}
+	out := make([]string, len(topics))
+	prefix := tax.String() + ":"
+	for i, t := range topics {
+		out[i] = prefix + t
+	}
+	return out
+}
+
+// Store is the subset of targeting.ContextStore that topicstore needs.
+// Declared here so writers can depend on the smaller surface without
+// pulling in the rest of the targeting package.
+type Store interface {
+	SetMembers(ctx context.Context, key string) ([]string, error)
+	SetIntersect(ctx context.Context, keys ...string) ([]string, error)
+	SetAdd(ctx context.Context, key string, members ...string) error
+	SetRemove(ctx context.Context, key string, members ...string) error
+	Del(ctx context.Context, keys ...string) error
+}
+
+// Writer writes artifact and package topic data. Callers construct one via
+// NewWriter and use the Set/Add/Remove methods rather than building Valkey
+// keys themselves.
+type Writer struct {
+	store Store
+}
+
+// NewWriter returns a Writer that persists topic data to the supplied
+// store. A nil store returns an error.
+func NewWriter(store Store) (*Writer, error) {
+	if store == nil {
+		return nil, errors.New("topicstore: store is required")
+	}
+	return &Writer{store: store}, nil
+}
+
+// SetArtifactTopics replaces the topic set for ref under tax with the
+// supplied topics. An empty topics slice deletes the key (no topics for
+// this artifact in this taxonomy). Idempotent.
+func (w *Writer) SetArtifactTopics(ctx context.Context, tax Taxonomy, ref string, topics []string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if ref == "" {
+		return errors.New("topicstore: artifact ref must be non-empty")
+	}
+	key := ArtifactKey(tax, ref)
+	if err := w.store.Del(ctx, key); err != nil {
+		return fmt.Errorf("topicstore: clear artifact topics: %w", err)
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+	if err := w.store.SetAdd(ctx, key, topics...); err != nil {
+		return fmt.Errorf("topicstore: write artifact topics: %w", err)
+	}
+	return nil
+}
+
+// AddArtifactTopics adds topics to ref's set under tax without removing
+// existing ones. Use when a classifier emits incremental updates.
+func (w *Writer) AddArtifactTopics(ctx context.Context, tax Taxonomy, ref string, topics []string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if ref == "" {
+		return errors.New("topicstore: artifact ref must be non-empty")
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+	return w.store.SetAdd(ctx, ArtifactKey(tax, ref), topics...)
+}
+
+// RemoveArtifact deletes every topic for ref under tax. Use when content is
+// retracted or the classification is invalidated.
+func (w *Writer) RemoveArtifact(ctx context.Context, tax Taxonomy, ref string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if ref == "" {
+		return errors.New("topicstore: artifact ref must be non-empty")
+	}
+	return w.store.Del(ctx, ArtifactKey(tax, ref))
+}
+
+// SetPackageTopics replaces the targeted-topic set for pkgID under tax with
+// topics. An empty topics slice deletes the key (the package no longer
+// targets any topic in this taxonomy). Idempotent.
+func (w *Writer) SetPackageTopics(ctx context.Context, tax Taxonomy, pkgID string, topics []string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if pkgID == "" {
+		return errors.New("topicstore: package id must be non-empty")
+	}
+	key := PackageKey(tax, pkgID)
+	if err := w.store.Del(ctx, key); err != nil {
+		return fmt.Errorf("topicstore: clear package topics: %w", err)
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+	if err := w.store.SetAdd(ctx, key, topics...); err != nil {
+		return fmt.Errorf("topicstore: write package topics: %w", err)
+	}
+	return nil
+}
+
+// AddPackageTopics adds topics to pkgID's targeted set under tax without
+// removing existing ones.
+func (w *Writer) AddPackageTopics(ctx context.Context, tax Taxonomy, pkgID string, topics []string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if pkgID == "" {
+		return errors.New("topicstore: package id must be non-empty")
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+	return w.store.SetAdd(ctx, PackageKey(tax, pkgID), topics...)
+}
+
+// RemovePackageTopics removes topics from pkgID's targeted set under tax.
+// Missing topics are silently skipped.
+func (w *Writer) RemovePackageTopics(ctx context.Context, tax Taxonomy, pkgID string, topics []string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if pkgID == "" {
+		return errors.New("topicstore: package id must be non-empty")
+	}
+	if len(topics) == 0 {
+		return nil
+	}
+	return w.store.SetRemove(ctx, PackageKey(tax, pkgID), topics...)
+}
+
+// RemovePackage deletes pkgID's targeted-topic key under tax. Use when the
+// package is retired from a taxonomy.
+func (w *Writer) RemovePackage(ctx context.Context, tax Taxonomy, pkgID string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	if pkgID == "" {
+		return errors.New("topicstore: package id must be non-empty")
+	}
+	return w.store.Del(ctx, PackageKey(tax, pkgID))
+}
+
+// Reader reads artifact and package topic data. The engine and the resolver
+// hold a Reader; production writers (classifier pipelines, media-buy sync)
+// hold a Writer.
+type Reader struct {
+	store Store
+}
+
+// NewReader returns a Reader backed by store.
+func NewReader(store Store) (*Reader, error) {
+	if store == nil {
+		return nil, errors.New("topicstore: store is required")
+	}
+	return &Reader{store: store}, nil
+}
+
+// ArtifactTopics returns the topic ids stored for ref under tax. Returns
+// nil (no error) when no topics are stored. The returned slice contains
+// raw topic ids in the taxonomy's namespace; use NamespaceTopic to lift
+// them into the namespaced form the engine indexes on.
+func (r *Reader) ArtifactTopics(ctx context.Context, tax Taxonomy, ref string) ([]string, error) {
+	if err := tax.Validate(); err != nil {
+		return nil, err
+	}
+	if ref == "" {
+		return nil, errors.New("topicstore: artifact ref must be non-empty")
+	}
+	return r.store.SetMembers(ctx, ArtifactKey(tax, ref))
+}
+
+// PackageTopics returns the topic ids pkgID targets under tax.
+func (r *Reader) PackageTopics(ctx context.Context, tax Taxonomy, pkgID string) ([]string, error) {
+	if err := tax.Validate(); err != nil {
+		return nil, err
+	}
+	if pkgID == "" {
+		return nil, errors.New("topicstore: package id must be non-empty")
+	}
+	return r.store.SetMembers(ctx, PackageKey(tax, pkgID))
+}
+
+// IntersectArtifactPackage returns the topic ids that appear in both the
+// artifact's topic set and the package's targeted-topic set under tax. A
+// non-empty result means the package's TopicTargets rule is satisfied by
+// the artifact under this taxonomy.
+//
+// This is the round-trip-minimal primitive the engine uses on the
+// non-resolved path: one Valkey SINTER per (artifact, package, taxonomy).
+func (r *Reader) IntersectArtifactPackage(ctx context.Context, tax Taxonomy, pkgID, ref string) ([]string, error) {
+	if err := tax.Validate(); err != nil {
+		return nil, err
+	}
+	if pkgID == "" {
+		return nil, errors.New("topicstore: package id must be non-empty")
+	}
+	if ref == "" {
+		return nil, errors.New("topicstore: artifact ref must be non-empty")
+	}
+	return r.store.SetIntersect(ctx, PackageKey(tax, pkgID), ArtifactKey(tax, ref))
+}

--- a/targeting/topicstore/topicstore.go
+++ b/targeting/topicstore/topicstore.go
@@ -286,6 +286,10 @@ func (w *Writer) RemovePackage(ctx context.Context, tax Taxonomy, pkgID string) 
 // error so partial state is observable on failure — callers SHOULD retry
 // idempotently. Pipelining across the entries is a future optimization;
 // today the implementation is a sequential loop over SetArtifactTopics.
+//
+// Iteration order is Go map iteration order (randomized). On a partial
+// failure, which entries landed before the error is non-deterministic
+// across runs; retry the whole batch rather than diffing.
 func (w *Writer) SetArtifactTopicsBatch(ctx context.Context, tax Taxonomy, byRef map[string][]string) error {
 	if err := tax.Validate(); err != nil {
 		return err
@@ -300,8 +304,9 @@ func (w *Writer) SetArtifactTopicsBatch(ctx context.Context, tax Taxonomy, byRef
 
 // SetPackageTopicsBatch replaces the package-topic sets for many packages
 // under tax in one call. byPkg maps the package id to its new targeted
-// topics (empty / nil slice deletes the key). Same failure shape as
-// SetArtifactTopicsBatch.
+// topics (empty / nil slice deletes the key). Same partial-failure shape
+// as SetArtifactTopicsBatch — non-deterministic iteration order means
+// callers retry the whole batch on error rather than diffing.
 func (w *Writer) SetPackageTopicsBatch(ctx context.Context, tax Taxonomy, byPkg map[string][]string) error {
 	if err := tax.Validate(); err != nil {
 		return err

--- a/targeting/topicstore/topicstore.go
+++ b/targeting/topicstore/topicstore.go
@@ -1,9 +1,9 @@
-// Package topicstore wraps targeting.ContextStore with taxonomy-aware key
-// construction for content topics. Topics in TMP are taxonomy-scoped: the
-// topic id "632" means "Food & Drink" under IAB Content Taxonomy 3.0 but
-// something different under a publisher's custom taxonomy. Without taxonomy
-// in the storage key, cross-taxonomy collisions would silently produce wrong
-// matches.
+// Package topicstore owns taxonomy-aware key construction for the TMP
+// context-engine's content-topic data. Topics in TMP are taxonomy-scoped:
+// the topic id "632" means "Food & Drink" under IAB Content Taxonomy 3.0
+// but something different under a publisher's custom taxonomy. Without
+// taxonomy in the storage key, cross-taxonomy collisions would silently
+// produce wrong matches.
 //
 // Two surfaces:
 //
@@ -16,6 +16,26 @@
 //     artifact ∩ package intersection. The engine also uses NamespaceTopic
 //     to convert raw topic ids into the taxonomy-qualified form the
 //     in-memory ResolvedPackages.TopicIndex is keyed on.
+//
+// # Lifecycle and TTL
+//
+// SetArtifactTopics and SetPackageTopics ship as full-replace primitives
+// implemented as Del+SAdd against the same key — two storage operations,
+// not atomic, with a transient zero-state window readers may observe
+// between them. Two common writer patterns avoid the race:
+//
+//   - Monotonic writers (add-only via AddArtifactTopics / AddPackageTopics)
+//     plus an out-of-band reaper that removes stale entries on a slower
+//     cadence than the read path. Recommended for high-churn artifact
+//     pipelines.
+//   - Idempotent writers that re-emit the full topic set every refresh and
+//     accept the transient zero-state as acceptable noise. Recommended for
+//     low-churn package configuration.
+//
+// TTL on topic keys is not exposed: artifact data is expected to be either
+// long-lived (URL-keyed, refreshed on classifier re-runs) or managed
+// out-of-band by the writer. Deployments that need automatic expiry should
+// implement it in their writer pipeline rather than relying on key TTL.
 package topicstore
 
 import (
@@ -23,7 +43,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 // Taxonomy identifies a topic taxonomy. Source is the publishing
@@ -40,8 +59,11 @@ type Taxonomy struct {
 }
 
 // Validate returns an error if the taxonomy cannot be safely serialized
-// into a Valkey key. Empty Source or characters that would break key
-// parsing (colons, slashes, whitespace) are rejected.
+// into a Valkey key. Source must be non-empty and drawn from the allowlist
+// [a-zA-Z0-9_.-]; an allowlist closes the Valkey-key injection vector for
+// deployments that ever feed a Taxonomy.Source value from an untrusted
+// origin (request payload, dynamic config) without re-validating
+// downstream.
 func (t Taxonomy) Validate() error {
 	if t.Source == "" {
 		return errors.New("topicstore: taxonomy.source must be non-empty")
@@ -49,8 +71,15 @@ func (t Taxonomy) Validate() error {
 	if t.ID < 0 {
 		return errors.New("topicstore: taxonomy.id must be non-negative")
 	}
-	if strings.ContainsAny(t.Source, ":\n\r\t /\\") {
-		return fmt.Errorf("topicstore: taxonomy.source %q contains invalid characters", t.Source)
+	for _, r := range t.Source {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-' || r == '.':
+		default:
+			return fmt.Errorf("topicstore: taxonomy.source %q contains invalid character %q (allowed: [a-zA-Z0-9_.-])", t.Source, r)
+		}
 	}
 	return nil
 }
@@ -96,27 +125,40 @@ func NamespaceTopics(tax Taxonomy, topics []string) []string {
 	return out
 }
 
-// Store is the subset of targeting.ContextStore that topicstore needs.
-// Declared here so writers can depend on the smaller surface without
-// pulling in the rest of the targeting package.
-type Store interface {
-	SetMembers(ctx context.Context, key string) ([]string, error)
-	SetIntersect(ctx context.Context, keys ...string) ([]string, error)
+// WriterStore is the minimal Valkey-side surface a Writer needs. Production
+// stores (redisstore, glidestore, MockStore) all satisfy it directly; the
+// engine's targeting.ContextStore deliberately does not require these
+// methods so the read path stays decoupled from the write path.
+type WriterStore interface {
 	SetAdd(ctx context.Context, key string, members ...string) error
 	SetRemove(ctx context.Context, key string, members ...string) error
 	Del(ctx context.Context, keys ...string) error
+}
+
+// ReaderStore is the minimal Valkey-side surface a Reader needs. It is a
+// subset of targeting.ContextStore.
+type ReaderStore interface {
+	SetMembers(ctx context.Context, key string) ([]string, error)
+	SetIntersect(ctx context.Context, keys ...string) ([]string, error)
+}
+
+// Store is the union of ReaderStore and WriterStore for callers that want
+// both. Concrete backends satisfy it automatically.
+type Store interface {
+	ReaderStore
+	WriterStore
 }
 
 // Writer writes artifact and package topic data. Callers construct one via
 // NewWriter and use the Set/Add/Remove methods rather than building Valkey
 // keys themselves.
 type Writer struct {
-	store Store
+	store WriterStore
 }
 
 // NewWriter returns a Writer that persists topic data to the supplied
 // store. A nil store returns an error.
-func NewWriter(store Store) (*Writer, error) {
+func NewWriter(store WriterStore) (*Writer, error) {
 	if store == nil {
 		return nil, errors.New("topicstore: store is required")
 	}
@@ -238,15 +280,49 @@ func (w *Writer) RemovePackage(ctx context.Context, tax Taxonomy, pkgID string) 
 	return w.store.Del(ctx, PackageKey(tax, pkgID))
 }
 
+// SetArtifactTopicsBatch replaces the artifact-topic sets for many refs
+// under tax in one call. byRef maps the artifact ref to the new topics
+// (empty / nil slice deletes the key). Stops on the first underlying
+// error so partial state is observable on failure — callers SHOULD retry
+// idempotently. Pipelining across the entries is a future optimization;
+// today the implementation is a sequential loop over SetArtifactTopics.
+func (w *Writer) SetArtifactTopicsBatch(ctx context.Context, tax Taxonomy, byRef map[string][]string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	for ref, topics := range byRef {
+		if err := w.SetArtifactTopics(ctx, tax, ref, topics); err != nil {
+			return fmt.Errorf("topicstore: artifact %q: %w", ref, err)
+		}
+	}
+	return nil
+}
+
+// SetPackageTopicsBatch replaces the package-topic sets for many packages
+// under tax in one call. byPkg maps the package id to its new targeted
+// topics (empty / nil slice deletes the key). Same failure shape as
+// SetArtifactTopicsBatch.
+func (w *Writer) SetPackageTopicsBatch(ctx context.Context, tax Taxonomy, byPkg map[string][]string) error {
+	if err := tax.Validate(); err != nil {
+		return err
+	}
+	for pkgID, topics := range byPkg {
+		if err := w.SetPackageTopics(ctx, tax, pkgID, topics); err != nil {
+			return fmt.Errorf("topicstore: package %q: %w", pkgID, err)
+		}
+	}
+	return nil
+}
+
 // Reader reads artifact and package topic data. The engine and the resolver
 // hold a Reader; production writers (classifier pipelines, media-buy sync)
 // hold a Writer.
 type Reader struct {
-	store Store
+	store ReaderStore
 }
 
 // NewReader returns a Reader backed by store.
-func NewReader(store Store) (*Reader, error) {
+func NewReader(store ReaderStore) (*Reader, error) {
 	if store == nil {
 		return nil, errors.New("topicstore: store is required")
 	}

--- a/targeting/topicstore/topicstore_test.go
+++ b/targeting/topicstore/topicstore_test.go
@@ -1,0 +1,177 @@
+package topicstore_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/targeting/topicstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaxonomy_String(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	assert.Equal(t, "iab:7", tax.String())
+}
+
+func TestTaxonomy_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		tax  topicstore.Taxonomy
+		ok   bool
+	}{
+		{"valid", topicstore.Taxonomy{Source: "iab", ID: 7}, true},
+		{"empty-source", topicstore.Taxonomy{Source: "", ID: 1}, false},
+		{"negative-id", topicstore.Taxonomy{Source: "iab", ID: -1}, false},
+		{"colon-in-source", topicstore.Taxonomy{Source: "ia:b", ID: 1}, false},
+		{"slash-in-source", topicstore.Taxonomy{Source: "ia/b", ID: 1}, false},
+		{"whitespace-in-source", topicstore.Taxonomy{Source: "iab v3", ID: 1}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.tax.Validate()
+			if tc.ok {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestKeyShapes(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	assert.Equal(t, "topics:artifact:iab:7:article:pasta", topicstore.ArtifactKey(tax, "article:pasta"))
+	assert.Equal(t, "topics:package:iab:7:pkg-food", topicstore.PackageKey(tax, "pkg-food"))
+	assert.Equal(t, "iab:7:632", topicstore.NamespaceTopic(tax, "632"))
+}
+
+// TestKeyShapes_DistinctAcrossTaxonomies guards the core invariant the
+// package exists to enforce: the same raw topic id in two taxonomies
+// serializes to two different namespaced strings — and to two different
+// Valkey keys — so a cross-taxonomy join cannot silently produce a hit.
+func TestKeyShapes_DistinctAcrossTaxonomies(t *testing.T) {
+	a := topicstore.Taxonomy{Source: "iab", ID: 7}
+	b := topicstore.Taxonomy{Source: "custom", ID: 1}
+
+	assert.NotEqual(t, topicstore.NamespaceTopic(a, "632"), topicstore.NamespaceTopic(b, "632"))
+	assert.NotEqual(t, topicstore.ArtifactKey(a, "x"), topicstore.ArtifactKey(b, "x"))
+	assert.NotEqual(t, topicstore.PackageKey(a, "p"), topicstore.PackageKey(b, "p"))
+}
+
+func TestWriter_SetArtifactTopics_Roundtrip(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, err := topicstore.NewWriter(store)
+	require.NoError(t, err)
+	r, err := topicstore.NewReader(store)
+	require.NoError(t, err)
+
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	ctx := context.Background()
+
+	require.NoError(t, w.SetArtifactTopics(ctx, tax, "article:pasta", []string{"632", "640"}))
+	topics, err := r.ArtifactTopics(ctx, tax, "article:pasta")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"632", "640"}, topics)
+}
+
+func TestWriter_SetArtifactTopics_ReplacesPrevious(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, _ := topicstore.NewWriter(store)
+	r, _ := topicstore.NewReader(store)
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	ctx := context.Background()
+
+	require.NoError(t, w.SetArtifactTopics(ctx, tax, "article:x", []string{"100", "200"}))
+	require.NoError(t, w.SetArtifactTopics(ctx, tax, "article:x", []string{"300"}))
+
+	topics, _ := r.ArtifactTopics(ctx, tax, "article:x")
+	assert.ElementsMatch(t, []string{"300"}, topics, "second SetArtifactTopics call must replace, not add")
+}
+
+func TestWriter_AddRemovePackageTopics(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, _ := topicstore.NewWriter(store)
+	r, _ := topicstore.NewReader(store)
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	ctx := context.Background()
+
+	require.NoError(t, w.AddPackageTopics(ctx, tax, "pkg-1", []string{"a", "b"}))
+	require.NoError(t, w.AddPackageTopics(ctx, tax, "pkg-1", []string{"c"}))
+	topics, _ := r.PackageTopics(ctx, tax, "pkg-1")
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, topics)
+
+	require.NoError(t, w.RemovePackageTopics(ctx, tax, "pkg-1", []string{"b"}))
+	topics, _ = r.PackageTopics(ctx, tax, "pkg-1")
+	assert.ElementsMatch(t, []string{"a", "c"}, topics)
+
+	require.NoError(t, w.RemovePackage(ctx, tax, "pkg-1"))
+	topics, _ = r.PackageTopics(ctx, tax, "pkg-1")
+	assert.Empty(t, topics)
+}
+
+func TestReader_IntersectArtifactPackage(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, _ := topicstore.NewWriter(store)
+	r, _ := topicstore.NewReader(store)
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	ctx := context.Background()
+
+	require.NoError(t, w.SetPackageTopics(ctx, tax, "pkg-food", []string{"632", "640"}))
+	require.NoError(t, w.SetArtifactTopics(ctx, tax, "article:pasta", []string{"632", "999"}))
+
+	inter, err := r.IntersectArtifactPackage(ctx, tax, "pkg-food", "article:pasta")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"632"}, inter)
+}
+
+// TestReader_IntersectArtifactPackage_CrossTaxonomyDisjoint verifies that
+// the same topic id written under two different taxonomies does not
+// produce an intersection — the key-shape distinction enforces taxonomy
+// isolation at the storage layer.
+func TestReader_IntersectArtifactPackage_CrossTaxonomyDisjoint(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, _ := topicstore.NewWriter(store)
+	r, _ := topicstore.NewReader(store)
+	ctx := context.Background()
+
+	a := topicstore.Taxonomy{Source: "iab", ID: 7}
+	b := topicstore.Taxonomy{Source: "custom", ID: 1}
+
+	require.NoError(t, w.SetPackageTopics(ctx, a, "pkg-food", []string{"632"}))
+	require.NoError(t, w.SetArtifactTopics(ctx, b, "article:pasta", []string{"632"}))
+
+	// Intersect under taxonomy a sees the package set but no artifact set.
+	inter, err := r.IntersectArtifactPackage(ctx, a, "pkg-food", "article:pasta")
+	require.NoError(t, err)
+	assert.Empty(t, inter)
+}
+
+func TestNamespaceTopics_PreservesOrderAndPrefixes(t *testing.T) {
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	got := topicstore.NamespaceTopics(tax, []string{"632", "640", "999"})
+	assert.Equal(t, []string{"iab:7:632", "iab:7:640", "iab:7:999"}, got)
+
+	assert.Nil(t, topicstore.NamespaceTopics(tax, nil))
+	assert.Nil(t, topicstore.NamespaceTopics(tax, []string{}))
+}
+
+func TestWriter_NilStoreRejected(t *testing.T) {
+	_, err := topicstore.NewWriter(nil)
+	assert.Error(t, err)
+	_, err = topicstore.NewReader(nil)
+	assert.Error(t, err)
+}
+
+func TestWriter_InvalidInputs(t *testing.T) {
+	store := targeting.NewMockStore()
+	w, _ := topicstore.NewWriter(store)
+	tax := topicstore.Taxonomy{Source: "iab", ID: 7}
+	bad := topicstore.Taxonomy{}
+	ctx := context.Background()
+
+	assert.Error(t, w.SetArtifactTopics(ctx, bad, "x", []string{"a"}), "invalid taxonomy must error")
+	assert.Error(t, w.SetArtifactTopics(ctx, tax, "", []string{"a"}), "empty ref must error")
+	assert.Error(t, w.SetPackageTopics(ctx, tax, "", []string{"a"}), "empty pkg must error")
+}


### PR DESCRIPTION
## Summary

- New `targeting/topicstore` package owns the Valkey key shape for content topics; writers (classifier pipelines, media-buy/governance sync) import `topicstore.Writer` and stop assembling keys inline.
- `ContextEngineConfig.AcceptedTaxonomies` declares the topic taxonomies the deployment trusts. Both engine paths (`EvaluateContext` and `EvaluateContextResolved`) union `ContextSignals.Topics` into the artifact-topic set when the publisher's declared `(TaxonomySource, TaxonomyID)` is in the accepted set, with a positive-only short-circuit on the resolved path that skips per-artifact Valkey SMEMBERS when publisher topics already cover every `TopicTargets` package.
- Multi-taxonomy support: topic keys and the in-memory `TopicIndex` are namespaced by `(source, id)` so id `"632"` under IAB-3.0 cannot cross-match the same string under a custom taxonomy. A publisher mis-declaring its taxonomy is treated as a failed topic match, not free activation. Empty `AcceptedTaxonomies` + `TopicTargets` fails-closed on both paths.

## Breaking changes

- **Storage format**: `topics:artifact:{ref}` → `topics:artifact:{src}:{id}:{ref}` and `topics:package:{pkg}` → `topics:package:{src}:{id}:{pkg}`. Pre-existing data must be rewritten; no migration script ships because the context-agent isn't in production yet — this is the cheap window. **Release-note callout**: any out-of-tree embedder writing topic data via `ContextStore.SetMembers` to the literal old keys will silently break; switch to `topicstore.Writer` or rewrite the keys to include the `(src, id)` segment.
- **`targeting.Resolve` signature** grows a `[]topicstore.Taxonomy` parameter so the resolver can load per-(package, taxonomy) topic sets into the in-memory index.
- **`ContextEngineConfig.AcceptedTaxonomies`** is now load-bearing for any deployment using `TopicTargets`. Empty fails-closed.

## What's covered

- `topicstore` unit tests: key construction, validation (including the `[a-zA-Z0-9_.-]` Source allowlist), round-trip writes, cross-taxonomy isolation, invalid inputs.
- Engine tests (`engine_context_signals_test.go`): publisher-topic union, taxonomy rejection, short-circuit Valkey skip, Valkey fallback when publisher topics are incomplete, no-artifact ephemeral content path, multi-taxonomy isolation, empty-`AcceptedTaxonomies` fail-closed (both paths), rogue-taxonomy plus real artifact (artifact side still matches), rogue-only-source fail-closed (both paths), defensive-copy invariant.
- Existing engine / resolver / scale / system / e2e / integration tests migrated to the new key shape and `topicstore.Writer` callsites.

## Surface design notes

- **Interface split**: `targeting.ContextStore` stays a read-only interface (custom embedders don't have to add write methods they never call). `topicstore` declares its own minimal `ReaderStore` / `WriterStore` / combined `Store` interfaces; production backends (redisstore, glidestore, MockStore) satisfy all three.
- **Topic-store writer lifecycle**: the package doc spells out the `SetArtifactTopics` Del+SAdd race (transient zero-state window between the two ops) and the deliberate TTL gap (deployments manage expiry in their writer pipeline, not via key TTL). Batch APIs are loop-based today; pipelining is a follow-up.
- **Errors**: per-(artifact, taxonomy) lookups in `EvaluateContextResolved` and per-(package, taxonomy) / URL-blocklist / URL-allowlist loads in `Resolve` log via slog alongside the existing `StoreError` metric. Fail-closed-per-taxonomy is documented on both functions.
- **Metrics**: empty-`AcceptedTaxonomies` + `TopicTargets` emits `StageTopicNoTaxonomy` (distinct from `StageTopicMatch`) so config drops are separable from misses in dashboards.

## Out of scope (explicitly)

- No new topic-blocklist primitive. AdCP has no topic-exclusion mention in TMP; the Governance Protocol's `content_standards` block actions live upstream and don't reach the TMP engine at request time. Adding request-time topic exclusion is a separate, larger PR.
- `ContextSignals.ContentPolicies`, `Sentiment`, `Keywords`, `Embedding`, `Summary` remain unconsumed. `ContentPolicies` is the closest thing to a normative brand-safety primitive — worth a follow-up RFC, but not in this PR.

## Test plan

- [x] CI green on `go test ./...` across the repo + all sub-modules (reference/context-agent, reference/seller-agent, cmd/identity-agent, adcp)
- [ ] Reviewer reads `targeting/topicstore/topicstore.go` to confirm the writer/reader surface matches what classifier pipelines and the planned media-buy sync will need
- [ ] Reviewer reads `targeting/engine.go` `EvaluateContextResolved` topic block + `publisherCoversTopicTargets` to validate the short-circuit logic
- [ ] Spot-check a redisstore/glidestore integration run in a follow-up — `//go:build integration` tag, requires a Valkey container

🤖 Generated with [Claude Code](https://claude.com/claude-code)