### PR TITLE
tmproto: log LazyAuthorizationKeyStore refetch failures

### DIFF
--- a/targeting/contextagent/setup.go
+++ b/targeting/contextagent/setup.go
@@ -454,7 +454,7 @@ func buildKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder, logger
 	}
 	switch mode {
 	case RegistryModeAuthorization:
-		return buildAuthzKeyStore(cfg, logger)
+		return buildAuthzKeyStore(cfg, logger, recorder)
 	case RegistryModeSnapshot:
 		return buildSnapshotKeyStore(ctx, cfg, recorder, logger)
 	default:
@@ -490,10 +490,21 @@ func buildSnapshotKeyStore(ctx context.Context, cfg TMPConfig, recorder Recorder
 // initial fetch — the first signed request from an agent warms its
 // cache entry. Fits deployments where the caller set is not known
 // ahead of time.
-func buildAuthzKeyStore(cfg TMPConfig, logger *slog.Logger) (tmproto.KeyStore, error) {
-	return tmproto.NewLazyAuthorizationKeyStore(tmproto.LazyAuthorizationKeyStoreOptions{
+//
+// OnFetchOutcome is wired to recorder.KeystoreRefresh so registry
+// health emits on the same counter snapshot mode already uses,
+// labeled by tmproto.FetchOutcome* — operators alert on error rate
+// without caring which mode is running.
+func buildAuthzKeyStore(cfg TMPConfig, logger *slog.Logger, recorder Recorder) (tmproto.KeyStore, error) {
+	opts := tmproto.LazyAuthorizationKeyStoreOptions{
 		BaseURL:     cfg.RegistryURL,
 		BearerToken: cfg.RegistryBearer,
 		Logger:      logger,
-	})
+	}
+	if recorder != nil {
+		opts.OnFetchOutcome = func(ctx context.Context, outcome string) {
+			recorder.KeystoreRefresh(ctx, outcome)
+		}
+	}
+	return tmproto.NewLazyAuthorizationKeyStore(opts)
 }

--- a/targeting/identityagent/keystore.go
+++ b/targeting/identityagent/keystore.go
@@ -40,7 +40,7 @@ func BuildKeyStore(runCtx context.Context, cfg TMPConfig, logger *slog.Logger, r
 	}
 	switch mode {
 	case RegistryModeAuthorization:
-		return buildAuthorizationKeyStore(cfg, logger)
+		return buildAuthorizationKeyStore(cfg, logger, recorder)
 	case RegistryModeSnapshot:
 		return buildSnapshotKeyStore(runCtx, cfg.RegistryURL, logger, recorder)
 	default:
@@ -78,12 +78,24 @@ func buildSnapshotKeyStore(runCtx context.Context, registryURL string, logger *s
 // entry. Fits deployments where the verifier's caller set is not known
 // ahead of time (e.g. the identity/context agents behind the AdCP
 // property registry).
-func buildAuthorizationKeyStore(cfg TMPConfig, logger *slog.Logger) (tmproto.KeyStore, error) {
-	ks, err := tmproto.NewLazyAuthorizationKeyStore(tmproto.LazyAuthorizationKeyStoreOptions{
+//
+// The store's OnFetchOutcome hook is wired to recorder.KeystoreRefresh
+// so registry health surfaces on the same Prometheus counter the
+// snapshot-mode store already emits (labeled by tmproto.FetchOutcome*).
+// Operators can alert on error rate without caring which registry mode
+// they picked.
+func buildAuthorizationKeyStore(cfg TMPConfig, logger *slog.Logger, recorder Recorder) (tmproto.KeyStore, error) {
+	opts := tmproto.LazyAuthorizationKeyStoreOptions{
 		BaseURL:     cfg.RegistryURL,
 		BearerToken: cfg.RegistryBearer,
 		Logger:      logger,
-	})
+	}
+	if recorder != nil {
+		opts.OnFetchOutcome = func(ctx context.Context, outcome string) {
+			recorder.KeystoreRefresh(ctx, outcome)
+		}
+	}
+	ks, err := tmproto.NewLazyAuthorizationKeyStore(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/targeting/identityagent/metrics.go
+++ b/targeting/identityagent/metrics.go
@@ -70,6 +70,12 @@ type Recorder interface {
 	StageDuration(ctx context.Context, stage string, d time.Duration)
 	StoreError(ctx context.Context, store string)
 	ConfigRefresh(ctx context.Context, outcome string)
+	// KeystoreRefresh records one outcome of a TMP keystore fetch —
+	// used by both the bulk RemoteKeyStore refresh path and the
+	// per-agent LazyAuthorizationKeyStore. Outcome values are the
+	// tmproto.FetchOutcome* constants (success / error /
+	// semaphore_full). Mirrors contextagent.Recorder.KeystoreRefresh.
+	KeystoreRefresh(ctx context.Context, outcome string)
 	ShutdownPanic(ctx context.Context)
 	HandlerPanic(ctx context.Context)
 	BackgroundPanic(ctx context.Context, where string)
@@ -230,6 +236,7 @@ type otelRecorder struct {
 	stageDuration        metric.Float64Histogram
 	storeError           metric.Int64Counter
 	configRefresh        metric.Int64Counter
+	keystoreRefresh      metric.Int64Counter
 	shutdownPanic        metric.Int64Counter
 	handlerPanic         metric.Int64Counter
 	backgroundPanic      metric.Int64Counter
@@ -285,6 +292,11 @@ func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error
 	if err != nil {
 		return nil, err
 	}
+	keystoreRefresh, err := meter.Int64Counter(
+		fmt.Sprintf("%s_keystore_refresh_total", namespace))
+	if err != nil {
+		return nil, err
+	}
 	shutdownPanic, err := meter.Int64Counter(
 		fmt.Sprintf("%s_shutdown_panic_total", namespace))
 	if err != nil {
@@ -317,6 +329,7 @@ func newOtelRecorder(meter metric.Meter, namespace string) (*otelRecorder, error
 		stageDuration:        stageDuration,
 		storeError:           storeError,
 		configRefresh:        configRefresh,
+		keystoreRefresh:      keystoreRefresh,
 		shutdownPanic:        shutdownPanic,
 		handlerPanic:         handlerPanic,
 		backgroundPanic:      backgroundPanic,
@@ -352,6 +365,10 @@ func (r *otelRecorder) ConfigRefresh(ctx context.Context, outcome string) {
 	r.configRefresh.Add(ctx, 1, metric.WithAttributes(stringAttr("outcome", outcome)))
 }
 
+func (r *otelRecorder) KeystoreRefresh(ctx context.Context, outcome string) {
+	r.keystoreRefresh.Add(ctx, 1, metric.WithAttributes(stringAttr("outcome", outcome)))
+}
+
 func (r *otelRecorder) ShutdownPanic(ctx context.Context) {
 	r.shutdownPanic.Add(ctx, 1)
 }
@@ -385,6 +402,7 @@ func (noopRecorder) StageOutcome(context.Context, string, string)            {}
 func (noopRecorder) StageDuration(context.Context, string, time.Duration)    {}
 func (noopRecorder) StoreError(context.Context, string)                      {}
 func (noopRecorder) ConfigRefresh(context.Context, string)                   {}
+func (noopRecorder) KeystoreRefresh(context.Context, string)                 {}
 func (noopRecorder) ShutdownPanic(context.Context)                           {}
 func (noopRecorder) HandlerPanic(context.Context)                            {}
 func (noopRecorder) BackgroundPanic(context.Context, string)                 {}

--- a/tmproto/keystore_authorization.go
+++ b/tmproto/keystore_authorization.go
@@ -370,6 +370,7 @@ func (s *LazyAuthorizationKeyStore) refetchAgent(ctx context.Context, canonical 
 		semAcquired = true
 	default:
 		in.err = errors.New("fetch semaphore full")
+		s.logger.Warn("authorization keystore refused refetch — concurrency ceiling reached", "seller_agent_url", canonical)
 		return nil
 	}
 
@@ -377,6 +378,10 @@ func (s *LazyAuthorizationKeyStore) refetchAgent(ctx context.Context, canonical 
 	in.entry = entry
 	in.err = err
 	if err != nil {
+		// Parity with entryFor: refetch failures are precisely the
+		// outage path an operator needs to see in logs. Silent nil
+		// here made a registry blip during a rotation invisible.
+		s.logger.Warn("authorization keystore refetch failed", "seller_agent_url", canonical, "error", err)
 		return nil
 	}
 	s.cache.Add(canonical, entry)

--- a/tmproto/keystore_authorization.go
+++ b/tmproto/keystore_authorization.go
@@ -47,15 +47,34 @@ import (
 //     spray cannot fan out to unbounded HTTP concurrency. Excess
 //     concurrent misses fail closed (the extra request 401s) rather
 //     than queue — a queue is the amplifier.
+//
+// FetchOutcome values reported to LazyAuthorizationKeyStoreOptions.OnFetchOutcome.
+// Kept as string constants (not an enum type) so the hook maps cleanly onto the
+// contextagent/identityagent Recorder.KeystoreRefresh(ctx, outcome string) shape
+// already used for RemoteKeyStore, and onto arbitrary metrics backends behind it.
+const (
+	// FetchOutcomeSuccess: the registry returned a valid response and
+	// the cache was updated. Positive or negative (0-keys) both count.
+	FetchOutcomeSuccess = "success"
+	// FetchOutcomeError: the registry call failed (timeout, 5xx, decode
+	// error, transport panic). Cached entries — if any — are preserved.
+	FetchOutcomeError = "error"
+	// FetchOutcomeSemaphoreFull: the concurrency ceiling was reached and
+	// the fetch was refused fail-closed. Distinct from Error because it
+	// signals verifier-side overload, not registry-side unavailability.
+	FetchOutcomeSemaphoreFull = "semaphore_full"
+)
+
 type LazyAuthorizationKeyStore struct {
 	// baseURL is parsed once at construction. Per-request URLs are built
 	// by cloning it and setting the `agent_url` query parameter — the
 	// host is never derived from caller input, only the query string is.
-	baseURL      *url.URL
-	bearerToken  string
-	client       *http.Client
-	logger       *slog.Logger
-	fetchTimeout time.Duration
+	baseURL        *url.URL
+	bearerToken    string
+	client         *http.Client
+	logger         *slog.Logger
+	fetchTimeout   time.Duration
+	onFetchOutcome func(ctx context.Context, outcome string)
 
 	positiveTTL               time.Duration
 	negativeTTL               time.Duration
@@ -153,6 +172,15 @@ type LazyAuthorizationKeyStoreOptions struct {
 
 	// Logger receives cache-miss and fetch-error events.
 	Logger *slog.Logger
+
+	// OnFetchOutcome, when non-nil, is invoked once per registry fetch
+	// attempt with one of the FetchOutcome* constants. The hook is fired
+	// from both the initial-miss path (entryFor) and the refetch-on-
+	// unknown-kid path (refetchAgent), so operators can alert on
+	// registry unavailability regardless of which lookup surface tripped
+	// it. Invoked synchronously on the caller's goroutine — implementations
+	// MUST NOT block. Typical wiring: an OTEL counter keyed by outcome.
+	OnFetchOutcome func(ctx context.Context, outcome string)
 }
 
 type agentCacheEntry struct {
@@ -267,6 +295,7 @@ func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyA
 		client:                    client,
 		logger:                    logger,
 		fetchTimeout:              fetchTimeout,
+		onFetchOutcome:            opts.OnFetchOutcome,
 		positiveTTL:               positiveTTL,
 		negativeTTL:               negativeTTL,
 		serveStaleGrace:           opts.ServeStaleGrace,
@@ -275,6 +304,16 @@ func NewLazyAuthorizationKeyStore(opts LazyAuthorizationKeyStoreOptions) (*LazyA
 		fetchSem:                  make(chan struct{}, maxConcurrent),
 		inflight:                  make(map[string]*inflightFetch),
 	}, nil
+}
+
+// recordOutcome is a nil-safe wrapper around onFetchOutcome. Every
+// fetch attempt flows through here so future callsites cannot forget
+// to emit.
+func (s *LazyAuthorizationKeyStore) recordOutcome(ctx context.Context, outcome string) {
+	if s.onFetchOutcome == nil {
+		return
+	}
+	s.onFetchOutcome(ctx, outcome)
 }
 
 // LookupKey implements KeyStore but always returns false. This store is
@@ -371,6 +410,7 @@ func (s *LazyAuthorizationKeyStore) refetchAgent(ctx context.Context, canonical 
 	default:
 		in.err = errors.New("fetch semaphore full")
 		s.logger.Warn("authorization keystore refused refetch — concurrency ceiling reached", "seller_agent_url", canonical)
+		s.recordOutcome(ctx, FetchOutcomeSemaphoreFull)
 		return nil
 	}
 
@@ -379,12 +419,15 @@ func (s *LazyAuthorizationKeyStore) refetchAgent(ctx context.Context, canonical 
 	in.err = err
 	if err != nil {
 		// Parity with entryFor: refetch failures are precisely the
-		// outage path an operator needs to see in logs. Silent nil
-		// here made a registry blip during a rotation invisible.
+		// outage path an operator needs to see in logs and dashboards.
+		// Silent nil here made a registry blip during a rotation
+		// invisible.
 		s.logger.Warn("authorization keystore refetch failed", "seller_agent_url", canonical, "error", err)
+		s.recordOutcome(ctx, FetchOutcomeError)
 		return nil
 	}
 	s.cache.Add(canonical, entry)
+	s.recordOutcome(ctx, FetchOutcomeSuccess)
 	return entry
 }
 
@@ -458,6 +501,7 @@ func (s *LazyAuthorizationKeyStore) entryFor(ctx context.Context, canonical stri
 	default:
 		in.err = errors.New("fetch semaphore full")
 		s.logger.Warn("authorization keystore refused fetch — concurrency ceiling reached", "seller_agent_url", canonical)
+		s.recordOutcome(ctx, FetchOutcomeSemaphoreFull)
 		return s.staleOrNil(cached, hasCached)
 	}
 
@@ -467,10 +511,12 @@ func (s *LazyAuthorizationKeyStore) entryFor(ctx context.Context, canonical stri
 
 	if err != nil {
 		s.logger.Warn("authorization keystore fetch failed", "seller_agent_url", canonical, "error", err)
+		s.recordOutcome(ctx, FetchOutcomeError)
 		return s.staleOrNil(cached, hasCached)
 	}
 
 	s.cache.Add(canonical, entry)
+	s.recordOutcome(ctx, FetchOutcomeSuccess)
 	return entry
 }
 

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -568,6 +568,93 @@ func TestLazyAuthorizationKeyStore_RefetchFailureIsLogged(t *testing.T) {
 	}
 }
 
+// OnFetchOutcome fires for every fetch attempt regardless of which
+// code path — initial miss vs refetch on unknown kid — triggered it,
+// so operators can alert on registry unavailability without caring
+// about the internal lookup surface. Exercises success + error +
+// semaphore_full outcomes.
+func TestLazyAuthorizationKeyStore_OnFetchOutcome(t *testing.T) {
+	oldJWK, _ := buildJWK(t, "kid-old")
+	var fail atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{oldJWK}}},
+		})
+	})
+	defer srv.Close()
+
+	var mu sync.Mutex
+	seen := map[string]int{}
+	record := func(_ context.Context, outcome string) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen[outcome]++
+	}
+
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:                   srv.URL,
+		AllowInsecureScheme:       true,
+		UnknownKidRefetchCooldown: 20 * time.Millisecond,
+		MaxConcurrentFetches:      1,
+		OnFetchOutcome:            record,
+	})
+
+	// 1) Initial fetch succeeds → FetchOutcomeSuccess.
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Fatal("initial lookup failed")
+	}
+	// 2) Cross cooldown, force server to fail → refetch fires and
+	//    reports FetchOutcomeError.
+	time.Sleep(40 * time.Millisecond)
+	fail.Store(1)
+	_, _ = ks.LookupKeyForAgent("kid-forged", "https://seller.example/agent")
+
+	// 3) Saturate the semaphore: hold a fetch open by making the
+	//    server slow, then queue a second concurrent lookup for a
+	//    different agent. The second lookup takes the semaphore-full
+	//    branch → FetchOutcomeSemaphoreFull.
+	fail.Store(0)
+	block := make(chan struct{})
+	slowSrv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		<-block
+		_ = json.NewEncoder(w).Encode(map[string]any{"rows": []any{}})
+	})
+	defer slowSrv.Close()
+	ks2, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:              slowSrv.URL,
+		AllowInsecureScheme:  true,
+		MaxConcurrentFetches: 1,
+		OnFetchOutcome:       record,
+	})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = ks2.LookupKeyForAgent("kid", "https://one.example/agent")
+	}()
+	// Give the leader a moment to take the semaphore.
+	time.Sleep(30 * time.Millisecond)
+	_, _ = ks2.LookupKeyForAgent("kid", "https://two.example/agent")
+	close(block)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if seen[FetchOutcomeSuccess] < 1 {
+		t.Errorf("expected at least one success outcome; got %v", seen)
+	}
+	if seen[FetchOutcomeError] < 1 {
+		t.Errorf("expected at least one error outcome; got %v", seen)
+	}
+	if seen[FetchOutcomeSemaphoreFull] < 1 {
+		t.Errorf("expected at least one semaphore_full outcome; got %v", seen)
+	}
+}
+
 // Blocker regression test: an attacker-triggered refetch failure MUST
 // NOT evict the still-valid cached entry. Fetch-then-swap semantics.
 func TestLazyAuthorizationKeyStore_RefetchFailurePreservesCachedEntry(t *testing.T) {

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -1,10 +1,12 @@
 package tmproto
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -525,6 +527,44 @@ func TestLazyAuthorizationKeyStore_UnknownKidRefetchesPastCooldown(t *testing.T)
 	// it, so kid-old is now genuinely absent. Confirm no crash / hang.
 	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); ok {
 		t.Error("kid-old should no longer resolve after registry dropped it")
+	}
+}
+
+// Refetch failures must not be silent — an operator debugging a
+// rotation-during-outage needs to see them in logs. Captures the
+// logger's output and asserts the failure line is present.
+func TestLazyAuthorizationKeyStore_RefetchFailureIsLogged(t *testing.T) {
+	oldJWK, _ := buildJWK(t, "kid-old")
+	var fail atomic.Int32
+	srv := newAuthzServer(t, func(_ string, w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"rows": []map[string]any{{"signing_keys": []SigningKey{oldJWK}}},
+		})
+	})
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	ks, _ := NewLazyAuthorizationKeyStore(LazyAuthorizationKeyStoreOptions{
+		BaseURL:                   srv.URL,
+		AllowInsecureScheme:       true,
+		UnknownKidRefetchCooldown: 20 * time.Millisecond,
+		Logger:                    logger,
+	})
+	if _, ok := ks.LookupKeyForAgent("kid-old", "https://seller.example/agent"); !ok {
+		t.Fatal("initial lookup failed")
+	}
+	time.Sleep(40 * time.Millisecond)
+	fail.Store(1)
+	_, _ = ks.LookupKeyForAgent("kid-forged", "https://seller.example/agent")
+
+	logs := buf.String()
+	if !strings.Contains(logs, "authorization keystore refetch failed") {
+		t.Errorf("expected refetch failure to be logged; got: %s", logs)
 	}
 }
 


### PR DESCRIPTION
Follow-up from the [#402 review](https://github.com/adcontextprotocol/adcp-go/pull/402#pullrequestreview-4707144075) — the "refetchAgent fails silently" observability gap.

## What

Two failure legs in \`refetchAgent\` returned \`nil\` with no log:

- **Semaphore saturated** (\`tmproto/keystore_authorization.go:372\`) — happens when a spray of unique agent URLs from an attacker fills the concurrency ceiling.
- **Fetch error** (\`:379\`) — the exact outage path this store's ServeStaleGrace was designed to survive: refetch fails, cached entry stays, silent nil returned to caller.

\`entryFor\` already warns on both equivalent paths (\`:388\`, \`:464\`). This PR brings \`refetchAgent\` to parity — same \`logger.Warn\` shape, same fields (\`seller_agent_url\`, \`error\`) — so a rotation-during-blip debug session actually shows in logs.

Also adds \`TestLazyAuthorizationKeyStore_RefetchFailureIsLogged\`: captures the logger's output and asserts the failure line is emitted on a simulated 5xx.

## Related follow-ups (not in this PR)

- **2x fetch during outage** — the interaction between \`entryFor\`'s stale-serve and \`refetchAgent\`'s cooldown fires two failing calls per lookup during a registry outage. Bounded by single-flight + semaphore, but worth suppressing the second call. Separate PR.
- **Interface godoc MUST NOT verb** — \`ad-tech-protocol-expert\`'s note on tightening the \`AgentAwareKeyStore\` godoc from "SHOULD only return keys the registry attests" to "MUST NOT return a key the registry did not attest". Doc-only, separate PR.
- **ServeStaleGrace §579/§590 conformance** — verify against the adcp spec repo before recommending non-zero. Default off keeps the shipped config conformant.