### PR TITLE
fix(identityagent): key fcap lookups by the raw seller URL

### DIFF
--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -3,7 +3,6 @@ package identityagent
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"maps"
 	"sync"
 	"time"
@@ -13,7 +12,6 @@ import (
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
 	"github.com/adcontextprotocol/adcp-go/targeting/identityconfig"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
-	"github.com/adcontextprotocol/adcp-go/urlutil"
 )
 
 // Service composes the audience-only IdentityEngine with a frequency-cap
@@ -233,29 +231,12 @@ func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRe
 	fcapCtx, cancelFcap := context.WithTimeout(ctx, s.fcapTimeout)
 	defer cancelFcap()
 
-	// Reduce the seller URL to its registrable domain so the marker key
-	// matches what frequency-writer wrote (writer applies the same
-	// transformation via urlutil.Registrable). Any deviation makes
-	// markers unreachable and silently disables caps.
-	sellerDomain, err := urlutil.Registrable(req.SellerAgentURL)
-	if err != nil {
-		// frequency-writer skips messages whose seller URL is not
-		// registrable, so no marker exists for this URL. The symmetric
-		// reader behavior is "no caps fired" — leave cappedByPkg empty
-		// and let the audience stage decide eligibility.
-		dur := time.Since(start)
-		s.recorder.StageDuration(ctx, StageFCap, dur)
-		s.recorder.StageOutcome(ctx, StageFCap, OutcomeError)
-		slog.Warn("seller_agent_url is not a registrable domain; skipping fcap lookup",
-			"request_id", req.RequestID,
-			"seller_agent_url", req.SellerAgentURL,
-			"error", err)
-		return fcapResult{outcome: OutcomeError, duration: dur}
-	}
-
+	// The seller URL is the marker key verbatim — frequency-writer writes
+	// it unchanged, so the reader must not transform it either. Any
+	// deviation makes markers unreachable and silently disables caps.
 	fields := make([]fcap.Field, len(pkgIDs))
 	for i, pkgID := range pkgIDs {
-		fields[i] = fcap.Field{SellerAgentURL: sellerDomain, PackageID: pkgID}
+		fields[i] = fcap.Field{SellerAgentURL: req.SellerAgentURL, PackageID: pkgID}
 	}
 	// Frequency-cap key selection. When verified identities are present, cap
 	// on their relying-party-scoped, namespaced nullifier keys — a true

--- a/targeting/identityagent/service_test.go
+++ b/targeting/identityagent/service_test.go
@@ -261,53 +261,20 @@ func TestService_FCapTimeout_FailClosed(t *testing.T) {
 	require.False(t, got["pkg-1"], "fcap timeout must fail closed")
 }
 
-// TestService_FCap_NormalizesSellerURLToRegistrableDomain ensures the fcap
-// stage reduces req.SellerAgentURL to its registrable domain (eTLD+1) before
-// looking up markers — matching the transformation frequency-writer applies
-// when it writes them. The cap is recorded under "seller.example.com" while
-// the request carries the full "https://sub.seller.example.com/agent" form;
-// the cap must still apply.
-func TestService_FCap_NormalizesSellerURLToRegistrableDomain(t *testing.T) {
-	// The full URL carries subdomain + path; its eTLD+1 is "seller.com".
-	// frequency-writer would record the marker under the eTLD+1; the
-	// fcap stage must reduce the request URL the same way for the
-	// lookup to find it.
-	fullURL := "https://api.seller.com/agent"
-	registrable := "seller.com"
-	entries := []identityconfig.Entry{
-		{Key: identityconfig.Key{SellerAgentURL: fullURL, PackageID: "pkg-1"}},
-	}
-	svc := newTestService(t, testServiceOptions{
-		configEntries: entries,
-		cappedTuples: []capTuple{
-			{identity: "u1", seller: registrable, pkg: "pkg-1"},
-		},
-	})
-	req := &tmproto.IdentityMatchRequest{
-		RequestID:      "r1",
-		SellerAgentURL: fullURL,
-		PackageIDs:     []string{"pkg-1"},
-		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
-	}
-	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
-	assert.False(t, got["pkg-1"], "cap recorded under registrable domain must apply to a request that uses a subdomain/path form")
-}
-
-// TestService_FCap_UnregistrableSellerURL_NoCapApplied verifies the symmetric
-// behavior to frequency-writer's "skip on invalid URL": if the request's
-// seller URL can't be reduced to a registrable domain, no marker exists, so
-// the fcap stage applies no caps and leaves eligibility to other stages.
-func TestService_FCap_UnregistrableSellerURL_NoCapApplied(t *testing.T) {
-	// "http://localhost" parses as a URL but localhost has no eTLD+1, so
-	// urlutil.Registrable returns ErrInvalid.
-	sellerURL := "http://localhost"
+// TestService_FCap_UsesSellerURLVerbatim ensures the fcap stage keys
+// marker lookups by req.SellerAgentURL verbatim — no registrable-domain
+// reduction — matching how frequency-writer writes them. A storefront
+// path with no registrable host must still resolve a cap.
+func TestService_FCap_UsesSellerURLVerbatim(t *testing.T) {
+	// A path-only seller URL has no registrable host; frequency-writer
+	// records the marker under the raw value, so the fcap stage must
+	// look it up by the same raw value.
+	sellerURL := "/storefront/wonderstruck/mcp"
 	entries := []identityconfig.Entry{
 		{Key: identityconfig.Key{SellerAgentURL: sellerURL, PackageID: "pkg-1"}},
 	}
 	svc := newTestService(t, testServiceOptions{
 		configEntries: entries,
-		// Seed a cap on the unreduced URL so we can prove the fcap stage
-		// never consults it.
 		cappedTuples: []capTuple{
 			{identity: "u1", seller: sellerURL, pkg: "pkg-1"},
 		},
@@ -319,7 +286,34 @@ func TestService_FCap_UnregistrableSellerURL_NoCapApplied(t *testing.T) {
 		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
 	}
 	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
-	assert.True(t, got["pkg-1"], "unregistrable seller URL must skip fcap and leave the package eligible")
+	assert.False(t, got["pkg-1"], "cap recorded under the verbatim seller URL must apply")
+}
+
+// TestService_FCap_DoesNotReduceSellerURL proves the fcap stage does not
+// reduce req.SellerAgentURL to a registrable domain: a cap recorded under
+// the bare domain must NOT apply to a request that carries the full
+// subdomain/path form, because the marker keys differ verbatim.
+func TestService_FCap_DoesNotReduceSellerURL(t *testing.T) {
+	fullURL := "https://api.seller.com/agent"
+	entries := []identityconfig.Entry{
+		{Key: identityconfig.Key{SellerAgentURL: fullURL, PackageID: "pkg-1"}},
+	}
+	svc := newTestService(t, testServiceOptions{
+		configEntries: entries,
+		// Cap recorded under the bare registrable domain — a request using
+		// the full URL must not match it (no reduction on either side).
+		cappedTuples: []capTuple{
+			{identity: "u1", seller: "seller.com", pkg: "pkg-1"},
+		},
+	})
+	req := &tmproto.IdentityMatchRequest{
+		RequestID:      "r1",
+		SellerAgentURL: fullURL,
+		PackageIDs:     []string{"pkg-1"},
+		Identities:     []tmproto.IdentityToken{{UserToken: "u1", UIDType: tmproto.UIDTypeID5}},
+	}
+	got := eligibilityMap(svc.Evaluate(t.Context(), req).Eligibility)
+	assert.True(t, got["pkg-1"], "a cap under the bare domain must not apply to the full-URL request")
 }
 
 // slowFCapStore is an fcap.Store wrapper that injects a fixed delay before


### PR DESCRIPTION
## What

Stop reducing `req.SellerAgentURL` to its registrable domain (eTLD+1) in the identity-agent fcap stage. Key marker lookups by the seller URL **verbatim**.

- `targeting/identityagent/service.go` (`runFcapStage`): drop `urlutil.Registrable` and its error branch; build `fcap.Field{SellerAgentURL: req.SellerAgentURL, …}` directly.

## Why

`urlutil.Registrable` rejects any URL with no registrable host — e.g. a storefront path like `/storefront/wonderstruck/mcp`. Those requests hit the error branch and skipped the fcap lookup entirely, so their packages were never frequency-capped.

The reduction only existed to match the same transformation frequency-writer applied on the write side. Both sides read the seller URL from the **same agent config**, so the raw strings already match — the reduction was lossy normalization whose only effect was to exclude path-only URLs.

## Paired change

This is the read side of the marker contract. The write side changes in lockstep: **scope3data/frequency-writer#22** (write the seller URL verbatim).

## Rollout note

The marker key format flips on both sides. Read/write symmetry is a deploy invariant: while one side keys by the registrable domain and the other by the raw URL, markers don't match and caps silently no-op (fail toward serving, not over-blocking). Markers already written under the old domain key age out via their cap-window TTL. Sequence: cut this release, bump the identity-agent service to it, and land frequency-writer#22 close together.

## Testing

- `go test ./...` (root module) — all green.
- `TestService_FCap_UsesSellerURLVerbatim`: a path-only seller URL now resolves a cap.
- `TestService_FCap_DoesNotReduceSellerURL`: a cap under the bare domain no longer applies to a full-URL request (proves the reduction is gone). Replaces the former `Normalizes…`/`Unregistrable…` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)