### PR TITLE
fix(tmp): make in-band World ID attestations reach the verified-identity stage (and stop the fcap panic)

### DIFF
--- a/targeting/fcap/service.go
+++ b/targeting/fcap/service.go
@@ -107,16 +107,25 @@ func (s *Service) IsCapped(ctx context.Context, userIdentity string, field Field
 // scales with the result slice (one per call) rather than N×M.
 //
 // Both input slices are read-only and must not be retained past return.
-// Empty identities or empty fields returns (nil, nil) without touching the
-// store.
+// Empty fields returns (nil, nil) without touching the store. Empty identities
+// (with non-empty fields) returns an all-false result of length len(fields) —
+// nothing can be capped without an identity — preserving the length-len(fields)
+// contract callers index against.
 //
 // Goroutine-safe: each invocation uses its own scratch buffer and shares no
 // state with concurrent callers. The store call inherits the supplied ctx
 // and routes through the configured topology — cluster/shadow distribution
 // is unchanged from IsCappedBatch.
 func (s *Service) IsCappedAny(ctx context.Context, identities []string, fields []Field) ([]bool, error) {
-	if len(identities) == 0 || len(fields) == 0 {
+	if len(fields) == 0 {
 		return nil, nil
+	}
+	if len(identities) == 0 {
+		// No identity can be capped, so nothing is capped. Return an all-false
+		// result sized to fields (not nil) to preserve the length-len(fields)
+		// contract; a nil result makes callers that index by field read out of
+		// range.
+		return make([]bool, len(fields)), nil
 	}
 	// Guard the cross-product against int overflow before it sizes the scratch
 	// allocation. len(fields) is non-zero here (the early return above), so

--- a/targeting/fcap/service_test.go
+++ b/targeting/fcap/service_test.go
@@ -169,11 +169,22 @@ func TestService_IsCappedAny_EmptyInputs(t *testing.T) {
 	svc := New(NewMockStore())
 	ctx := t.Context()
 
-	got, err := svc.IsCappedAny(ctx, nil, []Field{{SellerAgentURL: "s", PackageID: "p"}})
+	// No identities but non-empty fields: nothing can be capped, so the result
+	// is an all-false slice of length len(fields) — NOT nil. Callers index the
+	// result by field, so a nil result here reads out of range and panics.
+	got, err := svc.IsCappedAny(ctx, nil, []Field{
+		{SellerAgentURL: "s", PackageID: "p1"},
+		{SellerAgentURL: "s", PackageID: "p2"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []bool{false, false}, got)
+
+	// Empty fields returns nil regardless of identities (no fields to report).
+	got, err = svc.IsCappedAny(ctx, []string{"u"}, nil)
 	require.NoError(t, err)
 	assert.Nil(t, got)
 
-	got, err = svc.IsCappedAny(ctx, []string{"u"}, nil)
+	got, err = svc.IsCappedAny(ctx, nil, nil)
 	require.NoError(t, err)
 	assert.Nil(t, got)
 }

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -296,6 +296,38 @@ func (h *identityHandler) buildServiceRequest(ctx context.Context, req *tmproto.
 	}
 	decoded := h.canonicalizer.Decode(ctx, req.Identities)
 	shadow := *req
-	shadow.Identities = audienceEligibleIdentities(decoded)
+	shadow.Identities = serviceIdentities(req.Identities, decoded)
 	return &shadow, decoded
+}
+
+// serviceIdentities is the identity slice Evaluate operates on. It combines the
+// successfully-decoded identities (canonical lowercase-hex UserToken, for
+// audience/fcap keying) with any inbound identity carrying a verified-identity
+// attestation that the canonicalizer could not decode.
+//
+// The second group exists for identities that are intentionally not
+// inbound-decodable — notably a World ID nullifier, which must be
+// verifier-derived rather than trusted from a raw token, yet carries the
+// attestation the verified-identity stage verifies. Decoding drops both the
+// World token and every Attestation, so without this the in-band
+// verified-identity path is a no-op whenever a canonicalizer is configured.
+// Attestation-less and successfully-decoded identities are already represented
+// by the canonical set, so only undecoded attestation carriers are appended
+// (no double-counting).
+func serviceIdentities(inbound []tmproto.IdentityToken, decoded []DecodedIdentity) []tmproto.IdentityToken {
+	out := audienceEligibleIdentities(decoded)
+	for i := range inbound {
+		if inbound[i].Attestation == nil {
+			continue
+		}
+		if i < len(decoded) && len(decoded[i].Bytes) > 0 {
+			continue
+		}
+		out = append(out, tmproto.IdentityToken{
+			UIDType:     inbound[i].UIDType,
+			UserToken:   inbound[i].UserToken,
+			Attestation: inbound[i].Attestation,
+		})
+	}
+	return out
 }

--- a/targeting/identityagent/service.go
+++ b/targeting/identityagent/service.go
@@ -282,6 +282,15 @@ func (s *Service) runFcapStage(ctx context.Context, req *tmproto.IdentityMatchRe
 		return fcapResult{cappedByPkg: failClosedFcap(pkgIDs), outcome: outcome, duration: dur}
 	}
 
+	if len(cappedByField) != len(pkgIDs) {
+		// IsCappedAny returns one result per field (one field per pkgID); a
+		// shorter result would read out of range below. Treat the unexpected
+		// shape as a store error and fail closed rather than panic.
+		s.recorder.StoreError(ctx, StageFCap)
+		s.recorder.StageOutcome(ctx, StageFCap, OutcomeError)
+		return fcapResult{cappedByPkg: failClosedFcap(pkgIDs), outcome: OutcomeError, duration: dur}
+	}
+
 	capped := make(map[string]bool, len(pkgIDs))
 	allCapped := true
 	for i, pkgID := range pkgIDs {

--- a/targeting/identityagent/tmpx_test.go
+++ b/targeting/identityagent/tmpx_test.go
@@ -312,6 +312,48 @@ func TestAudienceEligibleIdentities_FiltersDropped(t *testing.T) {
 	assert.Equal(t, "ffee", got[1].UserToken, "HashedEmail UserToken is the canonical lowercase-hex form")
 }
 
+func TestServiceIdentities_PreservesUndecodedAttestation(t *testing.T) {
+	att := &tmproto.Attestation{
+		Scheme: "world_id_v4",
+		Proof:  map[string]any{"responses": []any{}},
+	}
+	inbound := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeMAID, UserToken: "maid-raw"},
+		// Not inbound-decodable, carries the attestation the verified-identity
+		// stage needs.
+		{UIDType: tmproto.UIDTypeWorldIDNullifier, UserToken: testNullifier, Attestation: att},
+	}
+	decoded := []DecodedIdentity{
+		{UIDType: tmproto.UIDTypeMAID, Bytes: []byte{0x01, 0x02, 0x03}},
+		{UIDType: tmproto.UIDTypeWorldIDNullifier, Bytes: nil}, // no decoder → dropped
+	}
+
+	got := serviceIdentities(inbound, decoded)
+	require.Len(t, got, 2, "decoded MAID plus the undecoded World attestation carrier")
+
+	// Decoded MAID is represented by its canonical token, no attestation.
+	assert.Equal(t, tmproto.UIDTypeMAID, got[0].UIDType)
+	assert.Equal(t, "010203", got[0].UserToken)
+	assert.Nil(t, got[0].Attestation)
+
+	// World token survives with its attestation and raw nullifier intact so the
+	// verified-identity stage can verify it.
+	assert.Equal(t, tmproto.UIDTypeWorldIDNullifier, got[1].UIDType)
+	assert.Equal(t, testNullifier, got[1].UserToken)
+	require.NotNil(t, got[1].Attestation)
+	assert.Equal(t, "world_id_v4", got[1].Attestation.Scheme)
+}
+
+func TestServiceIdentities_NoAttestationDropsUndecoded(t *testing.T) {
+	// An undecodable identity with NO attestation is not re-added — only the
+	// canonical (decoded) set represents it, and here it decoded to nothing.
+	inbound := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeUID2, UserToken: "uid2-raw"},
+	}
+	decoded := []DecodedIdentity{{UIDType: tmproto.UIDTypeUID2, Bytes: nil}}
+	assert.Empty(t, serviceIdentities(inbound, decoded))
+}
+
 func TestDecode_RecordsDropsByReason(t *testing.T) {
 	rec := newTestRecorder()
 	cfg := &TMPXSealer{


### PR DESCRIPTION
Two related fixes that together let an in-band World ID attestation be accepted on the TMP identity-match path (and stop a crash). Found while debugging a World ID request that crash-looped the identity-agent and never produced a verified identity.

## 1. `identityagent`: attestations now reach the verified-identity stage under canonicalization
`buildServiceRequest` decodes inbound identities before `Evaluate`, but the canonicalizer drops `world_id_nullifier` (intentionally not inbound-decodable) and `audienceEligibleIdentities` rebuilds tokens **without** their `Attestation`. The verified-identity in-band path reads attestations off `req.Identities` *inside* `Evaluate`, so with a canonicalizer configured it saw no attestations → `inbandAvailable` false → **no verified identities ever produced**. World ID requests then reached the fcap stage with zero identities.

`serviceIdentities` now carries undecoded attestation-bearing identities (the World nullifier) through to the shadow request alongside the decoded audience-eligible set. `VerifyAttestations` skips attestation-less identities, fcap uses the verified `CapKey` branch once a verified identity exists, and the audience engine finds no segment match for a raw nullifier — so no existing path regresses.

## 2. `fcap`: `IsCappedAny` no longer returns a nil result that panics the caller
`IsCappedAny` returned `(nil, nil)` for empty `identities`, violating its documented "result has length `len(fields)`" contract. `runFcapStage` then indexed `cappedByField[i]` over the non-empty package set → `panic: index out of range [0] with length 0`, crashing the identity-agent into CrashLoopBackOff (failing every TMP request routed to the pod). It now returns an all-false result sized to `fields` (nothing can be capped without an identity), and `runFcapStage` defensively fails closed on any length mismatch instead of indexing out of range.

Observed in prod with image `identity-agent:main-cd3c9fa`: `panic ... runFcapStage ... index out of range [0] with length 0`. Tests updated/added for both fixes; full `./targeting/...` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)