### PR TITLE
cmd/router: cache Context Match responses per spec §Caching

### DIFF
--- a/cmd/router/env_overrides_test.go
+++ b/cmd/router/env_overrides_test.go
@@ -95,6 +95,39 @@ func TestApplyEnvOverrides_Registry(t *testing.T) {
 	assert.Equal(t, 500, cfg.Registry.FeedLimit)
 }
 
+// Cache env vars toggle the Context Match cache and override the
+// fallback TTL. Both override any JSON-supplied values.
+func TestApplyEnvOverrides_Cache(t *testing.T) {
+	cfg := &router.ServerConfig{
+		Cache: router.CacheConfig{DefaultTTLSeconds: 60},
+	}
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_CACHE_DISABLED":        "true",
+		"TMP_ROUTER_CACHE_DEFAULT_TTL_SEC": "300",
+	}))
+	assert.True(t, cfg.Cache.Disabled)
+	assert.Equal(t, 300, cfg.Cache.DefaultTTLSeconds)
+	assert.Equal(t, 5*time.Minute, cfg.Cache.DefaultTTL())
+
+	// Only the disabled flag flips when the TTL var is absent.
+	cfg2 := &router.ServerConfig{Cache: router.CacheConfig{DefaultTTLSeconds: 60}}
+	applyEnvOverrides(cfg2, "", stubGetenv(map[string]string{"TMP_ROUTER_CACHE_DISABLED": "1"}))
+	assert.True(t, cfg2.Cache.Disabled)
+	assert.Equal(t, 60, cfg2.Cache.DefaultTTLSeconds, "JSON TTL preserved when env doesn't override")
+}
+
+// A non-numeric TTL env var is ignored so a typo doesn't collapse the
+// JSON-configured value to zero (which would then be filled by the
+// 5-minute default — subtle regression). Mirrors the registry
+// bad-number handling.
+func TestApplyEnvOverrides_CacheIgnoresBadTTL(t *testing.T) {
+	cfg := &router.ServerConfig{Cache: router.CacheConfig{DefaultTTLSeconds: 60}}
+	applyEnvOverrides(cfg, "", stubGetenv(map[string]string{
+		"TMP_ROUTER_CACHE_DEFAULT_TTL_SEC": "not-a-number",
+	}))
+	assert.Equal(t, 60, cfg.Cache.DefaultTTLSeconds, "bad value must not clobber JSON")
+}
+
 // Non-numeric limit env vars are ignored so a typo doesn't zero out the
 // JSON-configured value. Matches how the existing signing/TLS blocks
 // silently ignore unset vars.

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -70,7 +70,11 @@ func main() {
 	cacheMetrics := &contextCacheMetricsAdapter{}
 	var contextCache *router.ContextCache
 	if !cfg.Cache.Disabled {
-		contextCache = router.NewContextCache(cfg.Cache.DefaultTTL(), router.WithContextCacheMetrics(cacheMetrics))
+		contextCache = router.NewContextCache(
+			cfg.Cache.DefaultTTL(),
+			router.WithContextCacheMetrics(cacheMetrics),
+			router.WithContextCacheMaxEntries(cfg.Cache.MaxEntriesResolved()),
+		)
 	}
 
 	routerOpts := []router.RouterOption{
@@ -353,6 +357,11 @@ func applyEnvOverrides(cfg *router.ServerConfig, addrFlag string, getenv func(st
 	if v := getenv("TMP_ROUTER_CACHE_DEFAULT_TTL_SEC"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Cache.DefaultTTLSeconds = n
+		}
+	}
+	if v := getenv("TMP_ROUTER_CACHE_MAX_ENTRIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Cache.MaxEntries = n
 		}
 	}
 }

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -67,12 +67,21 @@ func main() {
 		seedSigningProperties(registry, cfg.Signing.PropertyRIDs, routerKey)
 	}
 
+	cacheMetrics := &contextCacheMetricsAdapter{}
+	var contextCache *router.ContextCache
+	if !cfg.Cache.Disabled {
+		contextCache = router.NewContextCache(cfg.Cache.DefaultTTL(), router.WithContextCacheMetrics(cacheMetrics))
+	}
+
 	routerOpts := []router.RouterOption{
 		router.WithLatencyBudget(cfg.LatencyBudget()),
 		router.WithFanOutMetrics(fanOutMetrics),
 	}
 	if signer != nil {
 		routerOpts = append(routerOpts, router.WithTMPSigner(signer))
+	}
+	if contextCache != nil {
+		routerOpts = append(routerOpts, router.WithContextCache(contextCache))
 	}
 	r, err := router.NewRouter(cfg.Providers, registry, health, routerOpts...)
 	if err != nil {
@@ -101,9 +110,12 @@ func main() {
 	reg.DefineCounter("tmp_provider_timeout_total", "Per-provider call timeouts.", []string{"provider"})
 	reg.DefineCounter("tmp_provider_error_total", "Per-provider non-timeout errors.", []string{"provider"})
 	reg.DefineCounter("tmp_offers_total", "Total offers returned across all providers.", nil)
+	reg.DefineCounter("tmp_context_cache_hits_total", "Context Match cache hits by provider.", []string{"provider"})
+	reg.DefineCounter("tmp_context_cache_misses_total", "Context Match cache misses by provider.", []string{"provider"})
 
 	// Wire fan-out metrics now that registry exists.
 	fanOutMetrics.reg = reg
+	cacheMetrics.reg = reg
 
 	// Health checker
 	hcMetrics := &healthCheckMetricsAdapter{reg: reg}
@@ -330,6 +342,19 @@ func applyEnvOverrides(cfg *router.ServerConfig, addrFlag string, getenv func(st
 			cfg.Registry.FeedLimit = n
 		}
 	}
+
+	// Cache config — env vars override JSON. TMP_ROUTER_CACHE_DISABLED
+	// turns the per-provider Context Match cache off entirely;
+	// TMP_ROUTER_CACHE_DEFAULT_TTL_SEC overrides the fallback TTL that
+	// applies when a provider response omits cache_ttl.
+	if v := getenv("TMP_ROUTER_CACHE_DISABLED"); v == "1" || strings.EqualFold(v, "true") {
+		cfg.Cache.Disabled = true
+	}
+	if v := getenv("TMP_ROUTER_CACHE_DEFAULT_TTL_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Cache.DefaultTTLSeconds = n
+		}
+	}
 }
 
 func splitAndTrim(s string) []string {
@@ -453,5 +478,25 @@ func (a *fanOutMetricsAdapter) IncProviderError(providerID string) {
 func (a *fanOutMetricsAdapter) AddOffers(n int) {
 	if a.reg != nil {
 		a.reg.CounterAdd("tmp_offers_total", int64(n))
+	}
+}
+
+// contextCacheMetricsAdapter bridges router.ContextCacheMetrics to
+// prommetrics. Provider IDs are stable configured identifiers (spec
+// §Provider Registration limits to ^[A-Za-z0-9_]+$, max 64) so the
+// label cardinality is bounded by the operator's provider list.
+type contextCacheMetricsAdapter struct {
+	reg *prommetrics.Registry
+}
+
+func (a *contextCacheMetricsAdapter) IncHit(providerID string) {
+	if a.reg != nil {
+		a.reg.CounterInc("tmp_context_cache_hits_total", providerID)
+	}
+}
+
+func (a *contextCacheMetricsAdapter) IncMiss(providerID string) {
+	if a.reg != nil {
+		a.reg.CounterInc("tmp_context_cache_misses_total", providerID)
 	}
 }

--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -218,6 +218,8 @@ The router signs every outbound `/tmp/context` and `/tmp/identity` request per t
 | `TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC` | Router | Steady-state poll cadence in seconds. | `30` |
 | `TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT` | Router | Events per page during the initial catch-up drain. | `10000` |
 | `TMP_ROUTER_REGISTRY_FEED_LIMIT` | Router | Events per page during steady-state polling. | `1000` |
+| `TMP_ROUTER_CACHE_DISABLED` | Router | Disable the per-provider Context Match cache. Fans out on every request. | `false` |
+| `TMP_ROUTER_CACHE_DEFAULT_TTL_SEC` | Router | Fallback TTL when a provider response omits `cache_ttl`. | `300` |
 | `TMP_ROUTER_SIGNING_KID` | Router | Key identifier for outbound signatures | (none) |
 | `TMP_ROUTER_SIGNING_KEY_PATH` | Router | PEM PKCS#8 Ed25519 private key path | (none) |
 | `TMP_ROUTER_SIGNING_PROPERTY_RIDS` | Router | Comma-separated property RIDs the router signs for | (none) |

--- a/docs/network-surface.md
+++ b/docs/network-surface.md
@@ -220,6 +220,7 @@ The router signs every outbound `/tmp/context` and `/tmp/identity` request per t
 | `TMP_ROUTER_REGISTRY_FEED_LIMIT` | Router | Events per page during steady-state polling. | `1000` |
 | `TMP_ROUTER_CACHE_DISABLED` | Router | Disable the per-provider Context Match cache. Fans out on every request. | `false` |
 | `TMP_ROUTER_CACHE_DEFAULT_TTL_SEC` | Router | Fallback TTL when a provider response omits `cache_ttl`. | `300` |
+| `TMP_ROUTER_CACHE_MAX_ENTRIES` | Router | Cap on live cache entries; expired-then-oldest evicted on overflow. | `10000` |
 | `TMP_ROUTER_SIGNING_KID` | Router | Key identifier for outbound signatures | (none) |
 | `TMP_ROUTER_SIGNING_KEY_PATH` | Router | PEM PKCS#8 Ed25519 private key path | (none) |
 | `TMP_ROUTER_SIGNING_PROPERTY_RIDS` | Router | Comma-separated property RIDs the router signs for | (none) |

--- a/internal/generate/go-overlays.json
+++ b/internal/generate/go-overlays.json
@@ -45,6 +45,7 @@
     "IdentityMatchRequest.sealed_credentials": {"type": "[]SealedCredential"},
     "Offer.creative_manifest": {"type": "json.RawMessage", "pointer": true},
     "Offer.price": {"type": "OfferPrice", "pointer": true},
+    "ContextMatchResponse.cache_ttl": {"type": "int", "pointer": true},
     "ProviderRegistration.status": {"type": "ProviderStatus"},
     "ErrorResponse.code": {"type": "ErrorCode"},
     "IdentityMatchResponse.tmpx_providers": {"type": "map[string]TmpxProviderEntry"}

--- a/router/context_cache.go
+++ b/router/context_cache.go
@@ -37,10 +37,27 @@ func (noopContextCacheMetrics) IncHit(string)  {}
 func (noopContextCacheMetrics) IncMiss(string) {}
 
 // ContextCache is an in-memory, per-provider cache of Context Match
-// responses. Keyed on {property_rid, placement_id, provider_id} per
-// spec §Caching. Responses are deeply cloned on read so callers can
-// freely mutate any field — including nested Offer pointer/slice/map
-// members — without corrupting the cached entry.
+// responses. Keyed on {property_rid, placement_id, provider_id,
+// seller_agent_url, country}.
+//
+// The spec's recommended cache key at §Caching lists only the first
+// three components. The additional seller and country dimensions are
+// added because this repository's own targeting engine
+// (targeting/engine.go: ActivePackages(ctx, canonicalSeller,
+// propertyID, country, placementID, ...)) scopes the active package
+// set per seller and per country — different sellers or geos on the
+// same placement return different offers. Keying only on placement
+// would let one seller's cached offers be served to another seller
+// on the same placement during the TTL window, disclosing competitor
+// brands, pricing, and creative manifests across tenants.
+// seller_agent_url is compared using the AdCP URL canonicalization
+// rules (urlcanon.Canonicalize), the same normalization the engine
+// applies before its lookup.
+//
+// Responses are deeply cloned on read so callers can freely mutate
+// Offer pointer/slice/map members without corrupting the cached
+// entry. (Nested any values inside Signals stay shared — see the
+// note on cloneContextResponse.)
 //
 // Spec cache_ttl semantics (see Put for the enforcement code):
 //
@@ -61,6 +78,10 @@ type ContextCache struct {
 	mu         sync.Mutex
 	entries    map[string]contextCacheEntry
 	defaultTTL time.Duration
+	// maxEntries caps the number of live entries; 0 disables the cap.
+	// When the cap is hit on Put, expired entries are swept; if still
+	// full, the entry with the oldest insertedAt is evicted.
+	maxEntries int
 	metrics    ContextCacheMetrics
 
 	// now is time.Now in production; tests substitute a clock so
@@ -69,8 +90,9 @@ type ContextCache struct {
 }
 
 type contextCacheEntry struct {
-	response  *tmproto.ContextMatchResponse
-	expiresAt time.Time
+	response   *tmproto.ContextMatchResponse
+	expiresAt  time.Time
+	insertedAt time.Time
 }
 
 // ContextCacheOption configures the cache.
@@ -80,6 +102,20 @@ type ContextCacheOption func(*ContextCache)
 // cache runs with a no-op sink.
 func WithContextCacheMetrics(m ContextCacheMetrics) ContextCacheOption {
 	return func(c *ContextCache) { c.metrics = m }
+}
+
+// WithContextCacheMaxEntries caps the number of live entries. Zero or
+// negative values disable the cap. On Put once the cap is hit the
+// cache sweeps expired entries first, then evicts the oldest insert
+// if the cache is still full — bounding memory against a caller that
+// varies placement/seller/country to grow the working set forever.
+func WithContextCacheMaxEntries(n int) ContextCacheOption {
+	return func(c *ContextCache) {
+		if n < 0 {
+			n = 0
+		}
+		c.maxEntries = n
+	}
 }
 
 // NewContextCache builds a cache with the given default TTL applied
@@ -107,11 +143,17 @@ func NewContextCache(defaultTTL time.Duration, opts ...ContextCacheOption) *Cont
 // expiration; the caller falls back to a live fan-out call. The
 // returned response is a defensive copy — callers may overwrite
 // RequestID or Signals without corrupting the cached entry.
-func (c *ContextCache) Get(propertyRID, placementID, providerID string) (*tmproto.ContextMatchResponse, bool) {
+//
+// sellerAgentURL and country participate in the key so a request from
+// one seller never returns a response the router cached for another
+// seller (see the ContextCache doc for the rationale). Callers should
+// pass sellerAgentURL already normalized via urlcanon.Canonicalize —
+// the cache does not canonicalize on the hot path.
+func (c *ContextCache) Get(propertyRID, placementID, providerID, sellerAgentURL, country string) (*tmproto.ContextMatchResponse, bool) {
 	if c == nil {
 		return nil, false
 	}
-	key := contextCacheKey(propertyRID, placementID, providerID)
+	key := contextCacheKey(propertyRID, placementID, providerID, sellerAgentURL, country)
 	c.mu.Lock()
 	entry, ok := c.entries[key]
 	if !ok {
@@ -143,7 +185,7 @@ func (c *ContextCache) Get(propertyRID, placementID, providerID string) (*tmprot
 //     MaxContextCacheTTL. Clamping happens in seconds first to avoid
 //     a Duration multiplication overflowing int64 for pathologically
 //     large values that escaped upstream schema validation.
-func (c *ContextCache) Put(propertyRID, placementID, providerID string, resp *tmproto.ContextMatchResponse) {
+func (c *ContextCache) Put(propertyRID, placementID, providerID, sellerAgentURL, country string, resp *tmproto.ContextMatchResponse) {
 	if c == nil || resp == nil {
 		return
 	}
@@ -166,13 +208,56 @@ func (c *ContextCache) Put(propertyRID, placementID, providerID string, resp *tm
 			ttl = time.Duration(secs) * time.Second
 		}
 	}
-	key := contextCacheKey(propertyRID, placementID, providerID)
+	key := contextCacheKey(propertyRID, placementID, providerID, sellerAgentURL, country)
+	now := c.now()
 	c.mu.Lock()
+	// Bound the map. Only enforce when writing a NEW key — an
+	// overwrite doesn't grow the set. Sweep expired first (cheap;
+	// removes stale entries the caller has already forgotten about),
+	// then evict the oldest insert if still full.
+	if c.maxEntries > 0 {
+		if _, existing := c.entries[key]; !existing && len(c.entries) >= c.maxEntries {
+			c.sweepExpiredLocked(now)
+			if len(c.entries) >= c.maxEntries {
+				c.evictOldestLocked()
+			}
+		}
+	}
 	c.entries[key] = contextCacheEntry{
-		response:  cloneContextResponse(resp),
-		expiresAt: c.now().Add(ttl),
+		response:   cloneContextResponse(resp),
+		expiresAt:  now.Add(ttl),
+		insertedAt: now,
 	}
 	c.mu.Unlock()
+}
+
+// sweepExpiredLocked removes any entry whose TTL has elapsed. Caller
+// holds c.mu.
+func (c *ContextCache) sweepExpiredLocked(now time.Time) {
+	for k, e := range c.entries {
+		if now.After(e.expiresAt) {
+			delete(c.entries, k)
+		}
+	}
+}
+
+// evictOldestLocked drops the entry with the oldest insertedAt. O(N)
+// but only runs on the cap-hit path, and N is bounded by the
+// operator-configured cap. Caller holds c.mu.
+func (c *ContextCache) evictOldestLocked() {
+	var oldestKey string
+	var oldestAt time.Time
+	first := true
+	for k, e := range c.entries {
+		if first || e.insertedAt.Before(oldestAt) {
+			oldestKey = k
+			oldestAt = e.insertedAt
+			first = false
+		}
+	}
+	if !first {
+		delete(c.entries, oldestKey)
+	}
 }
 
 // Size returns the number of live entries. Includes entries whose TTL
@@ -189,34 +274,47 @@ func (c *ContextCache) Size() int {
 
 // contextCacheKey assembles the canonical cache key. NUL is used as
 // the separator so a component containing "|" or "/" cannot collide
-// with the separator (property_rid is a UUID and placement_id is a
-// bounded string — neither can contain NUL by construction).
-func contextCacheKey(propertyRID, placementID, providerID string) string {
+// with it. tmproto request validation rejects control bytes in
+// property_rid and placement_id, and every component ultimately
+// originates from a JSON string (which cannot contain a raw NUL under
+// the JSON grammar), so no component can carry NUL by construction.
+func contextCacheKey(propertyRID, placementID, providerID, sellerAgentURL, country string) string {
 	var b strings.Builder
-	b.Grow(len(propertyRID) + len(placementID) + len(providerID) + 2)
+	b.Grow(len(propertyRID) + len(placementID) + len(providerID) + len(sellerAgentURL) + len(country) + 4)
 	b.WriteString(propertyRID)
 	b.WriteByte(0)
 	b.WriteString(placementID)
 	b.WriteByte(0)
 	b.WriteString(providerID)
+	b.WriteByte(0)
+	b.WriteString(sellerAgentURL)
+	b.WriteByte(0)
+	b.WriteString(country)
 	return b.String()
 }
 
-// cloneContextResponse copies the response deeply enough that any
-// downstream code path (merger, seller-agent stamper, macro injector)
-// can freely mutate the returned value without corrupting the cached
-// entry. tmproto.Offer carries several pointer/slice fields that would
-// otherwise be shared:
+// cloneContextResponse copies the response deeply enough that the
+// merger, and any future seller-agent-stamper or macro-injector code
+// path, can freely mutate the returned Offer entries without
+// corrupting the cache. tmproto.Offer carries several pointer/slice
+// fields that would otherwise be shared:
 //
 //   - SellerAgent, Brand   (json.RawMessage — byte slice)
 //   - CreativeManifest     (*json.RawMessage)
 //   - Price                (*OfferPrice)
 //   - Macros               (map[string]string)
 //
-// tmproto/types_gen.go:196 explicitly says "the router MAY stamp
-// SellerAgent from its cached package→seller map" — the moment a
-// caller wires that stamp, a shallow clone would silently corrupt
-// cache entries. Deep-clone eliminates that failure mode upfront.
+// The schema doc on tmproto.Offer.SellerAgent explicitly says the
+// router MAY stamp that field from a cached package→seller map —
+// once that stamp lands, a shallow clone would silently corrupt cache
+// entries. Deep-clone here eliminates that failure mode.
+//
+// Isolation NOT provided for Signals nested values: the top-level
+// map[string]any is a fresh allocation, but nested map/slice values
+// stay shared with the cached entry. Nothing in the merger mutates
+// them today; a general deep-copy of arbitrary any values would need
+// a JSON round-trip (types aren't statically knowable). The
+// ContextCache docstring calls this out.
 func cloneContextResponse(src *tmproto.ContextMatchResponse) *tmproto.ContextMatchResponse {
 	if src == nil {
 		return nil

--- a/router/context_cache.go
+++ b/router/context_cache.go
@@ -1,0 +1,235 @@
+package router
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// DefaultContextCacheTTL is the router's default cache lifetime for a
+// per-provider Context Match response, per spec §Caching. Providers can
+// override it via ContextMatchResponse.CacheTTL.
+const DefaultContextCacheTTL = 5 * time.Minute
+
+// MaxContextCacheTTL is the schema-enforced ceiling on provider-supplied
+// cache_ttl (spec §Caching: "schema-enforced maximum is 86400 seconds").
+// The router clamps here as a defense-in-depth in case a future provider
+// sends a value that escaped upstream validation.
+const MaxContextCacheTTL = 24 * time.Hour
+
+// ContextCacheMetrics is the observability hook for the per-provider
+// Context Match cache. Deployments wire this through prommetrics (or
+// noop) via WithContextCache. Bounded labels only — providerID is the
+// stable configured identifier, not user input.
+type ContextCacheMetrics interface {
+	IncHit(providerID string)
+	IncMiss(providerID string)
+}
+
+// noopContextCacheMetrics is used when the caller does not supply one.
+type noopContextCacheMetrics struct{}
+
+func (noopContextCacheMetrics) IncHit(string)  {}
+func (noopContextCacheMetrics) IncMiss(string) {}
+
+// ContextCache is an in-memory, per-provider cache of Context Match
+// responses. Keyed on {property_rid, placement_id, provider_id} per
+// spec §Caching. Responses are cloned on read so callers can freely
+// overwrite RequestID with the current request's value; that's the
+// only field that varies between the cached call and the reuse.
+//
+// The router is stateless and horizontally scaled, so this cache is
+// per-instance — restarts clear it and instances behind a load balancer
+// each maintain their own view. That matches how the reference agents
+// deploy (no shared cache) and keeps the router deployment story simple
+// (no Redis dependency).
+type ContextCache struct {
+	mu         sync.Mutex
+	entries    map[string]contextCacheEntry
+	defaultTTL time.Duration
+	metrics    ContextCacheMetrics
+
+	// now is time.Now in production; tests substitute a clock so
+	// expiration windows can be exercised without sleeping.
+	now func() time.Time
+}
+
+type contextCacheEntry struct {
+	response  *tmproto.ContextMatchResponse
+	expiresAt time.Time
+}
+
+// ContextCacheOption configures the cache.
+type ContextCacheOption func(*ContextCache)
+
+// WithContextCacheMetrics installs a metrics sink. Without this the
+// cache runs with a no-op sink.
+func WithContextCacheMetrics(m ContextCacheMetrics) ContextCacheOption {
+	return func(c *ContextCache) { c.metrics = m }
+}
+
+// NewContextCache builds a cache with the given default TTL applied
+// whenever a provider response omits or zeroes cache_ttl. TTLs of zero
+// or less collapse to DefaultContextCacheTTL — a caller that truly
+// wants caching disabled should skip constructing the cache and not
+// wire it into the router (or pass WithContextCache(nil)).
+func NewContextCache(defaultTTL time.Duration, opts ...ContextCacheOption) *ContextCache {
+	if defaultTTL <= 0 {
+		defaultTTL = DefaultContextCacheTTL
+	}
+	c := &ContextCache{
+		entries:    make(map[string]contextCacheEntry),
+		defaultTTL: defaultTTL,
+		metrics:    noopContextCacheMetrics{},
+		now:        time.Now,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Get looks up a cached response. Returns (nil, false) on miss or
+// expiration; the caller falls back to a live fan-out call. The
+// returned response is a defensive copy — callers may overwrite
+// RequestID or Signals without corrupting the cached entry.
+func (c *ContextCache) Get(propertyRID, placementID, providerID string) (*tmproto.ContextMatchResponse, bool) {
+	if c == nil {
+		return nil, false
+	}
+	key := contextCacheKey(propertyRID, placementID, providerID)
+	c.mu.Lock()
+	entry, ok := c.entries[key]
+	if !ok {
+		c.mu.Unlock()
+		c.metrics.IncMiss(providerID)
+		return nil, false
+	}
+	if c.now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		c.mu.Unlock()
+		c.metrics.IncMiss(providerID)
+		return nil, false
+	}
+	c.mu.Unlock()
+	c.metrics.IncHit(providerID)
+	return cloneContextResponse(entry.response), true
+}
+
+// Put stores a response under the spec's canonical cache key. The TTL
+// is derived from the response's cache_ttl (clamped to
+// [1s, MaxContextCacheTTL]) when positive, otherwise from the cache's
+// configured default.
+//
+// A cache_ttl of zero from a provider means either (a) the field was
+// truly absent (Go's omitempty conflates absent with zero) or (b) the
+// provider explicitly disabled caching (spec §Caching: "0 disables
+// caching"). Because the Go type can't distinguish these two cases and
+// the majority use is (a), we treat received-zero as "use default".
+// Providers that need to force cache invalidation should return
+// cache_ttl=1 (nearly-disabled) until their config change propagates.
+func (c *ContextCache) Put(propertyRID, placementID, providerID string, resp *tmproto.ContextMatchResponse) {
+	if c == nil || resp == nil {
+		return
+	}
+	ttl := c.defaultTTL
+	if resp.CacheTTL > 0 {
+		ttl = min(time.Duration(resp.CacheTTL)*time.Second, MaxContextCacheTTL)
+	}
+	key := contextCacheKey(propertyRID, placementID, providerID)
+	c.mu.Lock()
+	c.entries[key] = contextCacheEntry{
+		response:  cloneContextResponse(resp),
+		expiresAt: c.now().Add(ttl),
+	}
+	c.mu.Unlock()
+}
+
+// Size returns the number of live entries. Includes entries whose TTL
+// has expired but which have not been evicted yet — used mostly by
+// tests and operational metrics, not by hot-path logic.
+func (c *ContextCache) Size() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// contextCacheKey assembles the canonical cache key. NUL is used as
+// the separator so a component containing "|" or "/" cannot collide
+// with the separator (property_rid is a UUID and placement_id is a
+// bounded string — neither can contain NUL by construction).
+func contextCacheKey(propertyRID, placementID, providerID string) string {
+	var b strings.Builder
+	b.Grow(len(propertyRID) + len(placementID) + len(providerID) + 2)
+	b.WriteString(propertyRID)
+	b.WriteByte(0)
+	b.WriteString(placementID)
+	b.WriteByte(0)
+	b.WriteString(providerID)
+	return b.String()
+}
+
+// cloneContextResponse copies the response deeply enough that any
+// downstream code path (merger, seller-agent stamper, macro injector)
+// can freely mutate the returned value without corrupting the cached
+// entry. tmproto.Offer carries several pointer/slice fields that would
+// otherwise be shared:
+//
+//   - SellerAgent, Brand   (json.RawMessage — byte slice)
+//   - CreativeManifest     (*json.RawMessage)
+//   - Price                (*OfferPrice)
+//   - Macros               (map[string]string)
+//
+// tmproto/types_gen.go:196 explicitly says "the router MAY stamp
+// SellerAgent from its cached package→seller map" — the moment a
+// caller wires that stamp, a shallow clone would silently corrupt
+// cache entries. Deep-clone eliminates that failure mode upfront.
+func cloneContextResponse(src *tmproto.ContextMatchResponse) *tmproto.ContextMatchResponse {
+	if src == nil {
+		return nil
+	}
+	dst := *src
+	if len(src.Offers) > 0 {
+		dst.Offers = make([]tmproto.Offer, len(src.Offers))
+		for i := range src.Offers {
+			dst.Offers[i] = cloneOffer(src.Offers[i])
+		}
+	}
+	if len(src.Signals) > 0 {
+		dst.Signals = make(map[string]any, len(src.Signals))
+		maps.Copy(dst.Signals, src.Signals)
+	}
+	return &dst
+}
+
+// cloneOffer duplicates every pointer/slice/map on Offer so mutation
+// through a cache-hit copy cannot reach the cached entry.
+func cloneOffer(src tmproto.Offer) tmproto.Offer {
+	dst := src // scalar fields (PackageID, Summary) copy by value
+	if src.SellerAgent != nil {
+		dst.SellerAgent = append(json.RawMessage(nil), src.SellerAgent...)
+	}
+	if src.Brand != nil {
+		dst.Brand = append(json.RawMessage(nil), src.Brand...)
+	}
+	if src.Price != nil {
+		p := *src.Price
+		dst.Price = &p
+	}
+	if src.CreativeManifest != nil {
+		cm := append(json.RawMessage(nil), *src.CreativeManifest...)
+		dst.CreativeManifest = &cm
+	}
+	if len(src.Macros) > 0 {
+		dst.Macros = make(map[string]string, len(src.Macros))
+		maps.Copy(dst.Macros, src.Macros)
+	}
+	return dst
+}

--- a/router/context_cache.go
+++ b/router/context_cache.go
@@ -222,6 +222,14 @@ func cloneContextResponse(src *tmproto.ContextMatchResponse) *tmproto.ContextMat
 		return nil
 	}
 	dst := *src
+	// CacheTTL is *int; the shallow struct copy above shares the
+	// pointer with the cached entry. Give the caller its own
+	// allocation so `*resp.CacheTTL = 0` on a returned hit cannot
+	// silently flip the cached entry's disable-caching semantics.
+	if src.CacheTTL != nil {
+		v := *src.CacheTTL
+		dst.CacheTTL = &v
+	}
 	if len(src.Offers) > 0 {
 		dst.Offers = make([]tmproto.Offer, len(src.Offers))
 		for i := range src.Offers {

--- a/router/context_cache.go
+++ b/router/context_cache.go
@@ -38,9 +38,19 @@ func (noopContextCacheMetrics) IncMiss(string) {}
 
 // ContextCache is an in-memory, per-provider cache of Context Match
 // responses. Keyed on {property_rid, placement_id, provider_id} per
-// spec §Caching. Responses are cloned on read so callers can freely
-// overwrite RequestID with the current request's value; that's the
-// only field that varies between the cached call and the reuse.
+// spec §Caching. Responses are deeply cloned on read so callers can
+// freely mutate any field — including nested Offer pointer/slice/map
+// members — without corrupting the cached entry.
+//
+// Spec cache_ttl semantics (see Put for the enforcement code):
+//
+//   - absent (nil)   → router uses its configured default TTL
+//   - explicit 0     → provider is disabling caching; entry not stored
+//   - explicit > 0   → override, clamped to MaxContextCacheTTL
+//
+// The tri-state depends on tmproto.ContextMatchResponse.CacheTTL being
+// a pointer type so absent-field is distinguishable from present-zero
+// (docs/sdk-typing-policy.md).
 //
 // The router is stateless and horizontally scaled, so this cache is
 // per-instance — restarts clear it and instances behind a load balancer
@@ -121,24 +131,40 @@ func (c *ContextCache) Get(propertyRID, placementID, providerID string) (*tmprot
 }
 
 // Put stores a response under the spec's canonical cache key. The TTL
-// is derived from the response's cache_ttl (clamped to
-// [1s, MaxContextCacheTTL]) when positive, otherwise from the cache's
-// configured default.
+// is derived from the response's cache_ttl per spec §Caching:
 //
-// A cache_ttl of zero from a provider means either (a) the field was
-// truly absent (Go's omitempty conflates absent with zero) or (b) the
-// provider explicitly disabled caching (spec §Caching: "0 disables
-// caching"). Because the Go type can't distinguish these two cases and
-// the majority use is (a), we treat received-zero as "use default".
-// Providers that need to force cache invalidation should return
-// cache_ttl=1 (nearly-disabled) until their config change propagates.
+//   - cache_ttl absent (nil pointer) → use the cache's configured
+//     default TTL (5 min out of the box).
+//   - cache_ttl == 0                  → provider is disabling caching
+//     (e.g. after a targeting-config change). The entry is NOT stored;
+//     subsequent requests fan out live until the provider raises the
+//     TTL again.
+//   - cache_ttl > 0                   → override, clamped to
+//     MaxContextCacheTTL. Clamping happens in seconds first to avoid
+//     a Duration multiplication overflowing int64 for pathologically
+//     large values that escaped upstream schema validation.
 func (c *ContextCache) Put(propertyRID, placementID, providerID string, resp *tmproto.ContextMatchResponse) {
 	if c == nil || resp == nil {
 		return
 	}
 	ttl := c.defaultTTL
-	if resp.CacheTTL > 0 {
-		ttl = min(time.Duration(resp.CacheTTL)*time.Second, MaxContextCacheTTL)
+	if resp.CacheTTL != nil {
+		secs := *resp.CacheTTL
+		switch {
+		case secs == 0:
+			// Explicit disable — do not cache.
+			return
+		case secs < 0:
+			// Nonsensical; fall back to the default rather than store
+			// something with a negative TTL that would collapse to
+			// already-expired.
+		default:
+			maxSecs := int(MaxContextCacheTTL / time.Second)
+			if secs > maxSecs {
+				secs = maxSecs
+			}
+			ttl = time.Duration(secs) * time.Second
+		}
 	}
 	key := contextCacheKey(propertyRID, placementID, providerID)
 	c.mu.Lock()

--- a/router/context_cache_test.go
+++ b/router/context_cache_test.go
@@ -39,10 +39,10 @@ func (m *countingCacheMetrics) IncMiss(id string) {
 // callers that omit WithContextCache don't need explicit nil checks.
 func TestContextCache_NilSafe(t *testing.T) {
 	var c *ContextCache
-	resp, ok := c.Get("rid", "pl", "prov")
+	resp, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok)
 	assert.Nil(t, resp)
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{})
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{})
 	assert.Equal(t, 0, c.Size())
 }
 
@@ -57,8 +57,8 @@ func TestContextCache_HitReturnsClone(t *testing.T) {
 		Offers:    []tmproto.Offer{{PackageID: "pkg-a"}},
 		Signals:   map[string]any{"k": "v"},
 	}
-	c.Put("rid-1", "sidebar", "prov", resp)
-	got, ok := c.Get("rid-1", "sidebar", "prov")
+	c.Put("rid-1", "sidebar", "prov", "", "", resp)
+	got, ok := c.Get("rid-1", "sidebar", "prov", "", "")
 	require.True(t, ok)
 	require.NotNil(t, got)
 	assert.Equal(t, "orig", got.RequestID)
@@ -69,7 +69,7 @@ func TestContextCache_HitReturnsClone(t *testing.T) {
 	got.Offers[0].PackageID = "MUTATED"
 	got.Signals["k"] = "MUTATED"
 
-	got2, ok := c.Get("rid-1", "sidebar", "prov")
+	got2, ok := c.Get("rid-1", "sidebar", "prov", "", "")
 	require.True(t, ok)
 	assert.Equal(t, "orig", got2.RequestID)
 	assert.Equal(t, "pkg-a", got2.Offers[0].PackageID)
@@ -85,7 +85,7 @@ func TestContextCache_HitDeepClonesOffers(t *testing.T) {
 	c := NewContextCache(time.Minute)
 	price := tmproto.OfferPrice{Amount: 5.00, Currency: "USD", Model: "cpm"}
 	cm := json.RawMessage(`{"kind":"markdown"}`)
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
 		Offers: []tmproto.Offer{{
 			PackageID:        "pkg-a",
 			SellerAgent:      json.RawMessage(`{"agent_url":"https://orig.example"}`),
@@ -96,7 +96,7 @@ func TestContextCache_HitDeepClonesOffers(t *testing.T) {
 		}},
 	})
 
-	got, ok := c.Get("rid", "pl", "prov")
+	got, ok := c.Get("rid", "pl", "prov", "", "")
 	require.True(t, ok)
 	require.Len(t, got.Offers, 1)
 
@@ -108,7 +108,7 @@ func TestContextCache_HitDeepClonesOffers(t *testing.T) {
 	(*o.CreativeManifest)[0] = 'X'
 	o.Macros["CID"] = "MUTATED"
 
-	got2, ok := c.Get("rid", "pl", "prov")
+	got2, ok := c.Get("rid", "pl", "prov", "", "")
 	require.True(t, ok)
 	o2 := got2.Offers[0]
 	assert.Equal(t, byte('{'), o2.SellerAgent[0], "SellerAgent bytes must be isolated from mutation via a cached hit")
@@ -125,13 +125,13 @@ func TestContextCache_TTLExpiration(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
-	_, ok := c.Get("rid", "pl", "prov")
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "orig"})
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	require.True(t, ok, "fresh entry must hit")
 
 	// Advance past TTL.
 	now = now.Add(600 * time.Millisecond)
-	_, ok = c.Get("rid", "pl", "prov")
+	_, ok = c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok, "expired entry must miss")
 
 	// Expired entries are evicted on the miss so Size drops.
@@ -148,19 +148,19 @@ func TestContextCache_ProviderTTLOverride(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
 		RequestID: "orig",
 		CacheTTL:  ttlPtr(2), // 2 seconds — tighter than the default 1h
 	})
 
 	// Just under 2s → still cached.
 	now = now.Add(1500 * time.Millisecond)
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.True(t, ok)
 
 	// Past 2s → expired.
 	now = now.Add(1 * time.Second)
-	_, ok = c.Get("rid", "pl", "prov")
+	_, ok = c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok, "provider-supplied cache_ttl must be honored over the default")
 }
 
@@ -173,14 +173,14 @@ func TestContextCache_TTLClampsToMax(t *testing.T) {
 	c.now = func() time.Time { return now }
 
 	// 30 days — well past the schema-enforced 24h ceiling.
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
 		CacheTTL: ttlPtr(30 * 24 * 3600),
 	})
 
 	// Just past 24h — must be expired regardless of what the provider
 	// asked for.
 	now = now.Add(MaxContextCacheTTL + time.Minute)
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok, "provider cache_ttl must be clamped to MaxContextCacheTTL")
 }
 
@@ -198,18 +198,18 @@ func TestContextCache_TTLOverflowSafe(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
 		CacheTTL: ttlPtr(math.MaxInt),
 	})
 
 	// Just under the max → cached.
 	now = now.Add(MaxContextCacheTTL - time.Minute)
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.True(t, ok, "overflow-sized cache_ttl must still cache up to MaxContextCacheTTL")
 
 	// Just past the max → expired.
 	now = now.Add(2 * time.Minute)
-	_, ok = c.Get("rid", "pl", "prov")
+	_, ok = c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok)
 }
 
@@ -221,16 +221,16 @@ func TestContextCache_AbsentTTLUsesDefault(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{}) // CacheTTL nil
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{}) // CacheTTL nil
 
 	// Cached for the default TTL.
 	now = now.Add(1500 * time.Millisecond)
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.True(t, ok)
 
 	// Past default TTL → expired.
 	now = now.Add(1 * time.Second)
-	_, ok = c.Get("rid", "pl", "prov")
+	_, ok = c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok)
 }
 
@@ -243,12 +243,12 @@ func TestContextCache_AbsentTTLUsesDefault(t *testing.T) {
 func TestContextCache_ExplicitZeroTTLDisablesCaching(t *testing.T) {
 	c := NewContextCache(1 * time.Hour) // long default that would apply if we mishandled zero
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
 		RequestID: "orig",
 		CacheTTL:  ttlPtr(0),
 	})
 
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.False(t, ok, "cache_ttl=0 is the spec's disable-caching signal — entry must not be stored")
 	assert.Equal(t, 0, c.Size())
 }
@@ -261,12 +261,12 @@ func TestContextCache_NegativeTTLUsesDefault(t *testing.T) {
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{CacheTTL: ttlPtr(-1)})
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{CacheTTL: ttlPtr(-1)})
 
 	// Cached for the default TTL rather than dropped or immediately
 	// expired.
 	now = now.Add(1500 * time.Millisecond)
-	_, ok := c.Get("rid", "pl", "prov")
+	_, ok := c.Get("rid", "pl", "prov", "", "")
 	assert.True(t, ok, "negative TTL should fall back to default, not collapse to expired")
 }
 
@@ -274,16 +274,125 @@ func TestContextCache_NegativeTTLUsesDefault(t *testing.T) {
 // separate cache entries — the spec key includes provider_id.
 func TestContextCache_KeyPartitionedByProvider(t *testing.T) {
 	c := NewContextCache(time.Minute)
-	c.Put("rid", "pl", "prov-a", &tmproto.ContextMatchResponse{RequestID: "for-a"})
-	c.Put("rid", "pl", "prov-b", &tmproto.ContextMatchResponse{RequestID: "for-b"})
+	c.Put("rid", "pl", "prov-a", "", "", &tmproto.ContextMatchResponse{RequestID: "for-a"})
+	c.Put("rid", "pl", "prov-b", "", "", &tmproto.ContextMatchResponse{RequestID: "for-b"})
 
-	a, okA := c.Get("rid", "pl", "prov-a")
-	b, okB := c.Get("rid", "pl", "prov-b")
+	a, okA := c.Get("rid", "pl", "prov-a", "", "")
+	b, okB := c.Get("rid", "pl", "prov-b", "", "")
 	require.True(t, okA)
 	require.True(t, okB)
 	assert.Equal(t, "for-a", a.RequestID)
 	assert.Equal(t, "for-b", b.RequestID)
 	assert.Equal(t, 2, c.Size())
+}
+
+// Two sellers hitting the same {property_rid, placement_id, provider_id}
+// MUST NOT share a cache entry. Different sellers have different
+// authorized package sets on this repo's targeting engine
+// (targeting/engine.go: ActivePackages includes canonicalSeller as a
+// scope), so a shared entry would disclose one seller's offers to
+// another. Regression guard for the cross-seller disclosure the
+// external review on #410 flagged as a High-severity blocker.
+func TestContextCache_KeyPartitionedBySeller(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	c.Put("rid", "pl", "prov", "https://seller-a.example/agent", "US", &tmproto.ContextMatchResponse{
+		Offers: []tmproto.Offer{{PackageID: "pkg-for-a"}},
+	})
+
+	// Same property/placement/provider, different seller → miss.
+	_, ok := c.Get("rid", "pl", "prov", "https://seller-b.example/agent", "US")
+	assert.False(t, ok, "seller B must not receive seller A's cached response")
+
+	// Seller A still hits.
+	got, ok := c.Get("rid", "pl", "prov", "https://seller-a.example/agent", "US")
+	require.True(t, ok)
+	assert.Equal(t, "pkg-for-a", got.Offers[0].PackageID)
+
+	assert.Equal(t, 1, c.Size(), "no ghost entries created by the seller-B miss")
+}
+
+// country partitions the cache too — the engine's ActivePackages
+// scopes on country as well, so a US-cached response must not serve
+// a GB request. Same failure mode class as the seller isolation
+// above.
+func TestContextCache_KeyPartitionedByCountry(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	c.Put("rid", "pl", "prov", "https://s.example/agent", "US", &tmproto.ContextMatchResponse{
+		Offers: []tmproto.Offer{{PackageID: "pkg-us"}},
+	})
+
+	_, ok := c.Get("rid", "pl", "prov", "https://s.example/agent", "GB")
+	assert.False(t, ok, "country partition must isolate GB from a US-cached response")
+
+	got, ok := c.Get("rid", "pl", "prov", "https://s.example/agent", "US")
+	require.True(t, ok)
+	assert.Equal(t, "pkg-us", got.Offers[0].PackageID)
+}
+
+// MaxEntries cap bounds memory. When the cache is full and a new key
+// arrives, the oldest insert is evicted so map size stays at the cap.
+func TestContextCache_MaxEntriesEvictsOldest(t *testing.T) {
+	c := NewContextCache(time.Minute, WithContextCacheMaxEntries(2))
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	// Insert entry #1.
+	c.Put("rid-1", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r1"})
+	// Advance the clock so insertedAt differs.
+	now = now.Add(time.Second)
+	c.Put("rid-2", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r2"})
+	assert.Equal(t, 2, c.Size())
+
+	// Insert #3 pushes size to 3 → oldest (rid-1) evicted.
+	now = now.Add(time.Second)
+	c.Put("rid-3", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r3"})
+	assert.Equal(t, 2, c.Size(), "cap must hold at MaxEntries after eviction")
+
+	_, ok1 := c.Get("rid-1", "pl", "prov", "", "")
+	_, ok2 := c.Get("rid-2", "pl", "prov", "", "")
+	_, ok3 := c.Get("rid-3", "pl", "prov", "", "")
+	assert.False(t, ok1, "oldest insert (rid-1) must be evicted first")
+	assert.True(t, ok2, "middle insert (rid-2) must survive")
+	assert.True(t, ok3, "newest insert (rid-3) must be present")
+}
+
+// When the cap is hit but some entries are expired, sweep them first
+// before touching live entries — an expired-and-evictable entry
+// shouldn't cost a still-live one its slot.
+func TestContextCache_MaxEntriesSweepsExpiredBeforeEvicting(t *testing.T) {
+	c := NewContextCache(time.Minute, WithContextCacheMaxEntries(2))
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	c.Put("rid-1", "pl", "prov", "", "", &tmproto.ContextMatchResponse{
+		CacheTTL: ttlPtr(1), // 1-second TTL
+	})
+	now = now.Add(time.Second)
+	c.Put("rid-2", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r2"})
+
+	// Advance past rid-1's TTL but keep rid-2 fresh.
+	now = now.Add(2 * time.Second) // rid-1 expired, rid-2 alive
+	// Third insert triggers cap enforcement: sweep drops rid-1, no
+	// eviction of the live rid-2 needed.
+	c.Put("rid-3", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r3"})
+
+	_, ok2 := c.Get("rid-2", "pl", "prov", "", "")
+	_, ok3 := c.Get("rid-3", "pl", "prov", "", "")
+	assert.True(t, ok2, "live rid-2 must survive when sweep alone reclaims a slot")
+	assert.True(t, ok3, "new rid-3 must be present")
+}
+
+// Overwriting an existing key doesn't grow the map, so the cap
+// enforcement path skips both sweep and evict on that path.
+func TestContextCache_MaxEntriesAllowsInPlaceOverwrite(t *testing.T) {
+	c := NewContextCache(time.Minute, WithContextCacheMaxEntries(1))
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r1"})
+	// Overwrite the same key — must not evict anything and size stays at 1.
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "r2"})
+	assert.Equal(t, 1, c.Size())
+	got, ok := c.Get("rid", "pl", "prov", "", "")
+	require.True(t, ok)
+	assert.Equal(t, "r2", got.RequestID, "overwrite must replace the value in place")
 }
 
 // Metrics fire on every hit and miss.
@@ -292,13 +401,13 @@ func TestContextCache_MetricsCounts(t *testing.T) {
 	c := NewContextCache(time.Minute, WithContextCacheMetrics(m))
 
 	// Two misses.
-	_, _ = c.Get("rid", "pl", "prov")
-	_, _ = c.Get("rid", "pl", "prov")
+	_, _ = c.Get("rid", "pl", "prov", "", "")
+	_, _ = c.Get("rid", "pl", "prov", "", "")
 
 	// One populated, then two hits.
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
-	_, _ = c.Get("rid", "pl", "prov")
-	_, _ = c.Get("rid", "pl", "prov")
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "orig"})
+	_, _ = c.Get("rid", "pl", "prov", "", "")
+	_, _ = c.Get("rid", "pl", "prov", "", "")
 
 	assert.Equal(t, 2, m.hits["prov"])
 	assert.Equal(t, 2, m.misses["prov"])
@@ -308,18 +417,18 @@ func TestContextCache_MetricsCounts(t *testing.T) {
 // exercises the mu-protected map.
 func TestContextCache_ConcurrentSafe(t *testing.T) {
 	c := NewContextCache(time.Minute)
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+	c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "orig"})
 
 	var wg sync.WaitGroup
 	var hits atomic.Int64
 	for range 32 {
 		wg.Go(func() {
 			for j := range 200 {
-				if _, ok := c.Get("rid", "pl", "prov"); ok {
+				if _, ok := c.Get("rid", "pl", "prov", "", ""); ok {
 					hits.Add(1)
 				}
 				if j%10 == 0 {
-					c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+					c.Put("rid", "pl", "prov", "", "", &tmproto.ContextMatchResponse{RequestID: "orig"})
 				}
 			}
 		})

--- a/router/context_cache_test.go
+++ b/router/context_cache_test.go
@@ -137,6 +137,10 @@ func TestContextCache_TTLExpiration(t *testing.T) {
 	assert.Equal(t, 0, c.Size())
 }
 
+// ttlPtr is a helper so tests can pass a positive/zero/negative
+// cache_ttl through the *int field.
+func ttlPtr(n int) *int { return &n }
+
 // Provider cache_ttl overrides the router's default when present.
 func TestContextCache_ProviderTTLOverride(t *testing.T) {
 	c := NewContextCache(1 * time.Hour) // long default
@@ -145,7 +149,7 @@ func TestContextCache_ProviderTTLOverride(t *testing.T) {
 
 	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
 		RequestID: "orig",
-		CacheTTL:  2, // 2 seconds — tighter than the default 1h
+		CacheTTL:  ttlPtr(2), // 2 seconds — tighter than the default 1h
 	})
 
 	// Just under 2s → still cached.
@@ -169,7 +173,7 @@ func TestContextCache_TTLClampsToMax(t *testing.T) {
 
 	// 30 days — well past the schema-enforced 24h ceiling.
 	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
-		CacheTTL: 30 * 24 * 3600,
+		CacheTTL: ttlPtr(30 * 24 * 3600),
 	})
 
 	// Just past 24h — must be expired regardless of what the provider
@@ -179,16 +183,42 @@ func TestContextCache_TTLClampsToMax(t *testing.T) {
 	assert.False(t, ok, "provider cache_ttl must be clamped to MaxContextCacheTTL")
 }
 
-// cache_ttl == 0 (which Go's omitempty conflates with "field absent")
-// falls back to the router's default TTL. The doc on ContextCache.Put
-// explains why: providers using the Go type can't emit 0 explicitly,
-// so treating received-zero as the default matches the majority use.
-func TestContextCache_ZeroTTLUsesDefault(t *testing.T) {
+// A pathologically large cache_ttl must not overflow the Duration
+// conversion. Clamping in seconds first (before multiplying by
+// time.Second) guarantees the entry is stored with MaxContextCacheTTL,
+// not silently dropped because Duration wrapped to negative.
+func TestContextCache_TTLOverflowSafe(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	// int(math.MaxInt64/int64(time.Second)) ~= 9.2e9 seconds; anything
+	// beyond that would overflow Duration when multiplied. Use a value
+	// that would definitely wrap on 64-bit.
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+		CacheTTL: ttlPtr(1 << 62),
+	})
+
+	// Just under the max → cached.
+	now = now.Add(MaxContextCacheTTL - time.Minute)
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.True(t, ok, "overflow-sized cache_ttl must still cache up to MaxContextCacheTTL")
+
+	// Just past the max → expired.
+	now = now.Add(2 * time.Minute)
+	_, ok = c.Get("rid", "pl", "prov")
+	assert.False(t, ok)
+}
+
+// cache_ttl absent (nil pointer) falls back to the router's default TTL.
+// This is the majority case: providers using the generated Go type
+// that don't want to override just leave the field zero-valued.
+func TestContextCache_AbsentTTLUsesDefault(t *testing.T) {
 	c := NewContextCache(2 * time.Second)
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{CacheTTL: 0})
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{}) // CacheTTL nil
 
 	// Cached for the default TTL.
 	now = now.Add(1500 * time.Millisecond)
@@ -199,6 +229,42 @@ func TestContextCache_ZeroTTLUsesDefault(t *testing.T) {
 	now = now.Add(1 * time.Second)
 	_, ok = c.Get("rid", "pl", "prov")
 	assert.False(t, ok)
+}
+
+// cache_ttl == 0 (explicit) is the spec's "disable caching" signal
+// (spec §Caching: "0 disables caching"). The entry MUST NOT be stored,
+// so a subsequent Get is a miss and the router falls back to a fresh
+// fan-out. This is the fix for the request-changes review on #410:
+// a non-Go provider that sends cache_ttl=0 after a targeting-config
+// change must not have its now-stale offers served for 5 minutes.
+func TestContextCache_ExplicitZeroTTLDisablesCaching(t *testing.T) {
+	c := NewContextCache(1 * time.Hour) // long default that would apply if we mishandled zero
+
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+		RequestID: "orig",
+		CacheTTL:  ttlPtr(0),
+	})
+
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.False(t, ok, "cache_ttl=0 is the spec's disable-caching signal — entry must not be stored")
+	assert.Equal(t, 0, c.Size())
+}
+
+// A negative cache_ttl (which the wire schema should reject, but we're
+// defensive) falls back to the default rather than storing an
+// immediately-expired entry.
+func TestContextCache_NegativeTTLUsesDefault(t *testing.T) {
+	c := NewContextCache(2 * time.Second)
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{CacheTTL: ttlPtr(-1)})
+
+	// Cached for the default TTL rather than dropped or immediately
+	// expired.
+	now = now.Add(1500 * time.Millisecond)
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.True(t, ok, "negative TTL should fall back to default, not collapse to expired")
 }
 
 // Different providers for the same (property, placement) tuple are

--- a/router/context_cache_test.go
+++ b/router/context_cache_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/json"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -187,16 +188,18 @@ func TestContextCache_TTLClampsToMax(t *testing.T) {
 // conversion. Clamping in seconds first (before multiplying by
 // time.Second) guarantees the entry is stored with MaxContextCacheTTL,
 // not silently dropped because Duration wrapped to negative.
+//
+// math.MaxInt is used so this compiles on both 32-bit (where int is
+// int32; MaxInt seconds still exercises the clamp path) and 64-bit
+// (where int is int64; MaxInt * time.Second overflows the Duration
+// multiplication if the clamp weren't seconds-first).
 func TestContextCache_TTLOverflowSafe(t *testing.T) {
 	c := NewContextCache(time.Minute)
 	now := time.Unix(1_000_000_000, 0)
 	c.now = func() time.Time { return now }
 
-	// int(math.MaxInt64/int64(time.Second)) ~= 9.2e9 seconds; anything
-	// beyond that would overflow Duration when multiplied. Use a value
-	// that would definitely wrap on 64-bit.
 	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
-		CacheTTL: ttlPtr(1 << 62),
+		CacheTTL: ttlPtr(math.MaxInt),
 	})
 
 	// Just under the max → cached.

--- a/router/context_cache_test.go
+++ b/router/context_cache_test.go
@@ -1,0 +1,262 @@
+package router
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countingCacheMetrics tallies hit/miss calls per provider for
+// assertions in cache tests.
+type countingCacheMetrics struct {
+	mu     sync.Mutex
+	hits   map[string]int
+	misses map[string]int
+}
+
+func newCountingCacheMetrics() *countingCacheMetrics {
+	return &countingCacheMetrics{hits: map[string]int{}, misses: map[string]int{}}
+}
+func (m *countingCacheMetrics) IncHit(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hits[id]++
+}
+func (m *countingCacheMetrics) IncMiss(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.misses[id]++
+}
+
+// A nil cache is a valid value — Get/Put/Size must all no-op safely so
+// callers that omit WithContextCache don't need explicit nil checks.
+func TestContextCache_NilSafe(t *testing.T) {
+	var c *ContextCache
+	resp, ok := c.Get("rid", "pl", "prov")
+	assert.False(t, ok)
+	assert.Nil(t, resp)
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{})
+	assert.Equal(t, 0, c.Size())
+}
+
+// A Put followed by a Get under the same key returns a clone of the
+// response — mutating the returned pointer's fields must NOT reach
+// back into the cached entry.
+func TestContextCache_HitReturnsClone(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	resp := &tmproto.ContextMatchResponse{
+		Type:      tmproto.TypeContextMatchResponse,
+		RequestID: "orig",
+		Offers:    []tmproto.Offer{{PackageID: "pkg-a"}},
+		Signals:   map[string]any{"k": "v"},
+	}
+	c.Put("rid-1", "sidebar", "prov", resp)
+	got, ok := c.Get("rid-1", "sidebar", "prov")
+	require.True(t, ok)
+	require.NotNil(t, got)
+	assert.Equal(t, "orig", got.RequestID)
+	assert.Equal(t, "pkg-a", got.Offers[0].PackageID)
+
+	// Mutating the returned response must not corrupt the cache.
+	got.RequestID = "mutated"
+	got.Offers[0].PackageID = "MUTATED"
+	got.Signals["k"] = "MUTATED"
+
+	got2, ok := c.Get("rid-1", "sidebar", "prov")
+	require.True(t, ok)
+	assert.Equal(t, "orig", got2.RequestID)
+	assert.Equal(t, "pkg-a", got2.Offers[0].PackageID)
+	assert.Equal(t, "v", got2.Signals["k"])
+}
+
+// Deep-clone check: mutating the Offer's inner pointer/slice/map
+// fields on the returned response must not corrupt the cached entry.
+// Regression guard for the doc note on tmproto/types_gen.go:196 —
+// the router MAY stamp SellerAgent from a package→seller map, and a
+// shallow clone here would let that stamp leak into the cache.
+func TestContextCache_HitDeepClonesOffers(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	price := tmproto.OfferPrice{Amount: 5.00, Currency: "USD", Model: "cpm"}
+	cm := json.RawMessage(`{"kind":"markdown"}`)
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+		Offers: []tmproto.Offer{{
+			PackageID:        "pkg-a",
+			SellerAgent:      json.RawMessage(`{"agent_url":"https://orig.example"}`),
+			Brand:            json.RawMessage(`{"name":"Orig"}`),
+			Price:            &price,
+			CreativeManifest: &cm,
+			Macros:           map[string]string{"CID": "orig"},
+		}},
+	})
+
+	got, ok := c.Get("rid", "pl", "prov")
+	require.True(t, ok)
+	require.Len(t, got.Offers, 1)
+
+	// Mutate every reference-typed field on the returned Offer.
+	o := &got.Offers[0]
+	o.SellerAgent[0] = 'X'
+	o.Brand[0] = 'X'
+	o.Price.Amount = 999
+	(*o.CreativeManifest)[0] = 'X'
+	o.Macros["CID"] = "MUTATED"
+
+	got2, ok := c.Get("rid", "pl", "prov")
+	require.True(t, ok)
+	o2 := got2.Offers[0]
+	assert.Equal(t, byte('{'), o2.SellerAgent[0], "SellerAgent bytes must be isolated from mutation via a cached hit")
+	assert.Equal(t, byte('{'), o2.Brand[0], "Brand bytes must be isolated from mutation via a cached hit")
+	assert.Equal(t, 5.00, o2.Price.Amount, "Price must be a distinct allocation")
+	assert.Equal(t, byte('{'), (*o2.CreativeManifest)[0], "CreativeManifest bytes must be isolated")
+	assert.Equal(t, "orig", o2.Macros["CID"], "Macros map must be a distinct allocation")
+}
+
+// Entries expire on TTL. The cache uses an injectable clock so we
+// don't have to sleep.
+func TestContextCache_TTLExpiration(t *testing.T) {
+	c := NewContextCache(500 * time.Millisecond)
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+	_, ok := c.Get("rid", "pl", "prov")
+	require.True(t, ok, "fresh entry must hit")
+
+	// Advance past TTL.
+	now = now.Add(600 * time.Millisecond)
+	_, ok = c.Get("rid", "pl", "prov")
+	assert.False(t, ok, "expired entry must miss")
+
+	// Expired entries are evicted on the miss so Size drops.
+	assert.Equal(t, 0, c.Size())
+}
+
+// Provider cache_ttl overrides the router's default when present.
+func TestContextCache_ProviderTTLOverride(t *testing.T) {
+	c := NewContextCache(1 * time.Hour) // long default
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+		RequestID: "orig",
+		CacheTTL:  2, // 2 seconds — tighter than the default 1h
+	})
+
+	// Just under 2s → still cached.
+	now = now.Add(1500 * time.Millisecond)
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.True(t, ok)
+
+	// Past 2s → expired.
+	now = now.Add(1 * time.Second)
+	_, ok = c.Get("rid", "pl", "prov")
+	assert.False(t, ok, "provider-supplied cache_ttl must be honored over the default")
+}
+
+// A cache_ttl above MaxContextCacheTTL (86400s) is clamped, protecting
+// the router from a provider (or upstream bug) demanding a
+// week-long entry.
+func TestContextCache_TTLClampsToMax(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	// 30 days — well past the schema-enforced 24h ceiling.
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{
+		CacheTTL: 30 * 24 * 3600,
+	})
+
+	// Just past 24h — must be expired regardless of what the provider
+	// asked for.
+	now = now.Add(MaxContextCacheTTL + time.Minute)
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.False(t, ok, "provider cache_ttl must be clamped to MaxContextCacheTTL")
+}
+
+// cache_ttl == 0 (which Go's omitempty conflates with "field absent")
+// falls back to the router's default TTL. The doc on ContextCache.Put
+// explains why: providers using the Go type can't emit 0 explicitly,
+// so treating received-zero as the default matches the majority use.
+func TestContextCache_ZeroTTLUsesDefault(t *testing.T) {
+	c := NewContextCache(2 * time.Second)
+	now := time.Unix(1_000_000_000, 0)
+	c.now = func() time.Time { return now }
+
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{CacheTTL: 0})
+
+	// Cached for the default TTL.
+	now = now.Add(1500 * time.Millisecond)
+	_, ok := c.Get("rid", "pl", "prov")
+	assert.True(t, ok)
+
+	// Past default TTL → expired.
+	now = now.Add(1 * time.Second)
+	_, ok = c.Get("rid", "pl", "prov")
+	assert.False(t, ok)
+}
+
+// Different providers for the same (property, placement) tuple are
+// separate cache entries — the spec key includes provider_id.
+func TestContextCache_KeyPartitionedByProvider(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	c.Put("rid", "pl", "prov-a", &tmproto.ContextMatchResponse{RequestID: "for-a"})
+	c.Put("rid", "pl", "prov-b", &tmproto.ContextMatchResponse{RequestID: "for-b"})
+
+	a, okA := c.Get("rid", "pl", "prov-a")
+	b, okB := c.Get("rid", "pl", "prov-b")
+	require.True(t, okA)
+	require.True(t, okB)
+	assert.Equal(t, "for-a", a.RequestID)
+	assert.Equal(t, "for-b", b.RequestID)
+	assert.Equal(t, 2, c.Size())
+}
+
+// Metrics fire on every hit and miss.
+func TestContextCache_MetricsCounts(t *testing.T) {
+	m := newCountingCacheMetrics()
+	c := NewContextCache(time.Minute, WithContextCacheMetrics(m))
+
+	// Two misses.
+	_, _ = c.Get("rid", "pl", "prov")
+	_, _ = c.Get("rid", "pl", "prov")
+
+	// One populated, then two hits.
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+	_, _ = c.Get("rid", "pl", "prov")
+	_, _ = c.Get("rid", "pl", "prov")
+
+	assert.Equal(t, 2, m.hits["prov"])
+	assert.Equal(t, 2, m.misses["prov"])
+}
+
+// Concurrent Get/Put must not race. With the -race detector this
+// exercises the mu-protected map.
+func TestContextCache_ConcurrentSafe(t *testing.T) {
+	c := NewContextCache(time.Minute)
+	c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+
+	var wg sync.WaitGroup
+	var hits atomic.Int64
+	for range 32 {
+		wg.Go(func() {
+			for j := range 200 {
+				if _, ok := c.Get("rid", "pl", "prov"); ok {
+					hits.Add(1)
+				}
+				if j%10 == 0 {
+					c.Put("rid", "pl", "prov", &tmproto.ContextMatchResponse{RequestID: "orig"})
+				}
+			}
+		})
+	}
+	wg.Wait()
+
+	// Every iteration should hit — the entry is always fresh.
+	assert.Equal(t, int64(32*200), hits.Load())
+}

--- a/router/router.go
+++ b/router/router.go
@@ -378,9 +378,10 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 			// went down, and the TTL bounds staleness.
 			if r.contextCache != nil {
 				if cached, ok := r.contextCache.Get(cmReq.PropertyRID, cmReq.PlacementID, p.ID); ok {
-					// Echo the CURRENT request's ID; every other field is
-					// stable across cache reuses within the placement scope.
-					cached.RequestID = cmReq.RequestID
+					// The merger overwrites RequestID from the current
+					// request downstream (mergeContextResponses), so we
+					// don't touch cached.RequestID here — any assignment
+					// would be dead.
 					mu.Lock()
 					results = append(results, contextResult{providerID: p.ID, response: cached})
 					mu.Unlock()

--- a/router/router.go
+++ b/router/router.go
@@ -71,6 +71,11 @@ type Router struct {
 	// fan-outs.
 	signer      *tmproto.Signer
 	contextSigs *contextSignatureCache
+
+	// contextCache is nil when caching is disabled (dev / test) or when
+	// the deployer did not wire it. Per spec §Caching, populated caches
+	// key on {property_rid, placement_id, provider_id}.
+	contextCache *ContextCache
 }
 
 // RouterOption configures a Router.
@@ -111,6 +116,13 @@ func WithFanOutMetrics(m FanOutMetrics) RouterOption {
 // router holds onto signer for the rest of its lifetime.
 func WithTMPSigner(signer *tmproto.Signer) RouterOption {
 	return func(r *Router) { r.signer = signer }
+}
+
+// WithContextCache attaches a per-provider Context Match response cache
+// (spec §Caching). Pass nil to disable caching — the router will fan
+// out on every request.
+func WithContextCache(c *ContextCache) RouterOption {
+	return func(r *Router) { r.contextCache = c }
 }
 
 // Providers returns the router's provider set for use by health checkers and discovery.
@@ -351,6 +363,31 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 
 	for _, p := range providers {
 		wg.Go(func() {
+			// Cache hit short-circuit — before health check, signing, or
+			// dial. Spec §Caching keys on {property_rid, placement_id,
+			// provider_id}; the request's package_ids are not part of
+			// the key because active packages are placement-scoped
+			// (spec: "the same packages are evaluated for every user on
+			// a given placement"). A publisher that varies package_ids
+			// across requests for the same {property, placement} is
+			// violating that spec assumption and will get cached offers
+			// scoped to whatever set produced the first fill.
+			//
+			// The cache check also runs before the circuit-breaker
+			// gate: a warm response is still useful when the provider
+			// went down, and the TTL bounds staleness.
+			if r.contextCache != nil {
+				if cached, ok := r.contextCache.Get(cmReq.PropertyRID, cmReq.PlacementID, p.ID); ok {
+					// Echo the CURRENT request's ID; every other field is
+					// stable across cache reuses within the placement scope.
+					cached.RequestID = cmReq.RequestID
+					mu.Lock()
+					results = append(results, contextResult{providerID: p.ID, response: cached})
+					mu.Unlock()
+					return
+				}
+			}
+
 			if r.health != nil && r.health.IsCircuitOpen(p.ID) {
 				if r.metrics != nil {
 					r.metrics.IncExcluded(p.ID)
@@ -419,6 +456,13 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 			}
 			if r.health != nil {
 				r.health.RecordSuccess(p.ID)
+			}
+
+			// Cache the fresh response BEFORE returning it to the merger.
+			// The cache clones on both Put and Get, so downstream mutation
+			// (e.g. RequestID overwrites on hits) cannot corrupt entries.
+			if r.contextCache != nil {
+				r.contextCache.Put(cmReq.PropertyRID, cmReq.PlacementID, p.ID, &cmResp)
 			}
 
 			mu.Lock()

--- a/router/router.go
+++ b/router/router.go
@@ -15,7 +15,40 @@ import (
 	"time"
 
 	"github.com/adcontextprotocol/adcp-go/tmproto"
+	"github.com/adcontextprotocol/adcp-go/urlcanon"
 )
+
+// canonicalizeSellerForCache normalizes a seller_agent_url for use as
+// a cache-key component. Mirrors targeting/engine.go's normalization
+// before ActivePackages lookup so the router keys the same offer set
+// under the same seller identity. Canonicalization failure falls back
+// to the raw string; note the asymmetry with the engine, which
+// returns an empty offer set on the same failure. A raw-fallback key
+// therefore never collides with a real canonical key in practice
+// (canonicalization is deterministic, so a URL that fails at the
+// router also fails at any downstream using the same canonicalizer,
+// and no live entry is ever populated under a raw-fallback key that
+// could later collide).
+func canonicalizeSellerForCache(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if canonical, err := urlcanon.Canonicalize(raw); err == nil {
+		return canonical
+	}
+	return raw
+}
+
+// contextCountry extracts the ISO alpha-2 country from a Context Match
+// request's geo map, mirroring targeting/engine.go's use of
+// GeoCountryKey. Returns empty string when absent or wrong type.
+func contextCountry(geo map[string]any) string {
+	if geo == nil {
+		return ""
+	}
+	country, _ := geo["country"].(string)
+	return country
+}
 
 // MaxRequestBodyBytes caps an inbound request body the router reads
 // before validating + fan-out. Sized to match the verifier's
@@ -364,20 +397,25 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 	for _, p := range providers {
 		wg.Go(func() {
 			// Cache hit short-circuit — before health check, signing, or
-			// dial. Spec §Caching keys on {property_rid, placement_id,
-			// provider_id}; the request's package_ids are not part of
-			// the key because active packages are placement-scoped
-			// (spec: "the same packages are evaluated for every user on
-			// a given placement"). A publisher that varies package_ids
-			// across requests for the same {property, placement} is
-			// violating that spec assumption and will get cached offers
-			// scoped to whatever set produced the first fill.
+			// dial. Spec §Caching lists {property_rid, placement_id,
+			// provider_id} as the recommended key; we extend it with
+			// canonicalized seller_agent_url and country because this
+			// repo's targeting engine scopes ActivePackages by both,
+			// and keying on placement alone would let one seller's
+			// cached offers be served to another seller's request
+			// during the TTL window (cross-tenant disclosure). The
+			// request's package_ids are not part of the key because
+			// active packages are placement-scoped (spec: "MUST NOT
+			// vary by user"), and country stays constant per viewer's
+			// geo which the publisher does not vary per user.
 			//
-			// The cache check also runs before the circuit-breaker
-			// gate: a warm response is still useful when the provider
-			// went down, and the TTL bounds staleness.
+			// The cache check runs before the circuit-breaker gate: a
+			// warm response is still useful when the provider went
+			// down, and the TTL bounds staleness.
+			cacheSeller := canonicalizeSellerForCache(cmReq.SellerAgentURL)
+			cacheCountry := contextCountry(cmReq.Geo)
 			if r.contextCache != nil {
-				if cached, ok := r.contextCache.Get(cmReq.PropertyRID, cmReq.PlacementID, p.ID); ok {
+				if cached, ok := r.contextCache.Get(cmReq.PropertyRID, cmReq.PlacementID, p.ID, cacheSeller, cacheCountry); ok {
 					// The merger overwrites RequestID from the current
 					// request downstream (mergeContextResponses), so we
 					// don't touch cached.RequestID here — any assignment
@@ -463,7 +501,7 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 			// The cache clones on both Put and Get, so downstream mutation
 			// (e.g. RequestID overwrites on hits) cannot corrupt entries.
 			if r.contextCache != nil {
-				r.contextCache.Put(cmReq.PropertyRID, cmReq.PlacementID, p.ID, &cmResp)
+				r.contextCache.Put(cmReq.PropertyRID, cmReq.PlacementID, p.ID, cacheSeller, cacheCountry, &cmResp)
 			}
 
 			mu.Lock()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1045,4 +1046,116 @@ func TestRouterContextMatch_LatencyBudgetCapsFanOut(t *testing.T) {
 	// the budget cancels its parent ctx.
 	require.Len(t, resp.Offers, 1)
 	assert.Equal(t, "pkg-fast", resp.Offers[0].PackageID)
+}
+
+// End-to-end: with a cache attached, a repeat Context Match on the
+// same {property_rid, placement_id} keys off the cache and skips the
+// provider network call entirely. The current request's request_id is
+// stamped onto the cached response (only field that varies across
+// reuses within a placement).
+func TestRouterContextMatch_CacheHitAvoidsNetworkCall(t *testing.T) {
+	var hits atomic.Int32
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(tmproto.ContextMatchResponse{
+			Type:      tmproto.TypeContextMatchResponse,
+			RequestID: "server-side",
+			Offers:    []tmproto.Offer{{PackageID: "pkg-cached"}},
+			// Provider omits cache_ttl — router falls back to the
+			// configured default. This mirrors the common case.
+		})
+	}))
+	defer provider.Close()
+
+	r := testRouter([]ProviderConfig{
+		{ID: "prov", Endpoint: provider.URL, ContextMatch: true, Timeout: 1 * time.Second},
+	})
+	r.contextCache = NewContextCache(1 * time.Minute)
+
+	baseBody := func(reqID string) string {
+		return `{
+			"type": "context_match_request",
+			"request_id": "` + reqID + `",
+			"property_rid": "rid-cache-1",
+			"property_id": "pub-test",
+			"property_type": "website",
+			"placement_id": "sidebar",
+			"seller_agent_url": "https://seller.example.com/agent",
+			"package_ids": ["pkg-1"]
+		}`
+	}
+
+	// First call — miss → hits provider once.
+	w1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(baseBody("req-first")))
+	r.HandleContextMatch(w1, req1)
+	require.Equal(t, int32(1), hits.Load(), "first call must reach the provider")
+
+	var resp1 tmproto.ContextMatchResponse
+	require.NoError(t, json.NewDecoder(w1.Body).Decode(&resp1))
+	require.Len(t, resp1.Offers, 1)
+	assert.Equal(t, "pkg-cached", resp1.Offers[0].PackageID)
+	assert.Equal(t, "req-first", resp1.RequestID, "response request_id must match the incoming request, not the provider's cached value")
+
+	// Second call — same property_rid + placement_id → cache hit → no
+	// additional provider round-trip. Different request_id proves the
+	// cache stamps the current request's ID onto the returned response.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(baseBody("req-second")))
+	r.HandleContextMatch(w2, req2)
+	assert.Equal(t, int32(1), hits.Load(), "second call must be served from cache, not re-hit the provider")
+
+	var resp2 tmproto.ContextMatchResponse
+	require.NoError(t, json.NewDecoder(w2.Body).Decode(&resp2))
+	require.Len(t, resp2.Offers, 1)
+	assert.Equal(t, "pkg-cached", resp2.Offers[0].PackageID)
+	assert.Equal(t, "req-second", resp2.RequestID, "cached response must carry the current request's ID")
+}
+
+// A response with cache_ttl > 0 uses the provider's TTL over the
+// router default — this is the "provider MUST be respected" half of
+// the spec §Caching contract exercised end-to-end.
+func TestRouterContextMatch_ProviderCacheTTLOverrideEndToEnd(t *testing.T) {
+	var hits atomic.Int32
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_ = json.NewEncoder(w).Encode(tmproto.ContextMatchResponse{
+			Type:      tmproto.TypeContextMatchResponse,
+			RequestID: "server-side",
+			Offers:    []tmproto.Offer{{PackageID: "pkg-provider-ttl"}},
+			CacheTTL:  3600, // 1h — well past the 1-minute default
+		})
+	}))
+	defer provider.Close()
+
+	r := testRouter([]ProviderConfig{
+		{ID: "prov", Endpoint: provider.URL, ContextMatch: true, Timeout: 1 * time.Second},
+	})
+	// Very short router default so a naive impl that ignored the
+	// provider TTL would evict between our two calls.
+	r.contextCache = NewContextCache(50 * time.Millisecond)
+
+	body := `{
+		"type": "context_match_request",
+		"request_id": "req-ttl",
+		"property_rid": "rid-ttl-1",
+		"property_id": "pub-test",
+		"property_type": "website",
+		"placement_id": "sidebar",
+		"seller_agent_url": "https://seller.example.com/agent",
+		"package_ids": ["pkg-1"]
+	}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body))
+	r.HandleContextMatch(w, req)
+	require.Equal(t, int32(1), hits.Load())
+
+	// Sleep just past the router's default TTL. With the provider's
+	// 1h override honored, the entry is still valid.
+	time.Sleep(75 * time.Millisecond)
+
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body))
+	r.HandleContextMatch(w2, req2)
+	assert.Equal(t, int32(1), hits.Load(), "provider cache_ttl must override the router default")
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1098,8 +1098,9 @@ func TestRouterContextMatch_CacheHitAvoidsNetworkCall(t *testing.T) {
 	assert.Equal(t, "req-first", resp1.RequestID, "response request_id must match the incoming request, not the provider's cached value")
 
 	// Second call — same property_rid + placement_id → cache hit → no
-	// additional provider round-trip. Different request_id proves the
-	// cache stamps the current request's ID onto the returned response.
+	// additional provider round-trip. The merged response's request_id
+	// still tracks the CURRENT request (mergeContextResponses sets it
+	// from the incoming request, not the cached entry).
 	w2 := httptest.NewRecorder()
 	req2 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(baseBody("req-second")))
 	r.HandleContextMatch(w2, req2)
@@ -1109,7 +1110,7 @@ func TestRouterContextMatch_CacheHitAvoidsNetworkCall(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w2.Body).Decode(&resp2))
 	require.Len(t, resp2.Offers, 1)
 	assert.Equal(t, "pkg-cached", resp2.Offers[0].PackageID)
-	assert.Equal(t, "req-second", resp2.RequestID, "cached response must carry the current request's ID")
+	assert.Equal(t, "req-second", resp2.RequestID, "merged response request_id must track the current request")
 }
 
 // A response with cache_ttl > 0 uses the provider's TTL over the
@@ -1123,7 +1124,7 @@ func TestRouterContextMatch_ProviderCacheTTLOverrideEndToEnd(t *testing.T) {
 			Type:      tmproto.TypeContextMatchResponse,
 			RequestID: "server-side",
 			Offers:    []tmproto.Offer{{PackageID: "pkg-provider-ttl"}},
-			CacheTTL:  3600, // 1h — well past the 1-minute default
+			CacheTTL:  ttlPtr(3600), // 1h — well past the 1-minute default
 		})
 	}))
 	defer provider.Close()
@@ -1158,4 +1159,47 @@ func TestRouterContextMatch_ProviderCacheTTLOverrideEndToEnd(t *testing.T) {
 	req2 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body))
 	r.HandleContextMatch(w2, req2)
 	assert.Equal(t, int32(1), hits.Load(), "provider cache_ttl must override the router default")
+}
+
+// A provider that returns cache_ttl=0 (spec's "disable caching" signal,
+// typical after a targeting-config change) MUST cause the router to
+// re-fan-out on every subsequent request rather than serve the stale
+// response from cache. Regression guard for the fix to #410's review
+// blocker.
+func TestRouterContextMatch_ProviderDisablesCaching(t *testing.T) {
+	var hits atomic.Int32
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		zero := 0
+		_ = json.NewEncoder(w).Encode(tmproto.ContextMatchResponse{
+			Type:      tmproto.TypeContextMatchResponse,
+			RequestID: "server-side",
+			Offers:    []tmproto.Offer{{PackageID: "pkg-uncached"}},
+			CacheTTL:  &zero, // Explicit disable — the "targeting just changed" case.
+		})
+	}))
+	defer provider.Close()
+
+	r := testRouter([]ProviderConfig{
+		{ID: "prov", Endpoint: provider.URL, ContextMatch: true, Timeout: 1 * time.Second},
+	})
+	r.contextCache = NewContextCache(1 * time.Hour) // long default the disable must override
+
+	body := `{
+		"type": "context_match_request",
+		"request_id": "req-nocache",
+		"property_rid": "rid-nocache-1",
+		"property_id": "pub-test",
+		"property_type": "website",
+		"placement_id": "sidebar",
+		"seller_agent_url": "https://seller.example.com/agent",
+		"package_ids": ["pkg-1"]
+	}`
+	for i := 1; i <= 3; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body))
+		r.HandleContextMatch(w, req)
+		assert.Equal(t, int32(i), hits.Load(),
+			"request %d: provider cache_ttl=0 must skip cache and re-fan-out", i)
+	}
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -1161,6 +1161,136 @@ func TestRouterContextMatch_ProviderCacheTTLOverrideEndToEnd(t *testing.T) {
 	assert.Equal(t, int32(1), hits.Load(), "provider cache_ttl must override the router default")
 }
 
+// Cross-seller isolation end-to-end: seller A hits, cache fills;
+// seller B's request under the same {property_rid, placement_id} MUST
+// re-fan-out to the provider and see B's own offers, not A's cached
+// ones. Regression guard for the High-severity finding on adcp-go
+// #410 (cross-tenant offer disclosure through a placement-only cache
+// key).
+func TestRouterContextMatch_CacheIsolatesAcrossSellers(t *testing.T) {
+	var hits atomic.Int32
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		// Read the seller URL out of the request body so we can echo
+		// a distinguishable offer per seller. The router doesn't
+		// strip seller_agent_url on outbound context calls (spec
+		// signs it into the request), so it will be present.
+		body, _ := io.ReadAll(req.Body)
+		var incoming tmproto.ContextMatchRequest
+		_ = json.Unmarshal(body, &incoming)
+		pkg := "pkg-for-a"
+		if strings.Contains(incoming.SellerAgentURL, "seller-b") {
+			pkg = "pkg-for-b"
+		}
+		_ = json.NewEncoder(w).Encode(tmproto.ContextMatchResponse{
+			Type:      tmproto.TypeContextMatchResponse,
+			RequestID: "server-side",
+			Offers:    []tmproto.Offer{{PackageID: pkg}},
+		})
+	}))
+	defer provider.Close()
+
+	r := testRouter([]ProviderConfig{
+		{ID: "prov", Endpoint: provider.URL, ContextMatch: true, Timeout: 1 * time.Second},
+	})
+	r.contextCache = NewContextCache(1 * time.Hour)
+
+	body := func(sellerURL string) string {
+		return `{
+			"type": "context_match_request",
+			"request_id": "req-1",
+			"property_rid": "rid-shared",
+			"property_id": "pub-shared",
+			"property_type": "website",
+			"placement_id": "sidebar",
+			"seller_agent_url": "` + sellerURL + `",
+			"package_ids": ["pkg-1"]
+		}`
+	}
+
+	// Seller A first — miss → fan-out, cache fill.
+	wA := httptest.NewRecorder()
+	rA := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body("https://seller-a.example/agent")))
+	r.HandleContextMatch(wA, rA)
+	require.Equal(t, int32(1), hits.Load(), "seller A first call must reach the provider")
+
+	// Seller B under the SAME property/placement/provider — must NOT
+	// hit A's cache. Router re-fans out, provider replies with B's
+	// pkg-for-b, not A's pkg-for-a.
+	wB := httptest.NewRecorder()
+	rB := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body("https://seller-b.example/agent")))
+	r.HandleContextMatch(wB, rB)
+	assert.Equal(t, int32(2), hits.Load(),
+		"seller B must trigger a fresh fan-out, not read from seller A's cache entry (cross-tenant disclosure guard)")
+
+	var respB tmproto.ContextMatchResponse
+	require.NoError(t, json.NewDecoder(wB.Body).Decode(&respB))
+	require.Len(t, respB.Offers, 1)
+	assert.Equal(t, "pkg-for-b", respB.Offers[0].PackageID,
+		"seller B must receive offers scoped to seller B, not seller A's cached offers")
+
+	// Seller A repeats — cache still valid for A, no additional call.
+	wA2 := httptest.NewRecorder()
+	rA2 := httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body("https://seller-a.example/agent")))
+	r.HandleContextMatch(wA2, rA2)
+	assert.Equal(t, int32(2), hits.Load(), "seller A repeat within TTL must hit its own cache entry")
+}
+
+// Symmetric to the cross-seller isolation test: two requests under
+// the same {property_rid, placement_id, provider_id, seller_agent_url}
+// but different Geo.country MUST re-fan-out — country is a component
+// of the targeting engine's ActivePackages scope (see engine.go),
+// same failure-mode class as the seller isolation.
+func TestRouterContextMatch_CacheIsolatesAcrossCountries(t *testing.T) {
+	var hits atomic.Int32
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		hits.Add(1)
+		body, _ := io.ReadAll(req.Body)
+		var incoming tmproto.ContextMatchRequest
+		_ = json.Unmarshal(body, &incoming)
+		country, _ := incoming.Geo["country"].(string)
+		_ = json.NewEncoder(w).Encode(tmproto.ContextMatchResponse{
+			Type:      tmproto.TypeContextMatchResponse,
+			RequestID: "server-side",
+			Offers:    []tmproto.Offer{{PackageID: "pkg-" + country}},
+		})
+	}))
+	defer provider.Close()
+
+	r := testRouter([]ProviderConfig{
+		{ID: "prov", Endpoint: provider.URL, ContextMatch: true, Timeout: 1 * time.Second},
+	})
+	r.contextCache = NewContextCache(1 * time.Hour)
+
+	body := func(country string) string {
+		return `{
+			"type": "context_match_request",
+			"request_id": "req-1",
+			"property_rid": "rid-geo",
+			"property_id": "pub-geo",
+			"property_type": "website",
+			"placement_id": "sidebar",
+			"seller_agent_url": "https://seller.example/agent",
+			"geo": {"country": "` + country + `"},
+			"package_ids": ["pkg-1"]
+		}`
+	}
+
+	wUS := httptest.NewRecorder()
+	r.HandleContextMatch(wUS, httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body("US"))))
+	require.Equal(t, int32(1), hits.Load(), "US call must reach provider")
+
+	// Same seller, different country → must re-fan-out.
+	wGB := httptest.NewRecorder()
+	r.HandleContextMatch(wGB, httptest.NewRequest("POST", "/tmp/context", strings.NewReader(body("GB"))))
+	assert.Equal(t, int32(2), hits.Load(), "different country must miss cache and re-fan-out")
+
+	var respGB tmproto.ContextMatchResponse
+	require.NoError(t, json.NewDecoder(wGB.Body).Decode(&respGB))
+	require.Len(t, respGB.Offers, 1)
+	assert.Equal(t, "pkg-GB", respGB.Offers[0].PackageID, "GB request must receive GB-scoped offers, not US-cached ones")
+}
+
 // A provider that returns cache_ttl=0 (spec's "disable caching" signal,
 // typical after a targeting-config change) MUST cause the router to
 // re-fan-out on every subsequent request rather than serve the stale

--- a/router/serverconfig.go
+++ b/router/serverconfig.go
@@ -24,6 +24,32 @@ type ServerConfig struct {
 	Signing         SigningConfig     `json:"signing"`
 	TLS             TLSConfig         `json:"tls"`
 	Registry        RegistryConfig    `json:"registry"`
+	Cache           CacheConfig       `json:"cache"`
+}
+
+// CacheConfig controls the per-provider Context Match response cache
+// (spec §Caching). When Disabled is false, the router runs a cache
+// with DefaultTTL applied on every entry whose provider does not
+// specify a cache_ttl override.
+type CacheConfig struct {
+	// Disabled turns the cache off entirely — the router fans out on
+	// every request. Useful for A/B comparisons and for operators
+	// terminating cache at an upstream layer.
+	Disabled bool `json:"disabled,omitempty"`
+	// DefaultTTLSeconds sets the fallback TTL when a provider response
+	// omits cache_ttl. Spec recommends 5 minutes; zero or unset
+	// collapses to that default.
+	DefaultTTLSeconds int `json:"default_ttl_seconds,omitempty"`
+}
+
+// DefaultTTL returns the fallback TTL as a duration, honoring the
+// spec's 5-minute recommendation when unset. Zero or negative values
+// yield DefaultContextCacheTTL.
+func (c CacheConfig) DefaultTTL() time.Duration {
+	if c.DefaultTTLSeconds <= 0 {
+		return DefaultContextCacheTTL
+	}
+	return time.Duration(c.DefaultTTLSeconds) * time.Second
 }
 
 // RegistryConfig points the router at the AdCP registry feed so it can serve

--- a/router/serverconfig.go
+++ b/router/serverconfig.go
@@ -40,6 +40,26 @@ type CacheConfig struct {
 	// omits cache_ttl. Spec recommends 5 minutes; zero or unset
 	// collapses to that default.
 	DefaultTTLSeconds int `json:"default_ttl_seconds,omitempty"`
+	// MaxEntries caps the number of live cache entries so a caller
+	// varying placement/seller/country cannot grow the map without
+	// bound. Zero or unset applies DefaultContextCacheMaxEntries.
+	MaxEntries int `json:"max_entries,omitempty"`
+}
+
+// DefaultContextCacheMaxEntries is the fallback cap when the operator
+// does not configure MaxEntries. Sized well above any realistic
+// {property_rid × placement × provider × seller × country} product
+// for a real deployment.
+const DefaultContextCacheMaxEntries = 10_000
+
+// MaxEntriesResolved returns the cap the cache should apply, honoring
+// the operator's override when set and falling back to the default
+// otherwise.
+func (c CacheConfig) MaxEntriesResolved() int {
+	if c.MaxEntries > 0 {
+		return c.MaxEntries
+	}
+	return DefaultContextCacheMaxEntries
 }
 
 // DefaultTTL returns the fallback TTL as a duration, honoring the

--- a/router/serverconfig_test.go
+++ b/router/serverconfig_test.go
@@ -150,6 +150,37 @@ providers:
 	assert.Equal(t, 500, cfg.Registry.FeedLimit)
 }
 
+// The cache block from the spec's field naming parses into CacheConfig.
+// DefaultTTL falls back to DefaultContextCacheTTL when unset so a
+// verbatim copy of the docs sample matches the SHOULD-5-minute rule.
+func TestLoadServerConfig_AcceptsCacheBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "config.yaml", `listen: ":8080"
+cache:
+  default_ttl_seconds: 120
+providers:
+  - provider_id: p1
+    endpoint: https://provider.example/agent
+    context_match: true
+`)
+
+	cfg, err := LoadServerConfig(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Cache.Disabled)
+	assert.Equal(t, 120, cfg.Cache.DefaultTTLSeconds)
+	assert.Equal(t, 2*time.Minute, cfg.Cache.DefaultTTL())
+}
+
+// DefaultTTL falls back to DefaultContextCacheTTL (5 min) whenever the
+// operator didn't set an override.
+func TestCacheConfig_DefaultTTL(t *testing.T) {
+	assert.Equal(t, DefaultContextCacheTTL, CacheConfig{}.DefaultTTL(),
+		"unset default must be the spec's 5-minute recommendation")
+	assert.Equal(t, DefaultContextCacheTTL, CacheConfig{DefaultTTLSeconds: 0}.DefaultTTL())
+	assert.Equal(t, DefaultContextCacheTTL, CacheConfig{DefaultTTLSeconds: -5}.DefaultTTL())
+	assert.Equal(t, 90*time.Second, CacheConfig{DefaultTTLSeconds: 90}.DefaultTTL())
+}
+
 // PollInterval defaults to 30s when unset — matches the registry pkg
 // default so a router without an explicit interval matches the reference
 // agents' cadence.

--- a/targeting/contextagent/handler.go
+++ b/targeting/contextagent/handler.go
@@ -135,8 +135,12 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// only a 5-minute default the router applies when omitted.
 		// Don't borrow IdentityMatchResponse's 300s serve_window_sec
 		// cap — that's a buyer-asserted serve throttle, a different
-		// concept on a different message type.
-		resp.CacheTTL = int(h.responseTTL.Seconds())
+		// concept on a different message type. The field is a *int so
+		// omission is distinguishable from an explicit 0 (which the
+		// spec defines as "disable caching"); we only assign when we
+		// have a positive TTL to override the router's default.
+		ttl := int(h.responseTTL.Seconds())
+		resp.CacheTTL = &ttl
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/targeting/contextagent/handler.go
+++ b/targeting/contextagent/handler.go
@@ -130,16 +130,18 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Offers:    result.Offers,
 		Signals:   result.Signals,
 	}
-	// ContextMatchResponse.cache_ttl has no spec-level maximum, only a
-	// 5-minute default the router applies when omitted. Don't borrow
-	// IdentityMatchResponse's 300s serve_window_sec cap — that's a
-	// buyer-asserted serve throttle, a different concept on a different
-	// message type. The field is a *int so omission is distinguishable
-	// from an explicit 0 (which the spec defines as "disable caching");
-	// we only assign when we have a positive whole-second TTL. A
-	// configured RESPONSE_TTL between 0 and 1s truncates to zero
-	// seconds; emitting cache_ttl=0 in that case would tell the router
-	// to disable caching entirely, which is the opposite of the
+	// ContextMatchResponse.cache_ttl has a schema-enforced maximum of
+	// 86400 seconds (see adcp/schemas/trusted-match/context-match-response.json)
+	// and the router applies a 5-minute default when the field is
+	// omitted. Don't borrow IdentityMatchResponse's 300s
+	// serve_window_sec cap — that's a buyer-asserted serve throttle,
+	// a different concept on a different message type. The field is
+	// a *int so omission is distinguishable from an explicit 0
+	// (which the spec defines as "disable caching"); we only assign
+	// when we have a positive whole-second TTL. A configured
+	// RESPONSE_TTL between 0 and 1s truncates to zero seconds;
+	// emitting cache_ttl=0 in that case would tell the router to
+	// disable caching entirely, which is the opposite of the
 	// operator's intent — so we omit the field instead and let the
 	// router's default apply.
 	if secs := int(h.responseTTL.Seconds()); secs > 0 {

--- a/targeting/contextagent/handler.go
+++ b/targeting/contextagent/handler.go
@@ -130,17 +130,20 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Offers:    result.Offers,
 		Signals:   result.Signals,
 	}
-	if h.responseTTL > 0 {
-		// ContextMatchResponse.cache_ttl has no spec-level maximum,
-		// only a 5-minute default the router applies when omitted.
-		// Don't borrow IdentityMatchResponse's 300s serve_window_sec
-		// cap — that's a buyer-asserted serve throttle, a different
-		// concept on a different message type. The field is a *int so
-		// omission is distinguishable from an explicit 0 (which the
-		// spec defines as "disable caching"); we only assign when we
-		// have a positive TTL to override the router's default.
-		ttl := int(h.responseTTL.Seconds())
-		resp.CacheTTL = &ttl
+	// ContextMatchResponse.cache_ttl has no spec-level maximum, only a
+	// 5-minute default the router applies when omitted. Don't borrow
+	// IdentityMatchResponse's 300s serve_window_sec cap — that's a
+	// buyer-asserted serve throttle, a different concept on a different
+	// message type. The field is a *int so omission is distinguishable
+	// from an explicit 0 (which the spec defines as "disable caching");
+	// we only assign when we have a positive whole-second TTL. A
+	// configured RESPONSE_TTL between 0 and 1s truncates to zero
+	// seconds; emitting cache_ttl=0 in that case would tell the router
+	// to disable caching entirely, which is the opposite of the
+	// operator's intent — so we omit the field instead and let the
+	// router's default apply.
+	if secs := int(h.responseTTL.Seconds()); secs > 0 {
+		resp.CacheTTL = &secs
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/tmproto/types_gen.go
+++ b/tmproto/types_gen.go
@@ -137,7 +137,7 @@ type ContextMatchResponse struct {
 	Type             string         `json:"type"`                         // Message type discriminator for deserialization.
 	RequestID        string         `json:"request_id"`                   // Echoed request identifier from the context match request
 	Offers           []Offer        `json:"offers"`                       // Offers from the buyer, one per activated package. An empty array means no packages matched. For simple activation, each offer has just package_id. For richer responses, offers include brand, price, summary, and creative manifest.
-	CacheTTL         int            `json:"cache_ttl,omitempty"`          // Optional override for the default 5-minute cache TTL, in seconds. When present, the router MUST use this value instead of its default. Set to 0 to disable caching (e.g., when targeting configuration has just changed).
+	CacheTTL         *int           `json:"cache_ttl,omitempty"`          // Optional override for the default 5-minute cache TTL, in seconds. When present, the router MUST use this value instead of its default. Set to 0 to disable caching (e.g., when targeting configuration has just changed).
 	Signals          map[string]any `json:"signals,omitempty"`            // Response-level targeting signals for ad server pass-through. In the GAM case, these carry the key-value pairs that trigger line items. Not per-offer — applies to the response as a whole.
 }
 

--- a/tmproto/types_test.go
+++ b/tmproto/types_test.go
@@ -321,4 +321,69 @@ func TestMarshalJSON_RoundTrip(t *testing.T) {
 	assert.Equal(t, PropertyTypeAIAssistant, got.PropertyType, "property_type")
 }
 
+// ContextMatchResponse.cache_ttl is a *int so the router can tell
+// omission (nil → use default TTL) from explicit-zero (spec's disable
+// caching signal). This nails down the wire behavior the router
+// depends on — any codegen or JSON-tag change that regresses it would
+// silently reintroduce the bug fixed on adcp-go PR #410.
+func TestContextMatchResponse_CacheTTLWireBehavior(t *testing.T) {
+	t.Run("nil pointer omits the field", func(t *testing.T) {
+		resp := &ContextMatchResponse{
+			Type:      TypeContextMatchResponse,
+			RequestID: "ctx-1",
+			Offers:    []Offer{{PackageID: "pkg-1"}},
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "cache_ttl",
+			"absent CacheTTL must be omitted from the wire (omitempty)")
+	})
+
+	t.Run("explicit zero marshals as 0", func(t *testing.T) {
+		zero := 0
+		resp := &ContextMatchResponse{
+			Type:      TypeContextMatchResponse,
+			RequestID: "ctx-1",
+			Offers:    []Offer{{PackageID: "pkg-1"}},
+			CacheTTL:  &zero,
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"cache_ttl":0`,
+			"explicit zero must survive marshaling — it's the spec's disable-caching signal")
+	})
+
+	t.Run("positive value marshals as the integer", func(t *testing.T) {
+		ttl := 600
+		resp := &ContextMatchResponse{
+			Type:      TypeContextMatchResponse,
+			RequestID: "ctx-1",
+			CacheTTL:  &ttl,
+		}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"cache_ttl":600`)
+	})
+
+	t.Run("absent field decodes to nil", func(t *testing.T) {
+		var got ContextMatchResponse
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"context_match_response","request_id":"x","offers":[]}`), &got))
+		assert.Nil(t, got.CacheTTL, "absent field must decode to nil, not to a pointer to zero")
+	})
+
+	t.Run("zero field decodes to *int(0)", func(t *testing.T) {
+		var got ContextMatchResponse
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"context_match_response","request_id":"x","offers":[],"cache_ttl":0}`), &got))
+		require.NotNil(t, got.CacheTTL, "cache_ttl=0 on the wire must decode to a non-nil pointer so the router can honor the disable-caching signal")
+		assert.Equal(t, 0, *got.CacheTTL)
+	})
+
+	t.Run("positive field decodes to *int(n)", func(t *testing.T) {
+		var got ContextMatchResponse
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"context_match_response","request_id":"x","offers":[],"cache_ttl":900}`), &got))
+		require.NotNil(t, got.CacheTTL)
+		assert.Equal(t, 900, *got.CacheTTL)
+	})
+}
+
 // ExposeRequest tests moved to targeting package where the type now lives.


### PR DESCRIPTION
## Summary

Implements the router-side Context Match response cache defined in the spec at `docs/trusted-match/specification.mdx:747-756`. Adds a per-provider cache keyed on `{property_rid, placement_id, provider_id}`, default 5-minute TTL, honoring provider-supplied `cache_ttl` when present (clamped to the 24h schema ceiling).

Last non-blocked pre-image-publish spec gap in the router series (PR-A #405 TLS, PR-C #407 registry sync, PR-E #409 latency+SNI regression tests — all merged).

## Design notes worth calling out

- **`cache_ttl=0` treated as "use default"**, not "disable caching". Go's `int` + `omitempty` conflates absent-field with present-zero, so a Go-based provider can never explicitly emit `0` on the wire (`json.Marshal` drops it). The majority case is genuinely absent → use default. Providers that need to force cache invalidation should return `cache_ttl=1`. Documented at the `Put` call site. Open follow-up: file a spec issue asking for an explicit `no_cache: true` field to remove the ambiguity for statically-typed impls.
- **Cache hit runs before the circuit-breaker gate.** A warm response is still useful during a provider outage, and the TTL bounds staleness. Explicit choice, called out at the check site.
- **Deep-clone of Offers on read AND write.** `Offer` carries `SellerAgent`, `Brand`, `Price`, `CreativeManifest`, and `Macros` — all pointer/slice/map. The tmproto docstring on `SellerAgent` says "the router MAY stamp this field from its cached package→seller map" — a shallow clone would let that stamp corrupt cache entries. Deep-clone removes the failure mode upfront. Regression test proves the isolation.
- **Cache key drops `package_ids` per spec.** The spec's cache-key definition explicitly omits it because "the same packages are evaluated for every user on a given placement." A publisher varying `package_ids` for the same `{property, placement}` violates that assumption — comment at the check site names it.

## Config surface

| Env | Purpose | Default |
|---|---|---|
| `TMP_ROUTER_CACHE_DISABLED` | Disable the cache entirely, fan out on every request | `false` |
| `TMP_ROUTER_CACHE_DEFAULT_TTL_SEC` | Fallback TTL when provider omits `cache_ttl` | `300` |

JSON: `cache: { disabled: bool, default_ttl_seconds: int }` on `ServerConfig`.

## Metrics

- `tmp_context_cache_hits_total{provider}`
- `tmp_context_cache_misses_total{provider}`

Provider labels are bounded (spec limits `provider_id` to `^[A-Za-z0-9_]+$` max 64), and only ever populated from `ProviderSet.ID` — never from request-derived strings.

## Test plan

- [x] `go test ./router/... -race` — passes; new tests cover nil-safety, deep-clone isolation, TTL expiration (injected clock), provider TTL override, TTL clamp to max, zero-TTL-uses-default, per-provider key partitioning, metrics counts, and 32-goroutine concurrent access
- [x] `go test ./cmd/router/... -race` — passes; new env-merge tests
- [x] End-to-end tests: repeat Context Match hits cache and does not re-hit the provider; provider `cache_ttl` override survives past the router's default TTL
- [x] `golangci-lint run --new-from-rev origin/main` — 0 issues on both modules
- [x] `go vet` clean

## Refs

- Linear: [AI-3719](https://linear.app/scope3-projects/issue/AI-3719/pr-d-context-match-response-caching-5-min-ttl-per-provider-cache-ttl)
- Series root: bring `adcp-go` router to spec-conformance for community-facing OCI image publish