### PR TITLE
feat(targeting): verify-before-trust verified-identity engine seam (M1)

### DIFF
--- a/targeting/identity_config.go
+++ b/targeting/identity_config.go
@@ -114,5 +114,18 @@ func (r *SegmentRule) Matches(userSegments map[string]struct{}) bool {
 // service.
 type PackageIdentityConfig struct {
 	TargetSegments *SegmentRule
-}
 
+	// RequiresVerifiedIdentity, when true, makes the package ineligible
+	// unless a verified attestation is present for the request (fail-closed).
+	// This is a presence gate only; the required age threshold (if any) is
+	// resolved per (package, geo) through the Service's AgeResolver, not
+	// stored here, so age policy can change without re-publishing package
+	// config.
+	//
+	// The eligibility engine honors this field today. Populating it from the
+	// identityconfig snapshot (a new identityconfig.Entry field + carrying it
+	// through Lookup/GetBySeller, which currently index only *SegmentRule) is
+	// a follow-up; until then the age gate via AgeResolver is the live
+	// verified-identity gate.
+	RequiresVerifiedIdentity bool
+}

--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -22,11 +22,23 @@ import (
 // Stage labels for the request pipeline. Values are bounded for low
 // cardinality.
 const (
-	StageResolve  = "resolve"
-	StageFCap     = "fcap"
-	StageAudience = "audience"
-	StageRequest  = "request"
-	StageTMPX     = "tmpx"
+	StageResolve          = "resolve"
+	StageFCap             = "fcap"
+	StageAudience         = "audience"
+	StageRequest          = "request"
+	StageTMPX             = "tmpx"
+	StageVerifiedIdentity = "verified_identity"
+)
+
+// Verified-identity drop reasons. Each corresponds to one rejection branch in
+// the verified-identity stage; cardinality is bounded by this constant set
+// plus the targeting.PreCheck* reasons (malformed, no_binding, expired,
+// rp_mismatch) reused as labels. A non-zero verifier_error rate distinguishes
+// "verifier down/misconfigured" from organic absence (no metric ticks).
+const (
+	VIDropOpenFailed    = "open_failed"      // HPKE open / plaintext decode failed
+	VIDropVerifierError = "verifier_error"   // verifier returned an error (treat as absent)
+	VIDropMalformedSeal = "malformed_sealed" // sealed_credentials entry missing audience_kid/payload
 )
 
 // Outcome labels paired with stages. Bounded to a fixed set.
@@ -69,6 +81,12 @@ type Recorder interface {
 	// LiveRamp outage (TmpxDropDecoderError on rampid) or no RampIDs in
 	// inbound traffic (no metric ticks).
 	TmpxIdentityDrop(ctx context.Context, reason, uidType string)
+
+	// VerifiedIdentityDrop records one attestation/sealed-credential dropped
+	// from the verified-identity stage, by reason. A verifier_error rate
+	// makes a down/unwired verifier observable instead of indistinguishable
+	// from organic absence (the spike's silent-degradation blast radius).
+	VerifiedIdentityDrop(ctx context.Context, reason string)
 }
 
 // MetricsProvider wires together a Prometheus registry, an OTEL meter
@@ -207,16 +225,17 @@ func (m *MetricsProvider) RegisterConfigEntriesObserver(observerFn func() int64)
 // Prometheus exporter to surface metrics on the Prometheus registry the
 // /metrics handler reads from.
 type otelRecorder struct {
-	requestStarted    metric.Int64Counter
-	requestDuration   metric.Float64Histogram
-	stageOutcome      metric.Int64Counter
-	stageDuration     metric.Float64Histogram
-	storeError        metric.Int64Counter
-	configRefresh     metric.Int64Counter
-	shutdownPanic     metric.Int64Counter
-	handlerPanic      metric.Int64Counter
-	backgroundPanic   metric.Int64Counter
-	tmpxIdentityDrop  metric.Int64Counter
+	requestStarted       metric.Int64Counter
+	requestDuration      metric.Float64Histogram
+	stageOutcome         metric.Int64Counter
+	stageDuration        metric.Float64Histogram
+	storeError           metric.Int64Counter
+	configRefresh        metric.Int64Counter
+	shutdownPanic        metric.Int64Counter
+	handlerPanic         metric.Int64Counter
+	backgroundPanic      metric.Int64Counter
+	tmpxIdentityDrop     metric.Int64Counter
+	verifiedIdentityDrop metric.Int64Counter
 }
 
 var _ Recorder = (*otelRecorder)(nil)
@@ -272,17 +291,23 @@ func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error
 	if err != nil {
 		return nil, err
 	}
+	verifiedIdentityDrop, err := meter.Int64Counter(
+		fmt.Sprintf("%s_verified_identity_drops_total", namespace))
+	if err != nil {
+		return nil, err
+	}
 	return &otelRecorder{
-		requestStarted:   requestStarted,
-		requestDuration:  requestDuration,
-		stageOutcome:     stageOutcome,
-		stageDuration:    stageDuration,
-		storeError:       storeError,
-		configRefresh:    configRefresh,
-		shutdownPanic:    shutdownPanic,
-		handlerPanic:     handlerPanic,
-		backgroundPanic:  backgroundPanic,
-		tmpxIdentityDrop: tmpxIdentityDrop,
+		requestStarted:       requestStarted,
+		requestDuration:      requestDuration,
+		stageOutcome:         stageOutcome,
+		stageDuration:        stageDuration,
+		storeError:           storeError,
+		configRefresh:        configRefresh,
+		shutdownPanic:        shutdownPanic,
+		handlerPanic:         handlerPanic,
+		backgroundPanic:      backgroundPanic,
+		tmpxIdentityDrop:     tmpxIdentityDrop,
+		verifiedIdentityDrop: verifiedIdentityDrop,
 	}, nil
 }
 
@@ -332,6 +357,10 @@ func (r *otelRecorder) TmpxIdentityDrop(ctx context.Context, reason, uidType str
 	))
 }
 
+func (r *otelRecorder) VerifiedIdentityDrop(ctx context.Context, reason string) {
+	r.verifiedIdentityDrop.Add(ctx, 1, metric.WithAttributes(stringAttr("reason", reason)))
+}
+
 // noopRecorder is used when metrics are disabled or in tests. Every method
 // is a no-op.
 type noopRecorder struct{}
@@ -346,6 +375,7 @@ func (noopRecorder) ShutdownPanic(context.Context)                           {}
 func (noopRecorder) HandlerPanic(context.Context)                            {}
 func (noopRecorder) BackgroundPanic(context.Context, string)                 {}
 func (noopRecorder) TmpxIdentityDrop(context.Context, string, string)        {}
+func (noopRecorder) VerifiedIdentityDrop(context.Context, string)            {}
 
 // targetingMetricsAdapter projects the agent's Recorder onto the
 // targeting.Metrics interface the IdentityEngine wants. The engine emits

--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -30,6 +30,14 @@ type Service struct {
 	fcapTimeout     time.Duration
 	audienceTimeout time.Duration
 	recorder        Recorder
+
+	// Verified-identity dependencies are all optional. When verifier or
+	// recipientKeys is unset the verified-identity stage is a no-op and
+	// eligibility behaves exactly as before (fail-closed: no attestation is
+	// ever trusted without a wired verifier).
+	verifier      targeting.AttestationVerifier
+	recipientKeys map[string]RecipientKey
+	ageResolver   targeting.AgeResolver
 }
 
 // ServiceConfig packages the dependencies for NewService.
@@ -41,6 +49,17 @@ type ServiceConfig struct {
 	FCapTimeout     time.Duration
 	AudienceTimeout time.Duration
 	Recorder        Recorder
+
+	// Verifier validates attestations; nil disables the verified-identity
+	// stage (fail-closed — attestations are treated as absent).
+	Verifier targeting.AttestationVerifier
+	// RecipientKeys maps audience_kid → the HPKE recipient key + the relying
+	// party this deployment acts as for that audience. nil/empty disables the
+	// stage. The values contain secret key material — never log this map.
+	RecipientKeys map[string]RecipientKey
+	// AgeResolver resolves a package's required age threshold by geo; nil
+	// means no age gating.
+	AgeResolver targeting.AgeResolver
 }
 
 // NewService validates the supplied dependencies and returns a Service.
@@ -74,6 +93,9 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		fcapTimeout:     cfg.FCapTimeout,
 		audienceTimeout: cfg.AudienceTimeout,
 		recorder:        rec,
+		verifier:        cfg.Verifier,
+		recipientKeys:   cfg.RecipientKeys,
+		ageResolver:     cfg.AgeResolver,
 	}, nil
 }
 
@@ -95,6 +117,14 @@ func (s *Service) Evaluate(ctx context.Context, req *tmproto.IdentityMatchReques
 	s.recorder.StageOutcome(ctx, StageResolve, OutcomePass)
 	resolved := &targeting.ResolvedPackages{IdentityConfigs: idConfigs}
 
+	// Verified-identity stage runs synchronously before the parallel block:
+	// it may call a (possibly network) verifier, and its fail-closed verdict
+	// must be computed outside the cancelable goroutines so a short-circuit
+	// cancel cannot drop it. No-op (verified == nil, vidRejected empty) when
+	// no verifier is wired, leaving existing behavior unchanged.
+	verified := s.runVerifiedIdentityStage(ctx, req)
+	vidRejected := s.computeVerifiedIdentityGate(ctx, req, resolved, effectivePkgIDs, verified)
+
 	pkgsWithSegments := s.packagesWithSegmentRules(resolved, effectivePkgIDs)
 	audienceNeeded := s.audienceSvc != nil && len(pkgsWithSegments) > 0
 
@@ -108,7 +138,7 @@ func (s *Service) Evaluate(ctx context.Context, req *tmproto.IdentityMatchReques
 	)
 
 	wg.Go(func() {
-		fcapResult = s.runFcapStage(parCtx, req, effectivePkgIDs)
+		fcapResult = s.runFcapStage(parCtx, req, effectivePkgIDs, verified)
 		if fcapResult.allCapped(effectivePkgIDs) {
 			cancel()
 		}
@@ -137,7 +167,7 @@ func (s *Service) Evaluate(ctx context.Context, req *tmproto.IdentityMatchReques
 		}
 	}
 
-	eligibility := s.joinResults(effectivePkgIDs, pkgsWithSegments, fcapResult, audResult)
+	eligibility := s.joinResults(effectivePkgIDs, pkgsWithSegments, fcapResult, audResult, vidRejected)
 	return &targeting.IdentityResult{
 		RequestID:   req.RequestID,
 		Eligibility: eligibility,
@@ -188,7 +218,7 @@ func (r fcapResult) allCapped(pkgIDs []string) bool {
 // fcap.Service.IsCappedAny which pipelines the cross-product internally
 // using a pooled scratch buffer. The result is the per-package cap verdict
 // across all request identities.
-func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRequest, pkgIDs []string) fcapResult {
+func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRequest, pkgIDs []string, verified []targeting.VerifiedIdentity) fcapResult {
 	start := time.Now()
 	fcapCtx, cancelFcap := context.WithTimeout(ctx, s.fcapTimeout)
 	defer cancelFcap()
@@ -217,9 +247,31 @@ func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRe
 	for i, pkgID := range pkgIDs {
 		fields[i] = fcap.Field{SellerAgentURL: sellerDomain, PackageID: pkgID}
 	}
-	identities := make([]string, len(req.Identities))
-	for i, id := range req.Identities {
-		identities[i] = id.UserToken
+	// Frequency-cap key selection. When verified identities are present, cap
+	// on their relying-party-scoped, namespaced nullifier keys — a true
+	// per-human cap a rotating UserToken can't give. CapKey's "vid:<rp>:"
+	// namespace prevents cross-RP cap collisions and keeps verified-identity
+	// keys disjoint from raw UserToken keys, so a guessed nullifier sent as an
+	// ordinary token cannot poison a human's cap. With no verified identities,
+	// fall back to the request's user tokens (unchanged behavior).
+	//
+	// Read/write symmetry (deploy invariant): this reads caps under the
+	// nullifier key, so the frequency-writer MUST record verified-identity
+	// caps under the same "vid:<rp>:<nullifier>" key. Enabling a verifier
+	// before the writer emits nullifier-keyed caps would let a human already
+	// capped under their UserToken appear uncapped on any attested request
+	// (cap fail-open / over-delivery). Gate verifier-enable on writer parity.
+	var identities []string
+	if len(verified) > 0 {
+		identities = make([]string, len(verified))
+		for i, vi := range verified {
+			identities[i] = vi.CapKey()
+		}
+	} else {
+		identities = make([]string, len(req.Identities))
+		for i, id := range req.Identities {
+			identities[i] = id.UserToken
+		}
 	}
 
 	cappedByField, err := s.fcap.IsCappedAny(fcapCtx, identities, fields)
@@ -344,13 +396,20 @@ func (s *Service) runAudienceStage(ctx context.Context, req *tmproto.IdentityMat
 	return audienceResult{rejected: rejected, outcome: outcome, duration: dur}
 }
 
-// joinResults computes the final per-package eligibility from the parallel
-// stage outputs. A package is eligible only when:
+// joinResults computes the final per-package eligibility from the stage
+// outputs. A package is eligible only when ALL of:
 //
 //   - fcap did not flag it as capped for any identity, AND
 //   - audience did not reject it (or the package has no segment rule, in
-//     which case audience is a no-op for it).
-func (s *Service) joinResults(pkgIDs []string, pkgsWithSegments map[string]struct{}, fc fcapResult, aud audienceResult) []tmproto.PackageEligibility {
+//     which case audience is a no-op for it), AND
+//   - the verified-identity gate did not reject it (a package requiring a
+//     verified human, or a resolved age threshold, with none satisfied).
+//
+// The verdict starts eligible and each gate can only remove eligibility, so
+// the verified-identity gate (vidRejected) is fail-closed: a package that
+// demands verification is ineligible by default unless a verified identity
+// cleared it.
+func (s *Service) joinResults(pkgIDs []string, pkgsWithSegments map[string]struct{}, fc fcapResult, aud audienceResult, vidRejected map[string]struct{}) []tmproto.PackageEligibility {
 	out := make([]tmproto.PackageEligibility, 0, len(pkgIDs))
 	for _, id := range pkgIDs {
 		eligible := true
@@ -362,6 +421,11 @@ func (s *Service) joinResults(pkgIDs []string, pkgsWithSegments map[string]struc
 				if _, rejected := aud.rejected[id]; rejected {
 					eligible = false
 				}
+			}
+		}
+		if eligible {
+			if _, rejected := vidRejected[id]; rejected {
+				eligible = false
 			}
 		}
 		out = append(out, tmproto.PackageEligibility{PackageID: id, Eligible: eligible})

--- a/targeting/identityagent/service_test.go
+++ b/targeting/identityagent/service_test.go
@@ -90,6 +90,9 @@ func newTestService(t *testing.T, opts testServiceOptions) *Service {
 		ConfigService:   configSvc,
 		FCapTimeout:     50 * time.Millisecond,
 		AudienceTimeout: 50 * time.Millisecond,
+		Verifier:        opts.verifier,
+		RecipientKeys:   opts.recipientKeys,
+		AgeResolver:     opts.ageResolver,
 	})
 	require.NoError(t, err)
 	return svc
@@ -100,6 +103,11 @@ type testServiceOptions struct {
 	cappedTuples     []capTuple
 	memberships      []membershipFixture
 	audienceDisabled bool
+
+	// verified-identity deps (all optional; zero value disables the stage).
+	verifier      targeting.AttestationVerifier
+	recipientKeys map[string]RecipientKey
+	ageResolver   targeting.AgeResolver
 }
 
 type capTuple struct {

--- a/targeting/identityagent/verified_identity_stage.go
+++ b/targeting/identityagent/verified_identity_stage.go
@@ -1,0 +1,186 @@
+package identityagent
+
+import (
+	"context"
+	"crypto/ecdh"
+	"encoding/json"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// RecipientKey is the HPKE recipient identity for one audience_kid: the X25519
+// private key that opens sealed_credentials addressed to that kid, plus the
+// relying party THIS deployment acts as for that audience. RelyingPartyID is
+// the receiver-binding anchor — a sealed attestation whose relying_party_id
+// does not equal it is a forwarded/replayed proof and is rejected
+// (targeting.LocalPreCheck). The audience_kid that selected this key is how the
+// deployment knows which RP it is, so the binding is enforced locally and
+// fail-closed rather than deferred to the verifier.
+type RecipientKey struct {
+	PrivateKey     *ecdh.PrivateKey
+	RelyingPartyID string
+}
+
+const (
+	// maxSealedCredentials caps sealed_credentials entries processed per
+	// request (schema maxItems). Enforced before any crypto so a flood of
+	// garbage entries cannot force N HPKE opens + verifier round-trips.
+	maxSealedCredentials = 8
+	// maxSealedPayloadBytes caps one sealed payload's wire length (schema
+	// maxLength 8192) before opening.
+	maxSealedPayloadBytes = 8192
+)
+
+// runVerifiedIdentityStage opens and verifies the request's sealed_credentials
+// (the network-as-RP / Mechanism B carrier) and returns the verified
+// identities.
+//
+// Fail-closed: with no verifier or no recipient keys configured it returns nil
+// immediately (no opening, no allocation), so existing eligibility behavior is
+// byte-for-byte unchanged. Opening a credential proves only that it was sealed
+// to our key — never that the claims are true. Claims are trusted only after
+// the pluggable verifier validates the proof AND the local pre-checks pass
+// (signal_binding present, not expired, relying_party_id == the RP we act as).
+func (s *Service) runVerifiedIdentityStage(ctx context.Context, req *tmproto.IdentityMatchRequest) []targeting.VerifiedIdentity {
+	if s.verifier == nil || len(s.recipientKeys) == 0 || len(req.SealedCredentials) == 0 {
+		return nil
+	}
+	start := time.Now()
+	now := start
+	// The verifier is called on the parent ctx (the handler's request budget
+	// bounds a well-behaved, ctx-respecting verifier). A dedicated per-stage
+	// sub-timeout + OutcomeTimeout — mirroring runFcapStage/runAudienceStage —
+	// lands with the concrete network verifier, which is when a stalled
+	// verifier becomes a real risk; the nil/mock verifiers here are instant.
+
+	// Bound the count before any crypto (DoS): never open more than the
+	// schema maximum, regardless of how many entries arrived.
+	creds := req.SealedCredentials
+	if len(creds) > maxSealedCredentials {
+		creds = creds[:maxSealedCredentials]
+	}
+
+	var verified []targeting.VerifiedIdentity
+	verifierErrored := false
+	for _, c := range creds {
+		if c.AudienceKID == "" || c.Payload == "" {
+			s.recorder.VerifiedIdentityDrop(ctx, VIDropMalformedSeal)
+			continue
+		}
+		rk, ok := s.recipientKeys[c.AudienceKID]
+		if !ok {
+			// Not addressed to an audience we hold a key for. Correct
+			// multi-audience behavior — silently ignore, no drop metric.
+			continue
+		}
+		if len(c.Payload) > maxSealedPayloadBytes {
+			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
+			continue
+		}
+		// HPKE-open (cheap, local) with the sealed-credential size budget.
+		// Only AFTER it succeeds do we consider the network verifier, so
+		// undecryptable blobs cost at most local work.
+		pt, _, err := tmproto.OpenSealedCredential(rk.PrivateKey, nil, c.Payload)
+		if err != nil {
+			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
+			continue
+		}
+		var att tmproto.Attestation
+		if err := json.Unmarshal(pt, &att); err != nil {
+			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
+			continue
+		}
+		vctx := targeting.VerifyContext{
+			RequestID:              req.RequestID,
+			Country:                req.Country,
+			ExpectedRelyingPartyID: rk.RelyingPartyID,
+			Now:                    now,
+		}
+		// Local, fail-closed invariants BEFORE the (possibly network)
+		// verifier: empty signal_binding, expired, or RP mismatch ⇒ absent.
+		if reason := targeting.LocalPreCheck(&att, vctx); reason != targeting.PreCheckOK {
+			s.recorder.VerifiedIdentityDrop(ctx, reason)
+			continue
+		}
+		vi, err := s.verifier.Verify(ctx, &att, vctx)
+		if err != nil {
+			verifierErrored = true
+			s.recorder.VerifiedIdentityDrop(ctx, VIDropVerifierError)
+			continue
+		}
+		// Defense-in-depth: the verifier must return the RP we bound to.
+		if vi.RelyingPartyID != rk.RelyingPartyID {
+			s.recorder.VerifiedIdentityDrop(ctx, targeting.PreCheckRPMismatch)
+			continue
+		}
+		// Normalize to the closed claim set so the age gate only ever sees
+		// canonical values, regardless of verifier behavior.
+		vi.Claims = normalizeClaimSet(vi.Claims)
+		verified = append(verified, vi)
+	}
+
+	s.recorder.StageDuration(ctx, StageVerifiedIdentity, time.Since(start))
+	// A verifier error is recorded as an error outcome (not pass) so a
+	// down/misconfigured verifier is observable instead of indistinguishable
+	// from organic "no humans verified".
+	outcome := OutcomePass
+	if verifierErrored {
+		outcome = OutcomeError
+	}
+	s.recorder.StageOutcome(ctx, StageVerifiedIdentity, outcome)
+	return verified
+}
+
+// normalizeClaimSet drops any claim not in the closed attestation-claim set.
+func normalizeClaimSet(in map[tmproto.AttestationClaim]struct{}) map[tmproto.AttestationClaim]struct{} {
+	out := make(map[tmproto.AttestationClaim]struct{}, len(in))
+	for c := range in {
+		if targeting.IsClosedClaim(c) {
+			out[c] = struct{}{}
+		}
+	}
+	return out
+}
+
+// computeVerifiedIdentityGate returns the packages ineligible because of the
+// verified-identity gate: a package that requires verified identity when none
+// is present, or a package whose resolved age threshold no verified identity
+// satisfies. Computed synchronously (outside the parallel stages) so a cancel
+// race cannot drop the verdict — this is the fail-closed third gate, and
+// joinResults defaults packages to eligible.
+func (s *Service) computeVerifiedIdentityGate(ctx context.Context, req *tmproto.IdentityMatchRequest, resolved *targeting.ResolvedPackages, pkgIDs []string, verified []targeting.VerifiedIdentity) map[string]struct{} {
+	rejected := make(map[string]struct{})
+	for _, id := range pkgIDs {
+		cfg := resolved.IdentityConfigs[id]
+		requiresVID := cfg != nil && cfg.RequiresVerifiedIdentity
+
+		var ageClaim tmproto.AttestationClaim
+		ageRequired := false
+		if s.ageResolver != nil {
+			ageClaim, ageRequired = s.ageResolver.ResolveRequiredAge(ctx, id, req.Country)
+		}
+
+		if !requiresVID && !ageRequired {
+			continue // package has no verified-identity requirement
+		}
+		if len(verified) == 0 {
+			rejected[id] = struct{}{} // required but absent — fail closed
+			continue
+		}
+		if ageRequired && !anyVerifiedSatisfies(verified, ageClaim) {
+			rejected[id] = struct{}{}
+		}
+	}
+	return rejected
+}
+
+func anyVerifiedSatisfies(verified []targeting.VerifiedIdentity, required tmproto.AttestationClaim) bool {
+	for _, vi := range verified {
+		if vi.ClaimsSatisfy(required) {
+			return true
+		}
+	}
+	return false
+}

--- a/targeting/identityagent/verified_identity_stage_test.go
+++ b/targeting/identityagent/verified_identity_stage_test.go
@@ -1,0 +1,313 @@
+package identityagent
+
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/targeting/identityconfig"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// mockVerifier records call count and returns a fixed result (scoped to the
+// receiver's expected RP so the stage's defense-in-depth RP check passes) or
+// a fixed error.
+type mockVerifier struct {
+	nullifier string
+	claims    []tmproto.AttestationClaim
+	err       error
+	calls     int
+}
+
+func (m *mockVerifier) Verify(_ context.Context, _ *tmproto.Attestation, vctx targeting.VerifyContext) (targeting.VerifiedIdentity, error) {
+	m.calls++
+	if m.err != nil {
+		return targeting.VerifiedIdentity{}, m.err
+	}
+	return targeting.VerifiedIdentity{
+		Nullifier:      m.nullifier,
+		RelyingPartyID: vctx.ExpectedRelyingPartyID,
+		Claims:         targeting.NormalizeClaims(m.claims),
+	}, nil
+}
+
+// staticAgeResolver maps pkgID → required age claim. Geo-independent.
+type staticAgeResolver map[string]tmproto.AttestationClaim
+
+func (r staticAgeResolver) ResolveRequiredAge(_ context.Context, pkgID, _ string) (tmproto.AttestationClaim, bool) {
+	c, ok := r[pkgID]
+	return c, ok
+}
+
+func newRecipient(t *testing.T) (*ecdh.PrivateKey, map[string]RecipientKey) {
+	t.Helper()
+	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return sk, map[string]RecipientKey{"kid-1": {PrivateKey: sk, RelyingPartyID: "rp-1"}}
+}
+
+func validAtt(claims ...tmproto.AttestationClaim) tmproto.Attestation {
+	return tmproto.Attestation{
+		Issuer:         map[string]any{"domain": "world.org"},
+		Scheme:         "world_id_v4",
+		RelyingPartyID: "rp-1",
+		SignalBinding:  "binding-committing-to-r1",
+		Claims:         claims,
+		Proof:          map[string]any{"merkle_root": "0x1"},
+	}
+}
+
+func sealedCred(t *testing.T, kid string, pub *ecdh.PublicKey, att tmproto.Attestation) tmproto.SealedCredential {
+	t.Helper()
+	pt, err := json.Marshal(att)
+	require.NoError(t, err)
+	wire, err := tmproto.SealTmpx(tmproto.TmpxRecipient{Kid: kid, PublicKey: pub}, nil, pt)
+	require.NoError(t, err)
+	return tmproto.SealedCredential{AudienceKID: kid, Payload: wire}
+}
+
+func vidEntries() []identityconfig.Entry {
+	return []identityconfig.Entry{
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-alcohol"}},
+		{Key: identityconfig.Key{SellerAgentURL: "seller.com", PackageID: "pkg-general"}},
+	}
+}
+
+func vidReq(sealed ...tmproto.SealedCredential) *tmproto.IdentityMatchRequest {
+	return &tmproto.IdentityMatchRequest{
+		RequestID:         "r1",
+		SellerAgentURL:    "seller.com",
+		PackageIDs:        []string{"pkg-alcohol", "pkg-general"},
+		Identities:        []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
+		Country:           "US",
+		SealedCredentials: sealed,
+	}
+}
+
+// FAIL-CLOSED DEFAULT: with NO verifier wired, a correctly-sealed attestation
+// asserting age_over_21 is treated as absent — the age-gated package is
+// ineligible. Proves trust-without-verify is unreachable by configuration
+// omission.
+func TestService_VerifiedIdentity_FailClosedDefault(t *testing.T) {
+	sk, _ := newRecipient(t)
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+		// verifier and recipientKeys deliberately unset.
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "no verifier ⇒ attestation absent ⇒ age-gated package ineligible")
+	assert.True(t, got["pkg-general"], "ungated package stays eligible")
+}
+
+// HAPPY PATH: a wired verifier returns age_over_21; the age-gated package is
+// eligible.
+func TestService_VerifiedIdentity_HappyPath(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman, tmproto.AttestationClaimAgeOver21}}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.True(t, got["pkg-alcohol"], "verified age_over_21 satisfies the 21 gate")
+	assert.True(t, got["pkg-general"], "ungated package eligible")
+	assert.Equal(t, 1, mv.calls)
+}
+
+// AGE GATE: verified claim is only age_over_18; the age_over_21 package is
+// ineligible while the ungated package stays eligible.
+func TestService_VerifiedIdentity_AgeGateBelowThreshold(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver18}}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver18)))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "age_over_18 does not satisfy the 21 gate")
+	assert.True(t, got["pkg-general"], "ungated package eligible")
+}
+
+// FCAP ON NULLIFIER: a cap recorded on the relying-party-namespaced nullifier
+// key caps the package; a cap on the raw user token would NOT (proves fcap
+// keys on the verified nullifier, namespaced, not the UserToken).
+func TestService_VerifiedIdentity_FcapOnNullifier(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	capKey := targeting.VerifiedIdentity{Nullifier: "N", RelyingPartyID: "rp-1"}.CapKey()
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		// No age gate — isolate fcap behavior. Cap the namespaced nullifier
+		// key for pkg-alcohol, and (decoy) cap the raw user token too.
+		cappedTuples: []capTuple{
+			{identity: capKey, seller: "seller.com", pkg: "pkg-alcohol"},
+			{identity: "u1", seller: "seller.com", pkg: "pkg-general"},
+		},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimUniqueHuman)))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "capped on the namespaced nullifier key ⇒ ineligible")
+	assert.True(t, got["pkg-general"], "cap on the raw UserToken does not apply — fcap keys on the verified nullifier")
+}
+
+// RP BINDING (blocker): a sealed attestation minted for a different relying
+// party than this receiver acts as is dropped SDK-side BEFORE the verifier is
+// called — a forwarded/replayed proof cannot be trusted.
+func TestService_VerifiedIdentity_RPBindingMismatch(t *testing.T) {
+	sk, keys := newRecipient(t) // recipient acts as rp-1
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver21}}
+	att := validAtt(tmproto.AttestationClaimAgeOver21)
+	att.RelyingPartyID = "rp-EVIL" // minted for another RP
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), att))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "RP mismatch ⇒ attestation absent ⇒ age-gated package ineligible")
+	assert.Equal(t, 0, mv.calls, "verifier MUST NOT be called when relying_party_id != the RP we act as")
+}
+
+// MANDATORY SIGNAL_BINDING (blocker): an attestation with no signal_binding is
+// dropped pre-verify (fail-closed replay defense), verifier never called.
+func TestService_VerifiedIdentity_MissingSignalBinding(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver21}}
+	att := validAtt(tmproto.AttestationClaimAgeOver21)
+	att.SignalBinding = "" // omitted
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), att))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "empty signal_binding ⇒ absent ⇒ ineligible")
+	assert.Equal(t, 0, mv.calls, "verifier MUST NOT be called for an attestation with no signal_binding")
+}
+
+// VERIFIER ERROR: a verifier that errors yields no verified identity — the
+// age-gated package is ineligible (treated as absent, not asserted-true).
+func TestService_VerifiedIdentity_VerifierError(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{err: assertErr("verifier down")}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "verifier error ⇒ absent ⇒ ineligible")
+}
+
+// MULTI-AUDIENCE: two sealed credentials, one addressed to an audience_kid we
+// hold a key for and one we do not. Only the held entry is opened+verified;
+// the other is silently ignored (no error, no eligibility effect).
+func TestService_VerifiedIdentity_MultiAudienceOnlyHeldKey(t *testing.T) {
+	sk, keys := newRecipient(t) // we hold "kid-1"
+	other, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver21}}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	req := vidReq(
+		sealedCred(t, "kid-2", other.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)),
+		sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)),
+	)
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.True(t, got["pkg-alcohol"], "the held-key credential verifies; the other audience's entry is ignored")
+	assert.Equal(t, 1, mv.calls, "only the credential for an audience we hold a key for reaches the verifier")
+}
+
+// RequiresVerifiedIdentity fail-closed gate logic (unit-level, since the
+// config snapshot does not yet populate the field — see PackageIdentityConfig).
+func TestService_computeVerifiedIdentityGate_RequiresVerifiedIdentity(t *testing.T) {
+	svc := &Service{} // gate uses only resolved config + the verified slice
+	resolved := &targeting.ResolvedPackages{IdentityConfigs: map[string]*targeting.PackageIdentityConfig{
+		"pkg-strict": {RequiresVerifiedIdentity: true},
+		"pkg-open":   {},
+	}}
+	req := &tmproto.IdentityMatchRequest{RequestID: "r1"}
+
+	// No verified identity present ⇒ the strict package is rejected, the open
+	// one is not.
+	rejected := svc.computeVerifiedIdentityGate(t.Context(), req, resolved, []string{"pkg-strict", "pkg-open"}, nil)
+	_, strictRejected := rejected["pkg-strict"]
+	_, openRejected := rejected["pkg-open"]
+	assert.True(t, strictRejected, "RequiresVerifiedIdentity + no verified identity ⇒ rejected (fail-closed)")
+	assert.False(t, openRejected, "package without the requirement is unaffected")
+
+	// A verified identity present ⇒ the strict package clears.
+	withVID := []targeting.VerifiedIdentity{{Nullifier: "N", RelyingPartyID: "rp-1"}}
+	rejected = svc.computeVerifiedIdentityGate(t.Context(), req, resolved, []string{"pkg-strict"}, withVID)
+	_, strictRejected = rejected["pkg-strict"]
+	assert.False(t, strictRejected, "RequiresVerifiedIdentity satisfied by a present verified identity")
+}
+
+// DoS: more than maxSealedCredentials sealed entries are truncated BEFORE any
+// crypto — the verifier is called at most maxSealedCredentials times, so a
+// flood cannot force unbounded HPKE opens + verifier round-trips.
+func TestService_VerifiedIdentity_BoundsSealedCount(t *testing.T) {
+	sk, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver21}}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	creds := make([]tmproto.SealedCredential, 0, maxSealedCredentials+5)
+	for i := 0; i < maxSealedCredentials+5; i++ {
+		creds = append(creds, sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
+	}
+	svc.Evaluate(t.Context(), vidReq(creds...))
+	assert.LessOrEqual(t, mv.calls, maxSealedCredentials,
+		"sealed_credentials count must be bounded before any crypto/verifier call")
+}
+
+// DoS: a sealed entry whose payload exceeds maxSealedPayloadBytes is dropped at
+// the size check, before any HPKE open or verifier call.
+func TestService_VerifiedIdentity_DropsOversizedPayload(t *testing.T) {
+	_, keys := newRecipient(t)
+	mv := &mockVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimAgeOver21}}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: vidEntries(),
+		verifier:      mv,
+		recipientKeys: keys,
+		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
+	})
+	oversized := tmproto.SealedCredential{AudienceKID: "kid-1", Payload: strings.Repeat("A", maxSealedPayloadBytes+1)}
+	got := eligibilityMap(svc.Evaluate(t.Context(), vidReq(oversized)).Eligibility)
+	assert.False(t, got["pkg-alcohol"], "oversized payload ⇒ dropped ⇒ attestation absent ⇒ ineligible")
+	assert.Equal(t, 0, mv.calls, "an oversized payload must be dropped before any HPKE open or verifier call")
+}
+
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }

--- a/targeting/verified_identity.go
+++ b/targeting/verified_identity.go
@@ -1,0 +1,211 @@
+package targeting
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// verified_identity.go is the verify-before-trust seam for TMP verified
+// identity. The headline rule: opening or parsing an attestation proves
+// NOTHING about its truth. Claims become eligible inputs only after an
+// AttestationVerifier validates the proof AND the local, fail-closed
+// pre-checks pass. An attestation that fails any check is treated as ABSENT
+// (no attestation) — never as an asserted-true claim.
+
+// VerifiedIdentity is the post-verification result for one attestation that
+// passed every check: a relying-party-scoped pseudonym plus the claims the
+// receiver is allowed to trust. It is the ONLY way claims enter eligibility;
+// an unverified or absent attestation never produces one.
+type VerifiedIdentity struct {
+	// Nullifier is the relying-party-scoped, Sybil-resistant pseudonym. It is
+	// the frequency-cap key (namespaced by RelyingPartyID, see CapKey) — never
+	// used raw, so it cannot collide across relying parties.
+	Nullifier string
+	// RelyingPartyID is the RP scope this nullifier and these claims belong
+	// to. The receiver confirmed it matches the RP this receiver acts as.
+	RelyingPartyID string
+	// Claims is the verified claim set, normalised to the closed
+	// attestation-claim vocabulary.
+	Claims map[tmproto.AttestationClaim]struct{}
+}
+
+// CapKey returns the frequency-cap key for this verified identity. The key is
+// namespaced by relying party so the same nullifier byte-string under two
+// different relying parties yields two distinct keys (no cross-RP cap
+// contamination), and the "vid:" prefix segregates verified-identity keys
+// from raw UserToken cap keys (no cap-poisoning by sending a guessed nullifier
+// as an ordinary unverified token).
+func (vi VerifiedIdentity) CapKey() string {
+	return "vid:" + vi.RelyingPartyID + ":" + vi.Nullifier
+}
+
+// VerifyContext carries the request-scoped values a verifier needs to bind a
+// proof to THIS request and THIS receiver (replay + provenance defense)
+// without handing it the whole IdentityMatchRequest.
+type VerifyContext struct {
+	// RequestID is the anchor the attestation's signal_binding must commit to.
+	RequestID string
+	// Country is ISO-3166-1 alpha-2, for geo-scoped verifier/age logic.
+	Country string
+	// ExpectedRelyingPartyID is the relying party THIS receiver acts as for
+	// the audience that selected the recipient key. The attestation's
+	// relying_party_id must equal it (enforced SDK-side before Verify) so a
+	// proof minted for another RP cannot be replayed here.
+	ExpectedRelyingPartyID string
+	// Now is the reference time for expiry checks.
+	Now time.Time
+}
+
+// AttestationVerifier validates a wire Attestation against the AdCP
+// conformance invariants for its scheme. adcp-go cannot itself verify a World
+// ID zk proof, so verification is pluggable: a deployment wires a concrete
+// verifier (e.g. an HTTP call to a World ID verifier service, an mDL
+// validator). Verify returns the relying-party-scoped nullifier and the
+// verified claim set ONLY when every scheme invariant holds.
+//
+//   - Verify MUST validate scheme + issuer + proof per the scheme rules and
+//     confirm the proof was minted for vctx.ExpectedRelyingPartyID (the SDK
+//     also enforces relying_party_id == ExpectedRelyingPartyID before calling
+//     Verify, but the verifier owns the cryptographic binding + brand.json
+//     ownership lookup).
+//   - Verify MUST confirm the attestation's signal_binding commits to
+//     vctx.RequestID (the SDK guarantees signal_binding is non-empty but
+//     cannot check the scheme-specific hash).
+//   - It SHOULD dedupe nullifiers within the freshness window
+//     (nullifier-reuse tracking; not yet enforced SDK-side).
+//   - Any failure returns a non-nil error; callers treat that as "no
+//     attestation".
+//
+// There is intentionally no default verifier: a Service with a nil verifier
+// treats every attestation as absent (fail-closed), so trust-without-verify is
+// unreachable by configuration omission.
+type AttestationVerifier interface {
+	Verify(ctx context.Context, att *tmproto.Attestation, vctx VerifyContext) (VerifiedIdentity, error)
+}
+
+// AgeResolver resolves whether a package requires an age threshold for a given
+// geo, and which closed-set claim satisfies it. ok=false means no age
+// requirement applies. The production implementation resolves
+// (age policy, geo) → threshold via the AdCP Policy Registry; it is pluggable
+// so the registry integration lands behind this interface without changing
+// the pipeline.
+type AgeResolver interface {
+	ResolveRequiredAge(ctx context.Context, pkgID, country string) (claim tmproto.AttestationClaim, ok bool)
+}
+
+// Pre-check drop reasons. The local pre-check runs BEFORE the (possibly
+// network) verifier and before any expensive crypto on the verifier's side;
+// each reason is a bounded metric label.
+const (
+	PreCheckOK         = ""            // passed local checks; safe to call the verifier
+	PreCheckMalformed  = "malformed"   // nil attestation / unparseable
+	PreCheckNoBinding  = "no_binding"  // signal_binding empty — fail closed (replay defense)
+	PreCheckExpired    = "expired"     // expires_at present and in the past
+	PreCheckRPMismatch = "rp_mismatch" // relying_party_id != the RP this receiver acts as
+)
+
+// LocalPreCheck enforces the invariants the SDK can check locally and
+// fail-closed, before handing the attestation to the pluggable verifier.
+// Returns PreCheckOK ("") when the attestation may proceed to Verify, or a
+// drop reason otherwise. A dropped attestation MUST be treated as absent.
+//
+// These checks are deliberately NOT delegated to the verifier:
+//   - signal_binding non-empty: the field is optional on the wire, so an
+//     attacker could omit it; requiring it here closes the omit-and-replay
+//     path regardless of verifier quality.
+//   - expires_at: a present horizon must be in the future.
+//   - relying_party_id receiver-binding: the audience_kid that selected our
+//     recipient key tells us which RP we are; a proof for another RP is a
+//     forwarded/replayed proof and is rejected here, cheaply and locally.
+func LocalPreCheck(att *tmproto.Attestation, vctx VerifyContext) string {
+	if att == nil {
+		return PreCheckMalformed
+	}
+	if att.SignalBinding == "" {
+		return PreCheckNoBinding
+	}
+	// ExpiresAt is the wire string (RFC 3339) so it round-trips byte-for-byte
+	// through the request signature. A present horizon must parse and be in
+	// the future; an unparseable value fails closed (treated as expired).
+	if att.ExpiresAt != "" {
+		exp, err := time.Parse(time.RFC3339, att.ExpiresAt)
+		if err != nil || !exp.After(vctx.Now) {
+			return PreCheckExpired
+		}
+	}
+	if vctx.ExpectedRelyingPartyID == "" || att.RelyingPartyID != vctx.ExpectedRelyingPartyID {
+		return PreCheckRPMismatch
+	}
+	return PreCheckOK
+}
+
+// NormalizeClaims projects a claim slice onto the closed attestation-claim
+// set, dropping any value not in the vocabulary. The verified-identity
+// pipeline only ever stores normalised claims, so downstream age logic
+// (parseAgeOver) only ever sees canonical values.
+func NormalizeClaims(claims []tmproto.AttestationClaim) map[tmproto.AttestationClaim]struct{} {
+	out := make(map[tmproto.AttestationClaim]struct{}, len(claims))
+	for _, c := range claims {
+		if IsClosedClaim(c) {
+			out[c] = struct{}{}
+		}
+	}
+	return out
+}
+
+// IsClosedClaim reports whether c is one of the closed attestation-claim
+// values. The wire format tolerates unrecognized (additive) claim values; the
+// buyer-side age gate only acts on the closed set, so non-canonical values are
+// dropped here before they can reach eligibility logic.
+func IsClosedClaim(c tmproto.AttestationClaim) bool {
+	switch c {
+	case tmproto.AttestationClaimUniqueHuman,
+		tmproto.AttestationClaimAgeOver13,
+		tmproto.AttestationClaimAgeOver16,
+		tmproto.AttestationClaimAgeOver18,
+		tmproto.AttestationClaimAgeOver21:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClaimsSatisfy reports whether the verified claim set satisfies a required
+// claim. For an age threshold, a higher age claim satisfies a lower one
+// (age_over_21 satisfies a required age_over_18). For unique_human, the set
+// must contain unique_human.
+func (vi VerifiedIdentity) ClaimsSatisfy(required tmproto.AttestationClaim) bool {
+	if _, ok := vi.Claims[required]; ok {
+		return true
+	}
+	want, isAge := parseAgeOver(required)
+	if !isAge {
+		return false
+	}
+	for c := range vi.Claims {
+		if got, ok := parseAgeOver(c); ok && got >= want {
+			return true
+		}
+	}
+	return false
+}
+
+// parseAgeOver extracts N from an "age_over_<N>" claim. Returns ok=false for
+// non-age claims (e.g. unique_human). Operates on the closed set, so the input
+// is always canonical.
+func parseAgeOver(c tmproto.AttestationClaim) (int, bool) {
+	const prefix = "age_over_"
+	s := string(c)
+	if !strings.HasPrefix(s, prefix) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[len(prefix):])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/targeting/verified_identity_test.go
+++ b/targeting/verified_identity_test.go
@@ -1,0 +1,122 @@
+package targeting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// TestVerifiedIdentityCapKeyNamespaced proves the fcap key carries the relying
+// party scope: the SAME nullifier under two different relying parties yields
+// distinct cap keys (no cross-RP cap contamination), and every key is prefixed
+// so it cannot collide with a raw UserToken cap key (no cap-poisoning by
+// sending a guessed nullifier as an ordinary token).
+func TestVerifiedIdentityCapKeyNamespaced(t *testing.T) {
+	const nullifier = "0xNULLIFIER"
+	a := VerifiedIdentity{Nullifier: nullifier, RelyingPartyID: "rp-a"}
+	b := VerifiedIdentity{Nullifier: nullifier, RelyingPartyID: "rp-b"}
+
+	if a.CapKey() == b.CapKey() {
+		t.Fatalf("same nullifier under different RPs must produce distinct cap keys; both = %q", a.CapKey())
+	}
+	if a.CapKey() == nullifier {
+		t.Fatalf("cap key must be namespaced, not the raw nullifier (got %q)", a.CapKey())
+	}
+	for _, vi := range []VerifiedIdentity{a, b} {
+		if got := vi.CapKey(); got[:4] != "vid:" {
+			t.Errorf("cap key %q must carry the vid: namespace prefix", got)
+		}
+	}
+}
+
+func TestLocalPreCheck(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+
+	base := func() *tmproto.Attestation {
+		return &tmproto.Attestation{
+			Scheme:         "world_id_v4",
+			RelyingPartyID: "rp-1",
+			SignalBinding:  "binding-committing-to-request",
+			Claims:         []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman},
+		}
+	}
+	vctx := VerifyContext{RequestID: "r1", ExpectedRelyingPartyID: "rp-1", Now: now}
+
+	cases := []struct {
+		name string
+		mut  func(*tmproto.Attestation)
+		vctx VerifyContext
+		want string
+	}{
+		{"happy", func(*tmproto.Attestation) {}, vctx, PreCheckOK},
+		{"future expiry ok", func(a *tmproto.Attestation) { a.ExpiresAt = future.Format(time.RFC3339) }, vctx, PreCheckOK},
+		{"empty signal_binding fails closed", func(a *tmproto.Attestation) { a.SignalBinding = "" }, vctx, PreCheckNoBinding},
+		{"expired", func(a *tmproto.Attestation) { a.ExpiresAt = past.Format(time.RFC3339) }, vctx, PreCheckExpired},
+		{"unparseable expiry fails closed", func(a *tmproto.Attestation) { a.ExpiresAt = "not-a-date" }, vctx, PreCheckExpired},
+		{"rp mismatch", func(a *tmproto.Attestation) { a.RelyingPartyID = "rp-other" }, vctx, PreCheckRPMismatch},
+		{"missing rp", func(a *tmproto.Attestation) { a.RelyingPartyID = "" }, vctx, PreCheckRPMismatch},
+		{"empty expected rp", func(*tmproto.Attestation) {}, VerifyContext{RequestID: "r1", ExpectedRelyingPartyID: "", Now: now}, PreCheckRPMismatch},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			att := base()
+			c.mut(att)
+			if got := LocalPreCheck(att, c.vctx); got != c.want {
+				t.Fatalf("LocalPreCheck = %q, want %q", got, c.want)
+			}
+		})
+	}
+
+	if got := LocalPreCheck(nil, vctx); got != PreCheckMalformed {
+		t.Fatalf("nil attestation: got %q, want %q", got, PreCheckMalformed)
+	}
+}
+
+func TestClaimsSatisfy(t *testing.T) {
+	vi := func(claims ...tmproto.AttestationClaim) VerifiedIdentity {
+		return VerifiedIdentity{Claims: NormalizeClaims(claims)}
+	}
+	cases := []struct {
+		name     string
+		have     VerifiedIdentity
+		required tmproto.AttestationClaim
+		want     bool
+	}{
+		{"higher age satisfies lower threshold", vi(tmproto.AttestationClaimAgeOver21), tmproto.AttestationClaimAgeOver18, true},
+		{"exact age", vi(tmproto.AttestationClaimAgeOver18), tmproto.AttestationClaimAgeOver18, true},
+		{"lower age does not satisfy higher threshold", vi(tmproto.AttestationClaimAgeOver18), tmproto.AttestationClaimAgeOver21, false},
+		{"unique_human exact", vi(tmproto.AttestationClaimUniqueHuman), tmproto.AttestationClaimUniqueHuman, true},
+		{"unique_human does not satisfy age", vi(tmproto.AttestationClaimUniqueHuman), tmproto.AttestationClaimAgeOver18, false},
+		{"empty claim set", vi(), tmproto.AttestationClaimAgeOver18, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.have.ClaimsSatisfy(c.required); got != c.want {
+				t.Fatalf("ClaimsSatisfy(%q) = %v, want %v", c.required, got, c.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeClaims(t *testing.T) {
+	in := []tmproto.AttestationClaim{
+		tmproto.AttestationClaimAgeOver18,
+		"age_over_021",  // non-canonical: dropped
+		"unique_human ", // trailing space: dropped
+		tmproto.AttestationClaimUniqueHuman,
+		"totally_bogus", // dropped
+	}
+	got := NormalizeClaims(in)
+	if len(got) != 2 {
+		t.Fatalf("want 2 canonical claims, got %d: %v", len(got), got)
+	}
+	if _, ok := got[tmproto.AttestationClaimAgeOver18]; !ok {
+		t.Error("age_over_18 should survive normalization")
+	}
+	if _, ok := got[tmproto.AttestationClaimUniqueHuman]; !ok {
+		t.Error("unique_human should survive normalization")
+	}
+}

--- a/tmproto/tmpx_open.go
+++ b/tmproto/tmpx_open.go
@@ -21,15 +21,23 @@ import (
 
 const tmpxMaxPayloadBytes = 32 + TmpxHeaderBytes + 255*(1+48) + chacha20poly1305.Overhead
 
+// TmpxSealedMaxWireBytes bounds a sealed-credential TMPX wire string. The
+// top-level sealed_credentials carrier (network-as-RP / Mechanism B) reuses
+// the TMPX envelope FORMAT but carries an attestation, which the AdCP
+// verified-identity schema caps at 8192 base64 chars — far larger than the
+// identity-token wire budget (TmpxMaxWireBytes, sized for ~3 opaque tokens).
+// Receivers MUST still bound count and size to prevent DoS amplification.
+const TmpxSealedMaxWireBytes = TmpxMaxKidLen + 1 + 8192
+
 // TmpxKid returns the kid prefix from a TMPX wire token so receivers can look up
 // the matching X25519 private key before calling OpenTmpx.
 func TmpxKid(wire string) (string, error) {
-	kid, _, err := splitTmpxWire(wire)
+	kid, _, err := splitTmpxWire(wire, TmpxMaxWireBytes)
 	return kid, err
 }
 
-func splitTmpxWire(wire string) (kid, payload string, err error) {
-	if len(wire) > TmpxMaxWireBytes {
+func splitTmpxWire(wire string, maxWire int) (kid, payload string, err error) {
+	if len(wire) > maxWire {
 		return "", "", errors.New("tmproto: tmpx wire string exceeds maximum")
 	}
 	dot := strings.IndexByte(wire, '.')
@@ -59,13 +67,35 @@ func splitTmpxWire(wire string) (kid, payload string, err error) {
 // keystore. `info` MUST match the value passed to SealTmpx (nil per the spec
 // default).
 func OpenTmpx(skR *ecdh.PrivateKey, info []byte, wire string) (plaintext []byte, kid string, err error) {
+	return openTmpxWire(skR, info, wire, TmpxMaxWireBytes)
+}
+
+// OpenSealedCredential opens a sealed_credentials entry — an attestation
+// sealed in the TMPX envelope format and addressed to a specific audience_kid.
+// It is identical to OpenTmpx except it permits the larger sealed-credential
+// size budget (TmpxSealedMaxWireBytes) the AdCP verified-identity schema
+// defines, rather than the identity-token wire bound.
+//
+// Like OpenTmpx, a successful open proves only that the ciphertext was sealed
+// to skR — never that the attestation inside is true. Callers MUST verify the
+// attestation (issuer proof, signal_binding freshness, relying_party_id
+// provenance, expiry) before trusting any claim.
+func OpenSealedCredential(skR *ecdh.PrivateKey, info []byte, wire string) (plaintext []byte, kid string, err error) {
+	return openTmpxWire(skR, info, wire, TmpxSealedMaxWireBytes)
+}
+
+// openTmpxWire is the shared TMPX-envelope open, parameterized by the maximum
+// permitted wire length so the identity-token path (OpenTmpx) and the
+// larger sealed-credential path (OpenSealedCredential) share one
+// implementation with distinct size budgets.
+func openTmpxWire(skR *ecdh.PrivateKey, info []byte, wire string, maxWire int) (plaintext []byte, kid string, err error) {
 	if skR == nil {
 		return nil, "", errors.New("tmproto: tmpx recipient private key required")
 	}
 	if skR.Curve() != ecdh.X25519() {
 		return nil, "", errors.New("tmproto: tmpx recipient private key must be X25519")
 	}
-	kid, payloadText, err := splitTmpxWire(wire)
+	kid, payloadText, err := splitTmpxWire(wire, maxWire)
 	if err != nil {
 		return nil, "", err
 	}

--- a/tmproto/tmpx_sealed_test.go
+++ b/tmproto/tmpx_sealed_test.go
@@ -1,0 +1,45 @@
+package tmproto
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+// TestOpenSealedCredentialLargerBound proves the distinguishing behavior of the
+// sealed-credential open path: a wire string larger than the identity-token
+// bound (TmpxMaxWireBytes) opens via OpenSealedCredential but is rejected by
+// OpenTmpx. Guards against a future change to either bound silently regressing.
+func TestOpenSealedCredentialLargerBound(t *testing.T) {
+	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 300-byte plaintext seals to a wire comfortably above the 255-byte
+	// identity-token bound but within the sealed-credential bound.
+	pt := bytes.Repeat([]byte("A"), 300)
+	wire, err := SealTmpx(TmpxRecipient{Kid: "kid-1", PublicKey: sk.PublicKey()}, nil, pt)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if len(wire) <= TmpxMaxWireBytes {
+		t.Fatalf("test precondition: wire len %d must exceed TmpxMaxWireBytes %d", len(wire), TmpxMaxWireBytes)
+	}
+	if len(wire) > TmpxSealedMaxWireBytes {
+		t.Fatalf("test precondition: wire len %d must be within TmpxSealedMaxWireBytes %d", len(wire), TmpxSealedMaxWireBytes)
+	}
+
+	got, _, err := OpenSealedCredential(sk, nil, wire)
+	if err != nil {
+		t.Fatalf("OpenSealedCredential must open a sealed-sized wire: %v", err)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Fatalf("OpenSealedCredential round-trip mismatch")
+	}
+
+	if _, _, err := OpenTmpx(sk, nil, wire); err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
+		t.Fatalf("OpenTmpx must reject the over-255-byte wire with 'exceeds maximum', got err=%v", err)
+	}
+}


### PR DESCRIPTION
**Stacked on #371** (base = `ohalushchak-exadel/world-id-adcp-go`). #371 is the wire/router/signing half and explicitly scopes buyer verification out; **this is that buyer half** — open the sealed credential, verify it, gate eligibility. Merge #371 first, then I'll retarget this to `main`.

## Verify before trust
Opening a sealed credential proves only it was sealed to our key — **never** that the claims are true. Claims feed eligibility **only** after a pluggable `AttestationVerifier` validates the proof *and* local fail-closed pre-checks pass. **No default verifier**: with none wired, every attestation is absent, so existing eligibility is byte-for-byte unchanged and trust-without-verify is unreachable by omission. (Production config wires no verifier yet — this is the seam, not the activation.)

## Builds on #371's types
Adopts #371's `Attestation` / `AttestationClaim` / `SealedCredential` (incl. `ExpiresAt` as the signed RFC-3339 string — my buyer pre-check parses it, fail-closed on unparseable). Adds, on top:
- `tmproto.OpenSealedCredential` — opens the attestation-sized TMPX envelope (sealed payload exceeds the 255-byte identity-token wire bound; `OpenTmpx` unchanged, shared via `openTmpxWire`).
- `targeting`: `AttestationVerifier` (pluggable, nil ⇒ fail-closed), `AgeResolver` (Policy-Registry behind it), `VerifiedIdentity`, `LocalPreCheck`.
- `identityagent`: `runVerifiedIdentityStage` (bound count → open → pre-check → verify → normalize), threaded into the fcap stage + a fail-closed `joinResults` third gate, run synchronously before the parallel stages.

## Security (test-covered; adversarially reviewed → ship)
RP-namespaced fcap key (`vid:<rp>:<nullifier>`); `relying_party_id` receiver-binding enforced SDK-side from the `audience_kid` **before** the verifier; mandatory `signal_binding` + future-only `expires_at`; distinct verifier-error metric; count/size DoS bounds before any crypto. 15 tests (4 unit + 11 integration); backward-compat held; `-race` clean.

## Deferred behind interfaces
Concrete World ID verifier (+ per-stage timeout), Policy-Registry `AgeResolver`, recipient-key secret loader, populating `RequiresVerifiedIdentity` from the identityconfig snapshot. One deploy invariant documented in-code: enabling a verifier requires the frequency-writer to emit `vid:<rp>:<nullifier>` caps first, or caps fail open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)