### PR TITLE
tmproto: LazyAuthorizationKeyStore follow-ups (panic-safety, ctx, stale grace, refetch-on-unknown-kid)

### DIFF
--- a/tmproto/keystore_authorization.go
+++ b/tmproto/keystore_authorization.go
@@ -51,13 +51,15 @@ type LazyAuthorizationKeyStore struct {
 	// baseURL is parsed once at construction. Per-request URLs are built
 	// by cloning it and setting the `agent_url` query parameter — the
 	// host is never derived from caller input, only the query string is.
-	baseURL     *url.URL
-	bearerToken string
-	client      *http.Client
-	logger      *slog.Logger
+	baseURL      *url.URL
+	bearerToken  string
+	client       *http.Client
+	logger       *slog.Logger
+	fetchTimeout time.Duration
 
-	positiveTTL time.Duration
-	negativeTTL time.Duration
+	positiveTTL     time.Duration
+	negativeTTL     time.Duration
+	serveStaleGrace time.Duration
 
 	// cache is bounded by size; expiry is checked at read time. LRU
 	// promotion happens on Get, so entries for agents that keep signing
@@ -123,6 +125,23 @@ type LazyAuthorizationKeyStoreOptions struct {
 	// legitimate cold-start bursts, low enough to bound the amplifier.
 	MaxConcurrentFetches int
 
+	// FetchTimeout bounds a single outbound registry call. Defaults to
+	// 3 seconds. Set alongside HTTPClient's own Timeout — whichever is
+	// tighter wins. An operator-supplied HTTPClient with no Timeout
+	// still gets this ceiling.
+	FetchTimeout time.Duration
+
+	// ServeStaleGrace lets an expired positive entry keep serving for
+	// this window when a refetch fails (timeout / 5xx / network blip).
+	// Zero disables the grace — expiry means immediate 401 for that
+	// agent until the next successful fetch. A non-zero value trades a
+	// bounded revocation window (extends the effective positive TTL by
+	// up to Grace on failure) for continuity of service during a
+	// registry outage. Snapshot-mode RemoteKeyStore keeps serving its
+	// last snapshot indefinitely across refresh failures; this bounds
+	// that behaviour explicitly.
+	ServeStaleGrace time.Duration
+
 	// Logger receives cache-miss and fetch-error events.
 	Logger *slog.Logger
 }
@@ -132,8 +151,31 @@ type agentCacheEntry struct {
 	// all authorizations the registry returned. Nil for a negative
 	// cache entry.
 	byKid map[string]*SigningKey
+	// fetchedAt is when this entry was populated by a successful
+	// registry response. Used to gate refetch-on-unknown-kid so a
+	// freshly-fetched entry does not thrash on a spray of unknown kids
+	// from the same agent.
+	fetchedAt time.Time
 	// expires is when this entry becomes stale.
 	expires time.Time
+	// staleUntil is the wall-clock cutoff beyond which even
+	// serve-stale-on-error refuses to serve. Zero when serve-stale is
+	// disabled (returns nil on expiry+refetch-failure).
+	staleUntil time.Time
+}
+
+// unknownKidRefetchCooldown gates the "refetch on unknown kid" fallback:
+// once an entry is younger than this window, we trust the freshly-cached
+// keyset and do not refetch even if the incoming kid isn't in it. Long
+// enough to absorb a spray of forged kids from one agent; short enough
+// that a legitimate rotation lands quickly.
+const unknownKidRefetchCooldown = 30 * time.Second
+
+// unknownKidRefetchExhausted reports whether the entry is too young to
+// justify another refetch attempt. The kid argument is reserved for a
+// future per-kid tracking scheme; today the gate is entry-global.
+func (e *agentCacheEntry) unknownKidRefetchExhausted(_ string, cooldown time.Duration) bool {
+	return time.Since(e.fetchedAt) < cooldown
 }
 
 type inflightFetch struct {
@@ -169,10 +211,14 @@ func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyA
 	default:
 		return nil, fmt.Errorf("tmproto: LazyAuthorizationKeyStore BaseURL must use http(s) scheme, got %q", parsed.Scheme)
 	}
+	fetchTimeout := opts.FetchTimeout
+	if fetchTimeout <= 0 {
+		fetchTimeout = 3 * time.Second
+	}
 	client := opts.HTTPClient
 	if client == nil {
 		client = &http.Client{
-			Timeout:       3 * time.Second,
+			Timeout:       fetchTimeout,
 			CheckRedirect: denyCrossOriginRedirect,
 		}
 	}
@@ -201,15 +247,17 @@ func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyA
 		maxConcurrent = 32
 	}
 	return &LazyAuthorizationKeyStore{
-		baseURL:     parsed,
-		bearerToken: opts.BearerToken,
-		client:      client,
-		logger:      logger,
-		positiveTTL: positiveTTL,
-		negativeTTL: negativeTTL,
-		cache:       cache,
-		fetchSem:    make(chan struct{}, maxConcurrent),
-		inflight:    make(map[string]*inflightFetch),
+		baseURL:         parsed,
+		bearerToken:     opts.BearerToken,
+		client:          client,
+		logger:          logger,
+		fetchTimeout:    fetchTimeout,
+		positiveTTL:     positiveTTL,
+		negativeTTL:     negativeTTL,
+		serveStaleGrace: opts.ServeStaleGrace,
+		cache:           cache,
+		fetchSem:        make(chan struct{}, maxConcurrent),
+		inflight:        make(map[string]*inflightFetch),
 	}, nil
 }
 
@@ -226,17 +274,45 @@ func (s *LazyAuthorizationKeyStore) LookupKey(_ string) (*SigningKey, bool) {
 
 // LookupKeyForAgent implements AgentAwareKeyStore.
 func (s *LazyAuthorizationKeyStore) LookupKeyForAgent(kid, sellerAgentURL string) (*SigningKey, bool) {
+	return s.LookupKeyForAgentCtx(context.Background(), kid, sellerAgentURL)
+}
+
+// LookupKeyForAgentCtx is the context-aware variant. Callers on a
+// deadline (verify middleware inside a request handler) SHOULD use this
+// so a slow registry can't couple the agent's availability to it — the
+// context deadline caps how long the store will spend on a cold-miss
+// fetch. The interface method LookupKeyForAgent stays context-less to
+// match the KeyStore family.
+func (s *LazyAuthorizationKeyStore) LookupKeyForAgentCtx(ctx context.Context, kid, sellerAgentURL string) (*SigningKey, bool) {
 	canonical, err := urlcanon.Canonicalize(sellerAgentURL)
 	if err != nil {
 		s.logger.Debug("agent URL failed canonicalization; treating as unknown", "seller_agent_url", sellerAgentURL, "error", err)
 		return nil, false
 	}
-	entry := s.entryFor(canonical)
+	entry := s.entryFor(ctx, canonical)
 	if entry == nil || entry.byKid == nil {
 		return nil, false
 	}
-	k, ok := entry.byKid[kid]
-	return k, ok
+	if k, ok := entry.byKid[kid]; ok {
+		return k, true
+	}
+	// Kid isn't in the cached keyset. The most common cause is a
+	// legitimate signer that rotated to a new kid after we cached this
+	// agent — the registry has the new key, we're serving stale. Refetch
+	// once (bounded by a short cooldown to prevent thrash on genuinely
+	// unknown kids from the same agent) and try again. Spec §579 wants
+	// the effective rotation window shorter than the positive TTL.
+	if !entry.unknownKidRefetchExhausted(kid, unknownKidRefetchCooldown) {
+		s.cache.Remove(canonical)
+		entry = s.entryFor(ctx, canonical)
+		if entry == nil || entry.byKid == nil {
+			return nil, false
+		}
+		if k, ok := entry.byKid[kid]; ok {
+			return k, true
+		}
+	}
+	return nil, false
 }
 
 // Invalidate drops the cached entry for the given agent URL so the next
@@ -244,6 +320,12 @@ func (s *LazyAuthorizationKeyStore) LookupKeyForAgent(kid, sellerAgentURL string
 // call this on signature failure — a rotation therefore takes up to the
 // positive TTL (default 5 minutes) to propagate. Exported for host code
 // that wants to wire re-fetch-on-failure per spec §590.
+//
+// Race note: an in-flight leader fetch that completes AFTER Invalidate
+// will Add its result back into the cache, re-inserting the entry the
+// caller just wanted gone. Callers wiring §590 refetch-on-failure
+// SHOULD accept that as best-effort — a stale entry surviving one extra
+// round is bounded by the positive TTL either way.
 func (s *LazyAuthorizationKeyStore) Invalidate(sellerAgentURL string) {
 	canonical, err := urlcanon.Canonicalize(sellerAgentURL)
 	if err != nil {
@@ -254,9 +336,12 @@ func (s *LazyAuthorizationKeyStore) Invalidate(sellerAgentURL string) {
 
 // entryFor returns a cached entry for the canonical URL, fetching if
 // missing or expired. Concurrent misses for the same URL are collapsed.
-func (s *LazyAuthorizationKeyStore) entryFor(canonical string) *agentCacheEntry {
-	if entry, ok := s.cache.Get(canonical); ok && time.Now().Before(entry.expires) {
-		return entry
+// Callers pass a context so the fetch inherits the request's deadline
+// rather than pinning a semaphore slot for the full FetchTimeout.
+func (s *LazyAuthorizationKeyStore) entryFor(ctx context.Context, canonical string) *agentCacheEntry {
+	cached, hasCached := s.cache.Get(canonical)
+	if hasCached && time.Now().Before(cached.expires) {
+		return cached
 	}
 
 	// Single-flight the fetch so a burst of first requests for a new
@@ -266,7 +351,7 @@ func (s *LazyAuthorizationKeyStore) entryFor(canonical string) *agentCacheEntry 
 		s.inflightMu.Unlock()
 		in.wg.Wait()
 		if in.err != nil {
-			return nil
+			return s.staleOrNil(cached, hasCached)
 		}
 		return in.entry
 	}
@@ -275,6 +360,20 @@ func (s *LazyAuthorizationKeyStore) entryFor(canonical string) *agentCacheEntry 
 	s.inflight[canonical] = in
 	s.inflightMu.Unlock()
 
+	// Everything past this point must run even on panic — otherwise
+	// waiters block forever on wg.Wait(), the inflight entry leaks, and
+	// a semaphore slot is lost. defer covers all three legs.
+	semAcquired := false
+	defer func() {
+		if semAcquired {
+			<-s.fetchSem
+		}
+		in.wg.Done()
+		s.inflightMu.Lock()
+		delete(s.inflight, canonical)
+		s.inflightMu.Unlock()
+	}()
+
 	// Non-blocking semaphore acquire — if concurrent fetches are already
 	// at the ceiling, drop this request fail-closed rather than queuing.
 	// A queue is the amplifier we're guarding against; the caller's
@@ -282,33 +381,41 @@ func (s *LazyAuthorizationKeyStore) entryFor(canonical string) *agentCacheEntry 
 	// outcome under load.
 	select {
 	case s.fetchSem <- struct{}{}:
+		semAcquired = true
 	default:
 		in.err = errors.New("fetch semaphore full")
-		in.wg.Done()
-		s.inflightMu.Lock()
-		delete(s.inflight, canonical)
-		s.inflightMu.Unlock()
 		s.logger.Warn("authorization keystore refused fetch — concurrency ceiling reached", "seller_agent_url", canonical)
-		return nil
+		return s.staleOrNil(cached, hasCached)
 	}
 
-	entry, err := s.fetch(canonical)
-	<-s.fetchSem
+	entry, err := s.fetch(ctx, canonical)
 	in.entry = entry
 	in.err = err
-	in.wg.Done()
-
-	s.inflightMu.Lock()
-	delete(s.inflight, canonical)
-	s.inflightMu.Unlock()
 
 	if err != nil {
 		s.logger.Warn("authorization keystore fetch failed", "seller_agent_url", canonical, "error", err)
-		return nil
+		return s.staleOrNil(cached, hasCached)
 	}
 
 	s.cache.Add(canonical, entry)
 	return entry
+}
+
+// staleOrNil returns a still-valid stale entry when serve-stale grace is
+// configured and the cached entry has not yet passed its staleUntil, else
+// nil. Trades a bounded revocation window for continuity across registry
+// blips.
+func (s *LazyAuthorizationKeyStore) staleOrNil(cached *agentCacheEntry, hasCached bool) *agentCacheEntry {
+	if !hasCached || s.serveStaleGrace <= 0 {
+		return nil
+	}
+	if cached == nil || cached.byKid == nil {
+		return nil
+	}
+	if time.Now().Before(cached.staleUntil) {
+		return cached
+	}
+	return nil
 }
 
 // authorizationsResponse mirrors the JSON envelope of
@@ -320,8 +427,12 @@ type authorizationsResponse struct {
 	} `json:"rows"`
 }
 
-func (s *LazyAuthorizationKeyStore) fetch(canonicalAgentURL string) (*agentCacheEntry, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+func (s *LazyAuthorizationKeyStore) fetch(ctx context.Context, canonicalAgentURL string) (*agentCacheEntry, error) {
+	// Cap the fetch by the store's FetchTimeout, but only tighten the
+	// caller's deadline — never extend it. This lets a request-scoped
+	// context cancel a slow registry, while still bounding an
+	// unbounded (background) caller to FetchTimeout.
+	fetchCtx, cancel := context.WithTimeout(ctx, s.fetchTimeout)
 	defer cancel()
 
 	// Clone the pre-parsed base URL and set the query param. The host is
@@ -337,7 +448,7 @@ func (s *LazyAuthorizationKeyStore) fetch(canonicalAgentURL string) (*agentCache
 	// configuration (TMP_REGISTRY_URL); only the ?agent_url= query parameter
 	// is derived from request data, which is the documented registry
 	// contract. The Client is not a generic HTTP fetcher.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil) //nolint:gosec
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, u.String(), nil) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
@@ -355,11 +466,16 @@ func (s *LazyAuthorizationKeyStore) fetch(canonicalAgentURL string) (*agentCache
 		_ = resp.Body.Close()
 	}()
 
+	now := time.Now()
+
 	// 404 is a legitimate "no authorizations exist for this agent" —
 	// cache negatively so a burst of forged requests does not pound
 	// the registry.
 	if resp.StatusCode == http.StatusNotFound {
-		return &agentCacheEntry{expires: time.Now().Add(s.negativeTTL)}, nil
+		return &agentCacheEntry{
+			fetchedAt: now,
+			expires:   now.Add(s.negativeTTL),
+		}, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("authorizations returned %d", resp.StatusCode)
@@ -390,10 +506,18 @@ func (s *LazyAuthorizationKeyStore) fetch(canonicalAgentURL string) (*agentCache
 	// negative result from the verifier's point of view — but cache
 	// briefly so the registry is not hammered.
 	if len(byKid) == 0 {
-		return &agentCacheEntry{expires: time.Now().Add(s.negativeTTL)}, nil
+		return &agentCacheEntry{
+			fetchedAt: now,
+			expires:   now.Add(s.negativeTTL),
+		}, nil
 	}
-	return &agentCacheEntry{
-		byKid:   byKid,
-		expires: time.Now().Add(s.positiveTTL),
-	}, nil
+	entry := &agentCacheEntry{
+		byKid:     byKid,
+		fetchedAt: now,
+		expires:   now.Add(s.positiveTTL),
+	}
+	if s.serveStaleGrace > 0 {
+		entry.staleUntil = entry.expires.Add(s.serveStaleGrace)
+	}
+	return entry, nil
 }

--- a/tmproto/keystore_authorization.go
+++ b/tmproto/keystore_authorization.go
@@ -57,9 +57,10 @@ type LazyAuthorizationKeyStore struct {
 	logger       *slog.Logger
 	fetchTimeout time.Duration
 
-	positiveTTL     time.Duration
-	negativeTTL     time.Duration
-	serveStaleGrace time.Duration
+	positiveTTL               time.Duration
+	negativeTTL               time.Duration
+	serveStaleGrace           time.Duration
+	unknownKidRefetchCooldown time.Duration
 
 	// cache is bounded by size; expiry is checked at read time. LRU
 	// promotion happens on Get, so entries for agents that keep signing
@@ -131,6 +132,14 @@ type LazyAuthorizationKeyStoreOptions struct {
 	// still gets this ceiling.
 	FetchTimeout time.Duration
 
+	// UnknownKidRefetchCooldown gates how soon after a fetch the store
+	// will retry the registry when the incoming kid isn't in the cached
+	// keyset (typical cause: publisher rotation). Defaults to 30 s.
+	// Shorter values pick up rotations faster; longer values further
+	// dampen the impact of forged-kid probes. Exposed primarily so
+	// tests can shorten it without racing wall-clock time.
+	UnknownKidRefetchCooldown time.Duration
+
 	// ServeStaleGrace lets an expired positive entry keep serving for
 	// this window when a refetch fails (timeout / 5xx / network blip).
 	// Zero disables the grace — expiry means immediate 401 for that
@@ -164,18 +173,20 @@ type agentCacheEntry struct {
 	staleUntil time.Time
 }
 
-// unknownKidRefetchCooldown gates the "refetch on unknown kid" fallback:
-// once an entry is younger than this window, we trust the freshly-cached
-// keyset and do not refetch even if the incoming kid isn't in it. Long
-// enough to absorb a spray of forged kids from one agent; short enough
-// that a legitimate rotation lands quickly.
-const unknownKidRefetchCooldown = 30 * time.Second
+// defaultUnknownKidRefetchCooldown gates the "refetch on unknown kid"
+// fallback: once an entry is younger than this window, we trust the
+// freshly-cached keyset and do not refetch even if the incoming kid
+// isn't in it. Long enough to absorb a spray of forged kids from one
+// agent; short enough that a legitimate rotation lands quickly.
+const defaultUnknownKidRefetchCooldown = 30 * time.Second
 
-// unknownKidRefetchExhausted reports whether the entry is too young to
-// justify another refetch attempt. The kid argument is reserved for a
-// future per-kid tracking scheme; today the gate is entry-global.
-func (e *agentCacheEntry) unknownKidRefetchExhausted(_ string, cooldown time.Duration) bool {
-	return time.Since(e.fetchedAt) < cooldown
+// refetchOnUnknownKidAllowed reports whether the entry is old enough to
+// justify one more refetch attempt on an unknown kid. Semantics: a
+// brand-new entry answers false (still fresh, trust the keyset); an
+// entry past the cooldown answers true. The kid argument is reserved
+// for a future per-kid tracking scheme; today the gate is entry-global.
+func (e *agentCacheEntry) refetchOnUnknownKidAllowed(_ string, cooldown time.Duration) bool {
+	return time.Since(e.fetchedAt) >= cooldown
 }
 
 type inflightFetch struct {
@@ -246,18 +257,23 @@ func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyA
 	if maxConcurrent <= 0 {
 		maxConcurrent = 32
 	}
+	unknownKidCooldown := opts.UnknownKidRefetchCooldown
+	if unknownKidCooldown <= 0 {
+		unknownKidCooldown = defaultUnknownKidRefetchCooldown
+	}
 	return &LazyAuthorizationKeyStore{
-		baseURL:         parsed,
-		bearerToken:     opts.BearerToken,
-		client:          client,
-		logger:          logger,
-		fetchTimeout:    fetchTimeout,
-		positiveTTL:     positiveTTL,
-		negativeTTL:     negativeTTL,
-		serveStaleGrace: opts.ServeStaleGrace,
-		cache:           cache,
-		fetchSem:        make(chan struct{}, maxConcurrent),
-		inflight:        make(map[string]*inflightFetch),
+		baseURL:                   parsed,
+		bearerToken:               opts.BearerToken,
+		client:                    client,
+		logger:                    logger,
+		fetchTimeout:              fetchTimeout,
+		positiveTTL:               positiveTTL,
+		negativeTTL:               negativeTTL,
+		serveStaleGrace:           opts.ServeStaleGrace,
+		unknownKidRefetchCooldown: unknownKidCooldown,
+		cache:                     cache,
+		fetchSem:                  make(chan struct{}, maxConcurrent),
+		inflight:                  make(map[string]*inflightFetch),
 	}, nil
 }
 
@@ -298,21 +314,73 @@ func (s *LazyAuthorizationKeyStore) LookupKeyForAgentCtx(ctx context.Context, ki
 	}
 	// Kid isn't in the cached keyset. The most common cause is a
 	// legitimate signer that rotated to a new kid after we cached this
-	// agent — the registry has the new key, we're serving stale. Refetch
-	// once (bounded by a short cooldown to prevent thrash on genuinely
-	// unknown kids from the same agent) and try again. Spec §579 wants
-	// the effective rotation window shorter than the positive TTL.
-	if !entry.unknownKidRefetchExhausted(kid, unknownKidRefetchCooldown) {
-		s.cache.Remove(canonical)
-		entry = s.entryFor(ctx, canonical)
-		if entry == nil || entry.byKid == nil {
-			return nil, false
-		}
-		if k, ok := entry.byKid[kid]; ok {
-			return k, true
+	// agent — the registry has the new key, we're serving stale. Try to
+	// refetch once (bounded by a short cooldown to dampen forged-kid
+	// probes). CRUCIAL: fetch-then-swap. We do NOT evict the existing
+	// entry first, because an attacker with a bogus kid could otherwise
+	// force a refetch that fails (registry blip, semaphore saturation
+	// from a spray of unique agent URLs) and cancel the ServeStaleGrace
+	// net we hold for legitimate traffic. On refetch failure the old
+	// entry stays exactly where it was.
+	if entry.refetchOnUnknownKidAllowed(kid, s.unknownKidRefetchCooldown) {
+		if fresh := s.refetchAgent(ctx, canonical); fresh != nil && fresh.byKid != nil {
+			if k, ok := fresh.byKid[kid]; ok {
+				return k, true
+			}
 		}
 	}
 	return nil, false
+}
+
+// refetchAgent forces a registry call for the agent, updating the cache
+// only on success. Unlike entryFor, it bypasses the "cache still valid"
+// short-circuit — the caller has already established that the cached
+// entry needs refresh — but preserves single-flight and the fetch
+// semaphore. On failure it returns nil WITHOUT touching the existing
+// cache entry, so a still-valid entry (with respect to the caller's
+// original expectation) is preserved.
+func (s *LazyAuthorizationKeyStore) refetchAgent(ctx context.Context, canonical string) *agentCacheEntry {
+	s.inflightMu.Lock()
+	if in, ok := s.inflight[canonical]; ok {
+		s.inflightMu.Unlock()
+		in.wg.Wait()
+		if in.err != nil {
+			return nil
+		}
+		return in.entry
+	}
+	in := &inflightFetch{}
+	in.wg.Add(1)
+	s.inflight[canonical] = in
+	s.inflightMu.Unlock()
+
+	semAcquired := false
+	defer func() {
+		if semAcquired {
+			<-s.fetchSem
+		}
+		in.wg.Done()
+		s.inflightMu.Lock()
+		delete(s.inflight, canonical)
+		s.inflightMu.Unlock()
+	}()
+
+	select {
+	case s.fetchSem <- struct{}{}:
+		semAcquired = true
+	default:
+		in.err = errors.New("fetch semaphore full")
+		return nil
+	}
+
+	entry, err := s.fetch(ctx, canonical)
+	in.entry = entry
+	in.err = err
+	if err != nil {
+		return nil
+	}
+	s.cache.Add(canonical, entry)
+	return entry
 }
 
 // Invalidate drops the cached entry for the given agent URL so the next

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -1,6 +1,7 @@
 package tmproto
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
@@ -371,6 +372,145 @@ func TestLazyAuthorizationKeyStore_FetchConcurrencyCap(t *testing.T) {
 
 	if got := atomic.LoadInt32(&maxInflight); got > int32(semCap) {
 		t.Errorf("observed %d concurrent fetches; expected <= %d", got, semCap)
+	}
+}
+
+// After an entry expires and the refetch fails, ServeStaleGrace lets
+// the store keep serving the stale entry up to the grace window.
+func TestLazyAuthorizationKeyStore_ServeStaleGraceOnRefetchError(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	var fail int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		if atomic.LoadInt32(&fail) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+		PositiveTTL:         50 * time.Millisecond,
+		ServeStaleGrace:     time.Second,
+	})
+
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); !ok {
+		t.Fatal("initial lookup failed")
+	}
+	// Wait for expiry.
+	time.Sleep(80 * time.Millisecond)
+	atomic.StoreInt32(&fail, 1)
+
+	// Refetch fails; grace window still valid → stale entry served.
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); !ok {
+		t.Error("expected stale entry to be served within grace window on refetch error")
+	}
+}
+
+// Grace does NOT extend indefinitely — past staleUntil the store fails
+// closed even under refetch error.
+func TestLazyAuthorizationKeyStore_StaleGraceIsBounded(t *testing.T) {
+	jwk, _ := buildJWK(t, "kid-a")
+	var fail int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		if atomic.LoadInt32(&fail) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{jwk}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+		PositiveTTL:         30 * time.Millisecond,
+		ServeStaleGrace:     30 * time.Millisecond,
+	})
+
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); !ok {
+		t.Fatal("initial lookup failed")
+	}
+	atomic.StoreInt32(&fail, 1)
+	// Wait past positiveTTL + serveStaleGrace.
+	time.Sleep(120 * time.Millisecond)
+
+	if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); ok {
+		t.Error("expected fail-closed past stale grace window")
+	}
+}
+
+// A cached agent that now signs with a new kid should refetch once and
+// pick up the rotation, instead of 401ing until positive TTL expires.
+func TestLazyAuthorizationKeyStore_RefetchOnUnknownKid(t *testing.T) {
+	oldJWK, _ := buildJWK(t, "kid-old")
+	newJWK, _ := buildJWK(t, "kid-new")
+	var phase atomic.Int32
+	var calls atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		keys := []SigningKey{oldJWK}
+		if phase.Load() == 1 {
+			keys = []SigningKey{newJWK}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": keys}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+	// First lookup caches kid-old.
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Fatal("kid-old should be cached after first lookup")
+	}
+	// Simulate publisher rotation → registry now serves kid-new.
+	phase.Store(1)
+	// Immediately look up kid-new. The cached entry is <30s old, so the
+	// entry-age gate SHOULD say "too fresh, don't refetch" and this
+	// misses.
+	if _, ok := ks.LookupKeyForAgent("kid-new", "https://seller.example/agent"); ok {
+		t.Error("expected fresh-entry gate to block refetch inside cooldown")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 HTTP call inside cooldown; got %d", got)
+	}
+}
+
+func TestLazyAuthorizationKeyStore_FetchContextPropagates(t *testing.T) {
+	// A caller with an already-cancelled context should not trigger any
+	// HTTP call. Confirms context propagation into fetch.
+	var calls atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"rows":[]}`))
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:             srv.URL,
+		AllowInsecureScheme: true,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _ = ks.LookupKeyForAgentCtx(ctx, "kid", "https://seller.example/agent")
+	// The request may or may not have made it to the server before ctx
+	// was checked; what matters is that the lookup returned fail-closed
+	// (nil, false) rather than blocking. Sanity: server saw at most one
+	// call.
+	if got := calls.Load(); got > 1 {
+		t.Errorf("cancelled ctx produced %d HTTP calls, expected 0 or 1", got)
 	}
 }
 

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -446,9 +446,10 @@ func TestLazyAuthorizationKeyStore_StaleGraceIsBounded(t *testing.T) {
 	}
 }
 
-// A cached agent that now signs with a new kid should refetch once and
-// pick up the rotation, instead of 401ing until positive TTL expires.
-func TestLazyAuthorizationKeyStore_RefetchOnUnknownKid(t *testing.T) {
+// A cached entry younger than the cooldown must NOT trigger a refetch
+// on an unknown kid — otherwise a spray of forged kids from a real
+// seller's URL would amplify to the registry 1:1.
+func TestLazyAuthorizationKeyStore_UnknownKidBlockedWithinCooldown(t *testing.T) {
 	oldJWK, _ := buildJWK(t, "kid-old")
 	newJWK, _ := buildJWK(t, "kid-new")
 	var phase atomic.Int32
@@ -466,23 +467,106 @@ func TestLazyAuthorizationKeyStore_RefetchOnUnknownKid(t *testing.T) {
 	defer srv.Close()
 
 	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
-		BaseURL:             srv.URL,
-		AllowInsecureScheme: true,
+		BaseURL:                   srv.URL,
+		AllowInsecureScheme:       true,
+		UnknownKidRefetchCooldown: 5 * time.Second, // long enough that the test never crosses it
 	})
-	// First lookup caches kid-old.
 	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
 		t.Fatal("kid-old should be cached after first lookup")
 	}
-	// Simulate publisher rotation → registry now serves kid-new.
 	phase.Store(1)
-	// Immediately look up kid-new. The cached entry is <30s old, so the
-	// entry-age gate SHOULD say "too fresh, don't refetch" and this
-	// misses.
 	if _, ok := ks.LookupKeyForAgent("kid-new", "https://seller.example/agent"); ok {
 		t.Error("expected fresh-entry gate to block refetch inside cooldown")
 	}
 	if got := calls.Load(); got != 1 {
 		t.Errorf("expected 1 HTTP call inside cooldown; got %d", got)
+	}
+}
+
+// Past the cooldown, an unknown kid triggers exactly one refetch which
+// picks up a legitimate rotation. This is the feature this path exists
+// to provide.
+func TestLazyAuthorizationKeyStore_UnknownKidRefetchesPastCooldown(t *testing.T) {
+	oldJWK, _ := buildJWK(t, "kid-old")
+	newJWK, _ := buildJWK(t, "kid-new")
+	var phase atomic.Int32
+	var calls atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		keys := []SigningKey{oldJWK}
+		if phase.Load() == 1 {
+			keys = []SigningKey{newJWK}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": keys}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:                   srv.URL,
+		AllowInsecureScheme:       true,
+		UnknownKidRefetchCooldown: 20 * time.Millisecond,
+	})
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Fatal("kid-old should be cached after first lookup")
+	}
+	phase.Store(1)
+	time.Sleep(40 * time.Millisecond) // cross the cooldown
+
+	if _, ok := ks.LookupKeyForAgent("kid-new", "https://seller.example/agent"); !ok {
+		t.Error("expected refetch to pick up rotated key past cooldown")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 HTTP calls (initial + refetch), got %d", got)
+	}
+	// Legitimate old-kid traffic still verifies against the new snapshot
+	// only if the old kid is still authorized — here the server dropped
+	// it, so kid-old is now genuinely absent. Confirm no crash / hang.
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); ok {
+		t.Error("kid-old should no longer resolve after registry dropped it")
+	}
+}
+
+// Blocker regression test: an attacker-triggered refetch failure MUST
+// NOT evict the still-valid cached entry. Fetch-then-swap semantics.
+func TestLazyAuthorizationKeyStore_RefetchFailurePreservesCachedEntry(t *testing.T) {
+	oldJWK, _ := buildJWK(t, "kid-old")
+	var fail atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{oldJWK}}},
+		})
+	})
+	defer srv.Close()
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:                   srv.URL,
+		AllowInsecureScheme:       true,
+		UnknownKidRefetchCooldown: 20 * time.Millisecond,
+	})
+	// Warm the cache with kid-old.
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Fatal("initial lookup failed")
+	}
+	// Cross the cooldown and simulate a registry outage.
+	time.Sleep(40 * time.Millisecond)
+	fail.Store(1)
+
+	// Attacker: probe with a bogus kid. Refetch will 500 → return nil.
+	// The cached kid-old entry MUST survive.
+	if _, ok := ks.LookupKeyForAgent("kid-forged", "https://seller.example/agent"); ok {
+		t.Error("forged kid should not resolve")
+	}
+
+	// Legitimate traffic from the same seller with the real kid must
+	// still verify — the outage did not evict its key.
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Error("legitimate kid-old evicted by failed refetch — regression")
 	}
 }
 

--- a/tmproto/signing.go
+++ b/tmproto/signing.go
@@ -126,12 +126,16 @@ type KeyStore interface {
 // avoid syncing the entire registry and instead pull just the keys of
 // the agent that actually signed the request.
 //
-// LookupKeyForAgent MUST return the same key as LookupKey(kid) when kid
-// belongs to sellerAgentURL, and MAY return false in cases where a kid
-// exists in the store but is not registered for that agent — this
-// enforces the spec's per-agent scoping (see specification.mdx §514,
-// §601) so a captured signature from agent A cannot be replayed under
-// agent B's identity even if B has cached a copy of A's key.
+// The trust property this interface adds is authorization scoping, not
+// cross-agent replay protection. Cross-agent replay is already blocked
+// by the fact that seller_agent_url is part of the signed input
+// (specification.mdx §514, §555) — a captured signature under agent A
+// cannot verify when the request claims agent B because ed25519.Verify
+// fails over the swapped bytes. What LookupKeyForAgent adds on top:
+// even if a kid exists somewhere in the store's cache from a different
+// agent, resolving it under sellerAgentURL SHOULD only return keys the
+// registry attests were authorized for that agent — preventing a
+// silent cross-agent trust bleed at the key-store layer.
 type AgentAwareKeyStore interface {
 	KeyStore
 	LookupKeyForAgent(kid, sellerAgentURL string) (*SigningKey, bool)


### PR DESCRIPTION
Non-blocking follow-ups from the approving review on #401. All fixes are additive; the shipped interface stays back-compat.

## Changes

- **Panic-safety in the single-flight critical section.** The semaphore release, `wg.Done`, and inflight-map delete now run via `defer`. If `fetch` ever panics on a future edit, followers no longer block forever on `wg.Wait` and the semaphore slot is not leaked.
- **Context propagation.** `LookupKeyForAgent` now has a `LookupKeyForAgentCtx` variant; `entryFor` and `fetch` both honor the caller's ctx. A request handler with a 40 ms budget can cancel a slow registry instead of pinning a semaphore slot for the full `FetchTimeout`.
- **Timeout alignment.** New `FetchTimeout` option (default 3 s) bounds both the default HTTP client's `Timeout` and the per-fetch context deadline, so an operator-supplied client with no `Timeout` still gets a ceiling. The previous 10 s ctx / 3 s client mismatch is gone.
- **Serve-stale-on-error grace.** New `ServeStaleGrace` option (default `0`, disabled). When positive, an expired positive entry is served for up to `Grace` after expiry when a refetch fails — bounded continuity across registry blips; opt-in so fail-closed-favors-revocation stays the default.
- **Refetch-on-unknown-kid.** When a valid cached entry doesn't contain the incoming kid, the store refetches once (gated by a 30 s entry-age cooldown to prevent thrash from forged kids) before failing. Legitimate publisher rotations land inside seconds instead of at the next positive-TTL boundary.
- **`AgentAwareKeyStore` godoc nit.** Correct the earlier overclaim that the interface itself prevents cross-agent replay. The signed `seller_agent_url` is what blocks cross-agent replay; the interface adds *authorization scoping* on top of that.
- **`Invalidate`/`Add` race note.** Document the small window where an in-flight leader can `Add` after an `Invalidate` `Remove` — the effect is bounded by the positive TTL either way.

## Tests

Three new cases in `keystore_authorization_test.go`:
- serve-stale grace positive path (refetch fails, cached entry served within grace),
- stale-grace boundedness (past `staleUntil`, still fail-closed),
- refetch cooldown gate (a rotation inside 30 s does not thrash),
- ctx propagation (a cancelled ctx does not amplify).

All existing tmproto tests still green.

## Deliberately skipped from the review

- **Response envelope validation against the real registry** — that's a runbook check against `agenticadvertising.org`'s OpenAPI, not a code change.
- **Wiring `Invalidate` into the verify middleware** — same architectural gap `RemoteKeyStore` has; a broader change worth a separate PR (touches `verify_middleware.go` and needs to define retry semantics).
- **`AllowInsecureScheme` plumbing to the agent config** — snapshot-mode `RemoteKeyStore` has the same gap on the agent side. Consistent to leave for parity; can add on both together later.

Follows #401.