### PR TITLE
[codex] Harden AddTool permissive schema traversal

### DIFF
--- a/adcp/addtool.go
+++ b/adcp/addtool.go
@@ -83,9 +83,17 @@ func permissiveSchemaFor[In any]() *jsonschema.Schema {
 // properties whose schema serializes to `true` (the "any" type), since
 // some validators reject bare `true` as a property schema.
 func allowAdditionalProperties(s *jsonschema.Schema) {
+	allowAdditionalPropertiesSeen(s, map[*jsonschema.Schema]bool{})
+}
+
+func allowAdditionalPropertiesSeen(s *jsonschema.Schema, seen map[*jsonschema.Schema]bool) {
 	if s == nil {
 		return
 	}
+	if seen[s] {
+		return
+	}
+	seen[s] = true
 
 	// Remove additionalProperties: false (which is encoded as {not: {}})
 	if s.Type == "object" && s.AdditionalProperties != nil {
@@ -113,29 +121,60 @@ func allowAdditionalProperties(s *jsonschema.Schema) {
 
 	// Recurse into properties
 	for _, prop := range s.Properties {
-		allowAdditionalProperties(prop)
+		allowAdditionalPropertiesSeen(prop, seen)
 	}
 
 	// Recurse into items (array elements)
-	if s.Items != nil {
-		allowAdditionalProperties(s.Items)
+	allowAdditionalPropertiesSeen(s.Items, seen)
+	for _, sub := range s.ItemsArray {
+		allowAdditionalPropertiesSeen(sub, seen)
 	}
+	for _, sub := range s.PrefixItems {
+		allowAdditionalPropertiesSeen(sub, seen)
+	}
+	allowAdditionalPropertiesSeen(s.AdditionalItems, seen)
+	allowAdditionalPropertiesSeen(s.Contains, seen)
+	allowAdditionalPropertiesSeen(s.UnevaluatedItems, seen)
+
+	// Recurse into object-related subschemas. Preserve typed-map
+	// additionalProperties schemas, but make any object values inside them
+	// permissive too.
+	for _, sub := range s.PatternProperties {
+		allowAdditionalPropertiesSeen(sub, seen)
+	}
+	allowAdditionalPropertiesSeen(s.AdditionalProperties, seen)
+	allowAdditionalPropertiesSeen(s.PropertyNames, seen)
+	allowAdditionalPropertiesSeen(s.UnevaluatedProperties, seen)
 
 	// Recurse into schema combinators
 	for _, sub := range s.AllOf {
-		allowAdditionalProperties(sub)
+		allowAdditionalPropertiesSeen(sub, seen)
 	}
 	for _, sub := range s.AnyOf {
-		allowAdditionalProperties(sub)
+		allowAdditionalPropertiesSeen(sub, seen)
 	}
 	for _, sub := range s.OneOf {
-		allowAdditionalProperties(sub)
+		allowAdditionalPropertiesSeen(sub, seen)
 	}
+	allowAdditionalPropertiesSeen(s.Not, seen)
+	allowAdditionalPropertiesSeen(s.If, seen)
+	allowAdditionalPropertiesSeen(s.Then, seen)
+	allowAdditionalPropertiesSeen(s.Else, seen)
 
 	// Recurse into $defs
 	for _, def := range s.Defs {
-		allowAdditionalProperties(def)
+		allowAdditionalPropertiesSeen(def, seen)
 	}
+	for _, def := range s.Definitions {
+		allowAdditionalPropertiesSeen(def, seen)
+	}
+	for _, def := range s.DependencySchemas {
+		allowAdditionalPropertiesSeen(def, seen)
+	}
+	for _, def := range s.DependentSchemas {
+		allowAdditionalPropertiesSeen(def, seen)
+	}
+	allowAdditionalPropertiesSeen(s.ContentSchema, seen)
 }
 
 // isTrueSchema returns true if the schema serializes to the JSON value `true`,

--- a/adcp/addtool_test.go
+++ b/adcp/addtool_test.go
@@ -1,11 +1,13 @@
 package adcp
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +34,49 @@ func TestPermissiveSchemaFor(t *testing.T) {
 	require.NotNil(t, schema.Properties, "expected properties to be set")
 	assert.Contains(t, schema.Properties, "name", "expected 'name' property")
 	assert.Contains(t, schema.Properties, "age", "expected 'age' property")
+}
+
+func TestAddToolAllowsExtraFieldsToReachHandler(t *testing.T) {
+	server := mcp.NewServer(&mcp.Implementation{Name: "addtool-test", Version: "v0.0.1"}, nil)
+	called := false
+	var got testInput
+	AddTool(server, "echo_input", "Echo input",
+		func(_ context.Context, _ *mcp.CallToolRequest, input testInput) (*mcp.CallToolResult, any, error) {
+			called = true
+			got = input
+			return Result(map[string]any{"ok": true}, "ok")
+		})
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ctx := context.Background()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = serverSession.Close() }()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "addtool-test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSession.Close() }()
+
+	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "echo_input",
+		Arguments: map[string]any{
+			"name":               "Ada",
+			"adcp_major_version": 3,
+			"nested": map[string]any{
+				"value":    "nested-ok",
+				"metadata": "extra",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.IsError)
+	assert.True(t, called, "handler should run despite unknown root and nested fields")
+	assert.Equal(t, "Ada", got.Name)
+	require.NotNil(t, got.Nested)
+	assert.Equal(t, "nested-ok", got.Nested.Value)
 }
 
 func TestPermissiveSchemaForNested(t *testing.T) {
@@ -64,6 +109,47 @@ func TestAllowAdditionalProperties(t *testing.T) {
 
 	assert.Nil(t, schema.AdditionalProperties, "expected AdditionalProperties to be nil after patching")
 	assert.NotNil(t, schema.Properties["foo"], "expected properties to be preserved")
+}
+
+func TestAllowAdditionalPropertiesWalksTupleAndMapValueSchemas(t *testing.T) {
+	falseSchema := func() *jsonschema.Schema {
+		return &jsonschema.Schema{Not: &jsonschema.Schema{}}
+	}
+	itemsObject := &jsonschema.Schema{Type: "object", AdditionalProperties: falseSchema()}
+	prefixObject := &jsonschema.Schema{Type: "object", AdditionalProperties: falseSchema()}
+	mapValueObject := &jsonschema.Schema{Type: "object", AdditionalProperties: falseSchema()}
+	dependencyObject := &jsonschema.Schema{Type: "object", AdditionalProperties: falseSchema()}
+	dependentObject := &jsonschema.Schema{Type: "object", AdditionalProperties: falseSchema()}
+	mapSchema := &jsonschema.Schema{Type: "object", AdditionalProperties: mapValueObject}
+	schema := &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"items_array": {
+				Type:       "array",
+				ItemsArray: []*jsonschema.Schema{itemsObject},
+			},
+			"prefix_items": {
+				Type:        "array",
+				PrefixItems: []*jsonschema.Schema{prefixObject},
+			},
+			"typed_map": mapSchema,
+		},
+		DependencySchemas: map[string]*jsonschema.Schema{
+			"items_array": dependencyObject,
+		},
+		DependentSchemas: map[string]*jsonschema.Schema{
+			"prefix_items": dependentObject,
+		},
+	}
+
+	allowAdditionalProperties(schema)
+
+	assert.Nil(t, itemsObject.AdditionalProperties, "expected itemsArray object to be permissive")
+	assert.Nil(t, prefixObject.AdditionalProperties, "expected prefixItems object to be permissive")
+	assert.Same(t, mapValueObject, mapSchema.AdditionalProperties, "expected typed-map schema to be preserved")
+	assert.Nil(t, mapValueObject.AdditionalProperties, "expected typed-map object values to be permissive")
+	assert.Nil(t, dependencyObject.AdditionalProperties, "expected legacy dependency schema object to be permissive")
+	assert.Nil(t, dependentObject.AdditionalProperties, "expected dependentSchemas object to be permissive")
 }
 
 func TestJsonRoundTrip(t *testing.T) {


### PR DESCRIPTION
## Summary

- expand `adcp.AddTool` input-schema sanitization to walk all relevant `jsonschema.Schema` subschema slots
- keep typed-map value schemas intact while making nested object values permissive
- add an in-memory MCP client/server regression test proving calls with extra root and nested fields reach the handler

## Why

The MCP Go SDK currently generates strict object schemas that reject unknown fields before tool handlers run. AdCP callers and agent harnesses can send protocol metadata alongside tool inputs, so `adcp.AddTool` needs to remain permissive while preserving useful schema information.

## Validation

- `cd adcp && go test -run 'Test(AddToolAllowsExtraFieldsToReachHandler|AllowAdditionalPropertiesWalksTupleAndMapValueSchemas|PermissiveSchemaPreservesOptimizationGoalTarget|PermissiveSchemaForOptimizationGoalUsesProtocolBranches)' -count=1`
- `cd adcp && go test ./...`
- `go test ./...`
- `git diff --check`
- Expert review: protocol/schema reviewer found no issues
- Expert review: code/security reviewer found no issues

## Notes

`cd adcp/schemas && python3 lint.py` reports that schemas are not downloaded in this checkout and skips linting; this change does not modify schema-owned generated types.
