### PR TITLE
feat(tmpx): scope the world_id_nullifier token to its relying party

### DIFF
--- a/targeting/identityagent/tmpx.go
+++ b/targeting/identityagent/tmpx.go
@@ -454,7 +454,7 @@ func (s *TMPXSealer) verifiedIdentityEntries(ctx context.Context, verified []tar
 		if vi.Nullifier == "" {
 			continue
 		}
-		b, err := worldIDNullifierEncoder.Decode(ctx, vi.Nullifier)
+		b, err := worldIDNullifierEncoder.Token(ctx, vi.RelyingPartyID, vi.Nullifier)
 		if err != nil {
 			s.recordDrop(ctx, TmpxDropDecoderError, tmproto.UIDTypeWorldIDNullifier)
 			s.log().Warn("world id nullifier encode failed — dropping from tmpx", "error", err)

--- a/targeting/identityagent/tmpx_test.go
+++ b/targeting/identityagent/tmpx_test.go
@@ -37,13 +37,23 @@ func TestVerifiedIdentityEntries_SkipsEmptyAndMalformed(t *testing.T) {
 	rec := newTestRecorder()
 	cfg := &TMPXSealer{recorder: rec}
 	entries := cfg.verifiedIdentityEntries(t.Context(), []targeting.VerifiedIdentity{
-		{Nullifier: ""},            // skipped, no counter
-		{Nullifier: "0xnothex"},    // malformed → decoder_error drop
-		{Nullifier: testNullifier}, // survives
+		{Nullifier: ""}, // skipped, no counter
+		{Nullifier: "0xnothex", RelyingPartyID: "rp.example"},    // malformed → decoder_error drop
+		{Nullifier: testNullifier, RelyingPartyID: "rp.example"}, // survives
 	})
 	require.Len(t, entries, 1, "only the well-formed nullifier survives")
 	assert.Equal(t, 1, rec.dropCount(TmpxDropDecoderError, string(tmproto.UIDTypeWorldIDNullifier)),
 		"a malformed nullifier records a decoder_error drop and does not fail the batch")
+}
+
+func TestVerifiedIdentityEntries_DropsMissingRelyingParty(t *testing.T) {
+	rec := newTestRecorder()
+	cfg := &TMPXSealer{recorder: rec}
+	entries := cfg.verifiedIdentityEntries(t.Context(), []targeting.VerifiedIdentity{
+		{Nullifier: testNullifier}, // no relying party → cannot form an rp-scoped token
+	})
+	assert.Empty(t, entries, "a verified nullifier without a relying party cannot be sealed")
+	assert.Equal(t, 1, rec.dropCount(TmpxDropDecoderError, string(tmproto.UIDTypeWorldIDNullifier)))
 }
 
 // TestVerifiedNullifierSealsWhileInboundAssertedDropped is the verify-before-trust

--- a/targeting/tmpxdecoders/world_id_nullifier.go
+++ b/targeting/tmpxdecoders/world_id_nullifier.go
@@ -2,20 +2,21 @@ package tmpxdecoders
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"math/big"
 	"strings"
 )
 
-// WorldIDNullifier encodes a verified World ID nullifier into its 32-byte
-// TMPX token. The nullifier World returns is a relying-party-scoped field
-// element (BN254 scalar, ≤254 bits) rendered as a hex string with an
-// optional "0x" prefix; the binary form is that integer, big-endian, left-
-// padded to the fixed 32-byte width the TMPX type registry assigns
-// TmpxTypeWorldIDNullifier. Big-endian zero-padding is reversible by the
-// buyer master, which keys frequency-cap / unique-human state on the same
-// nullifier under its own relying-party scope.
+// WorldIDNullifier encodes a verified World ID nullifier into its TMPX token.
+// The nullifier World returns is a relying-party-scoped field element (BN254
+// scalar, ≤254 bits) rendered as a hex string with an optional "0x" prefix;
+// Decode renders it as a fixed-width big-endian integer. Token prepends a
+// digest of the relying party so the sealed token is self-describing: the
+// nullifier is meaningful only within the relying party it was minted for, and
+// the exposure consumer keys frequency-cap / unique-human state on the
+// (relying party, nullifier) pair.
 //
 // Verify-before-trust: this encoder is NOT part of NewDefaultRegistry, so it
 // is unreachable from the inbound IdentityToken decode path. A nullifier
@@ -26,9 +27,13 @@ import (
 // never be sealed.
 type WorldIDNullifier struct{}
 
-// worldIDNullifierBytes is the fixed TMPX token width for a World ID
-// nullifier, matching TmpxTokenSize(TmpxTypeWorldIDNullifier).
+// worldIDNullifierBytes is the big-endian width of the nullifier component.
 const worldIDNullifierBytes = 32
+
+// worldIDRelyingPartyDigestBytes is the width of the relying-party component
+// of the TMPX token: the leading bytes of SHA-256(relying_party_id). Together
+// with the nullifier it forms TmpxTokenSize(TmpxTypeWorldIDNullifier).
+const worldIDRelyingPartyDigestBytes = 16
 
 // Decode parses the hex nullifier into its 32-byte big-endian form. ctx is
 // unused — WorldIDNullifier is a pure-format encoder. A value wider than 32
@@ -52,4 +57,25 @@ func (WorldIDNullifier) Decode(_ context.Context, nullifier string) ([]byte, err
 	out := make([]byte, worldIDNullifierBytes)
 	copy(out[worldIDNullifierBytes-len(raw):], raw)
 	return out, nil
+}
+
+// Token builds the relying-party-scoped TMPX token: the first
+// worldIDRelyingPartyDigestBytes of SHA-256(relyingPartyID) followed by the
+// Decode'd nullifier. relyingPartyID must be the receiver-confirmed rp_id the
+// proof was verified against; an empty relyingPartyID or a malformed nullifier
+// is an error so the caller drops the identity rather than sealing an
+// unscoped or malformed token.
+func (e WorldIDNullifier) Token(ctx context.Context, relyingPartyID, nullifier string) ([]byte, error) {
+	if relyingPartyID == "" {
+		return nil, errors.New("world_id_nullifier: empty relying_party_id")
+	}
+	nullifierBytes, err := e.Decode(ctx, nullifier)
+	if err != nil {
+		return nil, err
+	}
+	digest := sha256.Sum256([]byte(relyingPartyID))
+	token := make([]byte, worldIDRelyingPartyDigestBytes+worldIDNullifierBytes)
+	copy(token, digest[:worldIDRelyingPartyDigestBytes])
+	copy(token[worldIDRelyingPartyDigestBytes:], nullifierBytes)
+	return token, nil
 }

--- a/targeting/tmpxdecoders/world_id_nullifier_test.go
+++ b/targeting/tmpxdecoders/world_id_nullifier_test.go
@@ -1,6 +1,7 @@
 package tmpxdecoders
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"strings"
 	"testing"
@@ -22,9 +23,36 @@ func TestWorldIDNullifier_FullWidthHex(t *testing.T) {
 		got, err := WorldIDNullifier{}.Decode(t.Context(), in)
 		require.NoError(t, err, "input %q", in)
 		assert.Equal(t, want, got, "input %q", in)
-		size, _ := tmproto.TmpxTokenSize(tmproto.TmpxTypeWorldIDNullifier)
-		assert.Len(t, got, size, "must produce the registry token width")
+		assert.Len(t, got, worldIDNullifierBytes, "Decode yields the 32-byte nullifier component")
 	}
+}
+
+func TestWorldIDNullifier_TokenIsRelyingPartyScoped(t *testing.T) {
+	const rp = "rp.example"
+	token, err := WorldIDNullifier{}.Token(t.Context(), rp, "0x2a")
+	require.NoError(t, err)
+
+	size, _ := tmproto.TmpxTokenSize(tmproto.TmpxTypeWorldIDNullifier)
+	require.Len(t, token, size, "token must be the registry width")
+
+	digest := sha256.Sum256([]byte(rp))
+	assert.Equal(t, digest[:worldIDRelyingPartyDigestBytes], token[:worldIDRelyingPartyDigestBytes],
+		"leading bytes are the relying-party digest")
+	nullifier, err := WorldIDNullifier{}.Decode(t.Context(), "0x2a")
+	require.NoError(t, err)
+	assert.Equal(t, nullifier, token[worldIDRelyingPartyDigestBytes:], "trailing bytes are the nullifier")
+
+	other, err := WorldIDNullifier{}.Token(t.Context(), "rp.other", "0x2a")
+	require.NoError(t, err)
+	assert.NotEqual(t, token, other, "same nullifier under different relying parties yields distinct tokens")
+}
+
+func TestWorldIDNullifier_TokenRejectsMissingRelyingPartyOrBadNullifier(t *testing.T) {
+	_, err := WorldIDNullifier{}.Token(t.Context(), "", "0x2a")
+	assert.Error(t, err, "a token without a relying party must not be formed")
+
+	_, err = WorldIDNullifier{}.Token(t.Context(), "rp.example", "0xnothex")
+	assert.Error(t, err, "a malformed nullifier must not be sealed")
 }
 
 func TestWorldIDNullifier_LeftPadsShortFieldElement(t *testing.T) {

--- a/tmproto/tmpx.go
+++ b/tmproto/tmpx.go
@@ -89,10 +89,14 @@ const (
 func TmpxTokenSize(typeID TmpxTypeID) (int, bool) {
 	switch typeID {
 	case TmpxTypeUID2, TmpxTypeEUID, TmpxTypeID5, TmpxTypeRampID,
-		TmpxTypePairID, TmpxTypeHashedEmail, TmpxTypePublisherFirstParty,
-		TmpxTypeWorldIDNullifier:
+		TmpxTypePairID, TmpxTypeHashedEmail, TmpxTypePublisherFirstParty:
 		return 32, true
 	case TmpxTypeRampIDDerived:
+		return 48, true
+	case TmpxTypeWorldIDNullifier:
+		// 16-byte relying-party digest followed by the 32-byte nullifier:
+		// the nullifier is meaningful only within its relying party, so the
+		// token is relying-party-scoped on the wire.
 		return 48, true
 	case TmpxTypeMAID:
 		return 16, true

--- a/tmproto/tmpx_test.go
+++ b/tmproto/tmpx_test.go
@@ -334,13 +334,13 @@ func TestTmpxWireSizeEmptyEntries(t *testing.T) {
 }
 
 func TestTmpxTokenSizeRegistry(t *testing.T) {
-	// Spec: types 1..4, 7, 8, 9, 10 are 32 bytes; 5 is 48; 6 is 16.
+	// Spec: types 1..4, 7, 8, 9 are 32 bytes; 5 and 10 are 48; 6 is 16.
 	cases := map[TmpxTypeID]int{
 		TmpxTypeUID2: 32, TmpxTypeEUID: 32, TmpxTypeID5: 32,
 		TmpxTypeRampID: 32, TmpxTypeRampIDDerived: 48,
 		TmpxTypeMAID: 16, TmpxTypePairID: 32,
 		TmpxTypeHashedEmail: 32, TmpxTypePublisherFirstParty: 32,
-		TmpxTypeWorldIDNullifier: 32,
+		TmpxTypeWorldIDNullifier: 48,
 	}
 	for id, want := range cases {
 		got, ok := TmpxTokenSize(id)


### PR DESCRIPTION
Implements the rp-scoped `world_id_nullifier` TMPX token defined in adcontextprotocol/adcp#5454.

## Why

A World ID nullifier is meaningful only within the `rp_id` it was minted for, and that `rp_id` rides the request-side `attestation` — which does **not** round-trip into the `tmpx` exposure token. Sealing only the bare nullifier left the out-of-band impression tracker unable to attribute an exposure to its relying party or reconstruct the `(rp_id, nullifier)` key frequency state is kept under.

## What

The `world_id_nullifier` TMPX token is now relying-party-scoped: `SHA-256(relying_party_id)[:16] ‖ nullifier` (48 bytes), with no `rp_id` cleartext on the wire.

- `TmpxTokenSize(TmpxTypeWorldIDNullifier)` → 48 (was 32), so both the seal and the parser agree on the width.
- `WorldIDNullifier.Decode` is unchanged — it still yields the 32-byte nullifier component (used to canonicalize a bare nullifier). A new `Token(ctx, relyingPartyID, nullifier)` builds the rp-scoped wire token and requires the receiver-confirmed `rp_id`.
- `TMPXSealer.verifiedIdentityEntries` passes `VerifiedIdentity.RelyingPartyID`; a verified nullifier without a relying party can't form a token and is dropped (`decoder_error`), so an unscoped token is never sealed.

Verify-before-trust is preserved and reinforced: the encoder remains out of the inbound decoder registry, and the token now structurally requires the *verified* `rp_id`, so a sender-asserted nullifier can't form one.

## Tests

- Registry width is 48; `Token` layout is digest-then-nullifier and is distinct across relying parties; empty rp / malformed nullifier are rejected.
- Sealer drops a verified nullifier that lacks a relying party.
- Full suite + `go vet` pass; the only `golangci-lint` findings are pre-existing (unrelated `gosec` flags in `config.go`/`keystore_*`).

Depends on adcontextprotocol/adcp#5454 (spec). The digest width (16 bytes) tracks the working-group open item there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)