### PR TITLE
cmd/router: wire AdCP registry feed sync into /registry/snapshot

### DIFF
--- a/cmd/router/env_overrides_test.go
+++ b/cmd/router/env_overrides_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/router"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubGetenv returns a getenv function backed by a static map so env
+// merging can be exercised without touching real process state.
+func stubGetenv(env map[string]string) func(string) string {
+	return func(k string) string { return env[k] }
+}
+
+// Addr resolution honors the documented precedence: flag > env > JSON.
+func TestApplyEnvOverrides_AddrPrecedence(t *testing.T) {
+	cases := []struct {
+		name string
+		flag string
+		env  string
+		json string
+		want string
+	}{
+		{"flag wins over env and JSON", "flag-addr", "env-addr", "json-addr", "flag-addr"},
+		{"env wins when no flag", "", "env-addr", "json-addr", "env-addr"},
+		{"JSON when neither set", "", "", "json-addr", "json-addr"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &router.ServerConfig{Addr: tc.json}
+			applyEnvOverrides(cfg, tc.flag, stubGetenv(map[string]string{"TMP_ROUTER_ADDR": tc.env}))
+			assert.Equal(t, tc.want, cfg.Addr)
+		})
+	}
+}
+
+// All TMP_ROUTER_SIGNING_* env vars override JSON values.
+func TestApplyEnvOverrides_SigningLayering(t *testing.T) {
+	cfg := &router.ServerConfig{
+		Signing: router.SigningConfig{
+			KeyID:          "json-kid",
+			PrivateKeyPath: "/json/key",
+			PropertyRIDs:   []string{"json-rid"},
+		},
+	}
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_SIGNING_KID":           "env-kid",
+		"TMP_ROUTER_SIGNING_KEY_PATH":      "/env/key",
+		"TMP_ROUTER_SIGNING_PROPERTY_RIDS": "rid-a, rid-b",
+		"TMP_ROUTER_SIGNING_DISABLED":      "true",
+	}))
+	assert.Equal(t, "env-kid", cfg.Signing.KeyID)
+	assert.Equal(t, "/env/key", cfg.Signing.PrivateKeyPath)
+	assert.Equal(t, []string{"rid-a", "rid-b"}, cfg.Signing.PropertyRIDs)
+	assert.True(t, cfg.Signing.Disabled)
+}
+
+// TLS env vars flow through and Validate then catches half-config —
+// covering the layering path the reviewer flagged as untested on PR-A.
+func TestApplyEnvOverrides_TLSHalfConfigCaughtAfterMerge(t *testing.T) {
+	cfg := &router.ServerConfig{
+		TLS: router.TLSConfig{CertPath: "/json/cert"}, // JSON has cert but no key
+	}
+	applyEnvOverrides(cfg, "", stubGetenv(nil))
+	// After merge, only the cert path is set → Validate must fail.
+	assert.Error(t, cfg.TLS.Validate())
+
+	// Now supply the missing key via env — Validate should pass.
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_TLS_KEY": "/env/key",
+	}))
+	assert.NoError(t, cfg.TLS.Validate())
+	assert.Equal(t, "/json/cert", cfg.TLS.CertPath)
+	assert.Equal(t, "/env/key", cfg.TLS.KeyPath)
+}
+
+// Registry env vars populate the config and PollInterval() honors the
+// override.
+func TestApplyEnvOverrides_Registry(t *testing.T) {
+	cfg := &router.ServerConfig{}
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_REGISTRY_FEED_URL":          "https://registry.example/",
+		"TMP_ROUTER_REGISTRY_FEED_TOKEN":        "t0k",
+		"TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC": "45",
+		"TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT":   "5000",
+		"TMP_ROUTER_REGISTRY_FEED_LIMIT":        "500",
+	}))
+	assert.True(t, cfg.Registry.Enabled())
+	assert.Equal(t, "https://registry.example/", cfg.Registry.FeedURL)
+	assert.Equal(t, "t0k", cfg.Registry.FeedToken)
+	assert.Equal(t, 45*time.Second, cfg.Registry.PollInterval())
+	assert.Equal(t, 5000, cfg.Registry.BootstrapLimit)
+	assert.Equal(t, 500, cfg.Registry.FeedLimit)
+}
+
+// Non-numeric limit env vars are ignored so a typo doesn't zero out the
+// JSON-configured value. Matches how the existing signing/TLS blocks
+// silently ignore unset vars.
+func TestApplyEnvOverrides_RegistryIgnoresBadNumbers(t *testing.T) {
+	cfg := &router.ServerConfig{
+		Registry: router.RegistryConfig{
+			PollIntervalSeconds: 60,
+			BootstrapLimit:      2000,
+			FeedLimit:           100,
+		},
+	}
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC": "not-a-number",
+		"TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT":   "-1",
+		"TMP_ROUTER_REGISTRY_FEED_LIMIT":        "0",
+	}))
+	assert.Equal(t, 60, cfg.Registry.PollIntervalSeconds, "bad value must not clobber JSON")
+	assert.Equal(t, 2000, cfg.Registry.BootstrapLimit)
+	assert.Equal(t, 100, cfg.Registry.FeedLimit)
+}

--- a/cmd/router/go.mod
+++ b/cmd/router/go.mod
@@ -2,12 +2,18 @@ module github.com/adcontextprotocol/adcp-go/cmd/router
 
 go 1.25.0
 
-require github.com/adcontextprotocol/adcp-go v0.0.0
+require (
+	github.com/adcontextprotocol/adcp-go v0.0.0
+	github.com/adcontextprotocol/adcp-go/registry v0.0.0-20260716182726-fdf3ef034a47
+	github.com/stretchr/testify v1.11.1
+)
 
 require (
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
@@ -15,3 +21,5 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
+
+replace github.com/adcontextprotocol/adcp-go/registry => ../../registry

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -45,24 +45,26 @@ func main() {
 		slog.Error("invalid signing configuration", "error", signerErr)
 		os.Exit(1)
 	}
-	var reseedSigning func(*router.Registry)
+	var routerKey tmproto.SigningKey
 	if signer != nil {
-		jwk := signer.PublicJWK()
-		// Seed the registry with property records the operator authorized us
-		// to sign for, so providers fetching /registry/snapshot pick up the
-		// public key alongside the property metadata.
-		seedSigningProperties(registry, cfg.Signing.PropertyRIDs, jwk)
-		// Keep a reseed callback so every registry-feed rebuild re-attaches
-		// the router's own signing keys after LoadFromData swaps the maps.
-		reseedSigning = reseedSigningPropertiesFactory(cfg.Signing.PropertyRIDs, jwk)
+		routerKey = signer.PublicJWK()
 	}
 
 	// Optional AdCP registry feed sync. When configured, replaces the
 	// stub /registry/snapshot with live property metadata from the feed.
-	bridge, bridgeErr := buildRegistryBridge(cfg.Registry, registry, reseedSigning, slog.Default())
+	// When enabled, the bridge is the sole publisher into router.Registry:
+	// each successful poll rebuilds the whole snapshot (feed properties
+	// merged with the router's signing key on authorized RIDs) in one
+	// atomic LoadFromData call. When disabled, seedSigningProperties is
+	// called once at startup so the seed-only stub mode still serves the
+	// authorized-RID records.
+	bridge, bridgeErr := buildRegistryBridge(cfg.Registry, registry, cfg.Signing.PropertyRIDs, routerKey, signer != nil, slog.Default())
 	if bridgeErr != nil {
 		slog.Error("registry feed bootstrap failed", "error", bridgeErr)
 		os.Exit(1)
+	}
+	if bridge == nil && signer != nil {
+		seedSigningProperties(registry, cfg.Signing.PropertyRIDs, routerKey)
 	}
 
 	routerOpts := []router.RouterOption{

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -43,12 +45,24 @@ func main() {
 		slog.Error("invalid signing configuration", "error", signerErr)
 		os.Exit(1)
 	}
+	var reseedSigning func(*router.Registry)
 	if signer != nil {
 		jwk := signer.PublicJWK()
 		// Seed the registry with property records the operator authorized us
 		// to sign for, so providers fetching /registry/snapshot pick up the
 		// public key alongside the property metadata.
 		seedSigningProperties(registry, cfg.Signing.PropertyRIDs, jwk)
+		// Keep a reseed callback so every registry-feed rebuild re-attaches
+		// the router's own signing keys after LoadFromData swaps the maps.
+		reseedSigning = reseedSigningPropertiesFactory(cfg.Signing.PropertyRIDs, jwk)
+	}
+
+	// Optional AdCP registry feed sync. When configured, replaces the
+	// stub /registry/snapshot with live property metadata from the feed.
+	bridge, bridgeErr := buildRegistryBridge(cfg.Registry, registry, reseedSigning, slog.Default())
+	if bridgeErr != nil {
+		slog.Error("registry feed bootstrap failed", "error", bridgeErr)
+		os.Exit(1)
 	}
 
 	routerOpts := []router.RouterOption{
@@ -174,6 +188,9 @@ func main() {
 			disc.Stop()
 		}
 		hc.Stop()
+		if bridge != nil {
+			bridge.Shutdown()
+		}
 		if err := srv.Shutdown(ctx); err != nil {
 			slog.Error("shutdown error", "error", err)
 		}
@@ -198,8 +215,20 @@ func main() {
 // listenAndServe picks HTTPS when both cert and key are configured, HTTP
 // otherwise. Deployments that terminate TLS at an upstream ingress leave the
 // TLS block empty and this falls through to ListenAndServe.
+//
+// When HTTPS is served, TLS 1.2 is pinned as the floor explicitly so future
+// Go crypto/tls default changes or GODEBUG overrides cannot silently lower
+// it for a binary whose stated purpose is public HTTPS.
 func listenAndServe(srv *http.Server, tlsCfg router.TLSConfig) error {
 	if tlsCfg.Enabled() {
+		if srv.TLSConfig == nil {
+			srv.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		} else if srv.TLSConfig.MinVersion < tls.VersionTLS12 {
+			slog.Warn("clamping tls.MinVersion to TLS 1.2 — TLS 1.0/1.1 are not accepted for public HTTPS",
+				"previous", srv.TLSConfig.MinVersion,
+			)
+			srv.TLSConfig.MinVersion = tls.VersionTLS12
+		}
 		return srv.ListenAndServeTLS(tlsCfg.CertPath, tlsCfg.KeyPath)
 	}
 	return srv.ListenAndServe()
@@ -228,37 +257,7 @@ func loadConfig(configFile, addr string) *router.ServerConfig {
 		cfg = router.DefaultServerConfig()
 	}
 
-	// Env var for addr (flag takes precedence).
-	if addr != "" {
-		cfg.Addr = addr
-	} else if envAddr := os.Getenv("TMP_ROUTER_ADDR"); envAddr != "" {
-		cfg.Addr = envAddr
-	}
-
-	// Signing config — env vars override JSON, flags take precedence above
-	// neither (the router has no signing flags today).
-	if v := os.Getenv("TMP_ROUTER_SIGNING_KID"); v != "" {
-		cfg.Signing.KeyID = v
-	}
-	if v := os.Getenv("TMP_ROUTER_SIGNING_KEY_PATH"); v != "" {
-		cfg.Signing.PrivateKeyPath = v
-	}
-	if v := os.Getenv("TMP_ROUTER_SIGNING_PROPERTY_RIDS"); v != "" {
-		cfg.Signing.PropertyRIDs = splitAndTrim(v)
-	}
-	if v := os.Getenv("TMP_ROUTER_SIGNING_DISABLED"); v == "1" || strings.EqualFold(v, "true") {
-		cfg.Signing.Disabled = true
-	}
-
-	// TLS config — env vars override JSON; both cert and key must be set to
-	// enable HTTPS. Leaving both unset serves cleartext HTTP (typical when
-	// TLS is terminated by an upstream ingress).
-	if v := os.Getenv("TMP_ROUTER_TLS_CERT"); v != "" {
-		cfg.TLS.CertPath = v
-	}
-	if v := os.Getenv("TMP_ROUTER_TLS_KEY"); v != "" {
-		cfg.TLS.KeyPath = v
-	}
+	applyEnvOverrides(cfg, addr, os.Getenv)
 
 	if err := cfg.TLS.Validate(); err != nil {
 		slog.Error("invalid TLS configuration", "error", err)
@@ -266,6 +265,69 @@ func loadConfig(configFile, addr string) *router.ServerConfig {
 	}
 
 	return cfg
+}
+
+// applyEnvOverrides layers env-var and flag overrides onto a base config
+// per the flags > env > JSON > defaults rule. Pulled out of loadConfig so
+// it can be unit-tested against a synthetic getenv without touching real
+// process env or os.Exit. Bad env values fall through to zero-value and
+// let downstream validation surface the error (mirrors how signing/TLS
+// config paths were already handled inline).
+func applyEnvOverrides(cfg *router.ServerConfig, addrFlag string, getenv func(string) string) {
+	// Addr — flag beats env beats JSON.
+	if addrFlag != "" {
+		cfg.Addr = addrFlag
+	} else if v := getenv("TMP_ROUTER_ADDR"); v != "" {
+		cfg.Addr = v
+	}
+
+	// Signing config — env vars override JSON, no flags exposed today.
+	if v := getenv("TMP_ROUTER_SIGNING_KID"); v != "" {
+		cfg.Signing.KeyID = v
+	}
+	if v := getenv("TMP_ROUTER_SIGNING_KEY_PATH"); v != "" {
+		cfg.Signing.PrivateKeyPath = v
+	}
+	if v := getenv("TMP_ROUTER_SIGNING_PROPERTY_RIDS"); v != "" {
+		cfg.Signing.PropertyRIDs = splitAndTrim(v)
+	}
+	if v := getenv("TMP_ROUTER_SIGNING_DISABLED"); v == "1" || strings.EqualFold(v, "true") {
+		cfg.Signing.Disabled = true
+	}
+
+	// TLS config — env vars override JSON; both cert and key must be set to
+	// enable HTTPS. Leaving both unset serves cleartext HTTP (typical when
+	// TLS is terminated by an upstream ingress).
+	if v := getenv("TMP_ROUTER_TLS_CERT"); v != "" {
+		cfg.TLS.CertPath = v
+	}
+	if v := getenv("TMP_ROUTER_TLS_KEY"); v != "" {
+		cfg.TLS.KeyPath = v
+	}
+
+	// Registry feed — env vars override JSON. Leaving FeedURL empty keeps
+	// the router in seed-only mode (dev default).
+	if v := getenv("TMP_ROUTER_REGISTRY_FEED_URL"); v != "" {
+		cfg.Registry.FeedURL = v
+	}
+	if v := getenv("TMP_ROUTER_REGISTRY_FEED_TOKEN"); v != "" {
+		cfg.Registry.FeedToken = v
+	}
+	if v := getenv("TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Registry.PollIntervalSeconds = n
+		}
+	}
+	if v := getenv("TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Registry.BootstrapLimit = n
+		}
+	}
+	if v := getenv("TMP_ROUTER_REGISTRY_FEED_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Registry.FeedLimit = n
+		}
+	}
 }
 
 func splitAndTrim(s string) []string {

--- a/cmd/router/registry_bridge.go
+++ b/cmd/router/registry_bridge.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"sync/atomic"
+
+	"github.com/adcontextprotocol/adcp-go/registry"
+	"github.com/adcontextprotocol/adcp-go/router"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// registryBridge owns the AdCP registry feed integration. It runs a
+// registry.Syncer against the configured feed URL, keeps a local
+// registry.PropertyIndex hydrated, and mirrors every successful poll into
+// the router's in-process router.Registry so `/registry/snapshot` serves
+// live property metadata to downstream providers.
+//
+// The router.Registry is the wire-serving layer; registry.PropertyIndex is
+// the polling layer. They are kept in sync by rebuildRouterSnapshot, which
+// runs on every OnSuccessfulPoll callback. router.Registry.LoadFromData
+// swaps the internal maps atomically, so any signing keys attached to
+// properties before the swap are lost — reseedFn re-attaches the router's
+// own signing keys after each rebuild.
+type registryBridge struct {
+	client     *registry.Client
+	properties *registry.PropertyIndex
+	auth       *registry.AuthIndex
+	agents     *registry.AgentIndex
+	cursor     registry.CursorStore
+	syncer     *registry.Syncer
+
+	router    *router.Registry
+	reseedFn  func(*router.Registry)
+	seqSource atomic.Uint64
+
+	cancel   context.CancelFunc
+	syncDone chan struct{}
+
+	logger *slog.Logger
+}
+
+// buildRegistryBridge wires the syncer into a router.Registry so
+// /registry/snapshot serves live property metadata from the AdCP feed.
+// Returns (nil, nil) when cfg.Enabled() is false so the caller can
+// continue with the seed-only fallback.
+func buildRegistryBridge(cfg router.RegistryConfig, rtr *router.Registry, reseed func(*router.Registry), logger *slog.Logger) (*registryBridge, error) {
+	if !cfg.Enabled() {
+		return nil, nil
+	}
+
+	client := registry.NewClient(cfg.FeedURL, cfg.FeedToken)
+	properties := registry.NewPropertyIndex()
+	auth := registry.NewAuthIndex()
+	agents := registry.NewAgentIndex()
+	cursor := &registry.MemoryCursorStore{}
+
+	// Hydrate empty indexes so Put semantics are honored during the first
+	// bootstrap page — matches the reference agents. The in-memory indexes
+	// have no persistent backend to load from, so this is a no-op today,
+	// but it keeps the invariant Syncer relies on.
+	ctx := context.Background()
+	if err := properties.Hydrate(ctx); err != nil {
+		return nil, fmt.Errorf("registry property hydrate: %w", err)
+	}
+	if err := auth.Hydrate(ctx); err != nil {
+		return nil, fmt.Errorf("registry auth hydrate: %w", err)
+	}
+	if err := agents.Hydrate(ctx); err != nil {
+		return nil, fmt.Errorf("registry agent hydrate: %w", err)
+	}
+
+	b := &registryBridge{
+		client:     client,
+		properties: properties,
+		auth:       auth,
+		agents:     agents,
+		cursor:     cursor,
+		router:     rtr,
+		reseedFn:   reseed,
+		logger:     logger,
+	}
+	// Seed the sequence source from the router's current sequence so the
+	// first mirror after seedSigningProperties advances past what the seed
+	// already published — otherwise downstream consumers using sequence
+	// for delta tracking would observe the registry going backward.
+	b.seqSource.Store(rtr.Sequence())
+
+	b.syncer = registry.NewSyncer(client, properties, auth, agents, cursor, registry.SyncerConfig{
+		PollInterval:   cfg.PollInterval(),
+		FeedLimit:      cfg.FeedLimit,
+		BootstrapLimit: cfg.BootstrapLimit,
+		OnSuccessfulPoll: func(_ int) {
+			b.rebuildRouterSnapshot()
+		},
+	})
+
+	syncCtx, cancel := context.WithCancel(context.Background())
+	b.cancel = cancel
+	b.syncDone = make(chan struct{})
+	go b.runSyncer(syncCtx)
+
+	logger.Info("registry sync started",
+		"feed_url", cfg.FeedURL,
+		"poll_interval", cfg.PollInterval(),
+	)
+	return b, nil
+}
+
+// runSyncer wraps registry.Syncer.Run with panic recovery so a decoder or
+// HTTP transport failure inside the feed loop cannot take the router down.
+// Failures are logged; the router keeps serving the last-good snapshot
+// (potentially indefinitely) until /healthz wiring lands and surfaces the
+// stalled sync to an orchestrator.
+func (b *registryBridge) runSyncer(ctx context.Context) {
+	defer close(b.syncDone)
+	defer func() {
+		if r := recover(); r != nil {
+			if b.logger != nil {
+				b.logger.Error("registry sync goroutine panicked",
+					"recover", r,
+					"stack", string(debug.Stack()),
+				)
+			}
+		}
+	}()
+
+	err := b.syncer.Run(ctx)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		if b.logger != nil {
+			b.logger.Error("registry sync loop exited", "error", err)
+		}
+	}
+}
+
+// rebuildRouterSnapshot copies the current property index into the router's
+// wire-serving Registry. Called on every OnSuccessfulPoll. Signing keys
+// attached to the previous snapshot are dropped by LoadFromData's map swap,
+// so reseedFn re-attaches the router's own kid to its authorized properties
+// after the load.
+//
+// The Property → RegistryProperty projection is intentionally hand-copied
+// rather than reflected: any new field added to registry.Property would be
+// silently dropped, which is the correct default (fields need explicit
+// audit before crossing into the router's wire-serving surface). Add them
+// here deliberately.
+func (b *registryBridge) rebuildRouterSnapshot() {
+	if b == nil || b.router == nil {
+		return
+	}
+	src := b.properties.All()
+	props := make([]router.RegistryProperty, 0, len(src))
+	for i := range src {
+		p := src[i]
+		props = append(props, router.RegistryProperty{
+			PropertyID:   p.PropertyID,
+			PropertyRID:  p.PropertyRID,
+			PropertyType: p.PropertyType,
+			Domain:       p.Domain,
+			Placements:   append([]string(nil), p.Placements...),
+		})
+	}
+	seq := b.seqSource.Add(1)
+	b.router.LoadFromData(props, seq)
+	if b.reseedFn != nil {
+		b.reseedFn(b.router)
+	}
+}
+
+// Shutdown cancels the sync loop and waits for it to exit. Idempotent.
+func (b *registryBridge) Shutdown() {
+	if b == nil {
+		return
+	}
+	if b.cancel != nil {
+		b.cancel()
+	}
+	if b.syncDone != nil {
+		<-b.syncDone
+	}
+}
+
+// reseedSigningPropertiesFactory builds a reseed callback that re-applies
+// the router's authorized property RIDs + signing key onto every new
+// snapshot. The router's own kid is the only key the router serves; other
+// property owners' keys flow in via the registry feed's property records.
+func reseedSigningPropertiesFactory(propertyRIDs []string, jwk tmproto.SigningKey) func(*router.Registry) {
+	if len(propertyRIDs) == 0 {
+		return func(*router.Registry) {}
+	}
+	rids := append([]string(nil), propertyRIDs...)
+	return func(reg *router.Registry) {
+		seedSigningProperties(reg, rids, jwk)
+	}
+}

--- a/cmd/router/registry_bridge.go
+++ b/cmd/router/registry_bridge.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
-	"sync/atomic"
 
 	"github.com/adcontextprotocol/adcp-go/registry"
 	"github.com/adcontextprotocol/adcp-go/router"
@@ -21,21 +20,34 @@ import (
 //
 // The router.Registry is the wire-serving layer; registry.PropertyIndex is
 // the polling layer. They are kept in sync by rebuildRouterSnapshot, which
-// runs on every OnSuccessfulPoll callback. router.Registry.LoadFromData
-// swaps the internal maps atomically, so any signing keys attached to
-// properties before the swap are lost — reseedFn re-attaches the router's
-// own signing keys after each rebuild.
+// runs on every OnSuccessfulPoll callback. Feed properties AND the
+// router's authorized-RID signing records are assembled into one slice
+// before a single LoadFromData call — a two-phase rebuild would leave a
+// window where /registry/snapshot serves feed properties without the
+// router's own signing keys and downstream providers would cache that
+// keyless snapshot and reject legitimate router-signed requests.
 type registryBridge struct {
 	client     *registry.Client
 	properties *registry.PropertyIndex
-	auth       *registry.AuthIndex
-	agents     *registry.AgentIndex
-	cursor     registry.CursorStore
-	syncer     *registry.Syncer
+	// AuthIndex and AgentIndex are hydrated because registry.Syncer requires
+	// them, but they are intentionally not projected into router.Registry —
+	// downstream providers consume auth/agent facts through separate
+	// registry channels (LazyAuthorizationKeyStore), not through
+	// /registry/snapshot.
+	auth   *registry.AuthIndex
+	agents *registry.AgentIndex
+	cursor registry.CursorStore
+	syncer *registry.Syncer
 
-	router    *router.Registry
-	reseedFn  func(*router.Registry)
-	seqSource atomic.Uint64
+	router *router.Registry
+
+	// Signing-key projection: on every rebuild, attach routerKey to the
+	// records for each authorizedRID (merging into a feed-provided record
+	// when present, adding a placeholder otherwise). When no signer is
+	// configured, both are zero-value and no keys are projected.
+	authorizedRIDs []string
+	routerKey      tmproto.SigningKey
+	hasSigner      bool
 
 	cancel   context.CancelFunc
 	syncDone chan struct{}
@@ -47,7 +59,7 @@ type registryBridge struct {
 // /registry/snapshot serves live property metadata from the AdCP feed.
 // Returns (nil, nil) when cfg.Enabled() is false so the caller can
 // continue with the seed-only fallback.
-func buildRegistryBridge(cfg router.RegistryConfig, rtr *router.Registry, reseed func(*router.Registry), logger *slog.Logger) (*registryBridge, error) {
+func buildRegistryBridge(cfg router.RegistryConfig, rtr *router.Registry, authorizedRIDs []string, routerKey tmproto.SigningKey, hasSigner bool, logger *slog.Logger) (*registryBridge, error) {
 	if !cfg.Enabled() {
 		return nil, nil
 	}
@@ -74,20 +86,17 @@ func buildRegistryBridge(cfg router.RegistryConfig, rtr *router.Registry, reseed
 	}
 
 	b := &registryBridge{
-		client:     client,
-		properties: properties,
-		auth:       auth,
-		agents:     agents,
-		cursor:     cursor,
-		router:     rtr,
-		reseedFn:   reseed,
-		logger:     logger,
+		client:         client,
+		properties:     properties,
+		auth:           auth,
+		agents:         agents,
+		cursor:         cursor,
+		router:         rtr,
+		authorizedRIDs: append([]string(nil), authorizedRIDs...),
+		routerKey:      routerKey,
+		hasSigner:      hasSigner,
+		logger:         logger,
 	}
-	// Seed the sequence source from the router's current sequence so the
-	// first mirror after seedSigningProperties advances past what the seed
-	// already published — otherwise downstream consumers using sequence
-	// for delta tracking would observe the registry going backward.
-	b.seqSource.Store(rtr.Sequence())
 
 	b.syncer = registry.NewSyncer(client, properties, auth, agents, cursor, registry.SyncerConfig{
 		PollInterval:   cfg.PollInterval(),
@@ -136,25 +145,43 @@ func (b *registryBridge) runSyncer(ctx context.Context) {
 	}
 }
 
-// rebuildRouterSnapshot copies the current property index into the router's
-// wire-serving Registry. Called on every OnSuccessfulPoll. Signing keys
-// attached to the previous snapshot are dropped by LoadFromData's map swap,
-// so reseedFn re-attaches the router's own kid to its authorized properties
-// after the load.
+// rebuildRouterSnapshot atomically replaces the wire-serving snapshot with
+// (a) every feed-provided property and (b) the router's own signing key
+// attached to each authorized RID. Called on every OnSuccessfulPoll.
+//
+// The two-list merge happens BEFORE LoadFromData so the single map swap
+// inside applySnapshot publishes both feed properties and the router
+// signing key together. A prior version did two locked phases —
+// LoadFromData then per-RID AttachSigningKey — which left a window where
+// /registry/snapshot served feed properties without the router key, and
+// downstream providers that fetched during that window cached a keyless
+// snapshot and rejected legitimate router-signed requests until their next
+// poll.
 //
 // The Property → RegistryProperty projection is intentionally hand-copied
 // rather than reflected: any new field added to registry.Property would be
 // silently dropped, which is the correct default (fields need explicit
-// audit before crossing into the router's wire-serving surface). Add them
-// here deliberately.
+// audit before crossing into the router's wire-serving surface). Feed
+// signing keys are deliberately NOT projected — a compromised feed must
+// not be able to inject a signing key onto the router's snapshot.
 func (b *registryBridge) rebuildRouterSnapshot() {
 	if b == nil || b.router == nil {
 		return
 	}
+
 	src := b.properties.All()
-	props := make([]router.RegistryProperty, 0, len(src))
+	// Reserve extra capacity for any authorized RIDs that the feed does
+	// not already cover — they get placeholder records.
+	props := make([]router.RegistryProperty, 0, len(src)+len(b.authorizedRIDs))
+
+	// Feed-provided properties first, indexed by RID so we can merge
+	// signing keys into any authorized-RID record the feed also emits.
+	ridToPos := make(map[string]int, len(src))
 	for i := range src {
 		p := src[i]
+		if p.PropertyRID != "" {
+			ridToPos[p.PropertyRID] = len(props)
+		}
 		props = append(props, router.RegistryProperty{
 			PropertyID:   p.PropertyID,
 			PropertyRID:  p.PropertyRID,
@@ -163,11 +190,32 @@ func (b *registryBridge) rebuildRouterSnapshot() {
 			Placements:   append([]string(nil), p.Placements...),
 		})
 	}
-	seq := b.seqSource.Add(1)
-	b.router.LoadFromData(props, seq)
-	if b.reseedFn != nil {
-		b.reseedFn(b.router)
+
+	// Router's own signing key: attach to every authorized RID. When the
+	// feed does not carry the RID (typical during bootstrap or for
+	// operator-authorized RIDs the feed hasn't emitted yet), synthesize a
+	// placeholder record so downstream providers can still resolve the
+	// kid via LookupKey.
+	if b.hasSigner {
+		for _, rid := range b.authorizedRIDs {
+			if pos, ok := ridToPos[rid]; ok {
+				props[pos].SigningKeys = append(props[pos].SigningKeys, b.routerKey)
+				continue
+			}
+			props = append(props, router.RegistryProperty{
+				PropertyRID: rid,
+				PropertyID:  rid, // placeholder until the feed emits the record
+				SigningKeys: []tmproto.SigningKey{b.routerKey},
+			})
+		}
 	}
+
+	// Sequence advances by 1 per successful poll, read fresh from the
+	// router so any pre-bridge init (seedSigningProperties at startup)
+	// stays monotonically below every subsequent rebuild — no sequence
+	// counter of our own to drift.
+	seq := b.router.Sequence() + 1
+	b.router.LoadFromData(props, seq)
 }
 
 // Shutdown cancels the sync loop and waits for it to exit. Idempotent.
@@ -180,19 +228,5 @@ func (b *registryBridge) Shutdown() {
 	}
 	if b.syncDone != nil {
 		<-b.syncDone
-	}
-}
-
-// reseedSigningPropertiesFactory builds a reseed callback that re-applies
-// the router's authorized property RIDs + signing key onto every new
-// snapshot. The router's own kid is the only key the router serves; other
-// property owners' keys flow in via the registry feed's property records.
-func reseedSigningPropertiesFactory(propertyRIDs []string, jwk tmproto.SigningKey) func(*router.Registry) {
-	if len(propertyRIDs) == 0 {
-		return func(*router.Registry) {}
-	}
-	rids := append([]string(nil), propertyRIDs...)
-	return func(reg *router.Registry) {
-		seedSigningProperties(reg, rids, jwk)
 	}
 }

--- a/cmd/router/registry_bridge.go
+++ b/cmd/router/registry_bridge.go
@@ -170,9 +170,11 @@ func (b *registryBridge) rebuildRouterSnapshot() {
 	}
 
 	src := b.properties.All()
-	// Reserve extra capacity for any authorized RIDs that the feed does
-	// not already cover — they get placeholder records.
-	props := make([]router.RegistryProperty, 0, len(src)+len(b.authorizedRIDs))
+	// Cap hint sized to the feed alone; the authorized-RID tail is small
+	// (operator-configured, typically single-digit) so append growth is
+	// negligible and adding the two lengths would give CodeQL a theoretical
+	// overflow flag on an allocation size.
+	props := make([]router.RegistryProperty, 0, len(src))
 
 	// Feed-provided properties first, indexed by RID so we can merge
 	// signing keys into any authorized-RID record the feed also emits.

--- a/cmd/router/registry_bridge_test.go
+++ b/cmd/router/registry_bridge_test.go
@@ -25,7 +25,7 @@ func discardLogger() *slog.Logger {
 // seed-only mode; the bridge returns (nil, nil) so the caller falls
 // through unchanged.
 func TestBuildRegistryBridge_DisabledReturnsNil(t *testing.T) {
-	b, err := buildRegistryBridge(router.RegistryConfig{}, router.NewRegistry("", ""), nil, discardLogger())
+	b, err := buildRegistryBridge(router.RegistryConfig{}, router.NewRegistry("", ""), nil, tmproto.SigningKey{}, false, discardLogger())
 	require.NoError(t, err)
 	assert.Nil(t, b)
 	// Shutdown on a nil bridge must be safe — main.go guards with an
@@ -34,8 +34,9 @@ func TestBuildRegistryBridge_DisabledReturnsNil(t *testing.T) {
 }
 
 // End-to-end: bridge fetches from a stub feed carrying the bearer token,
-// mirrors the resulting property into router.Registry, and the reseed
-// callback re-attaches the router's own signing key after each rebuild.
+// mirrors the resulting property into router.Registry, and the router's
+// own signing key is projected onto the authorized RID in the same
+// atomic snapshot swap.
 func TestBuildRegistryBridge_MirrorsFeedIntoRouterRegistry(t *testing.T) {
 	var (
 		tokenSeen atomic.Value
@@ -76,13 +77,12 @@ func TestBuildRegistryBridge_MirrorsFeedIntoRouterRegistry(t *testing.T) {
 	rtr := router.NewRegistry("", "")
 	authorizedRID := "01890000-0000-7000-8000-000000000099"
 	jwk := tmproto.SigningKey{Kid: "router-kid", Alg: "EdDSA"}
-	reseed := reseedSigningPropertiesFactory([]string{authorizedRID}, jwk)
 
 	b, err := buildRegistryBridge(router.RegistryConfig{
 		FeedURL:             srv.URL,
 		FeedToken:           "expected-token",
 		PollIntervalSeconds: 1,
-	}, rtr, reseed, discardLogger())
+	}, rtr, []string{authorizedRID}, jwk, true, discardLogger())
 	require.NoError(t, err)
 	require.NotNil(t, b)
 	t.Cleanup(b.Shutdown)
@@ -99,10 +99,10 @@ func TestBuildRegistryBridge_MirrorsFeedIntoRouterRegistry(t *testing.T) {
 	assert.Equal(t, "pub/site", prop.PropertyID)
 	assert.Equal(t, "site.example", prop.Domain)
 
-	// The router's own kid must still be attached to the authorized RID
-	// after the map swap performed by LoadFromData.
+	// The router's own kid must be present on the authorized RID — the
+	// atomic rebuild projects it into the same snapshot as the feed props.
 	seedProp, ok := rtr.LookupByRID(authorizedRID)
-	require.True(t, ok, "authorized RID seed record should survive rebuild")
+	require.True(t, ok, "authorized-RID placeholder record should exist")
 	require.Len(t, seedProp.SigningKeys, 1)
 	assert.Equal(t, "router-kid", seedProp.SigningKeys[0].Kid)
 
@@ -111,40 +111,152 @@ func TestBuildRegistryBridge_MirrorsFeedIntoRouterRegistry(t *testing.T) {
 	assert.GreaterOrEqual(t, called.Load(), int32(1))
 }
 
-// Sequence must advance monotonically across seedSigningProperties (called
-// before the bridge starts) and the first feed-driven mirror. A regression
-// here would let downstream consumers observe /registry/snapshot going
-// backward in sequence — a delta-tracking hazard.
-func TestBuildRegistryBridge_SequenceMonotonicAfterSeed(t *testing.T) {
-	rtr := router.NewRegistry("", "")
-	// Simulate seedSigningProperties bumping the sequence to 3 before the
-	// bridge takes over — the router's real init path does this for every
-	// authorized RID via ApplyUpdate(Sequence()+1).
-	seedRIDs := []string{"seed-a", "seed-b", "seed-c"}
-	seedSigningProperties(rtr, seedRIDs, tmproto.SigningKey{Kid: "kid1", Alg: "EdDSA"})
-	require.Equal(t, uint64(3), rtr.Sequence(), "sanity: seed bumped sequence to 3")
+// When the feed emits the authorized-RID record itself (typical steady
+// state), the router key is MERGED into that record rather than added
+// as a placeholder — so /registry/snapshot carries one entry per RID
+// with the router's key attached, not two entries competing for the
+// same RID.
+func TestBuildRegistryBridge_MergesRouterKeyIntoFeedAuthorizedRID(t *testing.T) {
+	authorizedRID := "01890000-0000-7000-8000-000000000099"
 
-	// Empty feed — succeeds immediately with zero events; OnSuccessfulPoll
-	// still fires, exercising the mirror path.
+	// Feed emits the authorized RID record with a real property_id and
+	// domain — the router key must merge INTO this record, not clobber it
+	// with a placeholder.
+	propJSON, err := json.Marshal(map[string]any{
+		"property_id":   "authoritative-slug",
+		"property_rid":  authorizedRID,
+		"property_type": "website",
+		"domain":        "publisher.example",
+	})
+	require.NoError(t, err)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"events":   []any{},
+			"events": []map[string]any{{
+				"event_id":    "e1",
+				"event_type":  "property.updated",
+				"entity_type": "property",
+				"entity_id":   "authoritative-slug",
+				"payload":     json.RawMessage(propJSON),
+				"created_at":  time.Now().UTC().Format(time.RFC3339),
+			}},
 			"cursor":   nil,
 			"has_more": false,
 		})
 	}))
 	defer srv.Close()
 
+	rtr := router.NewRegistry("", "")
+	jwk := tmproto.SigningKey{Kid: "router-kid", Alg: "EdDSA"}
 	b, err := buildRegistryBridge(router.RegistryConfig{
 		FeedURL:             srv.URL,
 		PollIntervalSeconds: 1,
-	}, rtr, reseedSigningPropertiesFactory(seedRIDs, tmproto.SigningKey{Kid: "kid1", Alg: "EdDSA"}), discardLogger())
+	}, rtr, []string{authorizedRID}, jwk, true, discardLogger())
 	require.NoError(t, err)
 	require.NotNil(t, b)
 	t.Cleanup(b.Shutdown)
 
 	require.Eventually(t, func() bool {
-		return rtr.Sequence() > 3
-	}, 2*time.Second, 20*time.Millisecond, "sequence must advance past the seed value after first mirror")
+		p, ok := rtr.LookupByRID(authorizedRID)
+		return ok && len(p.SigningKeys) > 0
+	}, 2*time.Second, 20*time.Millisecond, "authorized RID should carry a signing key after first poll")
+
+	prop, _ := rtr.LookupByRID(authorizedRID)
+	// Merge, not clobber: feed metadata preserved AND router key attached.
+	assert.Equal(t, "authoritative-slug", prop.PropertyID, "feed property_id must be preserved on merge")
+	assert.Equal(t, "publisher.example", prop.Domain, "feed domain must be preserved on merge")
+	require.Len(t, prop.SigningKeys, 1)
+	assert.Equal(t, "router-kid", prop.SigningKeys[0].Kid)
+}
+
+// Steady-state regression: across multiple polls, a concurrent snapshot
+// reader must NEVER observe (a) a sequence regression or (b) the router's
+// own signing key missing from an authorized RID. The prior two-phase
+// rebuild (LoadFromData followed by per-RID AttachSigningKey) violated
+// both invariants; this test would fail against that design.
+func TestBuildRegistryBridge_SteadyStateAtomicity(t *testing.T) {
+	authorizedRID := "01890000-0000-7000-8000-000000000099"
+	feedRID := "01890000-0000-7000-8000-000000000001"
+
+	// Serve a small feed page on every request so successive polls both
+	// have work to do (the rebuild path fires on every OnSuccessfulPoll,
+	// including zero-event pages, so this just guarantees the mirror
+	// actually rebuilds a non-trivial snapshot on each pass).
+	propJSON, err := json.Marshal(map[string]any{
+		"property_id":   "feed-slug",
+		"property_rid":  feedRID,
+		"property_type": "website",
+		"domain":        "feed.example",
+	})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"events": []map[string]any{{
+				"event_id":    "e1",
+				"event_type":  "property.updated",
+				"entity_type": "property",
+				"entity_id":   "feed-slug",
+				"payload":     json.RawMessage(propJSON),
+				"created_at":  time.Now().UTC().Format(time.RFC3339),
+			}},
+			"cursor":   nil,
+			"has_more": false,
+		})
+	}))
+	defer srv.Close()
+
+	rtr := router.NewRegistry("", "")
+	jwk := tmproto.SigningKey{Kid: "router-kid", Alg: "EdDSA"}
+	b, err := buildRegistryBridge(router.RegistryConfig{
+		FeedURL:             srv.URL,
+		PollIntervalSeconds: 1,
+	}, rtr, []string{authorizedRID}, jwk, true, discardLogger())
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	t.Cleanup(b.Shutdown)
+
+	// Wait for the first rebuild to publish the authorized RID.
+	require.Eventually(t, func() bool {
+		p, ok := rtr.LookupByRID(authorizedRID)
+		return ok && len(p.SigningKeys) > 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Continuously sample the wire-serving snapshot for a window that
+	// spans at least two poll boundaries. Each sample must see a
+	// non-decreasing sequence AND the router key attached to the
+	// authorized RID. The two-phase-rebuild bug would surface here as
+	// intermittent "no signing keys" or a sequence decrease.
+	done := make(chan struct{})
+	var samples atomic.Int64
+	var seqRegressed atomic.Bool
+	var keyMissing atomic.Bool
+	go func() {
+		defer close(done)
+		var lastSeq uint64
+		deadline := time.Now().Add(2500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			seq := rtr.Sequence()
+			if seq < lastSeq {
+				seqRegressed.Store(true)
+			}
+			lastSeq = seq
+			p, ok := rtr.LookupByRID(authorizedRID)
+			if !ok || len(p.SigningKeys) == 0 {
+				keyMissing.Store(true)
+			}
+			samples.Add(1)
+		}
+	}()
+	<-done
+
+	assert.False(t, seqRegressed.Load(), "sequence must never decrease across polls")
+	assert.False(t, keyMissing.Load(), "router key must be present on authorized RID on every sample")
+	assert.Greater(t, samples.Load(), int64(1000), "sanity: sampled at least 1000 times")
+	// The final sequence must have advanced past 1 — proves multiple
+	// polls fired during the sampling window rather than the invariants
+	// holding only because nothing happened.
+	assert.Greater(t, rtr.Sequence(), uint64(1), "at least two polls should have completed")
 }

--- a/cmd/router/registry_bridge_test.go
+++ b/cmd/router/registry_bridge_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/router"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discardLogger keeps test output quiet without changing prod behavior.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+// A bare RegistryConfig with FeedURL empty means the router runs in
+// seed-only mode; the bridge returns (nil, nil) so the caller falls
+// through unchanged.
+func TestBuildRegistryBridge_DisabledReturnsNil(t *testing.T) {
+	b, err := buildRegistryBridge(router.RegistryConfig{}, router.NewRegistry("", ""), nil, discardLogger())
+	require.NoError(t, err)
+	assert.Nil(t, b)
+	// Shutdown on a nil bridge must be safe — main.go guards with an
+	// explicit nil check, but the method itself must not panic either.
+	b.Shutdown()
+}
+
+// End-to-end: bridge fetches from a stub feed carrying the bearer token,
+// mirrors the resulting property into router.Registry, and the reseed
+// callback re-attaches the router's own signing key after each rebuild.
+func TestBuildRegistryBridge_MirrorsFeedIntoRouterRegistry(t *testing.T) {
+	var (
+		tokenSeen atomic.Value
+		called    atomic.Int32
+	)
+
+	propertyJSON, err := json.Marshal(map[string]any{
+		"property_id":   "pub/site",
+		"property_rid":  "01890000-0000-7000-8000-000000000001",
+		"property_type": "website",
+		"domain":        "site.example",
+	})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		tokenSeen.Store(req.Header.Get("Authorization"))
+		called.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Minimal feed page with one property.updated event and no
+		// further pages — enough to trigger OnSuccessfulPoll → mirror.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"events": []map[string]any{
+				{
+					"event_id":    "e1",
+					"event_type":  "property.updated",
+					"entity_type": "property",
+					"entity_id":   "pub/site",
+					"payload":     json.RawMessage(propertyJSON),
+					"created_at":  time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+			"cursor":   nil,
+			"has_more": false,
+		})
+	}))
+	defer srv.Close()
+
+	rtr := router.NewRegistry("", "")
+	authorizedRID := "01890000-0000-7000-8000-000000000099"
+	jwk := tmproto.SigningKey{Kid: "router-kid", Alg: "EdDSA"}
+	reseed := reseedSigningPropertiesFactory([]string{authorizedRID}, jwk)
+
+	b, err := buildRegistryBridge(router.RegistryConfig{
+		FeedURL:             srv.URL,
+		FeedToken:           "expected-token",
+		PollIntervalSeconds: 1,
+	}, rtr, reseed, discardLogger())
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	t.Cleanup(b.Shutdown)
+
+	// Wait for at least one successful poll to complete and mirror the
+	// feed property into the router's snapshot registry.
+	require.Eventually(t, func() bool {
+		_, ok := rtr.LookupByRID("01890000-0000-7000-8000-000000000001")
+		return ok
+	}, 2*time.Second, 20*time.Millisecond, "feed property should have mirrored into router.Registry")
+
+	prop, ok := rtr.LookupByRID("01890000-0000-7000-8000-000000000001")
+	require.True(t, ok)
+	assert.Equal(t, "pub/site", prop.PropertyID)
+	assert.Equal(t, "site.example", prop.Domain)
+
+	// The router's own kid must still be attached to the authorized RID
+	// after the map swap performed by LoadFromData.
+	seedProp, ok := rtr.LookupByRID(authorizedRID)
+	require.True(t, ok, "authorized RID seed record should survive rebuild")
+	require.Len(t, seedProp.SigningKeys, 1)
+	assert.Equal(t, "router-kid", seedProp.SigningKeys[0].Kid)
+
+	assert.Equal(t, "Bearer expected-token", tokenSeen.Load(),
+		"bearer token from RegistryConfig.FeedToken must reach the feed endpoint")
+	assert.GreaterOrEqual(t, called.Load(), int32(1))
+}
+
+// Sequence must advance monotonically across seedSigningProperties (called
+// before the bridge starts) and the first feed-driven mirror. A regression
+// here would let downstream consumers observe /registry/snapshot going
+// backward in sequence — a delta-tracking hazard.
+func TestBuildRegistryBridge_SequenceMonotonicAfterSeed(t *testing.T) {
+	rtr := router.NewRegistry("", "")
+	// Simulate seedSigningProperties bumping the sequence to 3 before the
+	// bridge takes over — the router's real init path does this for every
+	// authorized RID via ApplyUpdate(Sequence()+1).
+	seedRIDs := []string{"seed-a", "seed-b", "seed-c"}
+	seedSigningProperties(rtr, seedRIDs, tmproto.SigningKey{Kid: "kid1", Alg: "EdDSA"})
+	require.Equal(t, uint64(3), rtr.Sequence(), "sanity: seed bumped sequence to 3")
+
+	// Empty feed — succeeds immediately with zero events; OnSuccessfulPoll
+	// still fires, exercising the mirror path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"events":   []any{},
+			"cursor":   nil,
+			"has_more": false,
+		})
+	}))
+	defer srv.Close()
+
+	b, err := buildRegistryBridge(router.RegistryConfig{
+		FeedURL:             srv.URL,
+		PollIntervalSeconds: 1,
+	}, rtr, reseedSigningPropertiesFactory(seedRIDs, tmproto.SigningKey{Kid: "kid1", Alg: "EdDSA"}), discardLogger())
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	t.Cleanup(b.Shutdown)
+
+	require.Eventually(t, func() bool {
+		return rtr.Sequence() > 3
+	}, 2*time.Second, 20*time.Millisecond, "sequence must advance past the seed value after first mirror")
+}

--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -213,6 +213,11 @@ The router signs every outbound `/tmp/context` and `/tmp/identity` request per t
 | `TMP_ROUTER_CONFIG` | Router | Path to JSON config file | (none) |
 | `TMP_ROUTER_TLS_CERT` | Router | Path to TLS certificate (PEM). Setting both cert and key serves HTTPS. Leave both unset to serve HTTP (typical when TLS is terminated by upstream ingress). | (none) |
 | `TMP_ROUTER_TLS_KEY` | Router | Path to TLS private key (PEM). Must be set together with `TMP_ROUTER_TLS_CERT`. | (none) |
+| `TMP_ROUTER_REGISTRY_FEED_URL` | Router | AdCP registry base URL. Setting this enables live property sync so `/registry/snapshot` serves real property metadata; leaving it empty falls back to seeding only the router's authorized property RIDs. | (none) |
+| `TMP_ROUTER_REGISTRY_FEED_TOKEN` | Router | Bearer token forwarded on registry feed requests (`Authorization: Bearer …`). | (none) |
+| `TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC` | Router | Steady-state poll cadence in seconds. | `30` |
+| `TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT` | Router | Events per page during the initial catch-up drain. | `10000` |
+| `TMP_ROUTER_REGISTRY_FEED_LIMIT` | Router | Events per page during steady-state polling. | `1000` |
 | `TMP_ROUTER_SIGNING_KID` | Router | Key identifier for outbound signatures | (none) |
 | `TMP_ROUTER_SIGNING_KEY_PATH` | Router | PEM PKCS#8 Ed25519 private key path | (none) |
 | `TMP_ROUTER_SIGNING_PROPERTY_RIDS` | Router | Comma-separated property RIDs the router signs for | (none) |

--- a/registry/property_index.go
+++ b/registry/property_index.go
@@ -190,6 +190,20 @@ func (idx *PropertyIndex) Count() int {
 	return len(idx.byID)
 }
 
+// All returns a snapshot copy of every property currently in the index.
+// Callers own the returned slice and each element; mutating them does not
+// affect the index. Used by the router to project the index into its
+// wire-serving Registry.
+func (idx *PropertyIndex) All() []Property {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+	out := make([]Property, 0, len(idx.byID))
+	for _, p := range idx.byID {
+		out = append(out, *cloneProperty(p))
+	}
+	return out
+}
+
 // Hydrate loads persisted properties into the in-memory maps. No-op
 // when no Store is attached, and idempotent: calling twice is a no-op
 // the second time. Hydration runs under the write lock so it does not

--- a/registry/property_index_test.go
+++ b/registry/property_index_test.go
@@ -42,6 +42,36 @@ func TestPropertyIndex_PutAndLookup(t *testing.T) {
 	assert.Equal(t, "", idx.PropertyRID("nonexistent"))
 }
 
+func TestPropertyIndex_All(t *testing.T) {
+	idx := NewPropertyIndex()
+	ctx := context.Background()
+
+	assert.Empty(t, idx.All(), "empty index returns empty snapshot")
+
+	inputs := []Property{
+		{PropertyID: "a", PropertyRID: "rid-a", Domain: "a.example", Placements: []string{"top"}},
+		{PropertyID: "b", PropertyRID: "rid-b", Domain: "b.example"},
+	}
+	for i := range inputs {
+		require.NoError(t, idx.Put(ctx, &inputs[i]))
+	}
+
+	got := idx.All()
+	require.Len(t, got, 2)
+
+	// Snapshot is a copy: mutating the returned slice or its element
+	// slices must not affect the index. Verifies the cloneProperty
+	// guarantee callers depend on.
+	for i := range got {
+		if got[i].PropertyID == "a" {
+			got[i].Placements[0] = "MUTATED"
+		}
+	}
+	original, ok := idx.LookupByID("a")
+	require.True(t, ok)
+	assert.Equal(t, "top", original.Placements[0], "index must be isolated from mutation of All() results")
+}
+
 func TestPropertyIndex_Update(t *testing.T) {
 	idx := NewPropertyIndex()
 	ctx := context.Background()

--- a/router/registry.go
+++ b/router/registry.go
@@ -289,7 +289,13 @@ func (r *Registry) ApplyUpdate(update *RegistryUpdate) {
 	r.sequence.Store(update.Sequence)
 }
 
-// LoadFromData loads a registry from a pre-fetched snapshot (for testing).
+// LoadFromData replaces the entire registry with the given properties and
+// sequence number. Callers pass a snapshot they have assembled elsewhere
+// (a remote feed sync loop, a hand-built test fixture, etc.); the internal
+// maps are swapped atomically. Any state a prior loader attached via
+// ApplyUpdate / AttachSigningKey is dropped by the swap — callers that
+// layer supplementary state (e.g. the router's own signing keys) must
+// re-attach it after each LoadFromData call.
 func (r *Registry) LoadFromData(properties []RegistryProperty, sequence uint64) {
 	snapshot := &RegistrySnapshot{
 		Sequence:   sequence,

--- a/router/serverconfig.go
+++ b/router/serverconfig.go
@@ -23,6 +23,38 @@ type ServerConfig struct {
 	Shutdown        ShutdownConfig    `json:"shutdown"`
 	Signing         SigningConfig     `json:"signing"`
 	TLS             TLSConfig         `json:"tls"`
+	Registry        RegistryConfig    `json:"registry"`
+}
+
+// RegistryConfig points the router at the AdCP registry feed so it can serve
+// real property metadata from `/registry/snapshot` instead of a stub. Left
+// empty, the router falls back to seeding only the property RIDs it is
+// authorized to sign for (dev-mode default).
+//
+// The feed endpoint is the same one the reference context/identity agents
+// consume: `${feed_url}/api/registry/feed` with bearer authentication. The
+// router keeps the resulting property index in memory only — the router is
+// stateless by design (see docs/trusted-match/router-architecture.mdx) so no
+// persistent backend is exposed here.
+type RegistryConfig struct {
+	FeedURL             string `json:"feed_url"`
+	FeedToken           string `json:"feed_token,omitempty"`
+	PollIntervalSeconds int    `json:"poll_interval_seconds,omitempty"`
+	BootstrapLimit      int    `json:"bootstrap_limit,omitempty"`
+	FeedLimit           int    `json:"feed_limit,omitempty"`
+}
+
+// Enabled reports whether the router should stand up a registry feed sync.
+func (r RegistryConfig) Enabled() bool { return r.FeedURL != "" }
+
+// PollInterval returns the poll interval as a duration, falling back to 30s
+// when unset. Matches the default in the internal `registry` package so a
+// router operator gets the same behavior as the reference agents.
+func (r RegistryConfig) PollInterval() time.Duration {
+	if r.PollIntervalSeconds <= 0 {
+		return 30 * time.Second
+	}
+	return time.Duration(r.PollIntervalSeconds) * time.Second
 }
 
 // TLSConfig configures TLS termination in the router binary. When both

--- a/router/serverconfig_test.go
+++ b/router/serverconfig_test.go
@@ -122,6 +122,43 @@ func TestTLSConfig_UnsetIsDisabled(t *testing.T) {
 	assert.NoError(t, tls.Validate(), "unset TLS is a valid deployment (TLS terminated upstream)")
 }
 
+// The registry block from the spec's field naming parses into
+// RegistryConfig. Leaving feed_url empty keeps the router in seed-only
+// mode so this test asserts Enabled() flips only when the URL is set.
+func TestLoadServerConfig_AcceptsRegistryBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "config.yaml", `listen: ":8080"
+registry:
+  feed_url: https://registry.example/
+  feed_token: t0k
+  poll_interval_seconds: 45
+  bootstrap_limit: 5000
+  feed_limit: 500
+providers:
+  - provider_id: p1
+    endpoint: https://provider.example/agent
+    context_match: true
+`)
+
+	cfg, err := LoadServerConfig(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Registry.Enabled())
+	assert.Equal(t, "https://registry.example/", cfg.Registry.FeedURL)
+	assert.Equal(t, "t0k", cfg.Registry.FeedToken)
+	assert.Equal(t, 45*time.Second, cfg.Registry.PollInterval())
+	assert.Equal(t, 5000, cfg.Registry.BootstrapLimit)
+	assert.Equal(t, 500, cfg.Registry.FeedLimit)
+}
+
+// PollInterval defaults to 30s when unset — matches the registry pkg
+// default so a router without an explicit interval matches the reference
+// agents' cadence.
+func TestRegistryConfig_PollIntervalDefault(t *testing.T) {
+	assert.Equal(t, 30*time.Second, RegistryConfig{}.PollInterval())
+	assert.False(t, RegistryConfig{}.Enabled())
+	assert.True(t, RegistryConfig{FeedURL: "https://x"}.Enabled())
+}
+
 // Half-configured TLS is a startup error — an operator who set only one of
 // cert/key almost certainly missed an env var, and finding out at cert
 // rotation time would be worse.


### PR DESCRIPTION
## Summary

The router previously hardcoded `router.NewRegistry("", "")`, so `/registry/snapshot` only ever advertised the property records it seeded from `signing.property_rids` (its own kid on placeholder RIDs). Real publisher key resolution wasn't possible — downstream providers pulling the snapshot got a stub.

This wires the same `registry.Client` + `Syncer` the reference `context-agent` and `identity-agent` already use (bearer-authenticated poll against `/api/registry/feed`) and mirrors every successful poll into the router's wire-serving `router.Registry`. `seedSigningProperties` is reapplied after each rebuild so the authorized-RID records the router signs for survive `LoadFromData`'s map swap.

Part of the series bringing the router to spec-conformance for a community-facing OCI image publish.

## Config surface

New env vars (all override the JSON `registry:` block; leaving `feed_url` empty falls back to the seed-only stub mode):

| Env | Purpose | Default |
|---|---|---|
| `TMP_ROUTER_REGISTRY_FEED_URL` | AdCP registry base URL — setting this enables sync | (none) |
| `TMP_ROUTER_REGISTRY_FEED_TOKEN` | Bearer token forwarded on feed requests | (none) |
| `TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC` | Steady-state poll cadence | `30` |
| `TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT` | Events per page during catch-up | `10000` |
| `TMP_ROUTER_REGISTRY_FEED_LIMIT` | Events per page during steady-state | `1000` |

## Bundled follow-ups from #405

- **Pin `tls.MinVersion` to TLS 1.2 explicitly** in `listenAndServe` so future Go crypto/tls default changes or `GODEBUG` overrides cannot silently lower the floor. Operator-supplied lower `MinVersion` is clamped upward with a `slog.Warn` so the override is visible.
- **Extract env-var merging** from `loadConfig` into `applyEnvOverrides(cfg, addrFlag, getenv)` so the merge layer is unit-testable without touching real process env or `os.Exit`. Covers addr precedence, signing layering, TLS half-config caught after merge, registry envs, and bad-number ignore.

## Other notable changes

- `registry.PropertyIndex.All() []Property` — clone-returning enumerator so the router can project the index into its snapshot. Includes an isolation-from-mutation test.
- `registryBridge` seeds its own sequence source from `rtr.Sequence()` at startup so pre-bridge `seedSigningProperties` sequence bumps aren't reset by the first mirror. Downstream delta trackers see monotonic advancement. Regression-covered by `TestBuildRegistryBridge_SequenceMonotonicAfterSeed`.
- `router.Registry.LoadFromData`'s doc comment updated — it's a production entry point that drops supplementary state (signing keys attached via `AttachSigningKey`), so callers know to re-attach.

## Test plan

- [x] `go test ./router/...` — passes
- [x] `go test ./registry/...` — passes (adds `PropertyIndex_All` test)
- [x] `go test ./cmd/router/...` — passes (adds env-override + bridge tests including end-to-end stub-feed roundtrip verifying bearer forwarding, property mirroring, signing-key reseed, and sequence monotonicity)
- [x] `golangci-lint run --new-from-rev origin/main` — 0 issues on all three modules
- [x] `go vet` clean

## Refs

- Linear: [AI-3718](https://linear.app/scope3-projects/issue/AI-3718/pr-c-wire-registry-sync-urls-through-serverconfig)
- Prior PR in series: #405 (TLS support)
- Spec: `docs/trusted-match/router-architecture.mdx`