### PR TITLE
tmproto: agent-aware keystore for per-agent lazy key resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ The targeting engine (`targeting/`) is the shared evaluation core. Reference age
 | `tmproto/signing.go` | TMP request-authentication envelope (Ed25519, `X-AdCP-Signature`/`X-AdCP-Key-Id`, JCS for identity match, daily-epoch replay window). |
 | `tmproto/verify_middleware.go` | `VerifyContextMatchHandler` / `VerifyIdentityMatchHandler` middleware used by reference providers. |
 | `tmproto/keystore_remote.go` | `RemoteKeyStore` polls the router's `/registry/snapshot` for signing keys. |
+| `tmproto/keystore_authorization.go` | `LazyAuthorizationKeyStore` fetches signing keys on demand per `seller_agent_url` from the AdCP registry `/api/registry/authorizations` endpoint. Implements `AgentAwareKeyStore`. |
 | `router/serverconfig.go` | Config loading (JSON file, env vars, defaults). |
 | `cmd/router/main.go` | Router binary entry point — wires components, Prometheus metrics, env vars. |
 | `docs/network-surface.md` | Port map, data flow, pinhole spec, env var reference. |

--- a/targeting/contextagent/config.go
+++ b/targeting/contextagent/config.go
@@ -84,12 +84,22 @@ type Config struct {
 	Pprof   PprofConfig
 }
 
-// TMPConfig drives TMP signature verification on /context.
+// TMPConfig drives TMP signature verification on /context. See
+// identityagent.TMPConfig for full field semantics — the two are kept in
+// sync deliberately so operators wire the same env vars on both agents.
 type TMPConfig struct {
 	RegistryURL    string
+	RegistryMode   string
+	RegistryBearer string
 	OwnEndpointURL string
 	AllowUnsigned  bool
 }
+
+// Registry mode enum values (mirrors identityagent).
+const (
+	RegistryModeSnapshot      = "snapshot"
+	RegistryModeAuthorization = "authorization"
+)
 
 // ValkeyBlock is the Valkey configuration. The context-agent issues
 // reads against media-buy, package-config, URL-list, topic, and
@@ -305,6 +315,8 @@ func LoadConfigFromEnv() (Config, error) {
 		SuppressionRefreshInterval: suppressionRefresh,
 		TMP: TMPConfig{
 			RegistryURL:    strings.TrimSpace(os.Getenv("TMP_REGISTRY_URL")),
+			RegistryMode:   strings.TrimSpace(os.Getenv("TMP_REGISTRY_MODE")),
+			RegistryBearer: strings.TrimSpace(os.Getenv("TMP_REGISTRY_BEARER")),
 			OwnEndpointURL: strings.TrimSpace(os.Getenv("TMP_OWN_ENDPOINT_URL")),
 			AllowUnsigned:  allowUnsigned,
 		},

--- a/targeting/contextagent/setup.go
+++ b/targeting/contextagent/setup.go
@@ -437,10 +437,10 @@ func buildBundle(ctx context.Context, cfg Config, opts runOptions, recorder Reco
 	}, nil
 }
 
-// buildKeyStore wires up the TMP signature key store from
-// TMPConfig.RegistryURL. The background refresh runs under safeGo so a
-// panic in the upstream library is captured and reported instead of
-// taking the process down.
+// buildKeyStore wires up the TMP signature key store from TMPConfig.
+// The background refresh (snapshot mode) runs under safeGo so a panic in
+// the upstream library is captured and reported instead of taking the
+// process down.
 func buildKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder, logger *slog.Logger) (tmproto.KeyStore, error) {
 	if cfg.RegistryURL == "" {
 		if !cfg.AllowUnsigned {
@@ -448,6 +448,21 @@ func buildKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder, logger
 		}
 		return nil, nil
 	}
+	mode := cfg.RegistryMode
+	if mode == "" {
+		mode = RegistryModeSnapshot
+	}
+	switch mode {
+	case RegistryModeAuthorization:
+		return buildAuthzKeyStore(cfg, logger)
+	case RegistryModeSnapshot:
+		return buildSnapshotKeyStore(ctx, cfg, recorder, logger)
+	default:
+		return nil, fmt.Errorf("unknown TMP_REGISTRY_MODE %q; expected %q or %q", mode, RegistryModeSnapshot, RegistryModeAuthorization)
+	}
+}
+
+func buildSnapshotKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder, logger *slog.Logger) (tmproto.KeyStore, error) {
 	ks, err := tmproto.NewRemoteKeyStore(tmproto.RemoteKeyStoreOptions{URL: cfg.RegistryURL})
 	if err != nil {
 		return nil, err
@@ -469,4 +484,16 @@ func buildKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder, logger
 		}
 	})
 	return ks, nil
+}
+
+// buildAuthzKeyStore instantiates the lazy per-agent keystore. No
+// initial fetch — the first signed request from an agent warms its
+// cache entry. Fits deployments where the caller set is not known
+// ahead of time.
+func buildAuthzKeyStore(cfg TMPConfig, logger *slog.Logger) (tmproto.KeyStore, error) {
+	return tmproto.NewLazyAuthorizationKeyStore(tmproto.LazyAuthorizationKeyStoreOptions{
+		BaseURL:     cfg.RegistryURL,
+		BearerToken: cfg.RegistryBearer,
+		Logger:      logger,
+	})
 }

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -104,10 +104,32 @@ type Config struct {
 
 // TMPConfig drives TMP signature verification on /identity.
 type TMPConfig struct {
-	RegistryURL    string
+	// RegistryURL is where the agent resolves publisher signing keys.
+	// Meaning depends on RegistryMode:
+	//   - "snapshot" (default): a router's /registry/snapshot endpoint
+	//     that returns {properties[]{signing_keys[]}}. Bulk-synced.
+	//   - "authorization": an AdCP registry authorizations endpoint
+	//     (e.g. https://agenticadvertising.org/api/registry/authorizations)
+	//     that the agent queries per-request using
+	//     `?agent_url=<seller_agent_url>`.
+	RegistryURL string
+	// RegistryMode selects the KeyStore implementation. "snapshot" (default)
+	// preserves back-compat with existing deployments. "authorization"
+	// switches to per-agent lazy resolution — the right choice when the
+	// verifier does not know its callers ahead of time.
+	RegistryMode string
+	// RegistryBearer is sent as `Authorization: Bearer <token>` on
+	// authorization-mode registry calls. Ignored in snapshot mode.
+	RegistryBearer string
 	OwnEndpointURL string
 	AllowUnsigned  bool
 }
+
+// Registry mode enum values.
+const (
+	RegistryModeSnapshot      = "snapshot"
+	RegistryModeAuthorization = "authorization"
+)
 
 // TMPXConfig drives TMPX response sealing. Disabled when EncryptJWKSURL is
 // empty.
@@ -413,6 +435,8 @@ func LoadConfigFromEnv() (Config, error) {
 		LogLevel:                   lookupString("LOG_LEVEL", defaultLogLevel),
 		TMP: TMPConfig{
 			RegistryURL:    os.Getenv("TMP_REGISTRY_URL"),
+			RegistryMode:   os.Getenv("TMP_REGISTRY_MODE"),
+			RegistryBearer: os.Getenv("TMP_REGISTRY_BEARER"),
 			OwnEndpointURL: os.Getenv("TMP_OWN_ENDPOINT_URL"),
 			AllowUnsigned:  allowUnsigned,
 		},

--- a/targeting/identityagent/keystore.go
+++ b/targeting/identityagent/keystore.go
@@ -10,28 +10,48 @@ import (
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
-// BuildKeyStore constructs a tmproto.KeyStore from the configured registry
-// URL. Returns (nil, nil) when no registry URL is set and signature
-// verification is not required — callers then accept unsigned requests.
+// BuildKeyStore constructs a tmproto.KeyStore from TMPConfig. Returns
+// (nil, nil) when no registry URL is set and signature verification is
+// not required — callers then accept unsigned requests.
 //
-// runCtx governs the long-lived background refresh goroutine; cancel it
-// during shutdown to drain. The synchronous initial fetch is bounded to
-// 10 seconds independently.
+// runCtx governs long-lived background work (snapshot refreshes) so
+// callers can cancel on shutdown; the synchronous initial fetch is
+// bounded to 10 seconds independently.
 //
 // The background refresh goroutine runs under safeGo: a panic inside the
 // upstream library is logged at ERROR and recorded on
 // recorder.BackgroundPanic("keystore-refresh") instead of taking down the
 // process. recorder may be nil for callers without observability.
-func BuildKeyStore(runCtx context.Context, registryURL string, requireSignature bool, logger *slog.Logger, recorder Recorder) (tmproto.KeyStore, error) {
-	if registryURL == "" {
+func BuildKeyStore(runCtx context.Context, cfg TMPConfig, logger *slog.Logger, recorder Recorder) (tmproto.KeyStore, error) {
+	requireSignature := !cfg.AllowUnsigned
+	if cfg.RegistryURL == "" {
 		if requireSignature {
-			return nil, errors.New("registry URL is required for signature verification; pass requireSignature=false to opt out")
+			return nil, errors.New("TMP_REGISTRY_URL is required for signature verification; set TMP_ALLOW_UNSIGNED=true to opt out")
 		}
 		return nil, nil
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
+
+	mode := cfg.RegistryMode
+	if mode == "" {
+		mode = RegistryModeSnapshot
+	}
+	switch mode {
+	case RegistryModeAuthorization:
+		return buildAuthorizationKeyStore(cfg, logger)
+	case RegistryModeSnapshot:
+		return buildSnapshotKeyStore(runCtx, cfg.RegistryURL, logger, recorder)
+	default:
+		return nil, fmt.Errorf("unknown TMP_REGISTRY_MODE %q; expected %q or %q", mode, RegistryModeSnapshot, RegistryModeAuthorization)
+	}
+}
+
+// buildSnapshotKeyStore polls a bulk snapshot URL for signing keys. Used
+// when the verifier's caller set is known and bounded — typically when
+// pointing at a router's /registry/snapshot.
+func buildSnapshotKeyStore(runCtx context.Context, registryURL string, logger *slog.Logger, recorder Recorder) (tmproto.KeyStore, error) {
 	ks, err := tmproto.NewRemoteKeyStore(tmproto.RemoteKeyStoreOptions{URL: registryURL})
 	if err != nil {
 		return nil, err
@@ -50,5 +70,22 @@ func BuildKeyStore(runCtx context.Context, registryURL string, requireSignature 
 			logger.Error("registry keystore Run terminated", "url", registryURL, "error", err)
 		}
 	})
+	return ks, nil
+}
+
+// buildAuthorizationKeyStore instantiates the lazy per-agent keystore.
+// No initial fetch — the first request from an agent warms its cache
+// entry. Fits deployments where the verifier's caller set is not known
+// ahead of time (e.g. the identity/context agents behind the AdCP
+// property registry).
+func buildAuthorizationKeyStore(cfg TMPConfig, logger *slog.Logger) (tmproto.KeyStore, error) {
+	ks, err := tmproto.NewLazyAuthorizationKeyStore(tmproto.LazyAuthorizationKeyStoreOptions{
+		BaseURL:     cfg.RegistryURL,
+		BearerToken: cfg.RegistryBearer,
+		Logger:      logger,
+	})
+	if err != nil {
+		return nil, err
+	}
 	return ks, nil
 }

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -380,7 +380,7 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 		return nil, fmt.Errorf("build service: %w", err)
 	}
 
-	keystore, err := BuildKeyStore(bgCtx, cfg.TMP.RegistryURL, !cfg.TMP.AllowUnsigned, logger, recorder)
+	keystore, err := BuildKeyStore(bgCtx, cfg.TMP, logger, recorder)
 	if err != nil {
 		return nil, fmt.Errorf("keystore: %w", err)
 	}

--- a/tmproto/keystore_authorization.go
+++ b/tmproto/keystore_authorization.go
@@ -1,0 +1,339 @@
+package tmproto
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/urlcanon"
+)
+
+// LazyAuthorizationKeyStore is an AgentAwareKeyStore backed by an AdCP
+// registry authorizations endpoint (typically
+// https://agenticadvertising.org/api/registry/authorizations). Instead of
+// syncing every publisher's keys at startup, it fetches on demand for the
+// exact seller_agent_url a request is signed by, caches per agent, and
+// invalidates on TTL expiry or verification failure.
+//
+// Fits the deployment where the verifier does not know its callers ahead
+// of time and where the caller set is small relative to the global
+// registry: only agents that actually send traffic ever land in the cache.
+//
+// Trust anchor per the TMP spec (specification.mdx §601-603): the registry
+// materializes each publisher's adagents.json into per-(agent, publisher)
+// authorization rows with signing_keys[]. The endpoint canonicalizes
+// agent_url server-side; this store canonicalizes client-side too so cache
+// keys are stable across callers that submit non-canonical URLs.
+type LazyAuthorizationKeyStore struct {
+	baseURL     string
+	bearerToken string
+	client      *http.Client
+	logger      *slog.Logger
+
+	positiveTTL time.Duration
+	negativeTTL time.Duration
+
+	mu    sync.RWMutex
+	byURL map[string]*agentCacheEntry
+
+	// singleflight collapses concurrent misses for the same agent URL onto
+	// one HTTP call.
+	inflightMu sync.Mutex
+	inflight   map[string]*inflightFetch
+}
+
+// LazyAuthorizationKeyStoreOptions configures a LazyAuthorizationKeyStore.
+type LazyAuthorizationKeyStoreOptions struct {
+	// BaseURL is the authorizations endpoint. `?agent_url=<canonical>` is
+	// appended per request. Example:
+	//   https://agenticadvertising.org/api/registry/authorizations
+	// Must use https:// unless AllowInsecureScheme is true.
+	BaseURL string
+
+	// BearerToken is sent as `Authorization: Bearer <token>` on every
+	// request. Optional — leave empty when the endpoint permits
+	// unauthenticated reads.
+	BearerToken string
+
+	// AllowInsecureScheme permits http:// URLs. For local development only.
+	AllowInsecureScheme bool
+
+	// HTTPClient is the client used for authorization fetches. When nil, a
+	// 3-second client is constructed with cross-origin redirects denied.
+	// The default matches the spec's ~30μs verification target — a slow
+	// registry should never block the auction hot path indefinitely.
+	HTTPClient *http.Client
+
+	// PositiveTTL is how long a resolved agent's keys are cached before
+	// re-fetch. Defaults to 5 minutes (spec §579 recommended TTL).
+	PositiveTTL time.Duration
+
+	// NegativeTTL is how long a "no authorization rows" answer is cached
+	// to avoid pounding the registry on unknown callers. Defaults to 60
+	// seconds — short enough that a genuine new authorization is picked
+	// up quickly, long enough to absorb a burst of forged requests.
+	NegativeTTL time.Duration
+
+	// Logger receives cache-miss and fetch-error events.
+	Logger *slog.Logger
+}
+
+type agentCacheEntry struct {
+	// byKid is the flattened kid → SigningKey map for this agent across
+	// all authorizations the registry returned. Nil for a negative
+	// cache entry.
+	byKid map[string]*SigningKey
+	// expires is when this entry becomes stale.
+	expires time.Time
+}
+
+type inflightFetch struct {
+	wg    sync.WaitGroup
+	entry *agentCacheEntry
+	err   error
+}
+
+// MaxAuthorizationBodyBytes caps the per-agent authorization response
+// this store will ingest. Sized generously for hundreds of authorization
+// rows per agent (typical: single-digit); a runaway response cannot
+// exhaust the verifier's memory.
+const MaxAuthorizationBodyBytes = 1 * 1024 * 1024
+
+// NewLazyAuthorizationKeyStore constructs the store. It does not fetch
+// anything until LookupKeyForAgent is called for the first time — Run is
+// optional and only useful when the verifier wants a background timer to
+// prune stale entries.
+func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyAuthorizationKeyStore, error) {
+	if opts.BaseURL == "" {
+		return nil, errors.New("tmproto: LazyAuthorizationKeyStore BaseURL is required")
+	}
+	parsed, err := url.Parse(opts.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("tmproto: LazyAuthorizationKeyStore BaseURL invalid: %w", err)
+	}
+	switch strings.ToLower(parsed.Scheme) {
+	case "https":
+		// fine.
+	case "http":
+		if !opts.AllowInsecureScheme {
+			return nil, errors.New("tmproto: LazyAuthorizationKeyStore BaseURL must use https:// (set AllowInsecureScheme for local development)")
+		}
+	default:
+		return nil, fmt.Errorf("tmproto: LazyAuthorizationKeyStore BaseURL must use http(s) scheme, got %q", parsed.Scheme)
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{
+			Timeout:       3 * time.Second,
+			CheckRedirect: denyCrossOriginRedirect,
+		}
+	}
+	positiveTTL := opts.PositiveTTL
+	if positiveTTL <= 0 {
+		positiveTTL = 5 * time.Minute
+	}
+	negativeTTL := opts.NegativeTTL
+	if negativeTTL <= 0 {
+		negativeTTL = 60 * time.Second
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &LazyAuthorizationKeyStore{
+		baseURL:     opts.BaseURL,
+		bearerToken: opts.BearerToken,
+		client:      client,
+		logger:      logger,
+		positiveTTL: positiveTTL,
+		negativeTTL: negativeTTL,
+		byURL:       make(map[string]*agentCacheEntry),
+		inflight:    make(map[string]*inflightFetch),
+	}, nil
+}
+
+// LookupKey implements KeyStore. Without a seller_agent_url the store
+// falls back to a linear scan of the cache — this is only useful for
+// callers that have not yet been updated to pass agent context. Verifiers
+// on the current signing path always have req.SellerAgentURL and take the
+// LookupKeyForAgent path instead.
+func (s *LazyAuthorizationKeyStore) LookupKey(kid string) (*SigningKey, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	now := time.Now()
+	for _, entry := range s.byURL {
+		if entry == nil || entry.byKid == nil {
+			continue
+		}
+		if now.After(entry.expires) {
+			continue
+		}
+		if k, ok := entry.byKid[kid]; ok {
+			return k, true
+		}
+	}
+	return nil, false
+}
+
+// LookupKeyForAgent implements AgentAwareKeyStore.
+func (s *LazyAuthorizationKeyStore) LookupKeyForAgent(kid, sellerAgentURL string) (*SigningKey, bool) {
+	canonical, err := urlcanon.Canonicalize(sellerAgentURL)
+	if err != nil {
+		s.logger.Debug("agent URL failed canonicalization; treating as unknown", "seller_agent_url", sellerAgentURL, "error", err)
+		return nil, false
+	}
+	entry := s.entryFor(canonical)
+	if entry == nil || entry.byKid == nil {
+		return nil, false
+	}
+	k, ok := entry.byKid[kid]
+	return k, ok
+}
+
+// Invalidate drops the cached entry for the given agent URL so the next
+// lookup triggers a fresh fetch. Callers should Invalidate after a
+// signature verification failure — the spec (§590) requires re-fetching
+// on failure to pick up a rotation.
+func (s *LazyAuthorizationKeyStore) Invalidate(sellerAgentURL string) {
+	canonical, err := urlcanon.Canonicalize(sellerAgentURL)
+	if err != nil {
+		return
+	}
+	s.mu.Lock()
+	delete(s.byURL, canonical)
+	s.mu.Unlock()
+}
+
+// entryFor returns a cached entry for the canonical URL, fetching if
+// missing or expired. Concurrent misses for the same URL are collapsed.
+func (s *LazyAuthorizationKeyStore) entryFor(canonical string) *agentCacheEntry {
+	s.mu.RLock()
+	entry := s.byURL[canonical]
+	s.mu.RUnlock()
+	if entry != nil && time.Now().Before(entry.expires) {
+		return entry
+	}
+
+	// Single-flight the fetch so a burst of first requests for a new
+	// agent produces one HTTP call, not N.
+	s.inflightMu.Lock()
+	if in, ok := s.inflight[canonical]; ok {
+		s.inflightMu.Unlock()
+		in.wg.Wait()
+		if in.err != nil {
+			return nil
+		}
+		return in.entry
+	}
+	in := &inflightFetch{}
+	in.wg.Add(1)
+	s.inflight[canonical] = in
+	s.inflightMu.Unlock()
+
+	entry, err := s.fetch(canonical)
+	in.entry = entry
+	in.err = err
+	in.wg.Done()
+
+	s.inflightMu.Lock()
+	delete(s.inflight, canonical)
+	s.inflightMu.Unlock()
+
+	if err != nil {
+		s.logger.Warn("authorization keystore fetch failed", "seller_agent_url", canonical, "error", err)
+		return nil
+	}
+
+	s.mu.Lock()
+	s.byURL[canonical] = entry
+	s.mu.Unlock()
+	return entry
+}
+
+// authorizationsResponse mirrors the JSON envelope of
+// GET /api/registry/authorizations. Only the fields the keystore needs
+// are decoded — extension fields are ignored.
+type authorizationsResponse struct {
+	Rows []struct {
+		SigningKeys []SigningKey `json:"signing_keys,omitempty"`
+	} `json:"rows"`
+}
+
+func (s *LazyAuthorizationKeyStore) fetch(canonicalAgentURL string) (*agentCacheEntry, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	q := url.Values{}
+	q.Set("agent_url", canonicalAgentURL)
+	sep := "?"
+	if strings.Contains(s.baseURL, "?") {
+		sep = "&"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL+sep+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if s.bearerToken != "" {
+		req.Header.Set("Authorization", "Bearer "+s.bearerToken)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch authorizations: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+		_ = resp.Body.Close()
+	}()
+
+	// 404 is a legitimate "no authorizations exist for this agent" —
+	// cache negatively so a burst of forged requests does not pound
+	// the registry.
+	if resp.StatusCode == http.StatusNotFound {
+		return &agentCacheEntry{expires: time.Now().Add(s.negativeTTL)}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("authorizations returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, MaxAuthorizationBodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read authorizations: %w", err)
+	}
+	var parsed authorizationsResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("parse authorizations: %w", err)
+	}
+
+	byKid := make(map[string]*SigningKey)
+	for _, row := range parsed.Rows {
+		for i := range row.SigningKeys {
+			k := row.SigningKeys[i]
+			if k.Kid == "" {
+				continue
+			}
+			byKid[k.Kid] = &k
+		}
+	}
+
+	// An agent that exists in the registry but has zero signing keys
+	// (e.g. mid-onboarding, before adagents.json pins keys) is also a
+	// negative result from the verifier's point of view — but cache
+	// briefly so the registry is not hammered.
+	if len(byKid) == 0 {
+		return &agentCacheEntry{expires: time.Now().Add(s.negativeTTL)}, nil
+	}
+	return &agentCacheEntry{
+		byKid:   byKid,
+		expires: time.Now().Add(s.positiveTTL),
+	}, nil
+}

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -1,0 +1,314 @@
+package tmproto
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// buildJWK generates an Ed25519 key and returns its public JWK-shaped
+// SigningKey plus the private key so tests can sign locally.
+func buildJWK(t *testing.T, kid string) (SigningKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return PublicSigningKey(kid, pub), priv
+}
+
+// newAuthzServer stands up a fake authorizations endpoint that records
+// each request and returns whatever the handler function chooses. The
+// handler receives the raw agent_url query param so tests can assert
+// canonicalization was applied by the store.
+func newAuthzServer(t *testing.T, handler func(agentURL string, w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		agentURL := r.URL.Query().Get("agent_url")
+		if agentURL == "" {
+			http.Error(w, "agent_url is required", http.StatusBadRequest)
+			return
+		}
+		handler(agentURL, w, r)
+	}))
+}
+
+func TestLazyAuthorizationKeyStore_FetchAndCache(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+
+	var calls int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{
+				{"signing_keys": []SigningKey{jwk}},
+			},
+		})
+	})
+	defer srv.Close()
+
+	ks, err := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example.com/agent")
+	if !ok || got == nil || got.Kid != "kid-a" {
+		t.Fatalf("first lookup: got=%+v ok=%v", got, ok)
+	}
+
+	// Cache hit — no additional HTTP call.
+	got2, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example.com/agent")
+	if !ok || got2 == nil {
+		t.Fatal("second lookup missed the cache")
+	}
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 HTTP call, got %d", c)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_UnknownKidOnKnownAgent(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+
+	_, ok := ks.LookupKeyForAgent("kid-b", "https://seller.example.com/agent")
+	if ok {
+		t.Error("expected kid-b to be unknown for this agent")
+	}
+}
+
+func TestLazyAuthorizationKeyStore_NegativeCacheOn404(t *testing.T) {
+	var calls int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+		NegativeTTL:         time.Second,
+	})
+
+	for i := 0; i < 3; i++ {
+		if _, ok := ks.LookupKeyForAgent("kid", "https://nobody.example/agent"); ok {
+			t.Fatalf("iteration %d: expected miss on unknown agent", i)
+		}
+	}
+	if c := atomic.LoadInt32(&calls); c != 1 {
+		t.Errorf("expected 1 HTTP call (rest from negative cache); got %d", c)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_TTLExpiration(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	var calls int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+		PositiveTTL:         50 * time.Millisecond,
+	})
+
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); !ok {
+		t.Fatal("first fetch failed")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); !ok {
+		t.Fatal("second fetch after TTL expiry failed")
+	}
+	if c := atomic.LoadInt32(&calls); c != 2 {
+		t.Errorf("expected 2 HTTP calls after TTL expiry; got %d", c)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_BearerHeaderSent(t *testing.T) {
+	var sawAuth string
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{"rows": []any{}})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		BearerToken:         "tk-42",
+		AllowInsecureScheme: true,
+	})
+	_, _ = ks.LookupKeyForAgent("kid", "https://seller.example/agent")
+
+	if sawAuth != "Bearer tk-42" {
+		t.Errorf("Authorization header = %q, want %q", sawAuth, "Bearer tk-42")
+	}
+}
+
+func TestLazyAuthorizationKeyStore_URLCanonicalization(t *testing.T) {
+	// The fake server sees exactly what the store sent. If canonicalization
+	// happened, uppercase host + trailing slash should be normalized before
+	// being placed in the query string.
+	var sawAgent string
+	srv := newAuthzServer(t, func(agentURL string, w http.ResponseWriter, _ *http.Request) {
+		sawAgent = agentURL
+		_ = json.NewEncoder(w).Encode(map[string]any{"rows": []any{}})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+	_, _ = ks.LookupKeyForAgent("kid", "HTTPS://Seller.Example.COM/Agent/")
+
+	if strings.Contains(sawAgent, "Seller.Example.COM") {
+		t.Errorf("agent_url query still carries un-canonical host: %q", sawAgent)
+	}
+	if !strings.HasPrefix(sawAgent, "https://") {
+		t.Errorf("agent_url query should start with lowercased scheme; got %q", sawAgent)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_SingleFlight(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	var calls int32
+	release := make(chan struct{})
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		<-release
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	var hits int32
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); ok {
+				atomic.AddInt32(&hits, 1)
+			}
+		}()
+	}
+	// Give goroutines a moment to enqueue on the inflight fetch before
+	// releasing the server response.
+	time.Sleep(30 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&hits); got != goroutines {
+		t.Errorf("expected %d successful lookups, got %d", goroutines, got)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("expected 1 HTTP call under single-flight; got %d", got)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_InvalidateForcesRefetch(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	var calls int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+
+	_, _ = ks.LookupKeyForAgent("kid-a", "https://seller.example/agent")
+	ks.Invalidate("https://seller.example/agent")
+	_, _ = ks.LookupKeyForAgent("kid-a", "https://seller.example/agent")
+
+	if c := atomic.LoadInt32(&calls); c != 2 {
+		t.Errorf("expected 2 HTTP calls after Invalidate; got %d", c)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_RejectsInsecureSchemeByDefault(t *testing.T) {
+	_, err := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL: "http://example.com/api/registry/authorizations",
+	})
+	if err == nil || !strings.Contains(err.Error(), "https") {
+		t.Errorf("expected https-required error, got %v", err)
+	}
+}
+
+// Verify* end-to-end: the store implements AgentAwareKeyStore so
+// resolveSigningKey routes the lookup with req.SellerAgentURL, and
+// VerifyContextMatch succeeds against a locally-signed request.
+func TestLazyAuthorizationKeyStore_VerifyContextMatchEndToEnd(t *testing.T) {
+	jwk, priv := buildJWK(t, "kid-e2e")
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, err := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer, err := NewSigner("kid-e2e", priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &ContextMatchRequest{
+		Type:           "context_match_request",
+		RequestID:      "req-1",
+		PropertyRID:    "01916f3a-1234-7000-8000-000000000001",
+		PlacementID:    "slot-1",
+		SellerAgentURL: "https://seller.example/agent",
+	}
+	endpoint := "https://provider.example/context"
+	now := time.Now()
+	sig := signer.SignContextMatch(req, endpoint, EpochAt(now))
+
+	if err := VerifyContextMatch(req, endpoint, sig, "kid-e2e", ks, now); err != nil {
+		t.Fatalf("VerifyContextMatch failed: %v", err)
+	}
+}

--- a/tmproto/signing.go
+++ b/tmproto/signing.go
@@ -120,6 +120,23 @@ type KeyStore interface {
 	LookupKey(kid string) (*SigningKey, bool)
 }
 
+// AgentAwareKeyStore is a KeyStore that can resolve a kid scoped to a
+// specific seller_agent_url. Verifiers prefer this interface when the
+// backing store implements it, so a keystore that fetches on demand can
+// avoid syncing the entire registry and instead pull just the keys of
+// the agent that actually signed the request.
+//
+// LookupKeyForAgent MUST return the same key as LookupKey(kid) when kid
+// belongs to sellerAgentURL, and MAY return false in cases where a kid
+// exists in the store but is not registered for that agent — this
+// enforces the spec's per-agent scoping (see specification.mdx §514,
+// §601) so a captured signature from agent A cannot be replayed under
+// agent B's identity even if B has cached a copy of A's key.
+type AgentAwareKeyStore interface {
+	KeyStore
+	LookupKeyForAgent(kid, sellerAgentURL string) (*SigningKey, bool)
+}
+
 // StaticKeyStore is a concurrent-safe map-backed KeyStore for tests and for
 // wrapping a pre-built snapshot of the registry.
 type StaticKeyStore struct {
@@ -342,7 +359,7 @@ func canonicalSealedCredentialsHash(creds []SealedCredential) (string, error) {
 // the verifier's own registered endpoint URL. now should be the wall clock for
 // the request — current+previous epoch are accepted.
 func VerifyContextMatch(req *ContextMatchRequest, ownEndpointURL, sig, kid string, ks KeyStore, now time.Time) error {
-	pub, key, err := resolveSigningKey(kid, ks)
+	pub, key, err := resolveSigningKey(kid, req.SellerAgentURL, ks)
 	if err != nil {
 		return err
 	}
@@ -369,7 +386,7 @@ func VerifyContextMatch(req *ContextMatchRequest, ownEndpointURL, sig, kid strin
 
 // VerifyIdentityMatch verifies the signature on an identity-match request.
 func VerifyIdentityMatch(req *IdentityMatchRequest, ownEndpointURL, sig, kid string, ks KeyStore, now time.Time) error {
-	pub, key, err := resolveSigningKey(kid, ks)
+	pub, key, err := resolveSigningKey(kid, req.SellerAgentURL, ks)
 	if err != nil {
 		return err
 	}
@@ -426,11 +443,11 @@ func LoadEd25519PrivateKeyPEM(pemBytes []byte) (ed25519.PrivateKey, error) {
 	return priv, nil
 }
 
-func resolveSigningKey(kid string, ks KeyStore) (ed25519.PublicKey, *SigningKey, error) {
+func resolveSigningKey(kid, sellerAgentURL string, ks KeyStore) (ed25519.PublicKey, *SigningKey, error) {
 	if ks == nil {
 		return nil, nil, ErrSignatureKeyUnknown
 	}
-	key, ok := ks.LookupKey(kid)
+	key, ok := lookupKey(ks, kid, sellerAgentURL)
 	if !ok {
 		return nil, nil, ErrSignatureKeyUnknown
 	}
@@ -439,6 +456,20 @@ func resolveSigningKey(kid string, ks KeyStore) (ed25519.PublicKey, *SigningKey,
 		return nil, nil, fmt.Errorf("%w: %v", ErrSignatureKeyUnknown, err)
 	}
 	return pub, key, nil
+}
+
+// lookupKey prefers AgentAwareKeyStore.LookupKeyForAgent when the store
+// implements it and a sellerAgentURL is available — this gives per-agent
+// stores (see LazyAuthorizationKeyStore) the context they need to fetch
+// keys on demand rather than requiring a bulk registry sync. Falls back
+// to LookupKey(kid) for stores on the plain interface.
+func lookupKey(ks KeyStore, kid, sellerAgentURL string) (*SigningKey, bool) {
+	if sellerAgentURL != "" {
+		if aa, ok := ks.(AgentAwareKeyStore); ok {
+			return aa.LookupKeyForAgent(kid, sellerAgentURL)
+		}
+	}
+	return ks.LookupKey(kid)
 }
 
 func decodeSignature(s string) ([]byte, error) {


### PR DESCRIPTION
## Motivation

Today, TMP signature verification requires the verifier to sync every publisher's signing keys ahead of time — `RemoteKeyStore` polls a single snapshot URL that must contain every kid the verifier might ever need. That model fits routers well (they know which properties they sign for at startup), but not identity/context agents:

- The set of routers a provider will see is not known ahead of time.
- Providers typically see traffic from a small fraction of registered routers.
- Every startup pays the cost of fetching keys that will never be used.
- There is no widely deployed \"bulk snapshot\" endpoint today. `agenticadvertising.org` does not currently emit `{properties[]{signing_keys[]}}` — its equivalent is `/api/registry/authorizations` (per-agent narrow pull) and `/api/registry/authorizations/snapshot` (NDJSON), both keyed by `agent_url`.

The wire already carries the missing context. Every TMP request has `seller_agent_url` as a required signed field (specification.mdx §514, §555, §601-603 — the receiver \"uses this to resolve the publisher's signing keys for verification\"). All the verifier needs is for that URL to reach the keystore.

## Changes

- **New `AgentAwareKeyStore` interface** extending `KeyStore` with `LookupKeyForAgent(kid, sellerAgentURL string)`. Additive — existing implementations (`StaticKeyStore`, `RemoteKeyStore`) work unchanged.
- **`resolveSigningKey`** now takes `sellerAgentURL` and prefers the richer interface when the store implements it. Falls back to `LookupKey(kid)` otherwise.
- **`VerifyContextMatch` / `VerifyIdentityMatch`** pass `req.SellerAgentURL` through. Public function signatures unchanged.
- **New `LazyAuthorizationKeyStore`** — fetches per-agent from the AdCP registry `/api/registry/authorizations?agent_url=<canonical>` endpoint:
  - Per-agent cache keyed by `urlcanon.Canonicalize`'d URL so lookups are stable regardless of caller form.
  - Positive TTL 5 min (spec §579), negative TTL 60 s to absorb bursts of forged requests to unknown agents.
  - Single-flight collapses concurrent misses on the same URL onto one HTTP call.
  - `Invalidate(agentURL)` drops the entry so a verifier can re-fetch on signature failure (spec §590 requires this).
  - Bearer-token auth. Cross-origin redirects denied.

## Tests

10 new tests in `tmproto/keystore_authorization_test.go` cover fetch/cache, unknown-kid, 404 negative cache, TTL expiration, Bearer header, URL canonicalization, single-flight, Invalidate, https-only guard, and end-to-end `VerifyContextMatch` against a locally-signed request. Existing tmproto tests unchanged.

## Deployment shape (illustrative — no code here)

```go
ks, _ := tmproto.NewLazyAuthorizationKeyStore(tmproto.LazyAuthorizationKeyStoreOptions{
    BaseURL:     "https://agenticadvertising.org/api/registry/authorizations",
    BearerToken: os.Getenv("ADCP_REGISTRY_TOKEN"),
})
mux.Handle("/identity", tmproto.VerifyIdentityMatchHandler(handler, tmproto.VerifyOptions{
    OwnEndpointURL: "https://tmp.example.com/identity",
    KeyStore:       ks,
}))
```

## Related spec sections

- §506-518: signing model, seller_agent_url binding.
- §571-577: signature verification; providers use the publisher's public key from the registry.
- §579-593: key rotation and revocation — refetch on verify failure. Matches `Invalidate` semantics here.
- §601-603: key distribution via the property registry.