### PR TITLE
feat(identityagent): observe identity-config refreshes and snapshot size

### DIFF
--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -173,6 +173,36 @@ func (m *MetricsProvider) RegisterOpenConnectionsObserver(observerFn func() int6
 	return nil
 }
 
+// RegisterConfigEntriesObserver registers an OTEL ObservableGauge named
+// "<namespace>_config_entries" whose value is read from observerFn each
+// time the Prometheus exporter scrapes. Intended source is
+// identityconfig.Service.Len — the number of (sellerAgentURL, packageID)
+// entries currently held in the in-memory snapshot. A flat-line or
+// dropping value over time, paired with refresh errors, is a strong
+// signal the snapshot has gone stale or empty. No-op when metrics are
+// disabled.
+//
+// observerFn is invoked from arbitrary goroutines on the exporter's
+// schedule; it must be safe to call concurrently and should be cheap.
+func (m *MetricsProvider) RegisterConfigEntriesObserver(observerFn func() int64) error {
+	if m == nil || m.meterProvider == nil || observerFn == nil {
+		return nil
+	}
+	meter := m.meterProvider.Meter("identity-agent")
+	gauge, err := meter.Int64ObservableGauge(fmt.Sprintf("%s_config_entries", m.namespace))
+	if err != nil {
+		return fmt.Errorf("register config_entries gauge: %w", err)
+	}
+	_, err = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		o.ObserveInt64(gauge, observerFn())
+		return nil
+	}, gauge)
+	if err != nil {
+		return fmt.Errorf("register config_entries callback: %w", err)
+	}
+	return nil
+}
+
 // otelRecorder is the production Recorder. It uses an OTEL meter with the
 // Prometheus exporter to surface metrics on the Prometheus registry the
 // /metrics handler reads from.

--- a/targeting/identityagent/metrics_test.go
+++ b/targeting/identityagent/metrics_test.go
@@ -1,0 +1,43 @@
+package identityagent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterConfigEntriesObserver_DisabledProviderIsNoop(t *testing.T) {
+	p, err := Build(MetricsConfig{Enabled: false})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	// Must not error and must not panic with a nil meter provider.
+	require.NoError(t, p.RegisterConfigEntriesObserver(func() int64 { return 42 }))
+}
+
+func TestRegisterConfigEntriesObserver_PublishesGauge(t *testing.T) {
+	p, err := Build(MetricsConfig{Enabled: true, Namespace: "identity_agent"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	require.NoError(t, p.RegisterConfigEntriesObserver(func() int64 { return 7 }))
+
+	mfs, err := p.Registry.Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, mf := range mfs {
+		if !strings.HasSuffix(mf.GetName(), "_config_entries") {
+			continue
+		}
+		found = true
+		require.Len(t, mf.GetMetric(), 1)
+		assert.Equal(t, float64(7), mf.GetMetric()[0].GetGauge().GetValue(),
+			"observer callback value should be reported on the gauge at scrape time")
+		break
+	}
+	require.True(t, found, "identity_agent_config_entries gauge should be registered with the Prometheus registry")
+}

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -122,6 +122,11 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string) e
 	if err := metricsProvider.RegisterOpenConnectionsObserver(tracker.Open); err != nil {
 		return fmt.Errorf("register open-connections observer: %w", err)
 	}
+	if err := metricsProvider.RegisterConfigEntriesObserver(func() int64 {
+		return int64(bundle.configSvc.Len())
+	}); err != nil {
+		return fmt.Errorf("register config-entries observer: %w", err)
+	}
 
 	registry := newShutdownRegistry(logger, metricsProvider.Recorder)
 	registry.add("identity-config", func(_ context.Context) error {
@@ -313,6 +318,9 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 	configSvc, err := identityconfig.New(source, cfg.IdentityConfig.RefreshInterval,
 		identityconfig.WithStartConfig(startConfigFor(cfg.IdentityConfig)),
 		identityconfig.WithLogger(logger),
+		identityconfig.WithRefreshObserver(func(outcome string) {
+			recorder.ConfigRefresh(context.Background(), outcome)
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("init identityconfig service: %w", err)

--- a/targeting/identityconfig/service.go
+++ b/targeting/identityconfig/service.go
@@ -18,10 +18,11 @@ import (
 // each refresh constructs a new immutable snapshot and CAS-installs it via
 // atomic.Pointer.
 type Service struct {
-	source   Source
-	interval time.Duration
-	start    StartConfig
-	logger   *slog.Logger
+	source          Source
+	interval        time.Duration
+	start           StartConfig
+	logger          *slog.Logger
+	refreshObserver func(outcome string)
 
 	snap atomic.Pointer[snapshotData]
 
@@ -30,6 +31,14 @@ type Service struct {
 	running bool
 	done    chan struct{}
 }
+
+// Refresh outcomes reported to a WithRefreshObserver callback. Stable values
+// suitable for use as Prometheus label values; new outcomes may be added in
+// the future, so callers should not treat the set as exhaustive.
+const (
+	RefreshOutcomeSuccess = "success"
+	RefreshOutcomeError   = "error"
+)
 
 // snapshotData is the immutable view installed by every refresh. Readers
 // hold the pointer for the duration of their lookup; writers build a new
@@ -78,6 +87,24 @@ func WithLogger(logger *slog.Logger) Option {
 	return func(s *Service) {
 		if logger != nil {
 			s.logger = logger
+		}
+	}
+}
+
+// WithRefreshObserver registers a callback invoked once per refresh attempt,
+// covering both the initial load (including each retry in StartModeRetry) and
+// every periodic delta refresh. The outcome argument is one of the
+// RefreshOutcome* constants and is suitable for use as a Prometheus label
+// value.
+//
+// The callback runs synchronously on the goroutine that performed the
+// refresh. Implementations must be cheap and non-blocking — a blocked
+// callback delays the refresh loop and, on the initial-load path, delays
+// pod startup. Passing nil is a no-op.
+func WithRefreshObserver(fn func(outcome string)) Option {
+	return func(s *Service) {
+		if fn != nil {
+			s.refreshObserver = fn
 		}
 	}
 }
@@ -136,6 +163,13 @@ func (s *Service) GetBySeller(sellerAgentURL string) []Entry {
 // Useful for telemetry and health checks.
 func (s *Service) LastUpdatedAt() time.Time {
 	return s.snap.Load().lastUpdatedAt
+}
+
+// Len returns the number of (sellerAgentURL, packageID) entries in the
+// currently installed snapshot. Safe to call concurrently with refreshes.
+// Useful as an observable-gauge value source for telemetry.
+func (s *Service) Len() int {
+	return len(s.snap.Load().byKey)
 }
 
 // Start begins periodic refresh in a background goroutine. The initial
@@ -240,9 +274,11 @@ func (s *Service) initialLoad(ctx context.Context) error {
 func (s *Service) loadAllOnce(ctx context.Context) error {
 	snap, err := s.source.LoadAll(ctx)
 	if err != nil {
+		s.notifyRefresh(RefreshOutcomeError)
 		return fmt.Errorf("identityconfig: load all: %w", err)
 	}
 	s.snap.Store(buildSnapshot(snap))
+	s.notifyRefresh(RefreshOutcomeSuccess)
 	return nil
 }
 
@@ -322,6 +358,7 @@ func (s *Service) refreshDelta(ctx context.Context) error {
 	current := s.snap.Load()
 	delta, err := s.source.LoadUpdatedAfter(ctx, current.lastUpdatedAt)
 	if err != nil {
+		s.notifyRefresh(RefreshOutcomeError)
 		return err
 	}
 	if len(delta.Upserted) == 0 && len(delta.Removed) == 0 {
@@ -333,10 +370,28 @@ func (s *Service) refreshDelta(ctx context.Context) error {
 			updated.lastUpdatedAt = delta.LastUpdatedAt
 			s.snap.Store(&updated)
 		}
+		s.notifyRefresh(RefreshOutcomeSuccess)
 		return nil
 	}
 	s.snap.Store(applyDelta(current, delta))
+	s.notifyRefresh(RefreshOutcomeSuccess)
 	return nil
+}
+
+// notifyRefresh invokes the configured refresh-observer callback, if any.
+// Panics in the callback are recovered and logged so a buggy observer can
+// never bring the refresh loop down.
+func (s *Service) notifyRefresh(outcome string) {
+	if s.refreshObserver == nil {
+		return
+	}
+	defer func() {
+		if rec := recover(); rec != nil {
+			s.logger.Error("identityconfig: refresh observer panicked",
+				"outcome", outcome, "panic", fmt.Sprintf("%v", rec))
+		}
+	}()
+	s.refreshObserver(outcome)
 }
 
 // emptySnapshot returns a zero-value snapshotData with non-nil maps.

--- a/targeting/identityconfig/service_test.go
+++ b/targeting/identityconfig/service_test.go
@@ -528,3 +528,155 @@ func TestService_GetBeforeStartReturnsNil(t *testing.T) {
 	_, present := svc.Lookup("seller", "pkg")
 	assert.False(t, present)
 }
+
+// outcomeRecorder collects refresh outcomes for assertion. Safe for
+// concurrent use from the refresh goroutine.
+type outcomeRecorder struct {
+	mu  sync.Mutex
+	out []string
+}
+
+func (r *outcomeRecorder) record(outcome string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.out = append(r.out, outcome)
+}
+
+func (r *outcomeRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.out))
+	copy(out, r.out)
+	return out
+}
+
+func TestService_RefreshObserverEmitsOnInitialLoad(t *testing.T) {
+	src := newMemorySource()
+	src.put("seller", "pkg-1", nil, time.Unix(1, 0))
+
+	rec := &outcomeRecorder{}
+	svc, err := New(src, time.Hour, WithRefreshObserver(rec.record))
+	require.NoError(t, err)
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	assert.Equal(t, []string{RefreshOutcomeSuccess}, rec.snapshot(),
+		"a successful initial load should emit exactly one success outcome")
+}
+
+func TestService_RefreshObserverEmitsErrorOnInitialLoadFailure(t *testing.T) {
+	src := newMemorySource()
+	src.setLoadAllError(errors.New("boom"))
+
+	rec := &outcomeRecorder{}
+	svc, err := New(src, time.Hour, WithRefreshObserver(rec.record))
+	require.NoError(t, err)
+	require.Error(t, svc.Start(context.Background()))
+
+	assert.Equal(t, []string{RefreshOutcomeError}, rec.snapshot(),
+		"a failed fail-fast initial load should emit exactly one error outcome")
+}
+
+func TestService_RefreshObserverEmitsOnDelta(t *testing.T) {
+	src := newMemorySource()
+	src.put("seller", "pkg-1", nil, time.Unix(100, 0))
+	src.queueDelta(Delta{
+		Upserted:      []Entry{{Key: Key{SellerAgentURL: "seller", PackageID: "pkg-2"}, TargetSegments: nil}},
+		LastUpdatedAt: time.Unix(200, 0),
+	})
+
+	rec := &outcomeRecorder{}
+	svc, err := New(src, 10*time.Millisecond, WithRefreshObserver(rec.record))
+	require.NoError(t, err)
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	require.Eventually(t, func() bool {
+		return len(rec.snapshot()) >= 2
+	}, time.Second, 5*time.Millisecond, "observer should fire for both initial load and delta")
+
+	outcomes := rec.snapshot()
+	require.GreaterOrEqual(t, len(outcomes), 2)
+	assert.Equal(t, RefreshOutcomeSuccess, outcomes[0], "initial load is success")
+	assert.Equal(t, RefreshOutcomeSuccess, outcomes[1], "delta is success")
+}
+
+func TestService_RefreshObserverEmitsErrorOnDeltaFailure(t *testing.T) {
+	src := newMemorySource()
+	src.put("seller", "pkg-1", nil, time.Unix(100, 0))
+
+	rec := &outcomeRecorder{}
+	svc, err := New(src, 10*time.Millisecond, WithRefreshObserver(rec.record))
+	require.NoError(t, err)
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	// Initial load succeeded — flip the source into failure mode and
+	// wait for at least one delta tick to land an error outcome.
+	src.mu.Lock()
+	src.loadUpdatedAfterErr = errors.New("delta boom")
+	src.mu.Unlock()
+
+	require.Eventually(t, func() bool {
+		for _, o := range rec.snapshot() {
+			if o == RefreshOutcomeError {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 5*time.Millisecond, "observer should fire with an error outcome after a delta failure")
+}
+
+func TestService_RefreshObserverPanicDoesNotCrashLoop(t *testing.T) {
+	src := newMemorySource()
+	src.put("seller", "pkg-1", nil, time.Unix(1, 0))
+
+	var calls atomic.Int64
+	svc, err := New(src, 10*time.Millisecond, WithRefreshObserver(func(string) {
+		calls.Add(1)
+		panic("observer is buggy")
+	}))
+	require.NoError(t, err)
+	// Initial load runs the observer once and panics inside; Start must
+	// still return successfully because the panic is recovered in
+	// notifyRefresh.
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	require.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, time.Second, 5*time.Millisecond, "refresh loop should keep ticking through observer panics")
+}
+
+func TestService_LenReflectsSnapshot(t *testing.T) {
+	src := newMemorySource()
+	src.put("seller", "pkg-1", &targeting.SegmentRule{AnyOf: []string{"a"}}, time.Unix(1, 0))
+	src.put("seller", "pkg-2", &targeting.SegmentRule{AnyOf: []string{"b"}}, time.Unix(1, 0))
+	src.put("other", "pkg-3", nil, time.Unix(1, 0))
+
+	svc, err := New(src, 10*time.Millisecond)
+	require.NoError(t, err)
+	// Pre-Start: empty snapshot is installed by the constructor.
+	assert.Equal(t, 0, svc.Len())
+
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop()
+
+	assert.Equal(t, 3, svc.Len(), "Len should reflect every (seller, package) entry loaded")
+
+	// Queue a delta that adds one entry and removes another.
+	src.queueDelta(Delta{
+		Upserted:      []Entry{{Key: Key{SellerAgentURL: "seller", PackageID: "pkg-4"}, TargetSegments: nil}},
+		Removed:       []Key{{SellerAgentURL: "seller", PackageID: "pkg-1"}},
+		LastUpdatedAt: time.Unix(200, 0),
+	})
+
+	// 3 entries before, 3 after (one upsert + one remove). Wait for the
+	// upsert to land — Len alone can't distinguish pre- from post-delta.
+	require.Eventually(t, func() bool {
+		_, present := svc.Lookup("seller", "pkg-4")
+		return present
+	}, time.Second, 5*time.Millisecond, "delta refresh should land")
+	assert.Equal(t, 3, svc.Len(), "Len should still reflect every entry after an upsert+remove delta")
+	assert.Nil(t, svc.Get("seller", "pkg-1"), "removed entry should not be readable")
+}


### PR DESCRIPTION
## Summary

- `identity_agent_config_refresh_total` is registered but has no callers in-tree: `Recorder.ConfigRefresh` is dead code, and the identityconfig refresh loop has no telemetry hook. Operators have no signal that periodic refreshes are happening, let alone succeeding.
- `identityconfig.Service` holds an in-memory snapshot indexed by `(sellerAgentURL, packageID)` but doesn't expose its size. A pod whose initial `LoadAll` succeeded but whose subsequent delta refreshes are 401-ing will quietly serve a stale snapshot indefinitely — there's no metric to detect this.

This PR addresses both gaps.

## What

**`targeting/identityconfig`**
- New `WithRefreshObserver(func(outcome string)) Option`. Callback fires once per refresh attempt with outcome `"success"` or `"error"`. Covers:
  - Initial `LoadAll` (including every retry under `StartModeRetry`).
  - Every periodic delta refresh (including the watermark-only path, which is treated as success).
- New `Service.Len() int` returning the current snapshot's entry count. Lock-free, safe to call from arbitrary goroutines — intended use is an observable-gauge value source.
- Panics inside an observer callback are recovered and logged so a buggy observer can never bring the refresh loop down.
- Exported constants `RefreshOutcomeSuccess` / `RefreshOutcomeError` for caller use.

**`targeting/identityagent`**
- `MetricsProvider.RegisterConfigEntriesObserver(func() int64)` publishes a new OTEL `Int64ObservableGauge` named `<namespace>_config_entries`. Mirrors the existing `RegisterOpenConnectionsObserver` pattern.
- `Run` registers both:
  - The refresh observer, bridging `RefreshOutcome*` → `Recorder.ConfigRefresh(ctx, outcome)`. This is what finally drives `identity_agent_config_refresh_total{outcome}`.
  - The config-entries gauge, sourced from `bundle.configSvc.Len()`.

## Resulting metric surface

| Metric | Type | Labels | What it tells you |
|---|---|---|---|
| `identity_agent_config_refresh_total` | counter | `outcome=success\|error` | Whether the refresh loop is alive and whether the source is responding. Was dead-registered before. |
| `identity_agent_config_entries` | gauge | — | Current `(seller, package)` count in the snapshot. A flat or dropping value paired with `_config_refresh_total{outcome="error"}` increments is a clear "snapshot is stale" signal. |

## Test plan

- [x] `go test -race ./targeting/identityconfig/... ./targeting/identityagent/...`
- [x] New `service_test.go` cases:
  - Initial-load success emits exactly one `success`.
  - Initial-load failure (fail-fast) emits exactly one `error`.
  - Delta refresh emits `success` after the initial-load `success`.
  - Delta refresh emits `error` when the source returns an error.
  - Refresh-observer panic does not break the refresh loop.
  - `Len()` reflects entries after initial load and after an upsert+remove delta.
- [x] New `metrics_test.go` cases:
  - `RegisterConfigEntriesObserver` is a no-op when metrics are disabled.
  - When enabled, the gauge appears on the Prometheus registry at scrape time with the callback's value.
- [x] `gofmt -d` clean on touched code; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)