### PR TITLE
refactor(targeting): extract verify-before-trust receiver into reusable targeting API

### DIFF
--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -30,16 +30,15 @@ const (
 	StageVerifiedIdentity = "verified_identity"
 )
 
-// Verified-identity drop reasons. Each corresponds to one rejection branch in
-// the verified-identity stage; cardinality is bounded by this constant set
-// plus the targeting.PreCheck* reasons (malformed, no_binding, expired,
-// rp_mismatch) reused as labels. A non-zero verifier_error rate distinguishes
-// "verifier down/misconfigured" from organic absence (no metric ticks).
-const (
-	VIDropOpenFailed    = "open_failed"      // HPKE open / plaintext decode failed
-	VIDropVerifierError = "verifier_error"   // verifier returned an error (treat as absent)
-	VIDropMalformedSeal = "malformed_sealed" // sealed_credentials entry missing audience_kid/payload
-)
+// VIDropVerifierError is the drop label for a verifier that returned an error.
+// The receiver loop reports verifier failure out-of-band (targeting's
+// CredentialObserver.VerifierFailed) rather than as a labeled drop, so the
+// stage applies this label itself — a non-zero verifier_error rate
+// distinguishes "verifier down/misconfigured" from organic absence (no metric
+// ticks). The remaining drop labels are emitted by the loop from the
+// targeting.Drop* and targeting.PreCheck* constant sets, which bound the
+// verified-identity drop cardinality.
+const VIDropVerifierError = "verifier_error"
 
 // Outcome labels paired with stages. Bounded to a fixed set.
 const (

--- a/targeting/identityagent/verified_identity_stage.go
+++ b/targeting/identityagent/verified_identity_stage.go
@@ -2,146 +2,72 @@ package identityagent
 
 import (
 	"context"
-	"crypto/ecdh"
-	"encoding/json"
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
-// RecipientKey is the HPKE recipient identity for one audience_kid: the X25519
-// private key that opens sealed_credentials addressed to that kid, plus the
-// relying party THIS deployment acts as for that audience. RelyingPartyID is
-// the receiver-binding anchor — a sealed attestation whose relying_party_id
-// does not equal it is a forwarded/replayed proof and is rejected
-// (targeting.LocalPreCheck). The audience_kid that selected this key is how the
-// deployment knows which RP it is, so the binding is enforced locally and
-// fail-closed rather than deferred to the verifier.
-type RecipientKey struct {
-	PrivateKey     *ecdh.PrivateKey
-	RelyingPartyID string
+// RecipientKey is the HPKE recipient identity for one audience_kid — the X25519
+// private key plus the relying party this deployment acts as for that audience.
+// See targeting.RecipientKey for the receiver-binding semantics.
+type RecipientKey = targeting.RecipientKey
+
+// stageObserver adapts the verified-identity stage's Recorder to the
+// targeting.CredentialObserver the receiver loop emits to. A verifier error is
+// recorded both as a drop (so its rate is visible alongside the other drop
+// reasons) and as an error outcome via verifierErrored, so a
+// down/misconfigured verifier is observable instead of indistinguishable from
+// organic "no humans verified".
+type stageObserver struct {
+	recorder        Recorder
+	verifierErrored bool
 }
 
-const (
-	// maxSealedCredentials caps sealed_credentials entries processed per
-	// request (schema maxItems). Enforced before any crypto so a flood of
-	// garbage entries cannot force N HPKE opens + verifier round-trips.
-	maxSealedCredentials = 8
-	// maxSealedPayloadBytes caps one sealed payload's wire length (schema
-	// maxLength 8192) before opening.
-	maxSealedPayloadBytes = 8192
-)
+func (o *stageObserver) Dropped(ctx context.Context, reason string) {
+	o.recorder.VerifiedIdentityDrop(ctx, reason)
+}
+
+func (o *stageObserver) VerifierFailed(ctx context.Context) {
+	o.verifierErrored = true
+	o.recorder.VerifiedIdentityDrop(ctx, VIDropVerifierError)
+}
 
 // runVerifiedIdentityStage opens and verifies the request's sealed_credentials
 // (the network-as-RP / Mechanism B carrier) and returns the verified
 // identities.
 //
 // Fail-closed: with no verifier or no recipient keys configured it returns nil
-// immediately (no opening, no allocation), so existing eligibility behavior is
-// byte-for-byte unchanged. Opening a credential proves only that it was sealed
-// to our key — never that the claims are true. Claims are trusted only after
-// the pluggable verifier validates the proof AND the local pre-checks pass
-// (signal_binding present, not expired, relying_party_id == the RP we act as).
+// immediately, so existing eligibility behavior is byte-for-byte unchanged.
+// Opening a credential proves only that it was sealed to our key — never that
+// the claims are true. The verify-before-trust loop itself lives in
+// targeting.OpenAndVerify; this stage wires the request, the metric observer,
+// and the stage-level duration/outcome metrics around it.
 func (s *Service) runVerifiedIdentityStage(ctx context.Context, req *tmproto.IdentityMatchRequest) []targeting.VerifiedIdentity {
 	if s.verifier == nil || len(s.recipientKeys) == 0 || len(req.SealedCredentials) == 0 {
 		return nil
 	}
 	start := time.Now()
-	now := start
 	// The verifier is called on the parent ctx (the handler's request budget
 	// bounds a well-behaved, ctx-respecting verifier). A dedicated per-stage
 	// sub-timeout + OutcomeTimeout — mirroring runFcapStage/runAudienceStage —
 	// lands with the concrete network verifier, which is when a stalled
 	// verifier becomes a real risk; the nil/mock verifiers here are instant.
-
-	// Bound the count before any crypto (DoS): never open more than the
-	// schema maximum, regardless of how many entries arrived.
-	creds := req.SealedCredentials
-	if len(creds) > maxSealedCredentials {
-		creds = creds[:maxSealedCredentials]
+	obs := &stageObserver{recorder: s.recorder}
+	vctx := targeting.VerifyContext{
+		RequestID: req.RequestID,
+		Country:   req.Country,
+		Now:       start,
 	}
-
-	var verified []targeting.VerifiedIdentity
-	verifierErrored := false
-	for _, c := range creds {
-		if c.AudienceKID == "" || c.Payload == "" {
-			s.recorder.VerifiedIdentityDrop(ctx, VIDropMalformedSeal)
-			continue
-		}
-		rk, ok := s.recipientKeys[c.AudienceKID]
-		if !ok {
-			// Not addressed to an audience we hold a key for. Correct
-			// multi-audience behavior — silently ignore, no drop metric.
-			continue
-		}
-		if len(c.Payload) > maxSealedPayloadBytes {
-			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
-			continue
-		}
-		// HPKE-open (cheap, local) with the sealed-credential size budget.
-		// Only AFTER it succeeds do we consider the network verifier, so
-		// undecryptable blobs cost at most local work.
-		pt, _, err := tmproto.OpenSealedCredential(rk.PrivateKey, nil, c.Payload)
-		if err != nil {
-			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
-			continue
-		}
-		var att tmproto.Attestation
-		if err := json.Unmarshal(pt, &att); err != nil {
-			s.recorder.VerifiedIdentityDrop(ctx, VIDropOpenFailed)
-			continue
-		}
-		vctx := targeting.VerifyContext{
-			RequestID:              req.RequestID,
-			Country:                req.Country,
-			ExpectedRelyingPartyID: rk.RelyingPartyID,
-			Now:                    now,
-		}
-		// Local, fail-closed invariants BEFORE the (possibly network)
-		// verifier: empty signal_binding, expired, or RP mismatch ⇒ absent.
-		if reason := targeting.LocalPreCheck(&att, vctx); reason != targeting.PreCheckOK {
-			s.recorder.VerifiedIdentityDrop(ctx, reason)
-			continue
-		}
-		vi, err := s.verifier.Verify(ctx, &att, vctx)
-		if err != nil {
-			verifierErrored = true
-			s.recorder.VerifiedIdentityDrop(ctx, VIDropVerifierError)
-			continue
-		}
-		// Defense-in-depth: the verifier must return the RP we bound to.
-		if vi.RelyingPartyID != rk.RelyingPartyID {
-			s.recorder.VerifiedIdentityDrop(ctx, targeting.PreCheckRPMismatch)
-			continue
-		}
-		// Normalize to the closed claim set so the age gate only ever sees
-		// canonical values, regardless of verifier behavior.
-		vi.Claims = normalizeClaimSet(vi.Claims)
-		verified = append(verified, vi)
-	}
+	verified := targeting.OpenAndVerify(ctx, req.SealedCredentials, s.recipientKeys, s.verifier, vctx, obs)
 
 	s.recorder.StageDuration(ctx, StageVerifiedIdentity, time.Since(start))
-	// A verifier error is recorded as an error outcome (not pass) so a
-	// down/misconfigured verifier is observable instead of indistinguishable
-	// from organic "no humans verified".
 	outcome := OutcomePass
-	if verifierErrored {
+	if obs.verifierErrored {
 		outcome = OutcomeError
 	}
 	s.recorder.StageOutcome(ctx, StageVerifiedIdentity, outcome)
 	return verified
-}
-
-// normalizeClaimSet drops any claim not in the closed attestation-claim set.
-func normalizeClaimSet(in map[tmproto.AttestationClaim]struct{}) map[tmproto.AttestationClaim]struct{} {
-	out := make(map[tmproto.AttestationClaim]struct{}, len(in))
-	for c := range in {
-		if targeting.IsClosedClaim(c) {
-			out[c] = struct{}{}
-		}
-	}
-	return out
 }
 
 // computeVerifiedIdentityGate returns the packages ineligible because of the
@@ -151,36 +77,18 @@ func normalizeClaimSet(in map[tmproto.AttestationClaim]struct{}) map[tmproto.Att
 // race cannot drop the verdict — this is the fail-closed third gate, and
 // joinResults defaults packages to eligible.
 func (s *Service) computeVerifiedIdentityGate(ctx context.Context, req *tmproto.IdentityMatchRequest, resolved *targeting.ResolvedPackages, pkgIDs []string, verified []targeting.VerifiedIdentity) map[string]struct{} {
-	rejected := make(map[string]struct{})
+	reqs := make(map[string]targeting.VerifiedIdentityRequirement, len(pkgIDs))
 	for _, id := range pkgIDs {
 		cfg := resolved.IdentityConfigs[id]
-		requiresVID := cfg != nil && cfg.RequiresVerifiedIdentity
-
-		var ageClaim tmproto.AttestationClaim
-		ageRequired := false
+		pkgReq := targeting.VerifiedIdentityRequirement{
+			RequiresVerifiedHuman: cfg != nil && cfg.RequiresVerifiedIdentity,
+		}
 		if s.ageResolver != nil {
-			ageClaim, ageRequired = s.ageResolver.ResolveRequiredAge(ctx, id, req.Country)
+			if claim, ok := s.ageResolver.ResolveRequiredAge(ctx, id, req.Country); ok {
+				pkgReq.RequiredAge = claim
+			}
 		}
-
-		if !requiresVID && !ageRequired {
-			continue // package has no verified-identity requirement
-		}
-		if len(verified) == 0 {
-			rejected[id] = struct{}{} // required but absent — fail closed
-			continue
-		}
-		if ageRequired && !anyVerifiedSatisfies(verified, ageClaim) {
-			rejected[id] = struct{}{}
-		}
+		reqs[id] = pkgReq
 	}
-	return rejected
-}
-
-func anyVerifiedSatisfies(verified []targeting.VerifiedIdentity, required tmproto.AttestationClaim) bool {
-	for _, vi := range verified {
-		if vi.ClaimsSatisfy(required) {
-			return true
-		}
-	}
-	return false
+	return targeting.RejectByVerifiedIdentity(reqs, verified)
 }

--- a/targeting/identityagent/verified_identity_stage.go
+++ b/targeting/identityagent/verified_identity_stage.go
@@ -85,6 +85,7 @@ func (s *Service) computeVerifiedIdentityGate(ctx context.Context, req *tmproto.
 		}
 		if s.ageResolver != nil {
 			if claim, ok := s.ageResolver.ResolveRequiredAge(ctx, id, req.Country); ok {
+				pkgReq.RequiresAge = true
 				pkgReq.RequiredAge = claim
 			}
 		}

--- a/targeting/identityagent/verified_identity_stage_test.go
+++ b/targeting/identityagent/verified_identity_stage_test.go
@@ -270,8 +270,8 @@ func TestService_computeVerifiedIdentityGate_RequiresVerifiedIdentity(t *testing
 	assert.False(t, strictRejected, "RequiresVerifiedIdentity satisfied by a present verified identity")
 }
 
-// DoS: more than maxSealedCredentials sealed entries are truncated BEFORE any
-// crypto — the verifier is called at most maxSealedCredentials times, so a
+// DoS: more than targeting.MaxSealedCredentials sealed entries are truncated BEFORE any
+// crypto — the verifier is called at most targeting.MaxSealedCredentials times, so a
 // flood cannot force unbounded HPKE opens + verifier round-trips.
 func TestService_VerifiedIdentity_BoundsSealedCount(t *testing.T) {
 	sk, keys := newRecipient(t)
@@ -282,16 +282,16 @@ func TestService_VerifiedIdentity_BoundsSealedCount(t *testing.T) {
 		recipientKeys: keys,
 		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
 	})
-	creds := make([]tmproto.SealedCredential, 0, maxSealedCredentials+5)
-	for i := 0; i < maxSealedCredentials+5; i++ {
+	creds := make([]tmproto.SealedCredential, 0, targeting.MaxSealedCredentials+5)
+	for i := 0; i < targeting.MaxSealedCredentials+5; i++ {
 		creds = append(creds, sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
 	}
 	svc.Evaluate(t.Context(), vidReq(creds...))
-	assert.LessOrEqual(t, mv.calls, maxSealedCredentials,
+	assert.LessOrEqual(t, mv.calls, targeting.MaxSealedCredentials,
 		"sealed_credentials count must be bounded before any crypto/verifier call")
 }
 
-// DoS: a sealed entry whose payload exceeds maxSealedPayloadBytes is dropped at
+// DoS: a sealed entry whose payload exceeds targeting.MaxSealedPayloadBytes is dropped at
 // the size check, before any HPKE open or verifier call.
 func TestService_VerifiedIdentity_DropsOversizedPayload(t *testing.T) {
 	_, keys := newRecipient(t)
@@ -302,7 +302,7 @@ func TestService_VerifiedIdentity_DropsOversizedPayload(t *testing.T) {
 		recipientKeys: keys,
 		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
 	})
-	oversized := tmproto.SealedCredential{AudienceKID: "kid-1", Payload: strings.Repeat("A", maxSealedPayloadBytes+1)}
+	oversized := tmproto.SealedCredential{AudienceKID: "kid-1", Payload: strings.Repeat("A", targeting.MaxSealedPayloadBytes+1)}
 	got := eligibilityMap(svc.Evaluate(t.Context(), vidReq(oversized)).Eligibility)
 	assert.False(t, got["pkg-alcohol"], "oversized payload ⇒ dropped ⇒ attestation absent ⇒ ineligible")
 	assert.Equal(t, 0, mv.calls, "an oversized payload must be dropped before any HPKE open or verifier call")

--- a/targeting/verified_identity_receiver.go
+++ b/targeting/verified_identity_receiver.go
@@ -1,0 +1,221 @@
+package targeting
+
+import (
+	"context"
+	"crypto/ecdh"
+	"encoding/json"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// verified_identity_receiver.go is the shared verify-before-trust receiver: the
+// loop that turns inbound sealed_credentials into trusted VerifiedIdentity
+// values, and the fail-closed gate that decides which packages a verified
+// identity makes eligible. Both the in-process identity-agent and any external
+// network-as-RP operator run the SAME code here, so the security-critical
+// ordering (bound before crypto, local RP-binding before the verifier,
+// defense-in-depth RP recheck after) has exactly one home.
+
+const (
+	// MaxSealedCredentials caps sealed_credentials entries processed per
+	// request (schema maxItems). Enforced before any crypto so a flood of
+	// garbage entries cannot force N HPKE opens + verifier round-trips.
+	MaxSealedCredentials = 8
+	// MaxSealedPayloadBytes caps one sealed payload's wire length (schema
+	// maxLength 8192) before opening.
+	MaxSealedPayloadBytes = 8192
+)
+
+// Receiver drop reasons emitted by OpenAndVerify that are not already covered
+// by the PreCheck* constants. Each is a bounded metric label.
+const (
+	// DropMalformedSeal is a sealed_credentials entry missing audience_kid or
+	// payload — the envelope is malformed before any attestation is parsed.
+	DropMalformedSeal = "malformed_sealed"
+	// DropOpenFailed is an oversized payload, a failed HPKE open, or plaintext
+	// that does not decode to an attestation.
+	DropOpenFailed = "open_failed"
+	// DropRPMismatchPostVerify is the verifier returning an identity bound to a
+	// different relying party than the recipient key commits to. Distinct from
+	// the pre-verify PreCheckRPMismatch: this branch is defense-in-depth and
+	// should never fire — when it does, the verifier itself is misbehaving, not
+	// a forwarded proof.
+	DropRPMismatchPostVerify = "rp_mismatch_postverify"
+)
+
+// RecipientKey is the HPKE recipient identity for one audience_kid: the X25519
+// private key that opens sealed_credentials addressed to that kid, plus the
+// relying party THIS receiver acts as for that audience. RelyingPartyID is the
+// receiver-binding anchor — a sealed attestation whose relying_party_id does
+// not equal it is a forwarded/replayed proof and is rejected (LocalPreCheck).
+// The audience_kid that selected this key is how the receiver knows which RP it
+// is, so the binding is enforced locally and fail-closed rather than deferred
+// to the verifier.
+type RecipientKey struct {
+	PrivateKey     *ecdh.PrivateKey
+	RelyingPartyID string
+}
+
+// CredentialObserver receives per-credential observations from OpenAndVerify so
+// a receiver can record metrics without OpenAndVerify owning a metric
+// vocabulary. A nil observer is replaced with a no-op.
+type CredentialObserver interface {
+	// Dropped fires once per credential treated as absent, with a PreCheck* or
+	// Drop* reason label.
+	Dropped(ctx context.Context, reason string)
+	// VerifierFailed fires when the verifier itself returned an error — kept
+	// distinct from Dropped so a down/misconfigured verifier is observable, not
+	// mistaken for organic "no humans verified".
+	VerifierFailed(ctx context.Context)
+}
+
+type noopCredentialObserver struct{}
+
+func (noopCredentialObserver) Dropped(context.Context, string) {}
+func (noopCredentialObserver) VerifierFailed(context.Context)  {}
+
+// OpenAndVerify is the verify-before-trust receiver loop. For each inbound
+// sealed credential addressed to a held recipient key it HPKE-opens the
+// payload, enforces the local fail-closed pre-checks, calls the pluggable
+// verifier, and returns the verified identities with claims normalized to the
+// closed claim set.
+//
+// Fail-closed by construction. With no verifier or no recipient keys it returns
+// nil immediately (no opening, no allocation). Opening a credential proves only
+// that it was sealed to our key — never that the claims are true. Claims become
+// eligible inputs only after the verifier validates the proof AND the local
+// pre-checks pass (signal_binding present, not expired, relying_party_id == the
+// RP we act as). The count is bounded before any crypto, and an undecryptable
+// blob costs at most local work because the verifier is consulted only after a
+// successful open.
+//
+// vctx supplies RequestID, Country, and Now; ExpectedRelyingPartyID is filled
+// per-credential from the matched recipient key.
+func OpenAndVerify(
+	ctx context.Context,
+	creds []tmproto.SealedCredential,
+	keys map[string]RecipientKey,
+	verifier AttestationVerifier,
+	vctx VerifyContext,
+	obs CredentialObserver,
+) []VerifiedIdentity {
+	if verifier == nil || len(keys) == 0 || len(creds) == 0 {
+		return nil
+	}
+	if obs == nil {
+		obs = noopCredentialObserver{}
+	}
+	// Bound the count before any crypto (DoS): never open more than the schema
+	// maximum, regardless of how many entries arrived.
+	if len(creds) > MaxSealedCredentials {
+		creds = creds[:MaxSealedCredentials]
+	}
+
+	var verified []VerifiedIdentity
+	for _, c := range creds {
+		if c.AudienceKID == "" || c.Payload == "" {
+			obs.Dropped(ctx, DropMalformedSeal)
+			continue
+		}
+		rk, ok := keys[c.AudienceKID]
+		if !ok {
+			// Not addressed to an audience we hold a key for. Correct
+			// multi-audience behavior — silently ignore, no drop metric.
+			continue
+		}
+		if len(c.Payload) > MaxSealedPayloadBytes {
+			obs.Dropped(ctx, DropOpenFailed)
+			continue
+		}
+		// HPKE-open (cheap, local) with the sealed-credential size budget. Only
+		// AFTER it succeeds do we consider the network verifier, so
+		// undecryptable blobs cost at most local work.
+		pt, _, err := tmproto.OpenSealedCredential(rk.PrivateKey, nil, c.Payload)
+		if err != nil {
+			obs.Dropped(ctx, DropOpenFailed)
+			continue
+		}
+		var att tmproto.Attestation
+		if err := json.Unmarshal(pt, &att); err != nil {
+			obs.Dropped(ctx, DropOpenFailed)
+			continue
+		}
+		credVctx := vctx
+		credVctx.ExpectedRelyingPartyID = rk.RelyingPartyID
+		// Local, fail-closed invariants BEFORE the (possibly network) verifier:
+		// empty signal_binding, expired, or RP mismatch ⇒ absent.
+		if reason := LocalPreCheck(&att, credVctx); reason != PreCheckOK {
+			obs.Dropped(ctx, reason)
+			continue
+		}
+		vi, err := verifier.Verify(ctx, &att, credVctx)
+		if err != nil {
+			obs.VerifierFailed(ctx)
+			continue
+		}
+		// Defense-in-depth: the verifier must return the RP we bound to.
+		if vi.RelyingPartyID != rk.RelyingPartyID {
+			obs.Dropped(ctx, DropRPMismatchPostVerify)
+			continue
+		}
+		// Normalize to the closed claim set so the age gate only ever sees
+		// canonical values, regardless of verifier behavior.
+		vi.Claims = normalizeClaimSet(vi.Claims)
+		verified = append(verified, vi)
+	}
+	return verified
+}
+
+// VerifiedIdentityRequirement is one package's verified-identity requirement,
+// resolved by the caller from its own package config and age policy.
+type VerifiedIdentityRequirement struct {
+	// RequiresVerifiedHuman gates the package on at least one present verified
+	// identity (a verified unique human).
+	RequiresVerifiedHuman bool
+	// RequiredAge, when non-empty, is the age claim a verified identity must
+	// satisfy. Empty means no age requirement.
+	RequiredAge tmproto.AttestationClaim
+}
+
+// RejectByVerifiedIdentity returns the package IDs rejected by the
+// verified-identity gate: a package that requires a verified human, or an age
+// threshold, that no verified identity satisfies. Fail-closed —
+// required-but-absent ⇒ rejected. A package with no requirement is never
+// rejected here.
+func RejectByVerifiedIdentity(reqs map[string]VerifiedIdentityRequirement, verified []VerifiedIdentity) map[string]struct{} {
+	rejected := make(map[string]struct{})
+	for id, r := range reqs {
+		ageRequired := r.RequiredAge != ""
+		if !r.RequiresVerifiedHuman && !ageRequired {
+			continue // package has no verified-identity requirement
+		}
+		if len(verified) == 0 {
+			rejected[id] = struct{}{} // required but absent — fail closed
+			continue
+		}
+		if ageRequired && !anyVerifiedSatisfies(verified, r.RequiredAge) {
+			rejected[id] = struct{}{}
+		}
+	}
+	return rejected
+}
+
+func anyVerifiedSatisfies(verified []VerifiedIdentity, required tmproto.AttestationClaim) bool {
+	for _, vi := range verified {
+		if vi.ClaimsSatisfy(required) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeClaimSet drops any claim not in the closed attestation-claim set.
+func normalizeClaimSet(in map[tmproto.AttestationClaim]struct{}) map[tmproto.AttestationClaim]struct{} {
+	out := make(map[tmproto.AttestationClaim]struct{}, len(in))
+	for c := range in {
+		if IsClosedClaim(c) {
+			out[c] = struct{}{}
+		}
+	}
+	return out
+}

--- a/targeting/verified_identity_receiver.go
+++ b/targeting/verified_identity_receiver.go
@@ -172,8 +172,16 @@ type VerifiedIdentityRequirement struct {
 	// RequiresVerifiedHuman gates the package on at least one present verified
 	// identity (a verified unique human).
 	RequiresVerifiedHuman bool
-	// RequiredAge, when non-empty, is the age claim a verified identity must
-	// satisfy. Empty means no age requirement.
+	// RequiresAge gates the package on a verified age threshold. When set, a
+	// verified identity must satisfy RequiredAge. RequiredAge may be empty even
+	// when RequiresAge is set (the policy applies but resolved no closed-set
+	// claim); no verified identity can satisfy an empty claim, so the package
+	// is then rejected — fail-closed. Carried separately from RequiredAge so
+	// "age required, threshold empty" is not collapsed into "no age
+	// requirement".
+	RequiresAge bool
+	// RequiredAge is the age claim a verified identity must satisfy when
+	// RequiresAge is set.
 	RequiredAge tmproto.AttestationClaim
 }
 
@@ -185,15 +193,14 @@ type VerifiedIdentityRequirement struct {
 func RejectByVerifiedIdentity(reqs map[string]VerifiedIdentityRequirement, verified []VerifiedIdentity) map[string]struct{} {
 	rejected := make(map[string]struct{})
 	for id, r := range reqs {
-		ageRequired := r.RequiredAge != ""
-		if !r.RequiresVerifiedHuman && !ageRequired {
+		if !r.RequiresVerifiedHuman && !r.RequiresAge {
 			continue // package has no verified-identity requirement
 		}
 		if len(verified) == 0 {
 			rejected[id] = struct{}{} // required but absent — fail closed
 			continue
 		}
-		if ageRequired && !anyVerifiedSatisfies(verified, r.RequiredAge) {
+		if r.RequiresAge && !anyVerifiedSatisfies(verified, r.RequiredAge) {
 			rejected[id] = struct{}{}
 		}
 	}
@@ -209,13 +216,13 @@ func anyVerifiedSatisfies(verified []VerifiedIdentity, required tmproto.Attestat
 	return false
 }
 
-// normalizeClaimSet drops any claim not in the closed attestation-claim set.
+// normalizeClaimSet drops any claim not in the closed attestation-claim set,
+// applying the same closed-set policy as NormalizeClaims to a claim set the
+// verifier already returned as a map.
 func normalizeClaimSet(in map[tmproto.AttestationClaim]struct{}) map[tmproto.AttestationClaim]struct{} {
-	out := make(map[tmproto.AttestationClaim]struct{}, len(in))
+	claims := make([]tmproto.AttestationClaim, 0, len(in))
 	for c := range in {
-		if IsClosedClaim(c) {
-			out[c] = struct{}{}
-		}
+		claims = append(claims, c)
 	}
-	return out
+	return NormalizeClaims(claims)
 }

--- a/targeting/verified_identity_receiver_test.go
+++ b/targeting/verified_identity_receiver_test.go
@@ -256,12 +256,27 @@ func TestRejectByVerifiedIdentity(t *testing.T) {
 
 	t.Run("age threshold above the verified claim is rejected", func(t *testing.T) {
 		rejected := targeting.RejectByVerifiedIdentity(map[string]targeting.VerifiedIdentityRequirement{
-			"age21": {RequiredAge: tmproto.AttestationClaimAgeOver21},
-			"age18": {RequiredAge: tmproto.AttestationClaimAgeOver18},
+			"age21": {RequiresAge: true, RequiredAge: tmproto.AttestationClaimAgeOver21},
+			"age18": {RequiresAge: true, RequiredAge: tmproto.AttestationClaimAgeOver18},
 		}, human)
 		_, rejected21 := rejected["age21"]
 		_, rejected18 := rejected["age18"]
 		assert.True(t, rejected21, "age_over_18 does not satisfy a 21 gate")
 		assert.False(t, rejected18, "age_over_18 satisfies an 18 gate")
+	})
+
+	// Fail-closed: an age requirement whose threshold resolved to the empty
+	// claim (RequiresAge true, RequiredAge "") is rejected — no verified
+	// identity can satisfy an empty claim. RequiresAge must not be inferred from
+	// a non-empty RequiredAge, or this requirement silently evaporates.
+	t.Run("age required with empty threshold is rejected (fail-closed)", func(t *testing.T) {
+		reqs := map[string]targeting.VerifiedIdentityRequirement{"age": {RequiresAge: true}}
+		rejectedEmpty := targeting.RejectByVerifiedIdentity(reqs, nil)
+		_, absentRejected := rejectedEmpty["age"]
+		assert.True(t, absentRejected, "age required + no verified identity ⇒ rejected")
+
+		rejectedPresent := targeting.RejectByVerifiedIdentity(reqs, human)
+		_, presentRejected := rejectedPresent["age"]
+		assert.True(t, presentRejected, "empty age claim is satisfiable by no identity ⇒ rejected")
 	})
 }

--- a/targeting/verified_identity_receiver_test.go
+++ b/targeting/verified_identity_receiver_test.go
@@ -1,0 +1,267 @@
+package targeting_test
+
+import (
+	"context"
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// stubVerifier returns a fixed identity (scoped to the receiver's expected RP
+// so the post-verify RP check passes, unless rpOverride is set) or a fixed
+// error, and records how many times it was called.
+type stubVerifier struct {
+	nullifier  string
+	claims     []tmproto.AttestationClaim
+	rpOverride string
+	err        error
+	calls      int
+}
+
+func (s *stubVerifier) Verify(_ context.Context, _ *tmproto.Attestation, vctx targeting.VerifyContext) (targeting.VerifiedIdentity, error) {
+	s.calls++
+	if s.err != nil {
+		return targeting.VerifiedIdentity{}, s.err
+	}
+	rp := vctx.ExpectedRelyingPartyID
+	if s.rpOverride != "" {
+		rp = s.rpOverride
+	}
+	return targeting.VerifiedIdentity{
+		Nullifier:      s.nullifier,
+		RelyingPartyID: rp,
+		Claims:         targeting.NormalizeClaims(s.claims),
+	}, nil
+}
+
+// recordingObserver captures the drop reasons and verifier-failure count.
+type recordingObserver struct {
+	drops         []string
+	verifierFails int
+}
+
+func (o *recordingObserver) Dropped(_ context.Context, reason string) {
+	o.drops = append(o.drops, reason)
+}
+func (o *recordingObserver) VerifierFailed(context.Context) { o.verifierFails++ }
+
+func newKey(t *testing.T, rp string) (*ecdh.PrivateKey, map[string]targeting.RecipientKey) {
+	t.Helper()
+	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return sk, map[string]targeting.RecipientKey{"kid-1": {PrivateKey: sk, RelyingPartyID: rp}}
+}
+
+func attestation(rp string, claims ...tmproto.AttestationClaim) tmproto.Attestation {
+	return tmproto.Attestation{
+		Issuer:         map[string]any{"domain": "world.org"},
+		Scheme:         "world_id_v4",
+		RelyingPartyID: rp,
+		SignalBinding:  "binding-committing-to-r1",
+		Claims:         claims,
+		Proof:          map[string]any{"merkle_root": "0x1"},
+	}
+}
+
+func sealTo(t *testing.T, kid string, pub *ecdh.PublicKey, att tmproto.Attestation) tmproto.SealedCredential {
+	t.Helper()
+	pt, err := json.Marshal(att)
+	require.NoError(t, err)
+	wire, err := tmproto.SealTmpx(tmproto.TmpxRecipient{Kid: kid, PublicKey: pub}, nil, pt)
+	require.NoError(t, err)
+	return tmproto.SealedCredential{AudienceKID: kid, Payload: wire}
+}
+
+func baseCtx() targeting.VerifyContext {
+	return targeting.VerifyContext{RequestID: "r1", Country: "US", Now: time.Unix(1_700_000_000, 0)}
+}
+
+// Fail-closed by omission: with no verifier wired, OpenAndVerify returns nil and
+// never opens anything, so a perfectly-sealed attestation is treated as absent.
+func TestOpenAndVerify_NoVerifierIsAbsent(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimAgeOver21))}
+
+	assert.Nil(t, targeting.OpenAndVerify(t.Context(), creds, keys, nil, baseCtx(), nil))
+	assert.Nil(t, targeting.OpenAndVerify(t.Context(), creds, nil, &stubVerifier{}, baseCtx(), nil))
+	assert.Nil(t, targeting.OpenAndVerify(t.Context(), nil, keys, &stubVerifier{}, baseCtx(), nil))
+}
+
+// Verify-before-trust: claims come from the VERIFIER, never the asserted
+// attestation. An attestation asserting age_over_21 yields only the claims the
+// verifier confirms (unique_human) — the age claim does not leak through.
+func TestOpenAndVerify_TrustsVerifierNotAttestation(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimAgeOver21))}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "rp-1", got[0].RelyingPartyID)
+	assert.True(t, got[0].ClaimsSatisfy(tmproto.AttestationClaimUniqueHuman))
+	assert.False(t, got[0].ClaimsSatisfy(tmproto.AttestationClaimAgeOver21),
+		"the asserted age_over_21 must NOT be trusted — only the verifier's claims count")
+}
+
+// Pre-verify RP binding: an attestation minted for another RP is dropped by the
+// local pre-check BEFORE the verifier is consulted.
+func TestOpenAndVerify_RPMismatchPreVerify(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-EVIL", tmproto.AttestationClaimUniqueHuman))}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, v.calls, "verifier MUST NOT be called for a proof minted for another RP")
+	assert.Equal(t, []string{targeting.PreCheckRPMismatch}, obs.drops)
+}
+
+// Post-verify RP binding (defense-in-depth): the verifier returns an identity
+// bound to a different RP than the recipient key commits to. Dropped with the
+// distinct post-verify reason so a misbehaving verifier is observable.
+func TestOpenAndVerify_RPMismatchPostVerify(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}, rpOverride: "rp-OTHER"}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimUniqueHuman))}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, []string{targeting.DropRPMismatchPostVerify}, obs.drops)
+}
+
+// A verifier error yields no identity and is reported via VerifierFailed (not a
+// Dropped reason) so a down verifier is distinguishable from organic absence.
+func TestOpenAndVerify_VerifierError(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{err: errors.New("verifier down")}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimUniqueHuman))}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Empty(t, obs.drops)
+	assert.Equal(t, 1, obs.verifierFails)
+}
+
+// Missing signal_binding is dropped pre-verify (replay defense), verifier never
+// called.
+func TestOpenAndVerify_MissingSignalBinding(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	obs := &recordingObserver{}
+	att := attestation("rp-1", tmproto.AttestationClaimUniqueHuman)
+	att.SignalBinding = ""
+	creds := []tmproto.SealedCredential{sealTo(t, "kid-1", sk.PublicKey(), att)}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, v.calls)
+	assert.Equal(t, []string{targeting.PreCheckNoBinding}, obs.drops)
+}
+
+// Multi-audience: only the credential addressed to a held key is opened; the
+// other audience's entry is silently ignored (no drop metric).
+func TestOpenAndVerify_MultiAudienceOnlyHeldKey(t *testing.T) {
+	sk, keys := newKey(t, "rp-1") // hold kid-1
+	other, err := ecdh.X25519().GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{
+		sealTo(t, "kid-2", other.PublicKey(), attestation("rp-1", tmproto.AttestationClaimUniqueHuman)),
+		sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimUniqueHuman)),
+	}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Len(t, got, 1)
+	assert.Equal(t, 1, v.calls, "only the held-key credential reaches the verifier")
+	assert.Empty(t, obs.drops, "an unheld audience is ignored, not dropped")
+}
+
+// DoS: the count is bounded before any crypto, so the verifier is called at
+// most MaxSealedCredentials times regardless of how many entries arrived.
+func TestOpenAndVerify_BoundsCountBeforeCrypto(t *testing.T) {
+	sk, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	creds := make([]tmproto.SealedCredential, 0, targeting.MaxSealedCredentials+5)
+	for i := 0; i < targeting.MaxSealedCredentials+5; i++ {
+		creds = append(creds, sealTo(t, "kid-1", sk.PublicKey(), attestation("rp-1", tmproto.AttestationClaimUniqueHuman)))
+	}
+
+	targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), nil)
+	assert.LessOrEqual(t, v.calls, targeting.MaxSealedCredentials)
+}
+
+// DoS: an oversized payload is dropped at the size check, before any HPKE open.
+func TestOpenAndVerify_DropsOversizedBeforeOpen(t *testing.T) {
+	_, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{{AudienceKID: "kid-1", Payload: strings.Repeat("A", targeting.MaxSealedPayloadBytes+1)}}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, v.calls)
+	assert.Equal(t, []string{targeting.DropOpenFailed}, obs.drops)
+}
+
+// A sealed entry missing audience_kid or payload is a malformed envelope.
+func TestOpenAndVerify_MalformedEnvelope(t *testing.T) {
+	_, keys := newKey(t, "rp-1")
+	v := &stubVerifier{nullifier: "N"}
+	obs := &recordingObserver{}
+	creds := []tmproto.SealedCredential{{AudienceKID: "", Payload: "x"}}
+
+	got := targeting.OpenAndVerify(t.Context(), creds, keys, v, baseCtx(), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, []string{targeting.DropMalformedSeal}, obs.drops)
+}
+
+func TestRejectByVerifiedIdentity(t *testing.T) {
+	human := []targeting.VerifiedIdentity{{Nullifier: "N", RelyingPartyID: "rp-1", Claims: targeting.NormalizeClaims([]tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman, tmproto.AttestationClaimAgeOver18})}}
+
+	t.Run("no requirement is never rejected", func(t *testing.T) {
+		rejected := targeting.RejectByVerifiedIdentity(map[string]targeting.VerifiedIdentityRequirement{"open": {}}, nil)
+		_, ok := rejected["open"]
+		assert.False(t, ok)
+	})
+
+	t.Run("required but absent is rejected (fail-closed)", func(t *testing.T) {
+		rejected := targeting.RejectByVerifiedIdentity(map[string]targeting.VerifiedIdentityRequirement{
+			"human": {RequiresVerifiedHuman: true},
+		}, nil)
+		_, ok := rejected["human"]
+		assert.True(t, ok)
+	})
+
+	t.Run("present verified human clears the human gate", func(t *testing.T) {
+		rejected := targeting.RejectByVerifiedIdentity(map[string]targeting.VerifiedIdentityRequirement{
+			"human": {RequiresVerifiedHuman: true},
+		}, human)
+		_, ok := rejected["human"]
+		assert.False(t, ok)
+	})
+
+	t.Run("age threshold above the verified claim is rejected", func(t *testing.T) {
+		rejected := targeting.RejectByVerifiedIdentity(map[string]targeting.VerifiedIdentityRequirement{
+			"age21": {RequiredAge: tmproto.AttestationClaimAgeOver21},
+			"age18": {RequiredAge: tmproto.AttestationClaimAgeOver18},
+		}, human)
+		_, rejected21 := rejected["age21"]
+		_, rejected18 := rejected["age18"]
+		assert.True(t, rejected21, "age_over_18 does not satisfy a 21 gate")
+		assert.False(t, rejected18, "age_over_18 satisfies an 18 gate")
+	})
+}


### PR DESCRIPTION
## Why

The sealed-credential **receiver loop** (open → local pre-check → verify → defense-in-depth RP recheck → normalize) and the fail-closed **verified-identity gate** lived as unexported methods on `identityagent.Service` (`runVerifiedIdentityStage`, `computeVerifiedIdentityGate`) with unexported helpers (`normalizeClaimSet`, `anyVerifiedSatisfies`).

This is the **verify-before-trust security core**. Any other deployment acting as a network-as-RP / "World Ads" operator — i.e. a receiver that opens sealed credentials and verifies the proof inside — can today only re-derive this loop and gate by hand. Two hand-maintained copies of a security-critical ordering that must stay in lockstep is the hazard this PR removes.

The low-level primitives were already exported and shared (`LocalPreCheck`, `VerifyContext`, `AttestationVerifier`, `IsClosedClaim`, `ClaimsSatisfy`, `CapKey`) — only the orchestration was locked inside `Service`. This PR lifts the orchestration to sit next to those primitives.

## What

New `targeting/verified_identity_receiver.go`:

- **`OpenAndVerify`** — the receiver loop, parameterized by a `CredentialObserver` so each consumer keeps its own metric vocabulary without the loop owning one. Fail-closed by construction (nil verifier / no keys ⇒ nil), count bounded before any crypto, verifier consulted only after a successful HPKE open.
- **`RejectByVerifiedIdentity` + `VerifiedIdentityRequirement`** — the fail-closed gate, taking caller-resolved per-package requirements so age resolution (a possibly-network `AgeResolver` call) stays at the call site. `RequiresAge` is carried explicitly (not inferred from a non-empty claim) so "age required, threshold empty" stays fail-closed.
- **`RecipientKey`**, **`MaxSealedCredentials`**, **`MaxSealedPayloadBytes`**, and the `Drop*` reason constants move here.

`identityagent`:

- `identityagent.RecipientKey` becomes a **type alias** to `targeting.RecipientKey` — `WithRecipientKeys`, `ServiceConfig`, `cmd/identity-agent` and all call sites are unchanged.
- `runVerifiedIdentityStage` / `computeVerifiedIdentityGate` are now **thin wrappers**: adapt the `Recorder` to a `CredentialObserver`, resolve per-package requirements, keep the stage-level duration/outcome metrics.
- Net: `verified_identity_stage.go` drops from ~187 to ~95 lines; the security loop now has one home.

## Behavior preservation

The existing `Service.Evaluate` verified-identity integration tests (`verified_identity_stage_test.go`) pass **unchanged** — they exercise the full pipeline and prove eligibility behavior is byte-for-byte identical. New focused unit tests in `targeting/verified_identity_receiver_test.go` lock the public contract directly: verify-before-trust (asserted age_over_21 does not leak when the verifier confirms only unique_human), pre- and post-verify RP binding, verifier-error observability, DoS count bound + oversized-payload drop, multi-audience, and the gate's fail-closed logic (including age-required-with-empty-threshold).

## ⚠️ One deliberate metric-label change

The **post-verify** RP-mismatch branch (verifier returns an identity bound to a different RP than the recipient key commits to) now reports `rp_mismatch_postverify` instead of reusing `rp_mismatch`. This branch is defense-in-depth and should essentially never fire; distinguishing it from the *pre-verify* mismatch makes a misbehaving/compromised verifier observable rather than blended into forwarded-proof drops. Flagging because it touches a metric label — near-zero real series impact given the branch should never fire. Happy to revert to `rp_mismatch` if reviewers prefer label stability over the distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)