### PR TITLE
feat(tmpx): seal verified World ID nullifier into TMPX

### DIFF
--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -123,6 +123,8 @@ When the URL and country are set, the agent generates a TMPX token alongside eve
 
 **Decoder coverage:** MAID, HashedEmail, and ID5 have format-only decoders that need no external dependency. RampID and RampIDDerived are decoded via the LiveRamp sidecar when `LIVERAMP_SIDECAR_URL` is configured. UID types without a registered decoder are silently dropped from both the TMPX wire and the audience/fcap shadow request; the startup log enumerates which UID types are dropped.
 
+**Verified identity (World ID):** the `world_id_nullifier` type is verify-before-trust and has no inbound decoder — a sender-asserted nullifier on `identities` is dropped. Its TMPX entry comes only from the verified-identity stage, which seals the relying-party-scoped nullifier the verifier derived from World's authoritative response. The nullifier is encoded as a 32-byte big-endian field element. Under `TMPX_PRIORITY`, include `world_id_nullifier` to keep it on the wire when the resolved set is over budget.
+
 ## Pinhole Specification
 
 The identity agent is the privacy boundary. When running in a TEE:

--- a/targeting/identity_engine.go
+++ b/targeting/identity_engine.go
@@ -41,6 +41,14 @@ func NewIdentityEngine(cfg IdentityEngineConfig) *IdentityEngine {
 type IdentityResult struct {
 	RequestID   string
 	Eligibility []tmproto.PackageEligibility
+
+	// Verified carries the identities the verified-identity stage validated
+	// (verify-before-trust). The TMPX seal step encodes their nullifiers onto
+	// the wire so the buyer can frequency-cap / unique-human gate on its own
+	// relying-party-scoped pseudonym. Empty when no verifier is wired or no
+	// attestation passed verification — the audience-only engine never sets
+	// it. Never populated from sender-asserted inbound identities.
+	Verified []VerifiedIdentity
 }
 
 // EvaluateIdentityResolved evaluates package eligibility for an identity

--- a/targeting/identityagent/canonicalizer.go
+++ b/targeting/identityagent/canonicalizer.go
@@ -182,6 +182,9 @@ func logCanonicalizerLayout(logger *slog.Logger, decoders map[tmproto.UIDType]Tm
 	enabled := make([]tmproto.UIDType, 0, len(decoders))
 	dropped := make([]tmproto.UIDType, 0, len(uidToTmpxTypeID))
 	for uid := range uidToTmpxTypeID {
+		if !inboundDecodable(uid) {
+			continue
+		}
 		if _, ok := decoders[uid]; ok {
 			enabled = append(enabled, uid)
 		} else {

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -178,17 +178,17 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// When a canonicalizer ran, decoded already holds the per-request
 		// decode pass and we pass it through to keep the LiveRamp sidecar
 		// at one call per request. When canonicalization is opted-out
-		// (decoded is nil) the sealer falls back to its own decode pass
-		// — Seal(=Decode+SealDecoded) covers that explicitly.
-		var (
-			token string
-			terr  error
-		)
-		if decoded != nil {
-			token, terr = h.tmpx.SealDecoded(ctx, decoded)
-		} else {
-			token, terr = h.tmpx.Seal(ctx, req.Identities)
+		// (decoded is nil) the sealer runs its own decode pass over the
+		// inbound identities. Verified-identity nullifiers are appended as
+		// pre-decoded entries: they come from the verified-identity stage
+		// (verify-before-trust) and are never decoded from inbound
+		// sender-asserted identities.
+		seal := decoded
+		if seal == nil {
+			seal = h.tmpx.Decode(ctx, req.Identities)
 		}
+		seal = append(seal, h.tmpx.verifiedIdentityEntries(ctx, result.Verified)...)
+		token, terr := h.tmpx.SealDecoded(ctx, seal)
 		if terr != nil {
 			h.logger.Warn("tmpx generation failed, response will omit tmpx",
 				"request_id", req.RequestID, "error", terr)

--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -171,6 +171,7 @@ func (s *Service) Evaluate(ctx context.Context, req *tmproto.IdentityMatchReques
 	return &targeting.IdentityResult{
 		RequestID:   req.RequestID,
 		Eligibility: eligibility,
+		Verified:    verified,
 	}
 }
 

--- a/targeting/identityagent/tmpx.go
+++ b/targeting/identityagent/tmpx.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/internal/liveramp"
 	"github.com/adcontextprotocol/adcp-go/targeting/tmpxdecoders"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
@@ -259,6 +260,9 @@ func logDecoderLayout(logger *slog.Logger, country string, decoders map[tmproto.
 	enabled := make([]tmproto.UIDType, 0, len(decoders))
 	dropped := make([]tmproto.UIDType, 0, len(uidToTmpxTypeID))
 	for uid := range uidToTmpxTypeID {
+		if !inboundDecodable(uid) {
+			continue
+		}
 		if _, ok := decoders[uid]; ok {
 			enabled = append(enabled, uid)
 		} else {
@@ -412,6 +416,53 @@ var uidToTmpxTypeID = map[tmproto.UIDType]tmproto.TmpxTypeID{
 	tmproto.UIDTypePairID:              tmproto.TmpxTypePairID,
 	tmproto.UIDTypeHashedEmail:         tmproto.TmpxTypeHashedEmail,
 	tmproto.UIDTypePublisherFirstParty: tmproto.TmpxTypePublisherFirstParty,
+	tmproto.UIDTypeWorldIDNullifier:    tmproto.TmpxTypeWorldIDNullifier,
+}
+
+// inboundDecodable reports whether a TMPX-encodable UID type is expected to
+// have a decoder in the inbound registry. World ID nullifiers are
+// verify-before-trust and never decoded from inbound identities, so their
+// absence from the inbound registry is by design, not a misconfiguration —
+// the startup coverage logs exclude them so an operator doesn't read them as
+// a dropped type.
+func inboundDecodable(uid tmproto.UIDType) bool {
+	return uid != tmproto.UIDTypeWorldIDNullifier
+}
+
+// worldIDNullifierEncoder converts a verifier-derived nullifier string into
+// its TMPX token bytes. It is intentionally not part of the inbound decoder
+// registry (see tmpxdecoders.NewDefaultRegistry) so it is unreachable from
+// sender-asserted identities; the verified-identity stage is its only caller.
+var worldIDNullifierEncoder = tmpxdecoders.WorldIDNullifier{}
+
+// verifiedIdentityEntries converts the verifier-derived identities into
+// pre-decoded TMPX entries. These bypass the inbound decoder registry by
+// design — verify-before-trust: a World ID nullifier reaches the wire ONLY
+// after the verified-identity stage validated its proof. An inbound,
+// sender-asserted world_id_nullifier token has no registered decoder and is
+// dropped at Decode, so it can never arrive here.
+//
+// A nullifier that fails to encode (malformed/oversized) is dropped with a
+// decoder_error counter rather than failing the whole seal — one bad
+// nullifier must not suppress the other resolved identities.
+func (s *TMPXSealer) verifiedIdentityEntries(ctx context.Context, verified []targeting.VerifiedIdentity) []DecodedIdentity {
+	if len(verified) == 0 {
+		return nil
+	}
+	out := make([]DecodedIdentity, 0, len(verified))
+	for _, vi := range verified {
+		if vi.Nullifier == "" {
+			continue
+		}
+		b, err := worldIDNullifierEncoder.Decode(ctx, vi.Nullifier)
+		if err != nil {
+			s.recordDrop(ctx, TmpxDropDecoderError, tmproto.UIDTypeWorldIDNullifier)
+			s.log().Warn("world id nullifier encode failed — dropping from tmpx", "error", err)
+			continue
+		}
+		out = append(out, DecodedIdentity{UIDType: tmproto.UIDTypeWorldIDNullifier, Bytes: b})
+	}
+	return out
 }
 
 // selectEntries packs already-decoded identities into the wire TmpxEntry
@@ -494,4 +545,3 @@ func indexOfUIDType(list []tmproto.UIDType, uid tmproto.UIDType) int {
 	}
 	return -1
 }
-

--- a/targeting/identityagent/tmpx_test.go
+++ b/targeting/identityagent/tmpx_test.go
@@ -15,9 +15,72 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/adcontextprotocol/adcp-go/targeting"
 	"github.com/adcontextprotocol/adcp-go/targeting/tmpxdecoders"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
+
+const testNullifier = "0x" + "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+
+func TestVerifiedIdentityEntries_EncodesNullifier(t *testing.T) {
+	cfg := &TMPXSealer{}
+	entries := cfg.verifiedIdentityEntries(t.Context(), []targeting.VerifiedIdentity{
+		{Nullifier: testNullifier, RelyingPartyID: "rp.example"},
+	})
+	require.Len(t, entries, 1)
+	assert.Equal(t, tmproto.UIDTypeWorldIDNullifier, entries[0].UIDType)
+	size, _ := tmproto.TmpxTokenSize(tmproto.TmpxTypeWorldIDNullifier)
+	assert.Len(t, entries[0].Bytes, size, "verified nullifier must encode to the registry token width")
+}
+
+func TestVerifiedIdentityEntries_SkipsEmptyAndMalformed(t *testing.T) {
+	rec := newTestRecorder()
+	cfg := &TMPXSealer{recorder: rec}
+	entries := cfg.verifiedIdentityEntries(t.Context(), []targeting.VerifiedIdentity{
+		{Nullifier: ""},            // skipped, no counter
+		{Nullifier: "0xnothex"},    // malformed → decoder_error drop
+		{Nullifier: testNullifier}, // survives
+	})
+	require.Len(t, entries, 1, "only the well-formed nullifier survives")
+	assert.Equal(t, 1, rec.dropCount(TmpxDropDecoderError, string(tmproto.UIDTypeWorldIDNullifier)),
+		"a malformed nullifier records a decoder_error drop and does not fail the batch")
+}
+
+// TestVerifiedNullifierSealsWhileInboundAssertedDropped is the verify-before-trust
+// end-to-end check: a verifier-derived nullifier reaches the wire, while a
+// sender-asserted world_id_nullifier supplied on req.Identities is dropped at
+// decode (no inbound decoder) and never sealed.
+func TestVerifiedNullifierSealsWhileInboundAssertedDropped(t *testing.T) {
+	cfg := &TMPXSealer{
+		country:  "US",
+		encStore: newFakeResolver(t, "k1"),
+		decoders: defaultTestDecoders(t),
+	}
+
+	// Sender-asserted world_id_nullifier on the inbound identities: dropped.
+	inbound := cfg.Decode(t.Context(), []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeWorldIDNullifier, UserToken: testNullifier},
+	})
+	require.Len(t, inbound, 1)
+	assert.Empty(t, inbound[0].Bytes, "inbound asserted world_id_nullifier has no decoder and must drop")
+
+	inboundEntries, err := cfg.selectEntries(inbound)
+	require.NoError(t, err)
+	assert.Empty(t, inboundEntries, "asserted nullifier must not reach the wire")
+
+	// Verifier-derived nullifier: packs into a wire entry.
+	verified := cfg.verifiedIdentityEntries(t.Context(), []targeting.VerifiedIdentity{
+		{Nullifier: testNullifier, RelyingPartyID: "rp.example"},
+	})
+	entries, err := cfg.selectEntries(append(inbound, verified...))
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the verified nullifier is sealed")
+	assert.Equal(t, tmproto.TmpxTypeWorldIDNullifier, entries[0].TypeID)
+
+	wire, err := cfg.SealDecoded(t.Context(), append(inbound, verified...))
+	require.NoError(t, err)
+	assert.NotEmpty(t, wire, "verified nullifier must produce a TMPX wire")
+}
 
 // fakeRecipientResolver returns a fixed recipient. Used to exercise
 // (*TMPXSealer).Seal without spinning up an httptest JWKS server.
@@ -227,8 +290,8 @@ func TestNoDecoder_DropsFromBothWireAndAudience(t *testing.T) {
 func TestAudienceEligibleIdentities_FiltersDropped(t *testing.T) {
 	decoded := []DecodedIdentity{
 		{UIDType: tmproto.UIDTypeMAID, Bytes: []byte{0x01, 0x02, 0x03}},
-		{UIDType: tmproto.UIDTypeUID2, Bytes: nil},                       // dropped at decode (no decoder)
-		{UIDType: tmproto.UIDTypeRampID, Bytes: nil},                     // dropped (LR miss)
+		{UIDType: tmproto.UIDTypeUID2, Bytes: nil},   // dropped at decode (no decoder)
+		{UIDType: tmproto.UIDTypeRampID, Bytes: nil}, // dropped (LR miss)
 		{UIDType: tmproto.UIDTypeHashedEmail, Bytes: []byte{0xff, 0xee}},
 	}
 	got := audienceEligibleIdentities(decoded)

--- a/targeting/identityagent/verified_identity_stage_test.go
+++ b/targeting/identityagent/verified_identity_stage_test.go
@@ -120,10 +120,15 @@ func TestService_VerifiedIdentity_HappyPath(t *testing.T) {
 		ageResolver:   staticAgeResolver{"pkg-alcohol": tmproto.AttestationClaimAgeOver21},
 	})
 	req := vidReq(sealedCred(t, "kid-1", sk.PublicKey(), validAtt(tmproto.AttestationClaimAgeOver21)))
-	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	result := svc.Evaluate(t.Context(), req)
+	got := eligibilityMap(result.Eligibility)
 	assert.True(t, got["pkg-alcohol"], "verified age_over_21 satisfies the 21 gate")
 	assert.True(t, got["pkg-general"], "ungated package eligible")
 	assert.Equal(t, 1, mv.calls)
+	// The verified identity is surfaced on the result so the handler can seal
+	// its nullifier into TMPX.
+	require.Len(t, result.Verified, 1)
+	assert.Equal(t, "N", result.Verified[0].Nullifier)
 }
 
 // AGE GATE: verified claim is only age_over_18; the age_over_21 package is

--- a/targeting/tmpxdecoders/registry.go
+++ b/targeting/tmpxdecoders/registry.go
@@ -30,6 +30,13 @@ type RegistryOptions struct {
 // is non-nil. UID types without a registered decoder are silently dropped
 // at decode time.
 //
+// WorldIDNullifier is deliberately absent: a World ID nullifier is
+// verify-before-trust and must never be decoded from an inbound,
+// sender-asserted IdentityToken. It reaches the wire only via the
+// verified-identity stage, which encodes the verifier-derived nullifier
+// directly (see TMPXSealer.verifiedIdentityEntries). An inbound
+// world_id_nullifier token therefore has no decoder here and is dropped.
+//
 // The returned map is freshly allocated on every call so callers can mutate
 // it (e.g. swap in a custom decoder for tests) without affecting other
 // callers.

--- a/targeting/tmpxdecoders/world_id_nullifier.go
+++ b/targeting/tmpxdecoders/world_id_nullifier.go
@@ -1,0 +1,55 @@
+package tmpxdecoders
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+// WorldIDNullifier encodes a verified World ID nullifier into its 32-byte
+// TMPX token. The nullifier World returns is a relying-party-scoped field
+// element (BN254 scalar, ≤254 bits) rendered as a hex string with an
+// optional "0x" prefix; the binary form is that integer, big-endian, left-
+// padded to the fixed 32-byte width the TMPX type registry assigns
+// TmpxTypeWorldIDNullifier. Big-endian zero-padding is reversible by the
+// buyer master, which keys frequency-cap / unique-human state on the same
+// nullifier under its own relying-party scope.
+//
+// Verify-before-trust: this encoder is NOT part of NewDefaultRegistry, so it
+// is unreachable from the inbound IdentityToken decode path. A nullifier
+// reaches the wire ONLY after the verified-identity stage validated its
+// proof against the World ID backend and derived the nullifier from World's
+// authoritative response. An inbound, sender-asserted world_id_nullifier
+// token has no registered decoder and is dropped at decode time — it can
+// never be sealed.
+type WorldIDNullifier struct{}
+
+// worldIDNullifierBytes is the fixed TMPX token width for a World ID
+// nullifier, matching TmpxTokenSize(TmpxTypeWorldIDNullifier).
+const worldIDNullifierBytes = 32
+
+// Decode parses the hex nullifier into its 32-byte big-endian form. ctx is
+// unused — WorldIDNullifier is a pure-format encoder. A value wider than 32
+// bytes, empty input, or non-hex content is an error (the caller drops the
+// identity rather than emitting a malformed token).
+func (WorldIDNullifier) Decode(_ context.Context, nullifier string) ([]byte, error) {
+	hexDigits := strings.TrimSpace(nullifier)
+	hexDigits = strings.TrimPrefix(hexDigits, "0x")
+	hexDigits = strings.TrimPrefix(hexDigits, "0X")
+	if hexDigits == "" {
+		return nil, errors.New("world_id_nullifier: empty nullifier")
+	}
+	n, ok := new(big.Int).SetString(hexDigits, 16)
+	if !ok {
+		return nil, errors.New("world_id_nullifier: nullifier is not valid hex")
+	}
+	raw := n.Bytes()
+	if len(raw) > worldIDNullifierBytes {
+		return nil, fmt.Errorf("world_id_nullifier: nullifier is %d bytes, exceeds %d", len(raw), worldIDNullifierBytes)
+	}
+	out := make([]byte, worldIDNullifierBytes)
+	copy(out[worldIDNullifierBytes-len(raw):], raw)
+	return out, nil
+}

--- a/targeting/tmpxdecoders/world_id_nullifier_test.go
+++ b/targeting/tmpxdecoders/world_id_nullifier_test.go
@@ -1,0 +1,74 @@
+package tmpxdecoders
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+func TestWorldIDNullifier_FullWidthHex(t *testing.T) {
+	// A 64-hex-char (32-byte) nullifier round-trips to its raw bytes,
+	// with or without the 0x prefix.
+	raw := strings.Repeat("ab", 32)
+	want, err := hex.DecodeString(raw)
+	require.NoError(t, err)
+
+	for _, in := range []string{raw, "0x" + raw, "0X" + raw, "  0x" + raw + "  "} {
+		got, err := WorldIDNullifier{}.Decode(t.Context(), in)
+		require.NoError(t, err, "input %q", in)
+		assert.Equal(t, want, got, "input %q", in)
+		size, _ := tmproto.TmpxTokenSize(tmproto.TmpxTypeWorldIDNullifier)
+		assert.Len(t, got, size, "must produce the registry token width")
+	}
+}
+
+func TestWorldIDNullifier_LeftPadsShortFieldElement(t *testing.T) {
+	// World drops leading-zero nibbles, so a sub-32-byte field element must
+	// be left-padded big-endian to the fixed width — and the same logical
+	// value must encode identically with or without those leading zeros.
+	got, err := WorldIDNullifier{}.Decode(t.Context(), "0x2a")
+	require.NoError(t, err)
+	require.Len(t, got, 32)
+	assert.Equal(t, byte(0x2a), got[31])
+	for _, b := range got[:31] {
+		assert.Equal(t, byte(0), b)
+	}
+
+	padded, err := WorldIDNullifier{}.Decode(t.Context(), "0x"+strings.Repeat("0", 62)+"2a")
+	require.NoError(t, err)
+	assert.Equal(t, got, padded, "leading zeros must not change the encoding")
+}
+
+func TestWorldIDNullifier_RejectsBadInput(t *testing.T) {
+	cases := map[string]string{
+		"empty":         "",
+		"only prefix":   "0x",
+		"non-hex":       "0xnothex",
+		"over 32 bytes": "0x" + strings.Repeat("ff", 33),
+	}
+	for name, in := range cases {
+		_, err := WorldIDNullifier{}.Decode(t.Context(), in)
+		assert.Error(t, err, name)
+	}
+}
+
+// TestWorldIDNullifier_NotInDefaultRegistry locks the verify-before-trust
+// invariant: the nullifier encoder must never be reachable from the inbound
+// decode path, with or without LiveRamp. A sender-asserted
+// world_id_nullifier token has no decoder and is dropped; the nullifier
+// reaches the wire only via the verified-identity stage.
+func TestWorldIDNullifier_NotInDefaultRegistry(t *testing.T) {
+	for _, opts := range []RegistryOptions{
+		{},
+		{LiveRampClient: &fakeLiveRampClient{mappedLen: 32}},
+	} {
+		reg := NewDefaultRegistry(opts)
+		_, ok := reg[tmproto.UIDTypeWorldIDNullifier]
+		assert.False(t, ok, "world_id_nullifier must never have an inbound decoder")
+	}
+}

--- a/tmproto/tmpx.go
+++ b/tmproto/tmpx.go
@@ -80,6 +80,7 @@ const (
 	TmpxTypePairID              TmpxTypeID = 7
 	TmpxTypeHashedEmail         TmpxTypeID = 8
 	TmpxTypePublisherFirstParty TmpxTypeID = 9
+	TmpxTypeWorldIDNullifier    TmpxTypeID = 10
 )
 
 // TmpxTokenSize returns the spec-defined binary size for a Type ID.
@@ -88,7 +89,8 @@ const (
 func TmpxTokenSize(typeID TmpxTypeID) (int, bool) {
 	switch typeID {
 	case TmpxTypeUID2, TmpxTypeEUID, TmpxTypeID5, TmpxTypeRampID,
-		TmpxTypePairID, TmpxTypeHashedEmail, TmpxTypePublisherFirstParty:
+		TmpxTypePairID, TmpxTypeHashedEmail, TmpxTypePublisherFirstParty,
+		TmpxTypeWorldIDNullifier:
 		return 32, true
 	case TmpxTypeRampIDDerived:
 		return 48, true

--- a/tmproto/tmpx_test.go
+++ b/tmproto/tmpx_test.go
@@ -334,12 +334,13 @@ func TestTmpxWireSizeEmptyEntries(t *testing.T) {
 }
 
 func TestTmpxTokenSizeRegistry(t *testing.T) {
-	// Spec: types 1..4, 7, 8, 9 are 32 bytes; 5 is 48; 6 is 16.
+	// Spec: types 1..4, 7, 8, 9, 10 are 32 bytes; 5 is 48; 6 is 16.
 	cases := map[TmpxTypeID]int{
 		TmpxTypeUID2: 32, TmpxTypeEUID: 32, TmpxTypeID5: 32,
 		TmpxTypeRampID: 32, TmpxTypeRampIDDerived: 48,
 		TmpxTypeMAID: 16, TmpxTypePairID: 32,
 		TmpxTypeHashedEmail: 32, TmpxTypePublisherFirstParty: 32,
+		TmpxTypeWorldIDNullifier: 32,
 	}
 	for id, want := range cases {
 		got, ok := TmpxTokenSize(id)


### PR DESCRIPTION
## What

The verified-identity stage already validates a World ID nullifier, but it never reached the TMPX exposure token — it was used only for fcap keys and package gating, then dropped. This PR seals the verifier-derived nullifier onto the TMPX wire so the buyer (the relying party the nullifier is scoped to) receives its own Sybil-resistant pseudonym for unique-human / frequency-cap gating downstream.

## How

- **`tmproto`**: add `TmpxTypeWorldIDNullifier` (type id `10`, 32-byte token) to the TMPX type registry.
- **`tmpxdecoders`**: add `WorldIDNullifier`, which encodes the nullifier hex field element to 32 bytes big-endian. **Deliberately excluded from `NewDefaultRegistry`** so it is unreachable from the inbound decode path.
- **`targeting`**: surface verified identities on `IdentityResult`; `Service.Evaluate` populates them; `TMPXSealer.verifiedIdentityEntries` encodes them as pre-decoded entries, appended to the seal input in the handler (both the canonicalized and fallback paths).
- Startup decoder-coverage logs exclude `world_id_nullifier` (it intentionally has no inbound decoder, so it must not be reported as a misconfigured drop).
- Docs updated.

## Security invariant (verify-before-trust)

The nullifier reaches the wire **only** via the verified-identity stage, derived from World's authoritative verify response. A sender-asserted `world_id_nullifier` on inbound `identities` has no inbound decoder and is dropped at decode — it can never be sealed. This is locked by tests (`TestWorldIDNullifier_NotInDefaultRegistry`, `TestVerifiedNullifierSealsWhileInboundAssertedDropped`).

## Decisions that warrant a reviewer/spec check

These are greenfield (no existing consumer decodes this type yet), so they're cheap to change — flagging them explicitly:

1. **TMPX type id = `10`** — next free, append-only. Confirm this is the intended registry assignment (the numeric registry lives only in Go today, citing the TMP spec).
2. **Wire encoding = 32-byte big-endian field element** (hex, optional `0x`, left-padded). Chosen for consistency with the other ID types (UID2/EUID/ID5/RampID all carry the *actual* identifier, not a hash of it), and because World's nullifier is a BN254 scalar that fits in 32 bytes. The alternative — `SHA-256(nullifier)` — is format-agnostic but lossy; I went with carrying the real value. Confirm the buyer-side decode expects the raw field element.
3. **`TMPX_PRIORITY` interaction**: when a priority list is configured, operators must include `world_id_nullifier` to keep it on the wire under budget pressure — consistent with how every other type behaves.

## Tests

- Encoder: full-width, left-pad, bad-input, registry exclusion.
- Token-size registry entry.
- Sealer: nullifier encodes to a wire entry; empty/malformed skipped with a `decoder_error` counter (one bad nullifier doesn't fail the batch); end-to-end verified-seals-while-inbound-asserted-dropped.
- `Service.Evaluate` surfaces `Verified` end-to-end.

`go build`, `go vet`, full `go test ./...`, and `golangci-lint` (only pre-existing gosec findings in untouched files) all clean.
