### PR TITLE
feat(targeting): verify in-band World ID attestations (Mechanism A)

### DIFF
--- a/cmd/identity-agent/verified_identity.go
+++ b/cmd/identity-agent/verified_identity.go
@@ -23,14 +23,18 @@ import (
 //
 // Required when enabled:
 //
-//	TMP_RELYING_PARTY_ID  the relying party this deployment acts as; must match
-//	                      the rp_id the sealed credentials were sealed for.
-//	TMP_RECIPIENT_KID     the audience_kid identifying our HPKE recipient key.
-//	TMP_RECIPIENT_KEY     hex-encoded 32-byte X25519 private key (secret —
-//	                      injected from secret storage, never logged).
+//	TMP_RELYING_PARTY_ID  the relying party this deployment acts as. In-band
+//	                      attestations on req.Identities must carry this rp_id,
+//	                      and sealed credentials must be sealed for it.
 //
 // Optional:
 //
+//	TMP_RECIPIENT_KID     the audience_kid identifying our HPKE recipient key.
+//	TMP_RECIPIENT_KEY     hex-encoded 32-byte X25519 private key (secret —
+//	                      injected from secret storage, never logged). KID and
+//	                      KEY are set together to enable the sealed_credentials
+//	                      carrier; without them only in-band attestations are
+//	                      verified.
 //	WORLD_VERIFY_BASE_URL World's verifier backend (defaults to production).
 //	WORLD_API_KEY         API key for World's verifier backend, if required.
 //
@@ -49,24 +53,13 @@ func verifiedIdentityOptions(logger *slog.Logger) ([]identityagent.RunOption, er
 	}
 
 	rpID := os.Getenv("TMP_RELYING_PARTY_ID")
+	if rpID == "" {
+		return nil, fmt.Errorf("TMP_RELYING_PARTY_ID is required when TMP_VERIFIED_IDENTITY_ENABLED=true")
+	}
 	kid := os.Getenv("TMP_RECIPIENT_KID")
 	keyHex := os.Getenv("TMP_RECIPIENT_KEY")
-	switch {
-	case rpID == "":
-		return nil, fmt.Errorf("TMP_RELYING_PARTY_ID is required when TMP_VERIFIED_IDENTITY_ENABLED=true")
-	case kid == "":
-		return nil, fmt.Errorf("TMP_RECIPIENT_KID is required when TMP_VERIFIED_IDENTITY_ENABLED=true")
-	case keyHex == "":
-		return nil, fmt.Errorf("TMP_RECIPIENT_KEY is required when TMP_VERIFIED_IDENTITY_ENABLED=true")
-	}
-
-	raw, err := hex.DecodeString(keyHex)
-	if err != nil {
-		return nil, fmt.Errorf("TMP_RECIPIENT_KEY must be hex-encoded: %w", err)
-	}
-	key, err := tmproto.LoadX25519PrivateKey(raw)
-	if err != nil {
-		return nil, fmt.Errorf("TMP_RECIPIENT_KEY: %w", err)
+	if (kid == "") != (keyHex == "") {
+		return nil, fmt.Errorf("TMP_RECIPIENT_KID and TMP_RECIPIENT_KEY must be set together (the sealed_credentials carrier needs both)")
 	}
 
 	baseURL := worldid.DefaultBaseURL
@@ -78,15 +71,31 @@ func verifiedIdentityOptions(logger *slog.Logger) ([]identityagent.RunOption, er
 		worldid.WithAPIKey(os.Getenv("WORLD_API_KEY")),
 	)
 
-	logger.Info("verified-identity stage enabled",
-		"relying_party_id", rpID, "recipient_kid", kid, "world_verify_base_url", baseURL)
-
-	return []identityagent.RunOption{
+	opts := []identityagent.RunOption{
 		identityagent.WithAttestationVerifier(verifier),
-		identityagent.WithRecipientKeys(map[string]identityagent.RecipientKey{
+		identityagent.WithRelyingPartyID(rpID),
+	}
+
+	// Recipient keys enable the sealed_credentials carrier; without them only
+	// the in-band attestation carrier (req.Identities[].Attestation) is active.
+	if kid != "" {
+		raw, err := hex.DecodeString(keyHex)
+		if err != nil {
+			return nil, fmt.Errorf("TMP_RECIPIENT_KEY must be hex-encoded: %w", err)
+		}
+		key, err := tmproto.LoadX25519PrivateKey(raw)
+		if err != nil {
+			return nil, fmt.Errorf("TMP_RECIPIENT_KEY: %w", err)
+		}
+		opts = append(opts, identityagent.WithRecipientKeys(map[string]identityagent.RecipientKey{
 			kid: {PrivateKey: key, RelyingPartyID: rpID},
-		}),
-	}, nil
+		}))
+	}
+
+	logger.Info("verified-identity stage enabled",
+		"relying_party_id", rpID, "sealed_credentials_enabled", kid != "", "world_verify_base_url", baseURL)
+
+	return opts, nil
 }
 
 // lookupBool parses a boolean environment variable, returning def when unset.

--- a/targeting/identityagent/run_options.go
+++ b/targeting/identityagent/run_options.go
@@ -16,9 +16,10 @@ import "github.com/adcontextprotocol/adcp-go/targeting"
 type RunOption func(*runOptions)
 
 type runOptions struct {
-	verifier      targeting.AttestationVerifier
-	recipientKeys map[string]RecipientKey
-	ageResolver   targeting.AgeResolver
+	verifier       targeting.AttestationVerifier
+	recipientKeys  map[string]RecipientKey
+	ageResolver    targeting.AgeResolver
+	relyingPartyID string
 }
 
 // WithAttestationVerifier injects the verified-identity verifier. Without it,
@@ -32,6 +33,14 @@ func WithAttestationVerifier(v targeting.AttestationVerifier) RunOption {
 // relying party this deployment acts as) used to open sealed_credentials.
 func WithRecipientKeys(keys map[string]RecipientKey) RunOption {
 	return func(o *runOptions) { o.recipientKeys = keys }
+}
+
+// WithRelyingPartyID sets the relying party this deployment acts as for in-band
+// attestation verification (req.Identities[].Attestation). Without it, only the
+// sealed_credentials carrier is active; in-band attestations are treated as
+// absent.
+func WithRelyingPartyID(rpID string) RunOption {
+	return func(o *runOptions) { o.relyingPartyID = rpID }
 }
 
 // WithAgeResolver injects the age-policy resolver (e.g. AdCP Policy Registry

--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -38,6 +38,11 @@ type Service struct {
 	verifier      targeting.AttestationVerifier
 	recipientKeys map[string]RecipientKey
 	ageResolver   targeting.AgeResolver
+	// relyingPartyID is the RP this deployment acts as for in-band
+	// (req.Identities[].Attestation) verification. Empty disables the in-band
+	// carrier; the sealed_credentials carrier takes its RP from the recipient
+	// keys instead.
+	relyingPartyID string
 }
 
 // ServiceConfig packages the dependencies for NewService.
@@ -60,6 +65,9 @@ type ServiceConfig struct {
 	// AgeResolver resolves a package's required age threshold by geo; nil
 	// means no age gating.
 	AgeResolver targeting.AgeResolver
+	// RelyingPartyID is the RP this deployment acts as for in-band attestation
+	// verification (req.Identities[].Attestation). Empty disables that carrier.
+	RelyingPartyID string
 }
 
 // NewService validates the supplied dependencies and returns a Service.
@@ -96,6 +104,7 @@ func NewService(cfg ServiceConfig) (*Service, error) {
 		verifier:        cfg.Verifier,
 		recipientKeys:   cfg.RecipientKeys,
 		ageResolver:     cfg.AgeResolver,
+		relyingPartyID:  cfg.RelyingPartyID,
 	}, nil
 }
 

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -374,6 +374,7 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 		Verifier:        opts.verifier,
 		RecipientKeys:   opts.recipientKeys,
 		AgeResolver:     opts.ageResolver,
+		RelyingPartyID:  opts.relyingPartyID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build service: %w", err)

--- a/targeting/identityagent/verified_identity_stage.go
+++ b/targeting/identityagent/verified_identity_stage.go
@@ -44,7 +44,17 @@ func (o *stageObserver) VerifierFailed(ctx context.Context) {
 // targeting.OpenAndVerify; this stage wires the request, the metric observer,
 // and the stage-level duration/outcome metrics around it.
 func (s *Service) runVerifiedIdentityStage(ctx context.Context, req *tmproto.IdentityMatchRequest) []targeting.VerifiedIdentity {
-	if s.verifier == nil || len(s.recipientKeys) == 0 || len(req.SealedCredentials) == 0 {
+	if s.verifier == nil {
+		return nil
+	}
+	// Two verify-before-trust carriers share this stage: sealed_credentials
+	// (network-as-RP, RP from the recipient keys) and in-band attestations on
+	// req.Identities (RP from s.relyingPartyID). Either may be inactive by
+	// configuration or absent from the request; with neither available the
+	// stage is a no-op and eligibility is unchanged.
+	sealedAvailable := len(s.recipientKeys) > 0 && len(req.SealedCredentials) > 0
+	inbandAvailable := s.relyingPartyID != "" && len(req.Identities) > 0
+	if !sealedAvailable && !inbandAvailable {
 		return nil
 	}
 	start := time.Now()
@@ -59,7 +69,15 @@ func (s *Service) runVerifiedIdentityStage(ctx context.Context, req *tmproto.Ide
 		Country:   req.Country,
 		Now:       start,
 	}
-	verified := targeting.OpenAndVerify(ctx, req.SealedCredentials, s.recipientKeys, s.verifier, vctx, obs)
+	var verified []targeting.VerifiedIdentity
+	if sealedAvailable {
+		verified = targeting.OpenAndVerify(ctx, req.SealedCredentials, s.recipientKeys, s.verifier, vctx, obs)
+	}
+	if inbandAvailable {
+		inbandCtx := vctx
+		inbandCtx.ExpectedRelyingPartyID = s.relyingPartyID
+		verified = append(verified, targeting.VerifyAttestations(ctx, req.Identities, s.verifier, inbandCtx, obs)...)
+	}
 
 	s.recorder.StageDuration(ctx, StageVerifiedIdentity, time.Since(start))
 	outcome := OutcomePass

--- a/targeting/verified_identity_receiver.go
+++ b/targeting/verified_identity_receiver.go
@@ -142,26 +142,67 @@ func OpenAndVerify(
 		}
 		credVctx := vctx
 		credVctx.ExpectedRelyingPartyID = rk.RelyingPartyID
-		// Local, fail-closed invariants BEFORE the (possibly network) verifier:
-		// empty signal_binding, expired, or RP mismatch ⇒ absent.
-		if reason := LocalPreCheck(&att, credVctx); reason != PreCheckOK {
-			obs.Dropped(ctx, reason)
+		if vi, ok := verifyOne(ctx, &att, verifier, credVctx, obs); ok {
+			verified = append(verified, vi)
+		}
+	}
+	return verified
+}
+
+// verifyOne runs the verify-before-trust checks for a single attestation whose
+// expected relying party is already set on vctx: the local, fail-closed
+// pre-checks (signal_binding present, not expired, relying_party_id == the RP
+// we act as) BEFORE the possibly-network verifier, then the verifier, then the
+// defense-in-depth post-verify RP recheck. It returns the VerifiedIdentity with
+// claims normalized to the closed set so the age gate only ever sees canonical
+// values. ok is false — and the matching observer signal has already fired —
+// when the attestation must be treated as absent.
+func verifyOne(ctx context.Context, att *tmproto.Attestation, verifier AttestationVerifier, vctx VerifyContext, obs CredentialObserver) (VerifiedIdentity, bool) {
+	if reason := LocalPreCheck(att, vctx); reason != PreCheckOK {
+		obs.Dropped(ctx, reason)
+		return VerifiedIdentity{}, false
+	}
+	vi, err := verifier.Verify(ctx, att, vctx)
+	if err != nil {
+		obs.VerifierFailed(ctx)
+		return VerifiedIdentity{}, false
+	}
+	if vi.RelyingPartyID != vctx.ExpectedRelyingPartyID {
+		obs.Dropped(ctx, DropRPMismatchPostVerify)
+		return VerifiedIdentity{}, false
+	}
+	vi.Claims = normalizeClaimSet(vi.Claims)
+	return vi, true
+}
+
+// VerifyAttestations is the in-band sibling of OpenAndVerify: it runs the
+// verify-before-trust checks on the attestations carried directly on the
+// request's identity entries (req.Identities[].Attestation), with no HPKE seal
+// to open, and returns the verified identities. The same rule holds — claims
+// are trusted only from the verifier, never the asserted attestation — and the
+// expected relying party is vctx.ExpectedRelyingPartyID, the single RP this
+// receiver acts as; an attestation bound to any other RP is dropped by
+// LocalPreCheck.
+//
+// Fail-closed by construction: with no verifier or no expected relying party it
+// returns nil without consulting the verifier. An identity entry without an
+// attestation is an ordinary token, not a verified identity, and is skipped.
+func VerifyAttestations(ctx context.Context, identities []tmproto.IdentityToken, verifier AttestationVerifier, vctx VerifyContext, obs CredentialObserver) []VerifiedIdentity {
+	if verifier == nil || vctx.ExpectedRelyingPartyID == "" || len(identities) == 0 {
+		return nil
+	}
+	if obs == nil {
+		obs = noopCredentialObserver{}
+	}
+	var verified []VerifiedIdentity
+	for i := range identities {
+		att := identities[i].Attestation
+		if att == nil {
 			continue
 		}
-		vi, err := verifier.Verify(ctx, &att, credVctx)
-		if err != nil {
-			obs.VerifierFailed(ctx)
-			continue
+		if vi, ok := verifyOne(ctx, att, verifier, vctx, obs); ok {
+			verified = append(verified, vi)
 		}
-		// Defense-in-depth: the verifier must return the RP we bound to.
-		if vi.RelyingPartyID != rk.RelyingPartyID {
-			obs.Dropped(ctx, DropRPMismatchPostVerify)
-			continue
-		}
-		// Normalize to the closed claim set so the age gate only ever sees
-		// canonical values, regardless of verifier behavior.
-		vi.Claims = normalizeClaimSet(vi.Claims)
-		verified = append(verified, vi)
 	}
 	return verified
 }

--- a/targeting/verified_identity_receiver_test.go
+++ b/targeting/verified_identity_receiver_test.go
@@ -229,6 +229,83 @@ func TestOpenAndVerify_MalformedEnvelope(t *testing.T) {
 	assert.Equal(t, []string{targeting.DropMalformedSeal}, obs.drops)
 }
 
+// identityWithAtt wraps an attestation on a world_id_nullifier identity entry,
+// the in-band (Mechanism A) carrier VerifyAttestations consumes.
+func identityWithAtt(att tmproto.Attestation) tmproto.IdentityToken {
+	return tmproto.IdentityToken{UIDType: tmproto.UIDTypeWorldIDNullifier, UserToken: "0xnf", Attestation: &att}
+}
+
+// attCtx is baseCtx with the receiver's single expected relying party set — the
+// RP the in-band attestation must be bound to.
+func attCtx(rp string) targeting.VerifyContext {
+	v := baseCtx()
+	v.ExpectedRelyingPartyID = rp
+	return v
+}
+
+// Fail-closed by omission: no verifier, no expected RP, or no identities ⇒ nil
+// and the verifier is never consulted.
+func TestVerifyAttestations_FailClosedByOmission(t *testing.T) {
+	ids := []tmproto.IdentityToken{identityWithAtt(attestation("rp-1", tmproto.AttestationClaimUniqueHuman))}
+	assert.Nil(t, targeting.VerifyAttestations(t.Context(), ids, nil, attCtx("rp-1"), nil))
+	assert.Nil(t, targeting.VerifyAttestations(t.Context(), ids, &stubVerifier{}, baseCtx(), nil), "no expected RP ⇒ absent")
+	assert.Nil(t, targeting.VerifyAttestations(t.Context(), nil, &stubVerifier{}, attCtx("rp-1"), nil))
+}
+
+// Verify-before-trust: claims come from the verifier, never the asserted
+// attestation — the asserted age_over_21 does not leak through.
+func TestVerifyAttestations_TrustsVerifierNotAttestation(t *testing.T) {
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	ids := []tmproto.IdentityToken{identityWithAtt(attestation("rp-1", tmproto.AttestationClaimAgeOver21))}
+
+	got := targeting.VerifyAttestations(t.Context(), ids, v, attCtx("rp-1"), nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, "rp-1", got[0].RelyingPartyID)
+	assert.True(t, got[0].ClaimsSatisfy(tmproto.AttestationClaimUniqueHuman))
+	assert.False(t, got[0].ClaimsSatisfy(tmproto.AttestationClaimAgeOver21),
+		"the asserted age_over_21 must NOT be trusted — only the verifier's claims count")
+}
+
+// An attestation minted for another RP is dropped by the local pre-check before
+// the verifier is consulted.
+func TestVerifyAttestations_RPMismatchPreVerify(t *testing.T) {
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	obs := &recordingObserver{}
+	ids := []tmproto.IdentityToken{identityWithAtt(attestation("rp-EVIL", tmproto.AttestationClaimUniqueHuman))}
+
+	got := targeting.VerifyAttestations(t.Context(), ids, v, attCtx("rp-1"), obs)
+	assert.Empty(t, got)
+	assert.Equal(t, 0, v.calls, "verifier MUST NOT be called for a proof minted for another RP")
+	assert.Equal(t, []string{targeting.PreCheckRPMismatch}, obs.drops)
+}
+
+// Identity entries without an attestation are ordinary tokens, skipped without
+// reaching the verifier.
+func TestVerifyAttestations_SkipsEntriesWithoutAttestation(t *testing.T) {
+	v := &stubVerifier{nullifier: "N", claims: []tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman}}
+	ids := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeMAID, UserToken: "maid-1"},
+		identityWithAtt(attestation("rp-1", tmproto.AttestationClaimUniqueHuman)),
+	}
+
+	got := targeting.VerifyAttestations(t.Context(), ids, v, attCtx("rp-1"), nil)
+	assert.Len(t, got, 1)
+	assert.Equal(t, 1, v.calls, "only the entry carrying an attestation reaches the verifier")
+}
+
+// A verifier error yields no identity and is reported via VerifierFailed, not a
+// Dropped reason, so a down verifier is distinguishable from organic absence.
+func TestVerifyAttestations_VerifierError(t *testing.T) {
+	v := &stubVerifier{err: errors.New("verifier down")}
+	obs := &recordingObserver{}
+	ids := []tmproto.IdentityToken{identityWithAtt(attestation("rp-1", tmproto.AttestationClaimUniqueHuman))}
+
+	got := targeting.VerifyAttestations(t.Context(), ids, v, attCtx("rp-1"), obs)
+	assert.Empty(t, got)
+	assert.Empty(t, obs.drops)
+	assert.Equal(t, 1, obs.verifierFails)
+}
+
 func TestRejectByVerifiedIdentity(t *testing.T) {
 	human := []targeting.VerifiedIdentity{{Nullifier: "N", RelyingPartyID: "rp-1", Claims: targeting.NormalizeClaims([]tmproto.AttestationClaim{tmproto.AttestationClaimUniqueHuman, tmproto.AttestationClaimAgeOver18})}}
 


### PR DESCRIPTION
## What

Adds verify-before-trust consumption of **in-band World ID attestations** (Mechanism A) — the `attestation` carried directly on `identity_match_request.identities[]` — alongside the existing `sealed_credentials` (Mechanism B) carrier.

## Why

rtdp forwards a network-scoped World ID proof on `Identities[].Attestation` (it relays seller-side and cannot HPKE-seal to an audience key). The identity agent previously consumed only `sealed_credentials`, so that attestation was never verified. This wires the in-band carrier through the same verifier seam.

## How

- **`targeting`**: extract `verifyOne` (shared `LocalPreCheck` → verifier → post-verify RP recheck → normalize); add `VerifyAttestations`, the no-HPKE sibling of `OpenAndVerify`.
- **`identityagent`**: the verified-identity stage runs both carriers and merges results, so frequency-cap `CapKey`, the verified-identity gate, and the TMPX nullifier encoding all light up. Adds `RelyingPartyID` config + `WithRelyingPartyID` option.
- **`cmd/identity-agent`**: recipient keys become optional (they power only the sealed carrier); `TMP_RELYING_PARTY_ID` drives the in-band carrier.

Fail-closed preserved: no verifier or no `TMP_RELYING_PARTY_ID` ⇒ no in-band verification, behavior unchanged. Claims are trusted only from the verifier, never the asserted attestation.

## Trust surface note

This makes the agent verify an in-band attestation against a single configured relying party (network-as-RP). That is a deliberate addition to the trust surface that #377 left out — flagging for reviewer attention.

## Tests

`go test ./targeting/...` green; `go build`/`go vet` clean on the root and the `cmd/identity-agent` module; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)