### PR TITLE
cmd/router: add TLS support so operators can serve HTTPS

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -180,13 +180,29 @@ func main() {
 		close(done)
 	}()
 
-	slog.Info("TMP Router starting", "addr", cfg.Addr, "providers", len(cfg.Providers), "version", version)
-	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		slog.Error("listen error", "error", err)
+	slog.Info("TMP Router starting",
+		"addr", cfg.Addr,
+		"providers", len(cfg.Providers),
+		"tls", cfg.TLS.Enabled(),
+		"version", version,
+	)
+	serveErr := listenAndServe(srv, cfg.TLS)
+	if serveErr != nil && serveErr != http.ErrServerClosed {
+		slog.Error("listen error", "error", serveErr)
 		os.Exit(1)
 	}
 	<-done
 	slog.Info("TMP Router stopped")
+}
+
+// listenAndServe picks HTTPS when both cert and key are configured, HTTP
+// otherwise. Deployments that terminate TLS at an upstream ingress leave the
+// TLS block empty and this falls through to ListenAndServe.
+func listenAndServe(srv *http.Server, tlsCfg router.TLSConfig) error {
+	if tlsCfg.Enabled() {
+		return srv.ListenAndServeTLS(tlsCfg.CertPath, tlsCfg.KeyPath)
+	}
+	return srv.ListenAndServe()
 }
 
 // loadConfig resolves config from flags, env vars, JSON file, and defaults.
@@ -232,6 +248,21 @@ func loadConfig(configFile, addr string) *router.ServerConfig {
 	}
 	if v := os.Getenv("TMP_ROUTER_SIGNING_DISABLED"); v == "1" || strings.EqualFold(v, "true") {
 		cfg.Signing.Disabled = true
+	}
+
+	// TLS config — env vars override JSON; both cert and key must be set to
+	// enable HTTPS. Leaving both unset serves cleartext HTTP (typical when
+	// TLS is terminated by an upstream ingress).
+	if v := os.Getenv("TMP_ROUTER_TLS_CERT"); v != "" {
+		cfg.TLS.CertPath = v
+	}
+	if v := os.Getenv("TMP_ROUTER_TLS_KEY"); v != "" {
+		cfg.TLS.KeyPath = v
+	}
+
+	if err := cfg.TLS.Validate(); err != nil {
+		slog.Error("invalid TLS configuration", "error", err)
+		os.Exit(1)
 	}
 
 	return cfg

--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -28,7 +28,7 @@ AgenticAdvertising.org ◄── Registry Syncer (outbound HTTPS polling)
 
 | Service | Default Port | Protocol | Direction | Configurable Via |
 |---------|-------------|----------|-----------|------------------|
-| Router | `:8080` | HTTP | Inbound (publishers) | `--addr` / `TMP_ROUTER_ADDR` |
+| Router | `:8080` (HTTP), `:8443` (HTTPS when TLS configured) | HTTP / HTTPS | Inbound (publishers) | `--addr` / `TMP_ROUTER_ADDR`; `tls.{cert,key}` in config or `TMP_ROUTER_TLS_{CERT,KEY}` |
 | Context Agent | `:8081` | HTTP | Inbound (router) | `--addr` / `TMP_CONTEXT_ADDR` |
 | Identity Agent | `:8082` | HTTP | Inbound (router) | `--addr` / `TMP_IDENTITY_ADDR` |
 | Valkey | `localhost:6379` | Redis protocol | Local only | wired by the embedder via `glidestore`/`redisstore` |
@@ -211,6 +211,8 @@ The router signs every outbound `/tmp/context` and `/tmp/identity` request per t
 |----------|---------|---------|---------|
 | `TMP_ROUTER_ADDR` | Router | Listen address | `:8080` |
 | `TMP_ROUTER_CONFIG` | Router | Path to JSON config file | (none) |
+| `TMP_ROUTER_TLS_CERT` | Router | Path to TLS certificate (PEM). Setting both cert and key serves HTTPS. Leave both unset to serve HTTP (typical when TLS is terminated by upstream ingress). | (none) |
+| `TMP_ROUTER_TLS_KEY` | Router | Path to TLS private key (PEM). Must be set together with `TMP_ROUTER_TLS_CERT`. | (none) |
 | `TMP_ROUTER_SIGNING_KID` | Router | Key identifier for outbound signatures | (none) |
 | `TMP_ROUTER_SIGNING_KEY_PATH` | Router | PEM PKCS#8 Ed25519 private key path | (none) |
 | `TMP_ROUTER_SIGNING_PROPERTY_RIDS` | Router | Comma-separated property RIDs the router signs for | (none) |

--- a/router/serverconfig.go
+++ b/router/serverconfig.go
@@ -22,6 +22,36 @@ type ServerConfig struct {
 	Discovery       DiscoveryConfig   `json:"discovery"`
 	Shutdown        ShutdownConfig    `json:"shutdown"`
 	Signing         SigningConfig     `json:"signing"`
+	TLS             TLSConfig         `json:"tls"`
+}
+
+// TLSConfig configures TLS termination in the router binary. When both
+// CertPath and KeyPath are set, the router serves HTTPS. When both are empty,
+// the router serves cleartext HTTP (typical when TLS is terminated by an
+// upstream ingress/load balancer). Setting only one is a configuration error
+// and Validate reports it.
+//
+// The field names `cert` and `key` match the top-level `tls:` block in the
+// spec's sample deployment YAML (docs/trusted-match/router-architecture.mdx).
+type TLSConfig struct {
+	CertPath string `json:"cert"`
+	KeyPath  string `json:"key"`
+}
+
+// Enabled reports whether TLS should be enabled based on the presence of both
+// cert and key paths.
+func (t TLSConfig) Enabled() bool {
+	return t.CertPath != "" && t.KeyPath != ""
+}
+
+// Validate reports a configuration error when exactly one of cert/key is set,
+// which almost always indicates a missing env var or a typo the operator would
+// rather find at startup than after their next cert rotation.
+func (t TLSConfig) Validate() error {
+	if (t.CertPath == "") != (t.KeyPath == "") {
+		return fmt.Errorf("tls: both cert and key must be set together (cert=%q, key=%q)", t.CertPath, t.KeyPath)
+	}
+	return nil
 }
 
 // UnmarshalJSON accepts the top-level field names from the spec config

--- a/router/serverconfig_test.go
+++ b/router/serverconfig_test.go
@@ -91,6 +91,50 @@ providers:
 	assert.Equal(t, "p1", cfg.Providers[0].ID, "provider_id should still map to ID")
 }
 
+// LoadServerConfig MUST accept the spec's `tls: {cert, key}` block verbatim so
+// a copy of the sample deployment YAML from router-architecture.mdx parses
+// into a TLS-enabled ServerConfig.
+func TestLoadServerConfig_AcceptsSpecTLSBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "config.yaml", `listen: ":8443"
+tls:
+  cert: /etc/tmp/tls.crt
+  key: /etc/tmp/tls.key
+providers:
+  - provider_id: p1
+    endpoint: https://provider.example/agent
+    context_match: true
+`)
+
+	cfg, err := LoadServerConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, ":8443", cfg.Addr)
+	assert.Equal(t, "/etc/tmp/tls.crt", cfg.TLS.CertPath)
+	assert.Equal(t, "/etc/tmp/tls.key", cfg.TLS.KeyPath)
+	assert.True(t, cfg.TLS.Enabled(), "both cert and key set → TLS enabled")
+	assert.NoError(t, cfg.TLS.Validate())
+}
+
+// TLS is opt-in: no tls block → cleartext, no error.
+func TestTLSConfig_UnsetIsDisabled(t *testing.T) {
+	var tls TLSConfig
+	assert.False(t, tls.Enabled())
+	assert.NoError(t, tls.Validate(), "unset TLS is a valid deployment (TLS terminated upstream)")
+}
+
+// Half-configured TLS is a startup error — an operator who set only one of
+// cert/key almost certainly missed an env var, and finding out at cert
+// rotation time would be worse.
+func TestTLSConfig_HalfConfiguredIsError(t *testing.T) {
+	certOnly := TLSConfig{CertPath: "/etc/tmp/tls.crt"}
+	assert.False(t, certOnly.Enabled())
+	assert.Error(t, certOnly.Validate())
+
+	keyOnly := TLSConfig{KeyPath: "/etc/tmp/tls.key"}
+	assert.False(t, keyOnly.Enabled())
+	assert.Error(t, keyOnly.Validate())
+}
+
 // Existing impl-internal names continue to work — backward compat.
 func TestLoadServerConfig_AcceptsImplFieldNames(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

The router spec's sample deployment YAML (`docs/trusted-match/router-architecture.mdx`) shows `listen: :8443` with a `tls: {cert, key}` block, but the binary only called `srv.ListenAndServe` — so a verbatim copy of the sample silently served cleartext HTTP on :8443.

This wires TLS termination into `cmd/router` so operators can either:
- Configure `tls.cert` / `tls.key` in the config or `TMP_ROUTER_TLS_{CERT,KEY}` env vars to serve HTTPS directly, or
- Leave the TLS block empty and terminate TLS at an upstream ingress (typical container-orchestrator deployment).

Part of a series of PRs bringing the router to spec-conformance so we can publish a community-facing OCI image with confidence.

## Changes

- `router.TLSConfig{CertPath, KeyPath}` — new struct on `ServerConfig`, JSON tags `cert`/`key` matching the spec's YAML block verbatim
- `Enabled()` / `Validate()` methods — Enabled iff both paths set; Validate fails half-configured (one set, one empty) so a missing env var surfaces at startup instead of at cert-rotation time
- `TMP_ROUTER_TLS_CERT` / `TMP_ROUTER_TLS_KEY` env vars, layered per the project's flags > env > JSON > defaults rule
- `listenAndServe` helper picks `ListenAndServeTLS` when both are configured, `ListenAndServe` otherwise
- `docs/network-surface.md` port map and env-var table updated

## Test plan

- [x] `go test ./router/...` — passes; new tests cover spec YAML parse, unset-is-disabled, and both half-configured directions
- [x] `go build ./...` and `cmd/router` build clean
- [x] `go vet` clean on touched modules
- [x] `golangci-lint run --new-from-rev origin/main` — no new issues
- [x] Manual sanity: `TMP_ROUTER_TLS_CERT=foo ./router` exits with `invalid TLS configuration: tls: both cert and key must be set together`

## Refs

- Linear: [AI-3716](https://linear.app/scope3-projects/issue/AI-3716/pr-a-tls-support-in-adcp-go-cmdrouter)
- Related spec: docs/trusted-match/router-architecture.mdx §Deployment