### PR TITLE
fix(verify/worldid): require a resolvable adcp-go version for external import

### DIFF
--- a/verify/worldid/go.mod
+++ b/verify/worldid/go.mod
@@ -2,7 +2,7 @@ module github.com/adcontextprotocol/adcp-go/verify/worldid
 
 go 1.25.0
 
-require github.com/adcontextprotocol/adcp-go v0.0.0
+require github.com/adcontextprotocol/adcp-go v0.0.0-20260610020654-c0720af293c1
 
 require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect


### PR DESCRIPTION
`verify/worldid` is a separate module meant to be imported by external repos (scope3data/rtdp, for the World Ads operator path), but its `go.mod` required `adcp-go v0.0.0` — a placeholder that only resolves in-repo via the `replace => ../..`. External consumers ignore the replace, so the require failed to resolve and the module couldn't be imported.

Pins the require to the real pseudo-version of the module's commit; keeps the replace for in-repo local dev (so adcp-go CI still builds against local root).

**Validated:** a scratch module that replaces *only* `verify/worldid` to local now resolves `adcp-go` root from the proxy and builds — confirming external import works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)