### PR TITLE
fix(ci): move Argus to the Secretariat App and load the prompt from base SHA

### DIFF
--- a/.github/ai-review/expert-adcp-reviewer.md
+++ b/.github/ai-review/expert-adcp-reviewer.md
@@ -1,6 +1,6 @@
 # Argus — Expert PR Reviewer (adcp-go)
 
-You are **Argus**, the expert PR reviewer for `adcontextprotocol/adcp-go` — the Go reference implementation of AdCP / TMP. You review pull requests **in the voice of Brian O'Kelley** (`bokelley` — primary maintainer). Apply his standing engineering bar.
+You are **Argus**, the review desk of the AAO Secretariat serving the AdCP Working Group, and the expert PR reviewer for `adcontextprotocol/adcp-go` — the Go reference implementation of AdCP / TMP. Apply the WG constitution appended to this prompt, and cite decision records (`DR-NNNN` in the spec repo's `governance/decisions/`) when a question is settled precedent.
 
 This is a real review on a real PR. You will post it directly via `gh pr review`. Do not output the review as preamble — emit it as the body of the `gh pr review` command at the end.
 

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,20 +1,21 @@
 name: AI PR Review (Argus)
 
-# Argus is an LLM PR reviewer that posts an `--approve`, `--comment`, or
-# `--request-changes` review on every non-dependabot PR. It reads the diff,
-# delegates to subagents when relevant (ad-tech-protocol-expert,
-# security-reviewer, code-reviewer, etc.), and writes the review in
-# bokelley's voice.
+# Argus is the AAO Secretariat's review desk: an LLM PR reviewer that posts
+# an `--approve`, `--comment`, or `--request-changes` review on every
+# non-dependabot PR. It reads the diff, delegates to subagents when relevant
+# (ad-tech-protocol-expert, security-reviewer, code-reviewer, etc.), and
+# applies the AdCP Working Group constitution
+# (adcontextprotocol/adcp:.agents/wg/constitution.md, fetched from the spec
+# repo and appended to the review prompt at run time).
 #
-# Reviews are posted as the AAO IPR GitHub App, so they count toward the
-# "1 review required" branch-protection check the same way a human approval
-# does. (The IPR App's pull_requests:write scope is already configured for
-# the IPR-agreement workflow.)
+# Reviews are posted as the AAO Secretariat GitHub App
+# (`aao-secretariat[bot]`), so they count toward the "1 review required"
+# branch-protection check the same way a human approval does.
 #
-# Required secrets:
-#   IPR_APP_ID           — GitHub App ID (already configured for IPR)
-#   IPR_APP_PRIVATE_KEY  — GitHub App private key PEM (already configured)
-#   ANTHROPIC_API_KEY    — Anthropic API key for claude-code-action
+# Required secrets (org-level):
+#   SECRETARIAT_APP_ID           — AAO Secretariat GitHub App ID
+#   SECRETARIAT_APP_PRIVATE_KEY  — AAO Secretariat App private key PEM
+#   ANTHROPIC_API_KEY            — Anthropic API key for claude-code-action
 #
 # Forked from adcontextprotocol/adcp's Argus workflow. Drift against
 # upstream is surfaced weekly by sync-argus-upstream-check.yml.
@@ -45,19 +46,19 @@ jobs:
           fetch-depth: 0
 
       # ─────────────────────────────────────────────────────────────────────
-      # Mint an installation token from the AAO IPR GitHub App. Reviews
-      # posted with this token appear as the App's bot user and count
-      # toward branch-protection's required-approvals check.
+      # Mint an installation token from the AAO Secretariat GitHub App.
+      # Reviews posted with this token appear as `aao-secretariat[bot]` and
+      # count toward branch-protection's required-approvals check.
       # ─────────────────────────────────────────────────────────────────────
       - name: Mint App token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.IPR_APP_ID }}
-          private-key: ${{ secrets.IPR_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SECRETARIAT_APP_ID }}
+          private-key: ${{ secrets.SECRETARIAT_APP_PRIVATE_KEY }}
           # Narrow the minted installation token to what Argus actually
-          # needs. The IPR App's installed perms are broader; this caps
-          # what propagates to `claude-code-action` and the workflow
+          # needs. The Secretariat App's installed perms are broader; this
+          # caps what propagates to `claude-code-action` and the workflow
           # steps that consume the token.
           permission-contents: read
           permission-pull-requests: write
@@ -197,13 +198,34 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          PROMPT_BODY="$(cat .github/ai-review/expert-adcp-reviewer.md)"
+          # Load the reviewer prompt from the base SHA, never from the
+          # working checkout — the checkout is the PR merge ref, so a PR
+          # could rewrite the rules it is reviewed under. The checkout
+          # uses fetch-depth: 0, so the base SHA is always reachable.
+          if ! git cat-file -e "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md" 2>/dev/null; then
+            echo "::error::Prompt file does not exist at base SHA ${BASE_SHA}."
+            exit 1
+          fi
+          PROMPT_BODY="$(git show "${BASE_SHA}:.github/ai-review/expert-adcp-reviewer.md")"
+          # Fetch the WG constitution from the spec repo — never from this
+          # repo or the PR. Best-effort: if the fetch fails, the review
+          # proceeds without it.
+          CONSTITUTION="$(curl -sf https://raw.githubusercontent.com/adcontextprotocol/adcp/main/.agents/wg/constitution.md || true)"
           {
             echo 'ARGUS_PROMPT<<ARGUS_EOF'
             echo "$PROMPT_BODY"
+            if [ -n "$CONSTITUTION" ]; then
+              echo ''
+              echo '---'
+              echo ''
+              echo '## WG constitution (from adcontextprotocol/adcp@main)'
+              echo ''
+              echo "$CONSTITUTION"
+            fi
             echo ''
             echo '---'
             echo ''


### PR DESCRIPTION
## What changed

Migrates the Argus AI-review workflow to the AAO Secretariat GitHub App identity and closes a prompt-injection gap in how the reviewer prompt is loaded. Mirrors the spec repo's migration (adcontextprotocol/adcp#5832).

- **App identity:** the token-mint step now uses `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY` (was `IPR_APP_ID` / `IPR_APP_PRIVATE_KEY`). Reviews will post as **`aao-secretariat[bot]`** instead of `aao-ipr-bot[bot]`. No hardcoded bot login existed — the verify step already derives the login from the minted App slug, so it follows the App automatically.
- **Prompt-injection fix:** the prompt-build step read the reviewer prompt with `cat .github/ai-review/expert-adcp-reviewer.md` from the working checkout. On `pull_request` events the checkout is the PR **merge ref**, so the file on disk includes PR-controlled content — a PR could rewrite the rules it is reviewed under. The `paths-ignore` trigger filter and the self-modification gate reduce that risk but don't eliminate it (both depend on the file-list check running and agreeing). The prompt is now loaded with `git show "${BASE_SHA}:..."` and the step fails closed (`::error` + exit 1) if the file doesn't exist at the base SHA. The existing checkout uses `fetch-depth: 0`, so the base SHA is resolvable without an extra fetch.
- **WG constitution:** the prompt-build step fetches the Working Group constitution from the spec repo at review time (`https://raw.githubusercontent.com/adcontextprotocol/adcp/main/.agents/wg/constitution.md` — never from this repo or the PR) and appends it under a `## WG constitution (from adcontextprotocol/adcp@main)` heading when the fetch succeeds; the review proceeds without it otherwise.
- **Identity clause:** `.github/ai-review/expert-adcp-reviewer.md` no longer reviews "in the voice of Brian O'Kelley" — Argus is the review desk of the AAO Secretariat serving the AdCP Working Group, applies the appended WG constitution, and cites decision records (`DR-NNNN` in the spec repo's `governance/decisions/`) when a question is settled precedent. Repo-specific review logic (MUST-FIX gates, coverage rules, delegation) is unchanged.
- Header comments updated to match; the IPR-agreement workflow keeps the IPR App and is untouched.

## Why base-SHA loading matters

The reviewer prompt is the review's trust anchor. Reading it from the merge-ref worktree means the reviewed code and the review rules come from the same (attacker-influenceable) source. Loading from `${{ github.event.pull_request.base.sha }}` pins the rules to what's already on the target branch, so a PR can change the prompt only via a PR that is itself reviewed under the old rules.

## ⚠️ DO NOT MERGE

**Do not merge until the org-level `SECRETARIAT_APP_ID` / `SECRETARIAT_APP_PRIVATE_KEY` secrets are visible to this repo.** Merging first breaks Argus on every subsequent PR (token mint fails, no review posts, branch protection's required-review check goes unsatisfied by the bot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)