### PR TITLE
fix(identityagent): give duration histograms sub-second buckets

### DIFF
--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -239,6 +239,17 @@ type otelRecorder struct {
 
 var _ Recorder = (*otelRecorder)(nil)
 
+// durationBucketsSeconds are the explicit histogram boundaries for the
+// latency instruments. OTEL's default boundaries assume the recorded value is
+// in milliseconds, but these instruments record seconds; a request budget of
+// tens of milliseconds is far below OTEL's smallest default boundary, so every
+// observation would collapse into the first bucket and the percentiles would
+// carry no resolution. These boundaries span sub-millisecond to one second so
+// p50–p999 stay meaningful around the request budget.
+var durationBucketsSeconds = []float64{
+	0.0005, 0.001, 0.0025, 0.005, 0.01, 0.02, 0.035, 0.05, 0.075, 0.1, 0.25, 0.5, 1,
+}
+
 func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error) {
 	requestStarted, err := meter.Int64Counter(
 		fmt.Sprintf("%s_requests_started_total", namespace))
@@ -246,7 +257,8 @@ func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error
 		return nil, err
 	}
 	requestDuration, err := meter.Float64Histogram(
-		fmt.Sprintf("%s_request_duration_seconds", namespace))
+		fmt.Sprintf("%s_request_duration_seconds", namespace),
+		metric.WithExplicitBucketBoundaries(durationBucketsSeconds...))
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +268,8 @@ func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error
 		return nil, err
 	}
 	stageDuration, err := meter.Float64Histogram(
-		fmt.Sprintf("%s_stage_duration_seconds", namespace))
+		fmt.Sprintf("%s_stage_duration_seconds", namespace),
+		metric.WithExplicitBucketBoundaries(durationBucketsSeconds...))
 	if err != nil {
 		return nil, err
 	}

--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -245,7 +245,9 @@ var _ Recorder = (*otelRecorder)(nil)
 // tens of milliseconds is far below OTEL's smallest default boundary, so every
 // observation would collapse into the first bucket and the percentiles would
 // carry no resolution. These boundaries span sub-millisecond to one second so
-// p50–p999 stay meaningful around the request budget.
+// p50–p999 stay meaningful around the request budget. The 0.035 boundary is
+// tuned to sit just under the REQUEST_TIMEOUT budget (40ms by default); revisit
+// this slice if that budget changes so an edge keeps landing near it.
 var durationBucketsSeconds = []float64{
 	0.0005, 0.001, 0.0025, 0.005, 0.01, 0.02, 0.035, 0.05, 0.075, 0.1, 0.25, 0.5, 1,
 }

--- a/targeting/identityagent/metrics_test.go
+++ b/targeting/identityagent/metrics_test.go
@@ -4,10 +4,50 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// durationHistogramSuffixes are the histogram metric-name suffixes that record
+// latency in seconds and must carry sub-second bucket boundaries.
+var durationHistogramSuffixes = []string{
+	"_request_duration_seconds",
+	"_stage_duration_seconds",
+}
+
+func TestDurationHistograms_UseSubSecondBuckets(t *testing.T) {
+	p, err := Build(MetricsConfig{Enabled: true, Namespace: "identity_agent"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Shutdown(context.Background()) })
+
+	// Record a sub-second observation into each duration histogram so the
+	// Prometheus exporter materializes its buckets.
+	ctx := context.Background()
+	p.Recorder.RequestCompleted(ctx, "ok", 30*time.Millisecond)
+	p.Recorder.StageDuration(ctx, StageResolve, 5*time.Millisecond)
+
+	mfs, err := p.Registry.Gather()
+	require.NoError(t, err)
+
+	for _, suffix := range durationHistogramSuffixes {
+		var bounds []float64
+		for _, mf := range mfs {
+			if !strings.HasSuffix(mf.GetName(), suffix) {
+				continue
+			}
+			require.Len(t, mf.GetMetric(), 1)
+			for _, b := range mf.GetMetric()[0].GetHistogram().GetBucket() {
+				bounds = append(bounds, b.GetUpperBound())
+			}
+			break
+		}
+		require.NotNil(t, bounds, "histogram %q should be registered", suffix)
+		assert.Equal(t, durationBucketsSeconds, bounds,
+			"histogram %q should carry the explicit sub-second boundaries, not OTEL's millisecond-scaled defaults", suffix)
+	}
+}
 
 func TestRegisterConfigEntriesObserver_DisabledProviderIsNoop(t *testing.T) {
 	p, err := Build(MetricsConfig{Enabled: false})


### PR DESCRIPTION
## Problem

`identity_agent_request_duration_seconds` and `identity_agent_stage_duration_seconds` are `Float64Histogram`s that record latency in **seconds** (`d.Seconds()`). The OTEL meter provider in `Build` is constructed with `WithReader` + `WithResource` only — no explicit-bucket `View` — so the SDK falls back to its **default** explicit bucket boundaries `[0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]`. Those defaults assume the value is in **milliseconds**.

The identity-agent runs with a request budget of tens of milliseconds (e.g. `REQUEST_TIMEOUT=35ms`), i.e. `~0.035` seconds. Every observation therefore lands in the **first** bucket (`le=5` seconds), so `histogram_quantile(…)` over these series carries no resolution — p50/p95/p99/p999 are all meaningless.

This was found while building identity-match latency panels on the RTDP dashboard: the agent's own duration histograms couldn't produce usable percentiles.

## Fix

Attach explicit sub-second boundaries to both duration instruments via `metric.WithExplicitBucketBoundaries`, keeping the bucket definition next to the instruments:

```
0.0005, 0.001, 0.0025, 0.005, 0.01, 0.02, 0.035, 0.05, 0.075, 0.1, 0.25, 0.5, 1
```

These span sub-millisecond to one second with extra resolution around the ~35ms request budget, so p50–p999 stay meaningful.

## Test

`TestDurationHistograms_UseSubSecondBuckets` records a sub-second observation into each histogram, gathers from the Prometheus registry, and asserts the materialized bucket upper-bounds equal the explicit boundaries (rather than OTEL's millisecond-scaled defaults).

- `go test ./targeting/identityagent/` ✅
- `go vet` ✅
- `golangci-lint run` ✅ (0 issues)

## Follow-up (not in this PR)

`targeting/contextagent/metrics.go` has the identical pattern (`request_duration_seconds` / `stage_duration_seconds` with no bucket view) and the same latency-resolution problem. Left out to keep this PR scoped to the identity-agent; happy to fix it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)