### PR TITLE
identityagent: implement multi-chunk TMPX sealing

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -660,7 +660,17 @@ func mergeIdentityResponses(requestID string, providerIDs []string, responses []
 			tmpxProviders[providerID] = tmproto.TmpxProviderEntry{
 				Macros: append([]tmproto.TmpxMacro(nil), resp.TmpxMacros...),
 			}
-			if legacyTmpx == "" {
+			// The deprecated single-string `tmpx` carrier can only represent
+			// tokens that fit in one macro slot. Multi-chunk responses (>1
+			// TmpxMacros entry) produce a wire that spans multiple slots —
+			// any single chunk on its own is a broken ciphertext half that
+			// fails AEAD open silently. Populate the legacy field only when
+			// the emitting agent produced exactly one chunk; a multi-chunk
+			// emission leaves it empty so consumers still reading the
+			// deprecated field skip it rather than get identity loss. See
+			// the mirror guard in identityagent/handler.go's
+			// assignTmpxToResponse.
+			if legacyTmpx == "" && len(resp.TmpxMacros) == 1 {
 				legacyTmpx = resp.TmpxMacros[0].Value
 			}
 		} else if resp.Tmpx != "" {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -206,6 +206,38 @@ func TestMergeIdentityResponses_TmpxProvidersFromNewShape(t *testing.T) {
 		"legacy tmpx must mirror the first provider's first slot for back-compat")
 }
 
+// TestMergeIdentityResponses_MultiChunkClearsLegacyTmpx pins the guard
+// against the identity-loss regression Blocker 2 fixed: when an agent emits a
+// multi-chunk sealed token (len(TmpxMacros) > 1), the deprecated single-string
+// `tmpx` field cannot carry it — any one chunk on its own is a broken
+// ciphertext half that fails AEAD open silently. The router MUST leave the
+// legacy carrier empty in this case so consumers still reading `tmpx` skip it
+// rather than receive garbage; the authoritative multi-chunk data survives
+// intact on TmpxProviders[provider_id].Macros.
+func TestMergeIdentityResponses_MultiChunkClearsLegacyTmpx(t *testing.T) {
+	multi := &tmproto.IdentityMatchResponse{
+		EligiblePackageIDs: []string{"pkg-1"},
+		ServeWindowSec:     300,
+		TmpxMacros: []tmproto.TmpxMacro{
+			{Name: "PIN_TMPX_1", Value: "k1.first-half-of-sealed-token"},
+			{Name: "PIN_TMPX_2", Value: "second-half-of-sealed-token"},
+		},
+	}
+
+	merged := mergeIdentityResponses("id-multi", []string{"pinnacle_id"},
+		[]*tmproto.IdentityMatchResponse{multi}, nil)
+
+	require.NotNil(t, merged.TmpxProviders, "tmpx_providers MUST carry the multi-chunk data")
+	pin, ok := merged.TmpxProviders["pinnacle_id"]
+	require.True(t, ok, "pinnacle_id entry must exist")
+	require.Len(t, pin.Macros, 2, "both chunks MUST survive on tmpx_providers")
+	assert.Equal(t, "k1.first-half-of-sealed-token", pin.Macros[0].Value)
+	assert.Equal(t, "second-half-of-sealed-token", pin.Macros[1].Value)
+
+	assert.Empty(t, merged.Tmpx,
+		"multi-chunk emissions MUST leave the deprecated legacy `tmpx` field empty — a single chunk is a broken half-token")
+}
+
 // TestMergeIdentityResponses_LegacyOnlyAgent covers a transition case: an
 // agent that only emits the deprecated `tmpx` string with no TmpxMacros[].
 // The router preserves it in the legacy field but does NOT synthesize a

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -144,10 +144,12 @@ type TMPXConfig struct {
 	// `tmpx_macros` (provider-registration.json). The sealer pairs the
 	// sealed token with these names to populate IdentityMatchResponse's
 	// `tmpx_macros[]`. When empty the response carries only the legacy
-	// singular `tmpx` field (deprecated, removed in 4.0). Capped at 2 by
-	// the spec; multi-chunk encoding is not yet implemented — when
-	// configured with more than one name only the first slot is filled,
-	// matching the single-slot deployment shape.
+	// singular `tmpx` field (deprecated, removed in 4.0). The v1 spec
+	// caps the registered list at 2 entries — enforced at registration
+	// time, not here. When more than one name is configured the sealed
+	// token is split into up to len(MacroNames) chunks of at most 255
+	// bytes each (the GAM `%%PATTERN_MACRO%%` substitution limit), one
+	// per slot in the configured order.
 	MacroNames []string
 }
 

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/redisstore"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
 // Config is the env-derived configuration for a single identity-agent
@@ -391,6 +392,10 @@ func LoadConfigFromEnv() (Config, error) {
 	if err != nil {
 		errs = append(errs, err)
 	}
+	macroNames, err := parseTmpxMacroNames(os.Getenv("TMPX_MACRO_NAMES"))
+	if err != nil {
+		errs = append(errs, err)
+	}
 	audienceTimeout, err := lookupDuration("AUDIENCE_TIMEOUT", defaultAudienceTimeout)
 	if err != nil {
 		errs = append(errs, err)
@@ -452,7 +457,7 @@ func LoadConfigFromEnv() (Config, error) {
 			EncryptJWKSTTL: jwksTTL,
 			Country:        os.Getenv("TMPX_COUNTRY"),
 			Priority:       os.Getenv("TMPX_PRIORITY"),
-			MacroNames:     parseTmpxMacroNames(os.Getenv("TMPX_MACRO_NAMES")),
+			MacroNames:     macroNames,
 		},
 		LiveRamp: LiveRampSidecarConfig{
 			URL:         os.Getenv("LIVERAMP_SIDECAR_URL"),
@@ -692,15 +697,19 @@ func lookupString(name, def string) string {
 // `S3_TMPX` or `S3_TMPX_1,S3_TMPX_2`) into the ordered slot list emitted on
 // IdentityMatchResponse.tmpx_macros[]. Empty / whitespace-only values yield
 // nil, which keeps the legacy single-`tmpx`-string emission shape — no new
-// behavior until the env var is set. The spec caps the registered list at 2
-// (provider-registration.json `tmpx_macros.maxItems`); enforcement of that
-// happens at registration time, not here — this parser is permissive so an
-// operator sees the misconfig surface as a downstream schema-validation
-// error rather than a startup panic.
-func parseTmpxMacroNames(raw string) []string {
+// behavior until the env var is set.
+//
+// The v1 spec caps the registered list at tmproto.TmpxMaxSlots
+// (provider-registration.json `tmpx_macros.maxItems`) because each slot carries
+// at most TmpxMaxWireBytes of the sealed wire and the receiver's OpenTmpx
+// bound is TmpxMaxSlots * TmpxMaxWireBytes. An unbounded name list would
+// silently produce a wire the sealer's own conformant receiver refuses;
+// reject it at startup with a clear message rather than corrupt tokens at
+// serving time.
+func parseTmpxMacroNames(raw string) ([]string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
-		return nil
+		return nil, nil
 	}
 	parts := strings.Split(raw, ",")
 	names := make([]string, 0, len(parts))
@@ -712,9 +721,13 @@ func parseTmpxMacroNames(raw string) []string {
 		names = append(names, p)
 	}
 	if len(names) == 0 {
-		return nil
+		return nil, nil
 	}
-	return names
+	if len(names) > tmproto.TmpxMaxSlots {
+		return nil, fmt.Errorf("TMPX_MACRO_NAMES has %d entries, exceeds the v1 cap of %d (provider-registration.json `tmpx_macros.maxItems`); each slot carries at most %d bytes of the sealed wire and the receiver's OpenTmpx bound is %d * %d bytes",
+			len(names), tmproto.TmpxMaxSlots, tmproto.TmpxMaxWireBytes, tmproto.TmpxMaxSlots, tmproto.TmpxMaxWireBytes)
+	}
+	return names, nil
 }
 
 func lookupInt(name string, def int) (int, error) {

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -303,6 +303,43 @@ func TestLoadConfigFromEnv_ExtraHeaders(t *testing.T) {
 	})
 }
 
+// TestLoadConfigFromEnv_TmpxMacroNames pins the Blocker 3 guard: the v1 spec
+// caps the registered `tmpx_macros` list at TmpxMaxSlots. A permissive parser
+// would emit a wire the sealer's own OpenTmpx receiver refuses to open; reject
+// oversized configs at startup with a clear message.
+func TestLoadConfigFromEnv_TmpxMacroNames(t *testing.T) {
+	t.Setenv("CONFIG_SOURCE_URL", "https://config.example/")
+	t.Setenv("CONFIG_SOURCE_TOKEN", "tok")
+
+	t.Run("empty yields nil (legacy single-tmpx shape)", func(t *testing.T) {
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.Nil(t, cfg.TMPX.MacroNames)
+	})
+
+	t.Run("one entry within the cap", func(t *testing.T) {
+		t.Setenv("TMPX_MACRO_NAMES", "S3_TMPX")
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"S3_TMPX"}, cfg.TMPX.MacroNames)
+	})
+
+	t.Run("two entries within the cap", func(t *testing.T) {
+		t.Setenv("TMPX_MACRO_NAMES", "PIN_TMPX_1,PIN_TMPX_2")
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.Equal(t, []string{"PIN_TMPX_1", "PIN_TMPX_2"}, cfg.TMPX.MacroNames)
+	})
+
+	t.Run("three entries fails validation with a clear message", func(t *testing.T) {
+		t.Setenv("TMPX_MACRO_NAMES", "A,B,C")
+		_, err := LoadConfigFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "TMPX_MACRO_NAMES")
+		assert.Contains(t, err.Error(), "exceeds")
+	})
+}
+
 func TestIsValidPromName(t *testing.T) {
 	cases := map[string]bool{
 		"identity_agent": true,

--- a/targeting/identityagent/handler.go
+++ b/targeting/identityagent/handler.go
@@ -194,17 +194,7 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"request_id", req.RequestID, "error", terr)
 			h.recorder.StageOutcome(ctx, StageTMPX, OutcomeError)
 		} else if token != "" {
-			// Legacy single-string carrier — keep populated for back-compat
-			// with consumers that haven't moved to tmpx_providers. Deprecated;
-			// removed in 4.0 per the spec.
-			resp.Tmpx = token
-			// New shape: ordered macro/value pairs the router collects into
-			// tmpx_providers[provider_id]. Emitted only when the operator has
-			// declared the provider's registered macro slot names via
-			// TMPX_MACRO_NAMES; otherwise we stay on the legacy carrier.
-			if entry, ok := h.tmpx.MacroEntry(token); ok {
-				resp.TmpxMacros = []tmproto.TmpxMacro{entry}
-			}
+			assignTmpxToResponse(resp, h.tmpx, token)
 			h.recorder.StageOutcome(ctx, StageTMPX, OutcomePass)
 		}
 		h.recorder.StageDuration(ctx, StageTMPX, time.Since(tmpxStart))
@@ -220,6 +210,30 @@ func (h *identityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"eligible", len(eligible),
 		"latency_ms", time.Since(start).Milliseconds())
 	h.recordCompletion(ctx, start, status)
+}
+
+// assignTmpxToResponse populates the TMPX-carrying fields on an
+// IdentityMatchResponse from a freshly sealed wire token.
+//
+//   - TmpxMacros carries the sealer's ordered chunks (one per configured
+//     macro slot at TmpxMaxWireBytes boundaries). Multi-slot deployments
+//     traffic these; the router folds them into tmpx_providers[provider_id].
+//     Empty when no macro slots are configured.
+//   - Tmpx is the legacy single-string carrier. Populated only when the
+//     sealed token fits within one macro slot (255 bytes; the GAM
+//     `%%PATTERN_MACRO%%` substitution limit). Multi-chunk tokens cannot
+//     be represented in this single-string field — the field is
+//     deprecated and removed in AdCP 4.0 — so we omit it rather than
+//     emit a truncated value.
+//
+// Extracted from ServeHTTP as a package-private helper so the
+// legacy/new-field bookkeeping can be unit-tested without spinning up a
+// full request lifecycle.
+func assignTmpxToResponse(resp *tmproto.IdentityMatchResponse, sealer *TMPXSealer, token string) {
+	resp.TmpxMacros = sealer.MacroEntries(token)
+	if len(token) <= tmproto.TmpxMaxWireBytes {
+		resp.Tmpx = token
+	}
 }
 
 // writeResponse marshals payload to JSON in one shot and writes it. Using

--- a/targeting/identityagent/handler_test.go
+++ b/targeting/identityagent/handler_test.go
@@ -16,6 +16,47 @@ import (
 	"github.com/adcontextprotocol/adcp-go/tmproto"
 )
 
+// TestAssignTmpxToResponse_SingleSlotFillsBothCarriers pins the legacy /
+// new-field wiring for a single-slot deployment. The sealed token fits in
+// one macro slot, so TmpxMacros has one entry AND the legacy Tmpx string
+// is set for back-compat.
+func TestAssignTmpxToResponse_SingleSlotFillsBothCarriers(t *testing.T) {
+	sealer := &TMPXSealer{macroNames: []string{"S3_TMPX"}}
+	resp := &tmproto.IdentityMatchResponse{}
+	assignTmpxToResponse(resp, sealer, "k1.short-token")
+	require.Len(t, resp.TmpxMacros, 1)
+	assert.Equal(t, "S3_TMPX", resp.TmpxMacros[0].Name)
+	assert.Equal(t, "k1.short-token", resp.TmpxMacros[0].Value)
+	assert.Equal(t, "k1.short-token", resp.Tmpx, "single-slot token fits in the legacy carrier")
+}
+
+// TestAssignTmpxToResponse_MultiChunkOmitsLegacyTmpx locks the contract
+// that a token that exceeds one macro slot leaves the legacy Tmpx field
+// empty — that field is a single 255-byte carrier and cannot represent a
+// chunked value; consumers on those deployments must read the ordered
+// TmpxMacros / tmpx_providers shape.
+func TestAssignTmpxToResponse_MultiChunkOmitsLegacyTmpx(t *testing.T) {
+	sealer := &TMPXSealer{macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"}}
+	// 300-byte token: first chunk fills a whole slot, second slot carries the tail.
+	token := strings.Repeat("a", tmproto.TmpxMaxWireBytes) + strings.Repeat("b", 45)
+	resp := &tmproto.IdentityMatchResponse{}
+	assignTmpxToResponse(resp, sealer, token)
+	require.Len(t, resp.TmpxMacros, 2, "TmpxMacros slice length matches the number of chunks emitted")
+	assert.Empty(t, resp.Tmpx, "legacy single-string carrier must be omitted for multi-chunk tokens")
+}
+
+// TestAssignTmpxToResponse_NoMacrosKeepsOnlyLegacyTmpx covers the
+// no-macro-names deployment: TmpxMacros stays empty, the legacy Tmpx
+// carrier is filled. This is the shape existing single-slot deployments
+// see, and it must remain identical to the pre-multi-chunk behavior.
+func TestAssignTmpxToResponse_NoMacrosKeepsOnlyLegacyTmpx(t *testing.T) {
+	sealer := &TMPXSealer{} // no macroNames configured
+	resp := &tmproto.IdentityMatchResponse{}
+	assignTmpxToResponse(resp, sealer, "k1.tok")
+	assert.Empty(t, resp.TmpxMacros)
+	assert.Equal(t, "k1.tok", resp.Tmpx)
+}
+
 func TestIdentityHandlerValidationErrorIsGenericAndLogged(t *testing.T) {
 	var logs bytes.Buffer
 	h := NewIdentityHandler(IdentityHandlerConfig{

--- a/targeting/identityagent/tmpx.go
+++ b/targeting/identityagent/tmpx.go
@@ -114,18 +114,24 @@ type TMPXSealer struct {
 	// Sourced from TMPXConfig.MacroNames (env: TMPX_MACRO_NAMES) and MUST
 	// match the provider's registered tmpx_macros list in
 	// provider-registration.json. When empty the response carries only the
-	// legacy singular `tmpx` field (deprecated, removed in 4.0). The spec
-	// caps the registered list at 2; multi-chunk encoding is not yet
-	// implemented in this sealer — a single-slot deployment is the only
-	// shape this version emits, and additional slot names are ignored.
+	// legacy singular `tmpx` field (deprecated, removed in 4.0). The v1
+	// spec caps the registered list at 2 entries (enforced at registration
+	// time in provider-registration.json — not here); the sealer does not
+	// impose an extra cap so an operator can experiment beyond v1 without
+	// this code needing a bump. When more than one name is configured, the
+	// sealed token is chunked at 255-byte boundaries (one boundary per
+	// slot; the GAM `%%PATTERN_MACRO%%` substitution limit) and each
+	// chunk is emitted in slot order.
 	macroNames []string
 
 	// priority is the explicit per-spec priority ordering used when the
-	// resolved identities exceed the 255-byte wire budget. Entries earlier
-	// in the slice rank higher; entries whose UIDType is absent are
-	// dropped (the spec requires explicit configuration — arbitrary
-	// truncation is forbidden). When priority is empty, no truncation is
-	// performed and an over-budget token is reported as an error.
+	// resolved identities exceed the sealer's wireBudget (one macro slot
+	// by default, more for multi-chunk deployments; see wireBudget).
+	// Entries earlier in the slice rank higher; entries whose UIDType is
+	// absent are dropped (the spec requires explicit configuration —
+	// arbitrary truncation is forbidden). When priority is empty, no
+	// truncation is performed and an over-budget token is reported as an
+	// error.
 	priority []tmproto.UIDType
 
 	// decoders maps each TMPX-encodable UID type to the adapter that
@@ -219,7 +225,6 @@ func NewTMPXSealer(runCtx context.Context, cfg TMPXConfig, lrClient LiveRampSide
 	}
 	decoders := buildTmpxDecoders(tmpxdecoders.RegistryOptions{LiveRampClient: decoderAdapter})
 	logDecoderLayout(logger, cfg.Country, decoders, order)
-	warnIfMultiSlotIgnored(logger, cfg.MacroNames)
 	return &TMPXSealer{
 		country:    cfg.Country,
 		encStore:   store,
@@ -231,35 +236,48 @@ func NewTMPXSealer(runCtx context.Context, cfg TMPXConfig, lrClient LiveRampSide
 	}, nil
 }
 
-// warnIfMultiSlotIgnored surfaces the configuration/implementation mismatch
-// when an operator declares more than one TMPX_MACRO_NAMES slot. Multi-chunk
-// encoding splits a single sealed token across multiple ad-server slots; the
-// splitter (and the matching reassembler on the receiver side) is deferred
-// until production deployments actually exceed the 255-char single-slot
-// budget. Until then MacroEntry only fills macroNames[0] — log loudly so an
-// operator who expects two-slot emission sees that it's silently single-slot
-// today rather than discovering it at trafficking time.
-func warnIfMultiSlotIgnored(logger *slog.Logger, names []string) {
-	if logger == nil || len(names) <= 1 {
-		return
-	}
-	logger.Warn("TMPX_MACRO_NAMES configured with multiple slots but multi-chunk encoding is not implemented; only the first slot will be filled on responses",
-		"active_slot", names[0],
-		"ignored_slots", append([]string(nil), names[1:]...),
-	)
+// wireBudget is the maximum sealed-wire size the sealer targets for the
+// current macro-slot configuration. Each configured slot contributes one
+// TmpxMaxWireBytes-sized chunk (the GAM `%%PATTERN_MACRO%%` substitution
+// limit); a deployment with no macro slots configured falls back to the
+// legacy single-`tmpx` carrier and gets a one-slot budget.
+//
+// The v1 spec caps the registered macro list at 2 entries — enforced at
+// registration time in provider-registration.json rather than here — so
+// this returns len(macroNames)*TmpxMaxWireBytes without an extra ceiling.
+func (s *TMPXSealer) wireBudget() int {
+	slots := max(len(s.macroNames), 1)
+	return slots * tmproto.TmpxMaxWireBytes
 }
 
-// MacroEntry returns the {name, value} pair that fills the provider's first
-// registered macro slot for the given sealed token, or (zero, false) when no
-// macro names are configured. Single-slot is the only emission shape today;
-// multi-chunk splitting across more than one registered name is deferred
-// until production deployments actually exceed the 255-char ad-server slot
-// budget.
-func (s *TMPXSealer) MacroEntry(token string) (tmproto.TmpxMacro, bool) {
+// MacroEntries pairs the sealed wire token with the provider's registered
+// macro slot names, splitting the token at TmpxMaxWireBytes boundaries so
+// each entry fits inside one ad-server macro slot (255 bytes; the GAM
+// `%%PATTERN_MACRO%%` substitution limit). Entries are returned in slot
+// order — the receiver reassembles by concatenating in the same order.
+//
+// Returns nil when there is no token to place, no macro names are
+// configured (the response falls back to the legacy `tmpx` string), or
+// the receiver is nil. Never emits more entries than macroNames and
+// never emits an entry whose value exceeds TmpxMaxWireBytes; the sealer's
+// selectEntries pass keeps the produced token within wireBudget() so
+// chunking below never needs to overflow — but if a caller ever supplies
+// a longer token, the surplus is dropped rather than allowing a slot
+// value to exceed the substitution limit.
+func (s *TMPXSealer) MacroEntries(token string) []tmproto.TmpxMacro {
 	if s == nil || token == "" || len(s.macroNames) == 0 {
-		return tmproto.TmpxMacro{}, false
+		return nil
 	}
-	return tmproto.TmpxMacro{Name: s.macroNames[0], Value: token}, true
+	entries := make([]tmproto.TmpxMacro, 0, len(s.macroNames))
+	for i, name := range s.macroNames {
+		start := i * tmproto.TmpxMaxWireBytes
+		if start >= len(token) {
+			break
+		}
+		end := min(start+tmproto.TmpxMaxWireBytes, len(token))
+		entries = append(entries, tmproto.TmpxMacro{Name: name, Value: token[start:end]})
+	}
+	return entries
 }
 
 // log returns the sealer's logger, falling back to slog.Default() when none
@@ -511,12 +529,14 @@ func (s *TMPXSealer) verifiedIdentityEntries(ctx context.Context, verified []tar
 }
 
 // selectEntries packs already-decoded identities into the wire TmpxEntry
-// list under the TmpxMaxWireBytes budget. Identities the Decode pass
-// dropped (Bytes == nil) are skipped here; their drop counters fired in
-// Decode. Identities whose UIDType is not in TMPX_PRIORITY (when priority
-// is configured) are also skipped here without a counter — operators set
-// priority explicitly, so unreachable entries are intentional and surfaced
-// at startup by logDecoderLayout, not per-request.
+// list under the sealer's wireBudget() — TmpxMaxWireBytes per configured
+// macro slot, or a single slot's worth when no slots are configured (the
+// legacy single-`tmpx` carrier). Identities the Decode pass dropped
+// (Bytes == nil) are skipped here; their drop counters fired in Decode.
+// Identities whose UIDType is not in TMPX_PRIORITY (when priority is
+// configured) are also skipped here without a counter — operators set
+// priority explicitly, so unreachable entries are intentional and
+// surfaced at startup by logDecoderLayout, not per-request.
 //
 // The budget is computed against TmpxMaxKidLen rather than the currently
 // advertised kid: a JWKS rotation can change the kid length between
@@ -558,16 +578,17 @@ func (s *TMPXSealer) selectEntries(decoded []DecodedIdentity) ([]tmproto.TmpxEnt
 		})
 	}
 
+	budget := s.wireBudget()
 	entries := make([]tmproto.TmpxEntry, 0, len(survivors))
 	usedBytes := 0
 	budgetOverflowed := false
 	for _, c := range survivors {
 		need := 1 + len(c.d.Bytes)
 		nextWire := tmproto.TmpxWireSize(tmproto.TmpxMaxKidLen, usedBytes+need)
-		if nextWire > tmproto.TmpxMaxWireBytes {
+		if nextWire > budget {
 			if len(s.priority) == 0 {
 				return nil, fmt.Errorf("tmpx wire size %d exceeds %d-byte budget and no TMPX_PRIORITY configured: spec forbids arbitrary truncation",
-					nextWire, tmproto.TmpxMaxWireBytes)
+					nextWire, budget)
 			}
 			budgetOverflowed = true
 			break
@@ -576,7 +597,7 @@ func (s *TMPXSealer) selectEntries(decoded []DecodedIdentity) ([]tmproto.TmpxEnt
 		usedBytes += need
 	}
 	if len(entries) == 0 && budgetOverflowed {
-		return nil, fmt.Errorf("tmpx wire budget %d cannot fit even the highest-priority entry", tmproto.TmpxMaxWireBytes)
+		return nil, fmt.Errorf("tmpx wire budget %d cannot fit even the highest-priority entry", budget)
 	}
 	return entries, nil
 }

--- a/targeting/identityagent/tmpx.go
+++ b/targeting/identityagent/tmpx.go
@@ -259,13 +259,20 @@ func (s *TMPXSealer) wireBudget() int {
 // Returns nil when there is no token to place, no macro names are
 // configured (the response falls back to the legacy `tmpx` string), or
 // the receiver is nil. Never emits more entries than macroNames and
-// never emits an entry whose value exceeds TmpxMaxWireBytes; the sealer's
-// selectEntries pass keeps the produced token within wireBudget() so
-// chunking below never needs to overflow — but if a caller ever supplies
-// a longer token, the surplus is dropped rather than allowing a slot
-// value to exceed the substitution limit.
+// never emits an entry whose value exceeds TmpxMaxWireBytes.
+//
+// A token longer than len(macroNames) * TmpxMaxWireBytes would not fit into
+// the configured slots; fail closed and return nil rather than emit truncated
+// chunks that cannot be reassembled by the receiver. The sealer's
+// selectEntries pass keeps produced tokens within wireBudget(), so this is a
+// defensive floor against a future change raising the seal budget without
+// bumping the slot count — surface a wire that can't be trafficked as "no
+// TMPX" (identity drop) rather than silently corrupting downstream reassembly.
 func (s *TMPXSealer) MacroEntries(token string) []tmproto.TmpxMacro {
 	if s == nil || token == "" || len(s.macroNames) == 0 {
+		return nil
+	}
+	if len(token) > len(s.macroNames)*tmproto.TmpxMaxWireBytes {
 		return nil
 	}
 	entries := make([]tmproto.TmpxMacro, 0, len(s.macroNames))

--- a/targeting/identityagent/tmpx_test.go
+++ b/targeting/identityagent/tmpx_test.go
@@ -1,13 +1,11 @@
 package identityagent
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdh"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,32 +22,85 @@ import (
 
 const testNullifier = "0x" + "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 
-// MacroEntry pairs a sealed token with the provider's first registered slot
-// name; both inputs must be non-empty for a useful pair to come out.
-func TestMacroEntry_EmitsWhenConfigured(t *testing.T) {
+// MacroEntries pairs the sealed token with the provider's registered slot
+// names. Single-slot deployments emit exactly one entry carrying the whole
+// token — the legacy shape before multi-chunk encoding was implemented.
+func TestMacroEntries_SingleSlotEmitsWholeToken(t *testing.T) {
 	s := &TMPXSealer{macroNames: []string{"S3_TMPX"}}
-	entry, ok := s.MacroEntry("k1.token")
-	require.True(t, ok)
-	assert.Equal(t, "S3_TMPX", entry.Name)
-	assert.Equal(t, "k1.token", entry.Value)
+	entries := s.MacroEntries("k1.token")
+	require.Len(t, entries, 1)
+	assert.Equal(t, "S3_TMPX", entries[0].Name)
+	assert.Equal(t, "k1.token", entries[0].Value)
 }
 
-// MacroEntry returns (zero, false) on three independently-disabling
-// conditions: nil receiver, empty token, no registered macro names. Without
-// either side the pair is meaningless, so the response should fall back to
-// the legacy single-`tmpx` carrier.
-func TestMacroEntry_NotEmittedWhenDisabled(t *testing.T) {
+// MacroEntries returns nil on three independently-disabling conditions:
+// nil receiver, empty token, no registered macro names. Without either
+// side the pair is meaningless and the response falls back to the legacy
+// single-`tmpx` carrier.
+func TestMacroEntries_NotEmittedWhenDisabled(t *testing.T) {
 	var nilSealer *TMPXSealer
-	_, ok := nilSealer.MacroEntry("k1.token")
-	assert.False(t, ok, "nil sealer must not produce a macro entry")
+	assert.Nil(t, nilSealer.MacroEntries("k1.token"), "nil sealer must not produce entries")
 
 	noMacros := &TMPXSealer{}
-	_, ok = noMacros.MacroEntry("k1.token")
-	assert.False(t, ok, "sealer without registered macro names must not produce a macro entry")
+	assert.Nil(t, noMacros.MacroEntries("k1.token"), "sealer without registered macro names must not produce entries")
 
 	noToken := &TMPXSealer{macroNames: []string{"S3_TMPX"}}
-	_, ok = noToken.MacroEntry("")
-	assert.False(t, ok, "empty token must not produce a macro entry")
+	assert.Nil(t, noToken.MacroEntries(""), "empty token must not produce entries")
+}
+
+// MacroEntries with two slots but a token that fits in one slot emits only
+// the first slot; the empty trailing slot is dropped rather than emitted
+// with an empty value. This matches the AdCP wire contract: consumers
+// reassemble by concatenating present entries in order, and a trailing
+// empty entry would confuse "how many chunks did the sealer intend" for a
+// receiver that also supports N>2 in a later version.
+func TestMacroEntries_TwoSlots_TokenFitsInFirst(t *testing.T) {
+	s := &TMPXSealer{macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"}}
+	token := strings.Repeat("a", 100) // < 255 bytes
+	entries := s.MacroEntries(token)
+	require.Len(t, entries, 1, "second slot MUST NOT be emitted when the token fits in the first")
+	assert.Equal(t, "PIN_TMPX_1", entries[0].Name)
+	assert.Equal(t, token, entries[0].Value)
+}
+
+// MacroEntries with two slots and a token that straddles both slots
+// chunks at exactly TmpxMaxWireBytes (255) — the GAM %%PATTERN_MACRO%%
+// substitution limit. Reassembly is byte-concatenation in slot order,
+// so the boundary must be deterministic.
+func TestMacroEntries_TwoSlots_TokenStraddlesBothSlots(t *testing.T) {
+	s := &TMPXSealer{macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"}}
+	// Build a 300-byte token from distinguishable halves so we can pin the
+	// chunk boundary at 255.
+	first := strings.Repeat("a", tmproto.TmpxMaxWireBytes)
+	rest := strings.Repeat("b", 45)
+	token := first + rest
+	entries := s.MacroEntries(token)
+	require.Len(t, entries, 2, "both slots must be emitted when the token exceeds one slot")
+	assert.Equal(t, "PIN_TMPX_1", entries[0].Name)
+	assert.Equal(t, "PIN_TMPX_2", entries[1].Name)
+	require.Len(t, entries[0].Value, tmproto.TmpxMaxWireBytes, "first chunk MUST fill exactly one slot")
+	assert.Equal(t, first, entries[0].Value)
+	assert.Equal(t, rest, entries[1].Value)
+	// Reassembly is byte-concatenation in slot order.
+	assert.Equal(t, token, entries[0].Value+entries[1].Value)
+}
+
+// MacroEntries never emits an entry whose value exceeds one macro slot —
+// even if a caller supplies a token longer than the sealer's wireBudget().
+// The sealer's selectEntries pass keeps the produced token within budget,
+// so this is a defensive floor, not a code path production exercises.
+func TestMacroEntries_ClampsToConfiguredSlotCount(t *testing.T) {
+	s := &TMPXSealer{macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"}}
+	// A token that would need three chunks; the sealer should have refused
+	// to produce it, but MacroEntries still refuses to emit more than the
+	// configured slot count.
+	oversize := strings.Repeat("a", 3*tmproto.TmpxMaxWireBytes)
+	entries := s.MacroEntries(oversize)
+	require.Len(t, entries, 2, "must not exceed the configured slot count")
+	for i, e := range entries {
+		assert.LessOrEqual(t, len(e.Value), tmproto.TmpxMaxWireBytes,
+			"entry %d must not exceed the single-slot substitution limit", i)
+	}
 }
 
 func TestVerifiedIdentityEntries_EncodesNullifier(t *testing.T) {
@@ -141,44 +192,6 @@ func newFakeResolver(t *testing.T, kid string) *fakeRecipientResolver {
 		recipient: tmproto.TmpxRecipient{Kid: kid, PublicKey: sk.PublicKey()},
 		ok:        true,
 	}
-}
-
-// TestWarnIfMultiSlotIgnored pins the operator-visibility contract for the
-// multi-slot-config-but-single-slot-emission case. The wire shape accepts up
-// to two slots per provider; the sealer currently fills only the first.
-// An operator who configures both expecting multi-chunk emission should see
-// a startup warning naming the active slot and the ignored ones, not
-// discover the gap at trafficking time.
-func TestWarnIfMultiSlotIgnored(t *testing.T) {
-	t.Run("zero or one slot does not warn", func(t *testing.T) {
-		for _, names := range [][]string{nil, {}, {"S3_TMPX"}} {
-			var buf bytes.Buffer
-			logger := slog.New(slog.NewJSONHandler(&buf, nil))
-			warnIfMultiSlotIgnored(logger, names)
-			assert.Empty(t, buf.String(), "single/zero slots are the supported shape — no warning expected (input: %v)", names)
-		}
-	})
-
-	t.Run("two-plus slots warn naming active and ignored", func(t *testing.T) {
-		var buf bytes.Buffer
-		logger := slog.New(slog.NewJSONHandler(&buf, nil))
-		warnIfMultiSlotIgnored(logger, []string{"PIN_TMPX_1", "PIN_TMPX_2", "PIN_TMPX_3"})
-
-		got := buf.String()
-		assert.Contains(t, got, `"level":"WARN"`)
-		assert.Contains(t, got, "multi-chunk encoding is not implemented")
-		assert.Contains(t, got, `"active_slot":"PIN_TMPX_1"`)
-		assert.Contains(t, got, `"ignored_slots":["PIN_TMPX_2","PIN_TMPX_3"]`)
-	})
-
-	t.Run("nil logger is a no-op", func(t *testing.T) {
-		// Defensive: NewTMPXSealer reassigns nil logger to slog.Default
-		// before calling the helper, but pinning the contract avoids a
-		// nil-deref if a caller ever reaches this directly.
-		assert.NotPanics(t, func() {
-			warnIfMultiSlotIgnored(nil, []string{"A", "B"})
-		})
-	})
 }
 
 func TestNewTMPXSealerDisabled(t *testing.T) {
@@ -563,6 +576,90 @@ func TestSelectEntries_PriorityTruncatesUnderBudget(t *testing.T) {
 	assert.LessOrEqual(t, wire, tmproto.TmpxMaxWireBytes, "selected entries within budget")
 }
 
+// TestSelectEntries_TwoSlotBudget_FitsMoreEntries pins the multi-chunk
+// contract at the selection layer: an operator with two macro slots
+// configured gets a 2 * TmpxMaxWireBytes wire budget, so a survivor set
+// that overflows the single-slot budget (see
+// TestSelectEntries_PriorityTruncatesUnderBudget) survives here without
+// truncation. Priority ordering still applies.
+func TestSelectEntries_TwoSlotBudget_FitsMoreEntries(t *testing.T) {
+	cfg := &TMPXSealer{
+		macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"},
+		priority: []tmproto.UIDType{
+			tmproto.UIDTypeRampIDDerived, tmproto.UIDTypeRampID, tmproto.UIDTypeID5,
+			tmproto.UIDTypeHashedEmail, tmproto.UIDTypeMAID,
+		},
+		decoders: defaultTestDecoders(t),
+	}
+	// Same input set as TestSelectEntries_PriorityTruncatesUnderBudget: five
+	// identities that overflow the single-slot budget. With two slots the
+	// wire budget doubles and every survivor fits.
+	ids := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeMAID, UserToken: validUserTokenFor(tmproto.UIDTypeMAID)},
+		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: validUserTokenFor(tmproto.UIDTypeHashedEmail)},
+		{UIDType: tmproto.UIDTypeID5, UserToken: validUserTokenFor(tmproto.UIDTypeID5)},
+		{UIDType: tmproto.UIDTypeRampID, UserToken: validUserTokenFor(tmproto.UIDTypeRampID)},
+		{UIDType: tmproto.UIDTypeRampIDDerived, UserToken: validUserTokenFor(tmproto.UIDTypeRampIDDerived)},
+	}
+	got, err := decodeAndSelect(t, cfg, ids)
+	require.NoError(t, err)
+	assert.Equal(t, len(ids), len(got), "two-slot budget must fit every survivor that overflowed the single-slot budget")
+	// The wire fits under the doubled budget but exceeds the single-slot
+	// one — otherwise this test would be identical to the single-slot case.
+	usedBytes := 0
+	for _, e := range got {
+		usedBytes += 1 + len(e.Token)
+	}
+	wire := tmproto.TmpxWireSize(tmproto.TmpxMaxKidLen, usedBytes)
+	assert.Greater(t, wire, tmproto.TmpxMaxWireBytes, "the packed set MUST exceed a single slot's budget for this test to prove anything")
+	assert.LessOrEqual(t, wire, 2*tmproto.TmpxMaxWireBytes, "packed set must fit inside the two-slot budget")
+}
+
+// TestSelectEntries_TwoSlotBudget_PriorityTruncatesOnOverflow keeps the
+// priority-truncation contract for the multi-slot case: even with a
+// doubled wire budget, an input set that overflows it (spec caps macro
+// list at 2, so budget is 2 * TmpxMaxWireBytes) still triggers
+// priority-ordered truncation rather than an error.
+func TestSelectEntries_TwoSlotBudget_PriorityTruncatesOnOverflow(t *testing.T) {
+	// The two-slot wire budget is 510 bytes. Every TMPX-encodable UID type
+	// packed together overflows it, so priority truncation kicks in even at
+	// the doubled budget.
+	priority := []tmproto.UIDType{
+		tmproto.UIDTypeRampIDDerived, tmproto.UIDTypeWorldIDNullifier, tmproto.UIDTypeRampID,
+		tmproto.UIDTypeID5, tmproto.UIDTypeHashedEmail, tmproto.UIDTypeUID2,
+		tmproto.UIDTypeEUID, tmproto.UIDTypePairID, tmproto.UIDTypePublisherFirstParty,
+		tmproto.UIDTypeMAID,
+	}
+	cfg := &TMPXSealer{
+		macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"},
+		priority:   priority,
+	}
+	survivors := make([]DecodedIdentity, 0, len(priority))
+	for _, uid := range priority {
+		size, _ := tmproto.TmpxTokenSize(uidToTmpxTypeID[uid])
+		survivors = append(survivors, DecodedIdentity{UIDType: uid, Bytes: bytesOfLen(size)})
+	}
+	got, err := cfg.selectEntries(survivors)
+	require.NoError(t, err)
+	assert.Less(t, len(got), len(survivors), "expected priority truncation under the two-slot budget")
+	// Truncation drops from the tail of the priority list — the retained
+	// entries MUST be the highest-priority prefix.
+	for i, e := range got {
+		assert.Equal(t, uidToTmpxTypeID[priority[i]], e.TypeID, "entry %d must follow priority order", i)
+	}
+	usedBytes := 0
+	for _, e := range got {
+		usedBytes += 1 + len(e.Token)
+	}
+	wire := tmproto.TmpxWireSize(tmproto.TmpxMaxKidLen, usedBytes)
+	assert.LessOrEqual(t, wire, 2*tmproto.TmpxMaxWireBytes, "packed set must fit inside the two-slot budget")
+}
+
+// bytesOfLen returns a deterministic byte slice of the requested length —
+// zero-filled is sufficient since selectEntries only sizes against the
+// slice, it does not inspect content.
+func bytesOfLen(n int) []byte { return make([]byte, n) }
+
 func TestSelectEntries_NoPriorityErrorsOnOverflow(t *testing.T) {
 	cfg := &TMPXSealer{decoders: defaultTestDecoders(t)}
 	ids := []tmproto.IdentityToken{
@@ -586,6 +683,45 @@ func TestSelectEntries_NoPriorityPassesUnderBudget(t *testing.T) {
 	got, err := decodeAndSelect(t, cfg, ids)
 	require.NoError(t, err)
 	assert.Len(t, got, 2)
+}
+
+// TestSeal_TwoSlotEndToEnd exercises the full seal + chunk path with a
+// two-slot configuration. An identity set that overflows the single-slot
+// budget succeeds under the doubled budget, and MacroEntries returns two
+// entries whose concatenation reproduces the sealed wire — the AdCP
+// contract with the reassembler on the receiver side.
+func TestSeal_TwoSlotEndToEnd(t *testing.T) {
+	cfg := &TMPXSealer{
+		country:    "US",
+		encStore:   newFakeResolver(t, "kid-8chr"),
+		macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"},
+		priority: []tmproto.UIDType{
+			tmproto.UIDTypeRampIDDerived, tmproto.UIDTypeRampID, tmproto.UIDTypeID5,
+			tmproto.UIDTypeHashedEmail, tmproto.UIDTypeMAID,
+		},
+		decoders: defaultTestDecoders(t),
+	}
+	// Five identities that overflow the single-slot budget (see
+	// TestSelectEntries_PriorityTruncatesUnderBudget which drops from this
+	// same set at the 255-byte limit).
+	ids := []tmproto.IdentityToken{
+		{UIDType: tmproto.UIDTypeMAID, UserToken: validUserTokenFor(tmproto.UIDTypeMAID)},
+		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: validUserTokenFor(tmproto.UIDTypeHashedEmail)},
+		{UIDType: tmproto.UIDTypeID5, UserToken: validUserTokenFor(tmproto.UIDTypeID5)},
+		{UIDType: tmproto.UIDTypeRampID, UserToken: validUserTokenFor(tmproto.UIDTypeRampID)},
+		{UIDType: tmproto.UIDTypeRampIDDerived, UserToken: validUserTokenFor(tmproto.UIDTypeRampIDDerived)},
+	}
+	wire, err := cfg.Seal(t.Context(), ids)
+	require.NoError(t, err)
+	assert.Greater(t, len(wire), tmproto.TmpxMaxWireBytes, "test only proves multi-chunk if the seal exceeds a single slot")
+	assert.LessOrEqual(t, len(wire), 2*tmproto.TmpxMaxWireBytes, "seal must fit inside the two-slot budget")
+
+	entries := cfg.MacroEntries(wire)
+	require.Len(t, entries, 2, "an over-single-slot seal must yield two macro entries")
+	assert.Equal(t, "PIN_TMPX_1", entries[0].Name)
+	assert.Equal(t, "PIN_TMPX_2", entries[1].Name)
+	assert.Len(t, entries[0].Value, tmproto.TmpxMaxWireBytes, "first chunk MUST fill exactly one slot")
+	assert.Equal(t, wire, entries[0].Value+entries[1].Value, "reassembly is byte-concatenation in slot order")
 }
 
 func TestSeal_PriorityResultsInValidWire(t *testing.T) {

--- a/targeting/identityagent/tmpx_test.go
+++ b/targeting/identityagent/tmpx_test.go
@@ -85,22 +85,20 @@ func TestMacroEntries_TwoSlots_TokenStraddlesBothSlots(t *testing.T) {
 	assert.Equal(t, token, entries[0].Value+entries[1].Value)
 }
 
-// MacroEntries never emits an entry whose value exceeds one macro slot —
-// even if a caller supplies a token longer than the sealer's wireBudget().
-// The sealer's selectEntries pass keeps the produced token within budget,
-// so this is a defensive floor, not a code path production exercises.
-func TestMacroEntries_ClampsToConfiguredSlotCount(t *testing.T) {
+// MacroEntries fails closed on an over-budget token: a token longer than
+// len(macroNames) * TmpxMaxWireBytes cannot be reassembled by the receiver
+// (the trailing bytes have no slot), so returning truncated chunks would
+// silently corrupt downstream reassembly. The sealer's selectEntries pass
+// keeps produced tokens within budget, so this is a defensive floor against
+// a future change that raises the seal budget without bumping the slot count.
+func TestMacroEntries_FailsClosedOnOverBudgetToken(t *testing.T) {
 	s := &TMPXSealer{macroNames: []string{"PIN_TMPX_1", "PIN_TMPX_2"}}
 	// A token that would need three chunks; the sealer should have refused
-	// to produce it, but MacroEntries still refuses to emit more than the
-	// configured slot count.
+	// to produce it. MacroEntries surfaces this as "no TMPX" — an identity
+	// drop — rather than truncating.
 	oversize := strings.Repeat("a", 3*tmproto.TmpxMaxWireBytes)
-	entries := s.MacroEntries(oversize)
-	require.Len(t, entries, 2, "must not exceed the configured slot count")
-	for i, e := range entries {
-		assert.LessOrEqual(t, len(e.Value), tmproto.TmpxMaxWireBytes,
-			"entry %d must not exceed the single-slot substitution limit", i)
-	}
+	assert.Nil(t, s.MacroEntries(oversize),
+		"over-budget token MUST return nil so the response falls back to no-TMPX rather than truncated chunks")
 }
 
 func TestVerifiedIdentityEntries_EncodesNullifier(t *testing.T) {

--- a/tmproto/keystore_authorization_test.go
+++ b/tmproto/keystore_authorization_test.go
@@ -114,7 +114,7 @@ func TestLazyAuthorizationKeyStore_NegativeCacheOn404(t *testing.T) {
 		NegativeTTL:         time.Second,
 	})
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if _, ok := ks.LookupKeyForAgent("kid", "https://nobody.example/agent"); ok {
 			t.Fatalf("iteration %d: expected miss on unknown agent", i)
 		}
@@ -220,7 +220,7 @@ func TestLazyAuthorizationKeyStore_SingleFlight(t *testing.T) {
 	var wg sync.WaitGroup
 	var hits int32
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			if _, ok := ks.LookupKeyForAgent("kid-a", "https://seller.example/agent"); ok {
@@ -321,7 +321,7 @@ func TestLazyAuthorizationKeyStore_CacheSizeCap(t *testing.T) {
 		AllowInsecureScheme: true,
 		MaxCacheEntries:     cap,
 	})
-	for i := 0; i < cap*3; i++ {
+	for i := range cap * 3 {
 		_, _ = ks.LookupKeyForAgent("kid", "https://seller"+strings.Repeat("x", i)+".example/agent")
 	}
 	if got := ks.cache.Len(); got > cap {
@@ -360,7 +360,7 @@ func TestLazyAuthorizationKeyStore_FetchConcurrencyCap(t *testing.T) {
 	const goroutines = 8
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		agentURL := "https://seller" + strings.Repeat("x", i+1) + ".example/agent"
 		go func() {
 			defer wg.Done()
@@ -631,11 +631,9 @@ func TestLazyAuthorizationKeyStore_OnFetchOutcome(t *testing.T) {
 		OnFetchOutcome:       record,
 	})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		_, _ = ks2.LookupKeyForAgent("kid", "https://one.example/agent")
-	}()
+	})
 	// Give the leader a moment to take the semaphore.
 	time.Sleep(30 * time.Millisecond)
 	_, _ = ks2.LookupKeyForAgent("kid", "https://two.example/agent")

--- a/tmproto/tmpx.go
+++ b/tmproto/tmpx.go
@@ -54,6 +54,21 @@ const TmpxHPKEOverheadBytes = 48
 // cannot be inlined into creative tracking URLs without truncation.
 const TmpxMaxWireBytes = 255
 
+// TmpxMaxSlots is the v1 spec cap on the number of ad-server macro slots a
+// provider may register in `tmpx_macros` (provider-registration.json). Each
+// slot carries at most TmpxMaxWireBytes of the sealed wire — so a reassembled
+// multi-chunk token is bounded by TmpxMaxSlots * TmpxMaxWireBytes. The cap MAY
+// rise in a later version without a shape change; senders and receivers MUST
+// treat it as the maximum-permitted upper bound, not a required count.
+const TmpxMaxSlots = 2
+
+// TmpxMaxReassembledWireBytes bounds the reassembled (concatenated) wire the
+// receiver opens after collecting one chunk per macro slot. Sized as
+// TmpxMaxSlots * TmpxMaxWireBytes so OpenTmpx accepts an input the conformant
+// sealer may produce (up to TmpxMaxSlots chunks each at TmpxMaxWireBytes) while
+// still bounding memory for DoS-resistant receivers.
+const TmpxMaxReassembledWireBytes = TmpxMaxSlots * TmpxMaxWireBytes
+
 // HPKE algorithm IDs per RFC 9180.
 const (
 	hpkeKEMX25519HKDFSHA256 uint16 = 0x0020

--- a/tmproto/tmpx_open.go
+++ b/tmproto/tmpx_open.go
@@ -30,9 +30,12 @@ const tmpxMaxPayloadBytes = 32 + TmpxHeaderBytes + 255*(1+48) + chacha20poly1305
 const TmpxSealedMaxWireBytes = TmpxMaxKidLen + 1 + 8192
 
 // TmpxKid returns the kid prefix from a TMPX wire token so receivers can look up
-// the matching X25519 private key before calling OpenTmpx.
+// the matching X25519 private key before calling OpenTmpx. The wire may be a
+// single-slot token OR a receiver-reassembled multi-chunk token (concatenation
+// of up to TmpxMaxSlots chunks in slot order), so the bound is
+// TmpxMaxReassembledWireBytes rather than the per-slot TmpxMaxWireBytes.
 func TmpxKid(wire string) (string, error) {
-	kid, _, err := splitTmpxWire(wire, TmpxMaxWireBytes)
+	kid, _, err := splitTmpxWire(wire, TmpxMaxReassembledWireBytes)
 	return kid, err
 }
 
@@ -66,8 +69,16 @@ func splitTmpxWire(wire string, maxWire int) (kid, payload string, err error) {
 // example via TmpxKid and a keystore lookup); OpenTmpx does not consult a
 // keystore. `info` MUST match the value passed to SealTmpx (nil per the spec
 // default).
+//
+// The wire may be a single-slot token OR a receiver-reassembled multi-chunk
+// token: the AdCP TMPX macro carrier chunks sealed tokens at TmpxMaxWireBytes
+// boundaries so each chunk fits inside one ad-server macro slot (the GAM
+// `%%PATTERN_MACRO%%` substitution limit); the receiver concatenates chunks
+// in slot order before calling OpenTmpx. The bound accepts up to TmpxMaxSlots
+// chunks worth of payload so the sealer's own conformant receiver accepts
+// tokens the sealer may emit; larger reassembled inputs are rejected.
 func OpenTmpx(skR *ecdh.PrivateKey, info []byte, wire string) (plaintext []byte, kid string, err error) {
-	return openTmpxWire(skR, info, wire, TmpxMaxWireBytes)
+	return openTmpxWire(skR, info, wire, TmpxMaxReassembledWireBytes)
 }
 
 // OpenSealedCredential opens a sealed_credentials entry — an attestation

--- a/tmproto/tmpx_open_test.go
+++ b/tmproto/tmpx_open_test.go
@@ -128,7 +128,10 @@ func TestOpenReturnsKidOnPayloadError(t *testing.T) {
 
 func TestOpenRejectsOversizedWireBeforeDecode(t *testing.T) {
 	skR := newX25519(t)
-	wire := "k1." + strings.Repeat("A", TmpxMaxWireBytes)
+	// Bound is TmpxMaxReassembledWireBytes — the maximum reassembled
+	// multi-chunk token the receiver ever needs to accept. Anything above it
+	// is a protocol violation and must be rejected before base64 decode.
+	wire := "k1." + strings.Repeat("A", TmpxMaxReassembledWireBytes)
 	if _, _, err := OpenTmpx(skR, nil, wire); err == nil {
 		t.Fatal("expected oversized wire to fail")
 	}

--- a/tmproto/tmpx_sealed_test.go
+++ b/tmproto/tmpx_sealed_test.go
@@ -10,22 +10,25 @@ import (
 
 // TestOpenSealedCredentialLargerBound proves the distinguishing behavior of the
 // sealed-credential open path: a wire string larger than the identity-token
-// bound (TmpxMaxWireBytes) opens via OpenSealedCredential but is rejected by
-// OpenTmpx. Guards against a future change to either bound silently regressing.
+// bound (TmpxMaxReassembledWireBytes) opens via OpenSealedCredential but is
+// rejected by OpenTmpx. Guards against a future change to either bound
+// silently regressing.
 func TestOpenSealedCredentialLargerBound(t *testing.T) {
 	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// 300-byte plaintext seals to a wire comfortably above the 255-byte
-	// identity-token bound but within the sealed-credential bound.
-	pt := bytes.Repeat([]byte("A"), 300)
+	// Plaintext sized so the sealed wire lands comfortably above the
+	// reassembled identity-token bound but within the sealed-credential
+	// bound: base64url overhead is 4/3, so plaintext = TmpxMaxReassembledWireBytes
+	// (in raw bytes) is more than enough to overflow the identity-token cap.
+	pt := bytes.Repeat([]byte("A"), TmpxMaxReassembledWireBytes)
 	wire, err := SealTmpx(TmpxRecipient{Kid: "kid-1", PublicKey: sk.PublicKey()}, nil, pt)
 	if err != nil {
 		t.Fatalf("seal: %v", err)
 	}
-	if len(wire) <= TmpxMaxWireBytes {
-		t.Fatalf("test precondition: wire len %d must exceed TmpxMaxWireBytes %d", len(wire), TmpxMaxWireBytes)
+	if len(wire) <= TmpxMaxReassembledWireBytes {
+		t.Fatalf("test precondition: wire len %d must exceed TmpxMaxReassembledWireBytes %d", len(wire), TmpxMaxReassembledWireBytes)
 	}
 	if len(wire) > TmpxSealedMaxWireBytes {
 		t.Fatalf("test precondition: wire len %d must be within TmpxSealedMaxWireBytes %d", len(wire), TmpxSealedMaxWireBytes)
@@ -40,6 +43,55 @@ func TestOpenSealedCredentialLargerBound(t *testing.T) {
 	}
 
 	if _, _, err := OpenTmpx(sk, nil, wire); err == nil || !strings.Contains(err.Error(), "exceeds maximum") {
-		t.Fatalf("OpenTmpx must reject the over-255-byte wire with 'exceeds maximum', got err=%v", err)
+		t.Fatalf("OpenTmpx must reject a wire above the reassembled bound with 'exceeds maximum', got err=%v", err)
+	}
+}
+
+// TestOpenTmpxAcceptsReassembledMultiChunk pins the invariant Blocker 1 fixed:
+// a sealed wire larger than one macro slot (TmpxMaxWireBytes) but within the
+// two-slot budget round-trips through OpenTmpx when the receiver reassembles
+// the chunks by byte-concatenation in slot order. Before the fix OpenTmpx
+// rejected such tokens — the sealer emitted artifacts its own conformant
+// receiver refused.
+func TestOpenTmpxAcceptsReassembledMultiChunk(t *testing.T) {
+	sk, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Plaintext sized so the sealed wire exceeds one macro slot but fits in
+	// two. base64url is 4/3 expansion; ~200 raw bytes plus 48 bytes of HPKE
+	// overhead reliably overflows the 255-byte single-slot bound while
+	// staying under 2*255 = 510.
+	pt := bytes.Repeat([]byte("A"), 200)
+	wire, err := SealTmpx(TmpxRecipient{Kid: "kid-1", PublicKey: sk.PublicKey()}, nil, pt)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if len(wire) <= TmpxMaxWireBytes {
+		t.Fatalf("test precondition: wire len %d must exceed one slot (%d)", len(wire), TmpxMaxWireBytes)
+	}
+	if len(wire) > TmpxMaxReassembledWireBytes {
+		t.Fatalf("test precondition: wire len %d must fit in %d slots (%d)", len(wire), TmpxMaxSlots, TmpxMaxReassembledWireBytes)
+	}
+
+	// Simulate the receiver reassembling chunks from macro slots: split at
+	// the TmpxMaxWireBytes boundary and rejoin. Reassembly is exactly byte
+	// concatenation in slot order (the AdCP contract).
+	chunk1 := wire[:TmpxMaxWireBytes]
+	chunk2 := wire[TmpxMaxWireBytes:]
+	reassembled := chunk1 + chunk2
+	if reassembled != wire {
+		t.Fatalf("reassembly must be byte-identical to the sealed wire")
+	}
+
+	got, kid, err := OpenTmpx(sk, nil, reassembled)
+	if err != nil {
+		t.Fatalf("OpenTmpx must accept the reassembled multi-chunk wire: %v", err)
+	}
+	if kid != "kid-1" {
+		t.Fatalf("kid = %q, want kid-1", kid)
+	}
+	if !bytes.Equal(got, pt) {
+		t.Fatalf("OpenTmpx round-trip mismatch after reassembly")
 	}
 }


### PR DESCRIPTION
## Motivation

`targeting/identityagent/tmpx.go` previously carried a `warnIfMultiSlotIgnored` helper and a `MacroEntry` implementation that filled only the first configured macro slot, with an explicit warning that "multi-chunk encoding is not implemented; only the first slot will be filled on responses". The AdCP spec's `TmpxMacros` field allows up to two chunks in v1 (see `tmproto/types_gen.go` — `IdentityMatchResponse.TmpxMacros` and `ProviderRegistration.TmpxMacros`), so a provider registering `PIN_TMPX_1, PIN_TMPX_2` could not actually take advantage of the doubled ad-server slot budget. This PR closes that gap.

## What changes

- `TMPXSealer.wireBudget()` — new helper returning `max(1, len(macroNames)) * TmpxMaxWireBytes`. Each configured macro slot contributes one GAM `%%PATTERN_MACRO%%`-sized chunk to the wire budget; no-macro deployments keep the legacy single-slot budget.
- `TMPXSealer.selectEntries` — now packs entries against `wireBudget()` instead of a hard-coded `TmpxMaxWireBytes`. The existing priority-truncation contract is preserved: an overflow of the multi-slot budget still drops from the tail of `TMPX_PRIORITY` rather than erroring, and priority-empty deployments still fail closed.
- `TMPXSealer.MacroEntries(token)` — replaces the previous single-entry `MacroEntry`. Splits the sealed wire token at 255-byte boundaries in slot order, emits one `TmpxMacro` per non-empty chunk, and never emits more entries than `macroNames` or a chunk larger than one slot.
- `handler.go` — extracts the tmpx-response wiring into `assignTmpxToResponse`. `resp.TmpxMacros` now carries the chunked entries; the deprecated `resp.Tmpx` single-string field is populated only when the sealed token fits within one slot (a multi-chunk value cannot be represented in a single 255-byte carrier).
- Removes the now-obsolete `warnIfMultiSlotIgnored` helper and its startup warning.

## Test coverage

- Single-slot passthrough: `TestMacroEntries_SingleSlotEmitsWholeToken`, `TestSelectEntries_NoPriorityPassesUnderBudget` (unchanged).
- Multi-slot, fits in one slot: `TestMacroEntries_TwoSlots_TokenFitsInFirst` — only slot 1 is emitted; the trailing empty slot is dropped.
- Multi-slot, straddles both slots: `TestMacroEntries_TwoSlots_TokenStraddlesBothSlots` — chunk boundary at exactly 255 bytes, reassembly by byte-concatenation.
- Multi-slot, priority-truncation on overflow: `TestSelectEntries_TwoSlotBudget_FitsMoreEntries`, `TestSelectEntries_TwoSlotBudget_PriorityTruncatesOnOverflow`.
- End-to-end seal + chunk: `TestSeal_TwoSlotEndToEnd` — a real HPKE seal produces a wire > 255 bytes and `MacroEntries` reassembles it losslessly.
- Handler wiring: `TestAssignTmpxToResponse_SingleSlotFillsBothCarriers`, `TestAssignTmpxToResponse_MultiChunkOmitsLegacyTmpx`, `TestAssignTmpxToResponse_NoMacrosKeepsOnlyLegacyTmpx`.

## Backward compatibility

Single-slot operators — the only production shape this codebase has emitted so far — are unaffected: `wireBudget()` returns `TmpxMaxWireBytes`, `selectEntries` behavior is unchanged, `MacroEntries` returns one entry carrying the whole token, and the legacy `resp.Tmpx` field is still populated. No-macro operators are also unchanged.