### PR TITLE
feat(worldid): demo trust-mode verifier (TMP_WORLD_ID_TRUST_UNVERIFIED)

### DIFF
--- a/cmd/identity-agent/verified_identity.go
+++ b/cmd/identity-agent/verified_identity.go
@@ -37,6 +37,11 @@ import (
 //	                      verified.
 //	WORLD_VERIFY_BASE_URL World's verifier backend (defaults to production).
 //	WORLD_API_KEY         API key for World's verifier backend, if required.
+//	TMP_WORLD_ID_TRUST_UNVERIFIED
+//	                      Demo only. When true, attestations are trusted from
+//	                      their own self-reported nullifier and claims without
+//	                      validating the World ID proof or calling World — no
+//	                      Sybil resistance or proof-of-personhood. Default false.
 //
 // Age gating (AgeResolver) is intentionally left unset: production resolves the
 // required-age policy via the AdCP Policy Registry, which is not yet wired. With
@@ -62,18 +67,26 @@ func verifiedIdentityOptions(logger *slog.Logger) ([]identityagent.RunOption, er
 		return nil, fmt.Errorf("TMP_RECIPIENT_KID and TMP_RECIPIENT_KEY must be set together (the sealed_credentials carrier needs both)")
 	}
 
-	baseURL := worldid.DefaultBaseURL
-	if v := os.Getenv("WORLD_VERIFY_BASE_URL"); v != "" {
-		baseURL = v
+	trustUnverified, err := lookupBool("TMP_WORLD_ID_TRUST_UNVERIFIED", false)
+	if err != nil {
+		return nil, err
 	}
-	verifier := worldid.New(
-		worldid.WithBaseURL(baseURL),
-		worldid.WithAPIKey(os.Getenv("WORLD_API_KEY")),
-	)
 
 	opts := []identityagent.RunOption{
-		identityagent.WithAttestationVerifier(verifier),
 		identityagent.WithRelyingPartyID(rpID),
+	}
+	if trustUnverified {
+		logger.Warn("WORLD ID ATTESTATIONS TRUSTED WITHOUT VERIFICATION — TMP_WORLD_ID_TRUST_UNVERIFIED=true; demo only, no Sybil resistance or proof-of-personhood, never enable on production traffic")
+		opts = append(opts, identityagent.WithAttestationVerifier(worldid.NewTrustingVerifier()))
+	} else {
+		baseURL := worldid.DefaultBaseURL
+		if v := os.Getenv("WORLD_VERIFY_BASE_URL"); v != "" {
+			baseURL = v
+		}
+		opts = append(opts, identityagent.WithAttestationVerifier(worldid.New(
+			worldid.WithBaseURL(baseURL),
+			worldid.WithAPIKey(os.Getenv("WORLD_API_KEY")),
+		)))
 	}
 
 	// Recipient keys enable the sealed_credentials carrier; without them only
@@ -93,7 +106,7 @@ func verifiedIdentityOptions(logger *slog.Logger) ([]identityagent.RunOption, er
 	}
 
 	logger.Info("verified-identity stage enabled",
-		"relying_party_id", rpID, "sealed_credentials_enabled", kid != "", "world_verify_base_url", baseURL)
+		"relying_party_id", rpID, "sealed_credentials_enabled", kid != "", "trust_unverified", trustUnverified)
 
 	return opts, nil
 }

--- a/targeting/fcap/service.go
+++ b/targeting/fcap/service.go
@@ -3,6 +3,7 @@ package fcap
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -117,14 +118,15 @@ func (s *Service) IsCappedAny(ctx context.Context, identities []string, fields [
 	if len(identities) == 0 || len(fields) == 0 {
 		return nil, nil
 	}
-	need := len(identities) * len(fields)
 	// Guard the cross-product against int overflow before it sizes the scratch
-	// allocation. len(fields) is non-zero here (the early return above), so the
-	// division is safe; a wrapped product fails closed instead of allocating a
-	// corrupt-sized buffer.
-	if need/len(fields) != len(identities) {
+	// allocation. len(fields) is non-zero here (the early return above), so
+	// bounding len(identities) by MaxInt/len(fields) proves the product stays
+	// within int range; an oversized input fails closed instead of computing a
+	// wrapped, corrupt allocation size.
+	if len(identities) > math.MaxInt/len(fields) {
 		return nil, fmt.Errorf("fcap: identity-field cross-product overflows (%d identities x %d fields)", len(identities), len(fields))
 	}
+	need := len(identities) * len(fields)
 
 	bufPtr := fieldLookupBufPool.Get().(*[]FieldLookup)
 	buf := *bufPtr

--- a/targeting/fcap/service.go
+++ b/targeting/fcap/service.go
@@ -2,6 +2,7 @@ package fcap
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -117,6 +118,13 @@ func (s *Service) IsCappedAny(ctx context.Context, identities []string, fields [
 		return nil, nil
 	}
 	need := len(identities) * len(fields)
+	// Guard the cross-product against int overflow before it sizes the scratch
+	// allocation. len(fields) is non-zero here (the early return above), so the
+	// division is safe; a wrapped product fails closed instead of allocating a
+	// corrupt-sized buffer.
+	if need/len(fields) != len(identities) {
+		return nil, fmt.Errorf("fcap: identity-field cross-product overflows (%d identities x %d fields)", len(identities), len(fields))
+	}
 
 	bufPtr := fieldLookupBufPool.Get().(*[]FieldLookup)
 	buf := *bufPtr

--- a/verify/worldid/trusting.go
+++ b/verify/worldid/trusting.go
@@ -1,0 +1,67 @@
+package worldid
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// TrustingVerifier derives the verified identity from the proof's own
+// self-reported responses WITHOUT validating the World ID proof or contacting
+// World's backend. It exists to exercise the identity-match and TMPX path
+// end-to-end without a live verifier; because it trusts the sender, it offers
+// no Sybil resistance and no proof-of-personhood guarantee. A deployment wires
+// it in only behind an explicit, default-off switch and never serves production
+// traffic with it.
+//
+// It reads the same nullifier and credential fields Verifier reads from World's
+// verify response, but from the inbound proof rather than an authoritative one.
+type TrustingVerifier struct{}
+
+// NewTrustingVerifier returns a TrustingVerifier.
+func NewTrustingVerifier() *TrustingVerifier { return &TrustingVerifier{} }
+
+var _ targeting.AttestationVerifier = (*TrustingVerifier)(nil)
+
+// Verify returns the nullifier and claims the proof reports about itself,
+// scoped to vctx.ExpectedRelyingPartyID, performing no cryptographic
+// validation. No proof, no nullifier, no recognised claim, or no expected
+// relying party returns an error, which the caller treats as "no attestation".
+func (TrustingVerifier) Verify(_ context.Context, att *tmproto.Attestation, vctx targeting.VerifyContext) (targeting.VerifiedIdentity, error) {
+	var zero targeting.VerifiedIdentity
+	if att == nil || len(att.Proof) == 0 {
+		return zero, errors.New("worldid: attestation carries no proof material")
+	}
+	if vctx.ExpectedRelyingPartyID == "" {
+		return zero, errors.New("worldid: no expected relying_party_id to scope to")
+	}
+
+	// The proof's responses[] carry the nullifier and credential identifier in
+	// the same shape as World's verify response — read them without validating.
+	raw, err := json.Marshal(att.Proof)
+	if err != nil {
+		return zero, fmt.Errorf("worldid: marshal proof: %w", err)
+	}
+	var vr verifyResponse
+	if err := json.Unmarshal(raw, &vr); err != nil {
+		return zero, fmt.Errorf("worldid: decode proof: %w", err)
+	}
+	nullifier := vr.nullifier()
+	if nullifier == "" {
+		return zero, errors.New("worldid: proof carried no nullifier")
+	}
+	claims := vr.claims()
+	if len(claims) == 0 {
+		return zero, errors.New("worldid: proof reported no recognised claim")
+	}
+
+	return targeting.VerifiedIdentity{
+		Nullifier:      nullifier,
+		RelyingPartyID: vctx.ExpectedRelyingPartyID,
+		Claims:         claims,
+	}, nil
+}

--- a/verify/worldid/trusting_test.go
+++ b/verify/worldid/trusting_test.go
@@ -1,0 +1,64 @@
+package worldid
+
+import (
+	"context"
+	"testing"
+
+	"github.com/adcontextprotocol/adcp-go/targeting"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// attWithResponses carries a proof whose responses[] self-report a nullifier and
+// the proof_of_human credential — the shape TrustingVerifier reads.
+func attWithResponses() *tmproto.Attestation {
+	return &tmproto.Attestation{
+		Scheme:         "world_id_v4",
+		RelyingPartyID: "rp-1",
+		SignalBinding:  "binding",
+		Proof: map[string]any{
+			"responses": []any{
+				map[string]any{"nullifier": "0xNULL", "identifier": "proof_of_human"},
+			},
+		},
+	}
+}
+
+func TestTrustingVerify_DerivesFromProofWithoutNetwork(t *testing.T) {
+	got, err := NewTrustingVerifier().Verify(context.Background(), attWithResponses(), vctx())
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got.Nullifier != "0xNULL" {
+		t.Errorf("nullifier = %q, want 0xNULL", got.Nullifier)
+	}
+	if got.RelyingPartyID != "rp-1" {
+		t.Errorf("relying_party_id = %q, want rp-1", got.RelyingPartyID)
+	}
+	if _, ok := got.Claims[tmproto.AttestationClaimUniqueHuman]; !ok {
+		t.Errorf("want unique_human in claims, got %v", got.Claims)
+	}
+}
+
+func TestTrustingVerify_RejectsEmptyProof(t *testing.T) {
+	att := attWithResponses()
+	att.Proof = nil
+	if _, err := NewTrustingVerifier().Verify(context.Background(), att, vctx()); err == nil {
+		t.Fatal("expected error when attestation has no proof")
+	}
+}
+
+func TestTrustingVerify_RejectsEmptyExpectedRP(t *testing.T) {
+	if _, err := NewTrustingVerifier().Verify(context.Background(), attWithResponses(), targeting.VerifyContext{}); err == nil {
+		t.Fatal("expected error with no expected relying_party_id")
+	}
+}
+
+func TestTrustingVerify_RejectsNoRecognisedClaim(t *testing.T) {
+	att := attWithResponses()
+	att.Proof = map[string]any{
+		"responses": []any{map[string]any{"nullifier": "0xNULL", "identifier": "something_unknown"}},
+	}
+	if _, err := NewTrustingVerifier().Verify(context.Background(), att, vctx()); err == nil {
+		t.Fatal("expected error when no recognised claim is reported")
+	}
+}


### PR DESCRIPTION
## What

Adds `worldid.TrustingVerifier` — an `AttestationVerifier` that derives the nullifier and claims from the proof's **own self-reported `responses[]`** without validating the World ID proof or calling World's backend. The identity-agent wires it behind `TMP_WORLD_ID_TRUST_UNVERIFIED` (default **false**, loud startup `WARN`).

## Why

A real World `/api/v4/verify` is a hundreds-of-ms network call, and the identity-agent runs a ~35ms request budget — so synchronous verification can't fit on the hot path yet (the cached-root / async-verify fix is larger work). This switch lets the **identity-match + TMPX path run end-to-end** for a demo: the nullifier flows into fcap keying, the verified-identity gate, and the rp-scoped TMPX token, with **no network call** (so the 35ms budget is a non-issue).

## ⚠️ Demo only

It **trusts the sender** — no Sybil resistance, no proof-of-personhood. It's default-off, logs a loud warning when on, and lives behind the existing pluggable verifier seam (core stays verify-before-trust). On production traffic this is a Sybil / cap-poisoning hole; it must be replaced by `worldid.Verifier` (cached-root in-mem verify, or async-verify + cache) before real reliance.

## How to enable (the agent)

```
TMP_VERIFIED_IDENTITY_ENABLED=true
TMP_RELYING_PARTY_ID=rp_99e78bf31cd5427f
TMP_WORLD_ID_TRUST_UNVERIFIED=true
```
No `WORLD_VERIFY_BASE_URL` / `WORLD_API_KEY` needed; no recipient keys (in-band carrier).

## Tests

`go test ./verify/worldid/` (4 new cases: derives-without-network, empty proof, empty rp, no recognised claim); build + vet clean on root and the cmd module; gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)