### PR TITLE
tmproto: add TMPX receiver open API

### DIFF
--- a/tmproto/tmpx_open.go
+++ b/tmproto/tmpx_open.go
@@ -1,0 +1,133 @@
+package tmproto
+
+// tmpx_open.go is the receiver side of TMPX: it reverses SealTmpx. The buyer
+// cluster master holds the X25519 recipient private key and opens the token to
+// recover the resolved identity tokens for impression-time frequency state.
+//
+// SealTmpx shipped without an in-package Open (round-trip verification used a
+// test-only helper); OpenTmpx promotes that to a usable receiver API for any
+// party that decrypts a TMPX token (e.g. the tracking endpoint, conformance tests).
+
+import (
+	"crypto/ecdh"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// OpenTmpx reverses SealTmpx. It parses the wire-format string
+// `kid.b64url_no_pad(enc || ciphertext)`, HPKE-opens it under the recipient's
+// X25519 private key, and returns the recovered plaintext plus the parsed kid.
+//
+// The caller resolves which private key to use from the kid out of band (a
+// keystore lookup); OpenTmpx does not consult a keystore. `info` MUST match the
+// value passed to SealTmpx (nil per the spec default).
+func OpenTmpx(skR *ecdh.PrivateKey, info []byte, wire string) (plaintext []byte, kid string, err error) {
+	if skR == nil {
+		return nil, "", errors.New("tmproto: tmpx recipient private key required")
+	}
+	if skR.Curve() != ecdh.X25519() {
+		return nil, "", errors.New("tmproto: tmpx recipient private key must be X25519")
+	}
+	dot := strings.IndexByte(wire, '.')
+	if dot <= 0 || dot > TmpxMaxKidLen {
+		return nil, "", errors.New("tmproto: tmpx wire string missing valid kid prefix")
+	}
+	kid = wire[:dot]
+	payload, err := base64.RawURLEncoding.DecodeString(wire[dot+1:])
+	if err != nil {
+		return nil, "", fmt.Errorf("tmproto: tmpx base64url decode: %w", err)
+	}
+	// payload = enc (32-byte X25519 ephemeral public key) || ciphertext+tag.
+	if len(payload) < 32+chacha20poly1305.Overhead {
+		return nil, "", errors.New("tmproto: tmpx payload too short")
+	}
+	enc, ct := payload[:32], payload[32:]
+	pt, err := hpkeOpenBase(skR, enc, info, nil, ct)
+	if err != nil {
+		return nil, "", err
+	}
+	return pt, kid, nil
+}
+
+// hpkeOpenBase is the inverse of hpkeSealBase: single-shot HPKE Open in
+// mode_base for suite (DHKEM(X25519, HKDF-SHA256), HKDF-SHA256,
+// ChaCha20-Poly1305). enc is the 32-byte encapsulated KEM key (sender's
+// ephemeral X25519 public key); ct is the AEAD ciphertext+tag.
+func hpkeOpenBase(skR *ecdh.PrivateKey, enc, info, aad, ct []byte) ([]byte, error) {
+	pkE, err := ecdh.X25519().NewPublicKey(enc)
+	if err != nil {
+		return nil, fmt.Errorf("tmproto: hpke open: parse enc: %w", err)
+	}
+
+	// DHKEM Decap: dh = DH(skR, pkE); kem_context = enc || pkRm (same byte
+	// order the sender used in Encap).
+	dh, err := skR.ECDH(pkE)
+	if err != nil {
+		return nil, fmt.Errorf("tmproto: hpke open: ecdh: %w", err)
+	}
+	pkRBytes := skR.PublicKey().Bytes()
+
+	suiteID := buildHPKESuiteID(hpkeKEMX25519HKDFSHA256, hpkeKDFHKDFSHA256, hpkeAEADChaCha20Poly)
+	kemSuiteID := buildHPKEKEMSuiteID(hpkeKEMX25519HKDFSHA256)
+
+	kemContext := make([]byte, 0, len(enc)+len(pkRBytes))
+	kemContext = append(kemContext, enc...)
+	kemContext = append(kemContext, pkRBytes...)
+	sharedSecret, err := dhkemExtractAndExpand(dh, kemContext, kemSuiteID, hpkeNh)
+	if err != nil {
+		return nil, err
+	}
+
+	// Key schedule (mode_base: empty psk / psk_id) — identical to Seal.
+	pskIDHash, err := labeledExtract(nil, []byte("psk_id_hash"), nil, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	infoHash, err := labeledExtract(nil, []byte("info_hash"), info, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	keyScheduleContext := make([]byte, 0, 1+len(pskIDHash)+len(infoHash))
+	keyScheduleContext = append(keyScheduleContext, hpkeModeBase)
+	keyScheduleContext = append(keyScheduleContext, pskIDHash...)
+	keyScheduleContext = append(keyScheduleContext, infoHash...)
+
+	secret, err := labeledExtract(sharedSecret, []byte("secret"), nil, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	key, err := labeledExpand(secret, []byte("key"), keyScheduleContext, hpkeNk, suiteID)
+	if err != nil {
+		return nil, err
+	}
+	baseNonce, err := labeledExpand(secret, []byte("base_nonce"), keyScheduleContext, hpkeNn, suiteID)
+	if err != nil {
+		return nil, err
+	}
+
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+	// Single-shot: sequence number 0, so the per-message nonce equals base_nonce.
+	pt, err := aead.Open(nil, baseNonce, ct, aad)
+	if err != nil {
+		return nil, fmt.Errorf("tmproto: hpke open (auth/decrypt failed): %w", err)
+	}
+	return pt, nil
+}
+
+// LoadX25519PrivateKey parses 32 raw bytes into an ecdh.PrivateKey — the
+// receiver-side mirror of LoadX25519PublicKey, used to load the recipient key a
+// kid maps to.
+func LoadX25519PrivateKey(b []byte) (*ecdh.PrivateKey, error) {
+	sk, err := ecdh.X25519().NewPrivateKey(b)
+	if err != nil {
+		return nil, fmt.Errorf("tmproto: parse X25519 private key: %w", err)
+	}
+	return sk, nil
+}

--- a/tmproto/tmpx_open.go
+++ b/tmproto/tmpx_open.go
@@ -37,7 +37,7 @@ func OpenTmpx(skR *ecdh.PrivateKey, info []byte, wire string) (plaintext []byte,
 		return nil, "", errors.New("tmproto: tmpx wire string missing valid kid prefix")
 	}
 	kid = wire[:dot]
-	payload, err := base64.RawURLEncoding.DecodeString(wire[dot+1:])
+	payload, err := base64.RawURLEncoding.Strict().DecodeString(wire[dot+1:])
 	if err != nil {
 		return nil, "", fmt.Errorf("tmproto: tmpx base64url decode: %w", err)
 	}

--- a/tmproto/tmpx_open_test.go
+++ b/tmproto/tmpx_open_test.go
@@ -1,0 +1,77 @@
+package tmproto
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+func newX25519(t *testing.T) *ecdh.PrivateKey {
+	t.Helper()
+	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate X25519 key: %v", err)
+	}
+	return sk
+}
+
+// TestSealOpenRoundTrip seals a token to a recipient public key and opens it
+// with the matching private key, asserting the plaintext and kid round-trip.
+func TestSealOpenRoundTrip(t *testing.T) {
+	skR := newX25519(t)
+	recipient := TmpxRecipient{Kid: "k1", PublicKey: skR.PublicKey()}
+	plaintext := []byte("resolved-identity-token-set")
+
+	wire, err := SealTmpx(recipient, nil, plaintext)
+	if err != nil {
+		t.Fatalf("SealTmpx: %v", err)
+	}
+	if !strings.HasPrefix(wire, "k1.") {
+		t.Fatalf("wire missing kid prefix: %q", wire)
+	}
+
+	got, kid, err := OpenTmpx(skR, nil, wire)
+	if err != nil {
+		t.Fatalf("OpenTmpx: %v", err)
+	}
+	if kid != "k1" {
+		t.Errorf("kid = %q, want k1", kid)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+// TestOpenTamperFails confirms a modified ciphertext fails authentication.
+func TestOpenTamperFails(t *testing.T) {
+	skR := newX25519(t)
+	wire, err := SealTmpx(TmpxRecipient{Kid: "k1", PublicKey: skR.PublicKey()}, nil, []byte("hello"))
+	if err != nil {
+		t.Fatalf("SealTmpx: %v", err)
+	}
+	b := []byte(wire)
+	last := len(b) - 1
+	if b[last] == 'A' {
+		b[last] = 'B'
+	} else {
+		b[last] = 'A'
+	}
+	if _, _, err := OpenTmpx(skR, nil, string(b)); err == nil {
+		t.Fatal("expected Open to fail on tampered ciphertext, got nil error")
+	}
+}
+
+// TestOpenWrongKeyFails confirms Open fails under a different recipient key.
+func TestOpenWrongKeyFails(t *testing.T) {
+	skR := newX25519(t)
+	other := newX25519(t)
+	wire, err := SealTmpx(TmpxRecipient{Kid: "k1", PublicKey: skR.PublicKey()}, nil, []byte("hello"))
+	if err != nil {
+		t.Fatalf("SealTmpx: %v", err)
+	}
+	if _, _, err := OpenTmpx(other, nil, wire); err == nil {
+		t.Fatal("expected Open to fail under a different recipient key, got nil error")
+	}
+}

--- a/tmproto/tmpx_open_test.go
+++ b/tmproto/tmpx_open_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/ecdh"
 	"crypto/rand"
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -51,16 +52,49 @@ func TestOpenTamperFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SealTmpx: %v", err)
 	}
-	b := []byte(wire)
-	last := len(b) - 1
-	if b[last] == 'A' {
-		b[last] = 'B'
-	} else {
-		b[last] = 'A'
+	dot := strings.IndexByte(wire, '.')
+	payload, err := base64.RawURLEncoding.DecodeString(wire[dot+1:])
+	if err != nil {
+		t.Fatalf("decode sealed payload: %v", err)
 	}
-	if _, _, err := OpenTmpx(skR, nil, string(b)); err == nil {
+	payload[len(payload)-1] ^= 0x01
+	tampered := wire[:dot+1] + base64.RawURLEncoding.EncodeToString(payload)
+	if _, _, err := OpenTmpx(skR, nil, tampered); err == nil {
 		t.Fatal("expected Open to fail on tampered ciphertext, got nil error")
 	}
+}
+
+// TestOpenRejectsNonCanonicalBase64 confirms Open rejects alternate raw
+// base64url spellings that decode to the same bytes under Go's non-strict
+// decoder. The final quantum can carry unused low bits; accepting those would
+// allow multiple wire strings for one TMPX token.
+func TestOpenRejectsNonCanonicalBase64(t *testing.T) {
+	skR := newX25519(t)
+	wire, err := SealTmpx(TmpxRecipient{Kid: "k1", PublicKey: skR.PublicKey()}, nil, []byte("hello"))
+	if err != nil {
+		t.Fatalf("SealTmpx: %v", err)
+	}
+	dot := strings.IndexByte(wire, '.')
+	wantPayload, err := base64.RawURLEncoding.DecodeString(wire[dot+1:])
+	if err != nil {
+		t.Fatalf("decode sealed payload: %v", err)
+	}
+	const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	for _, c := range alphabet {
+		alias := wire[:len(wire)-1] + string(c)
+		if alias == wire {
+			continue
+		}
+		gotPayload, err := base64.RawURLEncoding.DecodeString(alias[dot+1:])
+		if err != nil || !bytes.Equal(gotPayload, wantPayload) {
+			continue
+		}
+		if _, _, err := OpenTmpx(skR, nil, alias); err == nil {
+			t.Fatal("expected Open to reject non-canonical base64url payload, got nil error")
+		}
+		return
+	}
+	t.Fatal("test setup did not find a non-canonical base64url alias")
 }
 
 // TestOpenWrongKeyFails confirms Open fails under a different recipient key.

--- a/tmproto/tmpx_test.go
+++ b/tmproto/tmpx_test.go
@@ -12,64 +12,7 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/crypto/chacha20poly1305"
 )
-
-// hpkeOpenBase is a test-only HPKE Open in mode_base for the TMPX cipher
-// suite — used for roundtrip verification. Mirrors hpkeSealBase but recipient
-// uses skR with the encapsulated pkE.
-func hpkeOpenBase(skR *ecdh.PrivateKey, enc, info, aad, ct []byte) ([]byte, error) {
-	pkE, err := ecdh.X25519().NewPublicKey(enc)
-	if err != nil {
-		return nil, err
-	}
-	dh, err := skR.ECDH(pkE)
-	if err != nil {
-		return nil, err
-	}
-
-	pkRBytes := skR.PublicKey().Bytes()
-	suiteID := buildHPKESuiteID(hpkeKEMX25519HKDFSHA256, hpkeKDFHKDFSHA256, hpkeAEADChaCha20Poly)
-	kemSuiteID := buildHPKEKEMSuiteID(hpkeKEMX25519HKDFSHA256)
-
-	kemContext := append([]byte{}, enc...)
-	kemContext = append(kemContext, pkRBytes...)
-	sharedSecret, err := dhkemExtractAndExpand(dh, kemContext, kemSuiteID, hpkeNh)
-	if err != nil {
-		return nil, err
-	}
-
-	pskIDHash, err := labeledExtract(nil, []byte("psk_id_hash"), nil, suiteID)
-	if err != nil {
-		return nil, err
-	}
-	infoHash, err := labeledExtract(nil, []byte("info_hash"), info, suiteID)
-	if err != nil {
-		return nil, err
-	}
-	keyScheduleContext := append([]byte{hpkeModeBase}, pskIDHash...)
-	keyScheduleContext = append(keyScheduleContext, infoHash...)
-
-	secret, err := labeledExtract(sharedSecret, []byte("secret"), nil, suiteID)
-	if err != nil {
-		return nil, err
-	}
-	key, err := labeledExpand(secret, []byte("key"), keyScheduleContext, hpkeNk, suiteID)
-	if err != nil {
-		return nil, err
-	}
-	baseNonce, err := labeledExpand(secret, []byte("base_nonce"), keyScheduleContext, hpkeNn, suiteID)
-	if err != nil {
-		return nil, err
-	}
-
-	aead, err := chacha20poly1305.New(key)
-	if err != nil {
-		return nil, err
-	}
-	return aead.Open(nil, baseNonce, ct, aad)
-}
 
 // TestHPKERFC9180A3Vector validates the implementation against the test
 // vector in RFC 9180 Appendix A.3 (mode_base, KEM=DHKEM(X25519,HKDF-SHA256),


### PR DESCRIPTION
Adds an exported TMPX receiver API that opens SealTmpx wire tokens with the buyer X25519 private key and returns the plaintext plus kid. Moves the HPKE open path out of test-only code, adds a private-key loader, and keeps the implementation aligned with the existing fixed TMPX HPKE suite. Hardens payload parsing with strict raw base64url decoding so non-canonical encodings are rejected. Adds round-trip, tamper, wrong-key, and non-canonical encoding tests.