### PR TITLE
argus: add ARGUS.md, wire it into the review prompt, raise max-turns to 70

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -65,11 +65,13 @@ jobs:
 
       # ─────────────────────────────────────────────────────────────────────
       # Self-modification gate. If the PR's cumulative diff touches Argus's
-      # own configuration (`.github/workflows/ai-review.yml` or any file
-      # under `.github/ai-review/**`), skip Argus entirely and post a
-      # notice that a human reviewer is required. Argus must not approve
-      # PRs that rewrite its own gates — CODEOWNERS gates the merge, but
-      # this stops a misleading "approved by bot" signal from showing up.
+      # own configuration (`.github/workflows/ai-review.yml`, any file
+      # under `.github/ai-review/**`, or the repo-root `ARGUS.md` whose
+      # content is injected into every review prompt), skip Argus entirely
+      # and post a notice that a human reviewer is required. Argus must not
+      # approve PRs that rewrite its own gates — CODEOWNERS gates the
+      # merge, but this stops a misleading "approved by bot" signal from
+      # showing up.
       # ─────────────────────────────────────────────────────────────────────
       - name: Self-modification check
         id: self-mod
@@ -82,7 +84,7 @@ jobs:
           set -euo pipefail
           TOUCHED="$(gh api --paginate "/repos/${REPO}/pulls/${PR_NUMBER}/files" \
             --jq '.[].filename' \
-            | grep -E '^(\.github/workflows/ai-review\.yml|\.github/ai-review/)' || true)"
+            | grep -E '^(\.github/workflows/ai-review\.yml|\.github/ai-review/|ARGUS\.md$)' || true)"
           if [ -n "$TOUCHED" ]; then
             echo "touches=true" >> "$GITHUB_OUTPUT"
             echo "Argus paths touched — pausing Argus on this PR. Files:"
@@ -117,7 +119,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${marker}\n🛑 **Argus paused on this PR.**\n\nThis PR modifies Argus's own configuration (\`.github/workflows/ai-review.yml\` or \`.github/ai-review/**\`). Argus will not post an approving review on changes to its own gates — a human reviewer must take this PR. CODEOWNERS already requires a human approval on these paths.\n\n[Workflow run](${runUrl})\n\n<sub>Automated by the Argus self-modification gate.</sub>`,
+              body: `${marker}\n🛑 **Argus paused on this PR.**\n\nThis PR modifies Argus's own configuration (\`.github/workflows/ai-review.yml\`, \`.github/ai-review/**\`, or \`ARGUS.md\`). Argus will not post an approving review on changes to its own gates — a human reviewer must take this PR. CODEOWNERS already requires a human approval on these paths.\n\n[Workflow run](${runUrl})\n\n<sub>Automated by the Argus self-modification gate.</sub>`,
             });
 
       # ─────────────────────────────────────────────────────────────────────
@@ -201,9 +203,27 @@ jobs:
         run: |
           set -euo pipefail
           PROMPT_BODY="$(cat .github/ai-review/expert-adcp-reviewer.md)"
+          # Repo-specific context lives in ARGUS.md at the repo root. It is
+          # optional — the review still runs without it, just without the
+          # repo-tailored priors (high-risk paths, mandatory-coverage rules,
+          # escalation reviewers). Content is injected verbatim under a
+          # dedicated header so the reviewer sees it as authoritative
+          # repo-scope context rather than folded into the base prompt.
+          REPO_CONTEXT=""
+          if [ -f ARGUS.md ]; then
+            REPO_CONTEXT="$(cat ARGUS.md)"
+          fi
           {
             echo 'ARGUS_PROMPT<<ARGUS_EOF'
             echo "$PROMPT_BODY"
+            if [ -n "$REPO_CONTEXT" ]; then
+              echo ''
+              echo '---'
+              echo ''
+              echo '# Repo-specific context (from ARGUS.md)'
+              echo ''
+              echo "$REPO_CONTEXT"
+            fi
             echo ''
             echo '---'
             echo ''
@@ -228,7 +248,7 @@ jobs:
           track_progress: false
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Read,Glob,Grep,Task"
-            --max-turns 60
+            --max-turns 70
             --model claude-opus-4-8
             --effort high
 

--- a/ARGUS.md
+++ b/ARGUS.md
@@ -1,0 +1,35 @@
+# Argus configuration
+
+## Repo Context
+
+`adcp-go` is the Go reference implementation of the [Ad Context Protocol (AdCP)](https://adcontextprotocol.org) and its Trusted Match Protocol (TMP). The public `adcontextprotocol/adcp` repo owns the spec, JSON schemas, and skill contracts; this repo implements them: router, targeting engine, identity/context reference agents, TMP request-authentication envelope, and an SDK for building AdCP agents. Every wire-level change here must be pinned to a corresponding position in `adcontextprotocol/adcp` — schema regeneration, signing semantics, envelope headers, and pinhole surface are all downstream of that repo.
+
+The rules below layer on top of `AGENTS.md` and `.github/ai-review/expert-adcp-reviewer.md` — they cover ground the base prompt does not.
+
+### Trusted-Match read/write symmetry (fcap `seller_agent_url`)
+
+`fcap.Field.SellerAgentURL` is the marker key on both the reader (`targeting/identityagent/service.go`) and any downstream frequency-writer service. Since PR #406 both sides canonicalize via `github.com/adcontextprotocol/adcp-go/urlcanon` with best-effort semantics: canonical form for well-formed http/https URLs, raw pass-through for non-URL routing strings. A change that reintroduces read/write asymmetry — canonicalizing only one side, or adding a new `fcap.Field{...}` construction site that skips `canonicalizeSellerAgentURL` (defined at `targeting/identityagent/service.go`) — fragments cap buckets by URL spelling and silently fails cap enforcement open. Flag any new `fcap.Field{...}` construction that does not route the seller URL through the helper.
+
+### Router public endpoints and env-var contract
+
+The public router surface is `/registry/snapshot`, `/tmp/context`, and `/tmp/identity` (wired in `cmd/router/main.go`). Env-var contracts use the `TMP_*` prefix — 16 declared vars in `main.go`. Renaming or removing a `TMP_*` var, or changing an HTTP status or response shape on these endpoints, silently breaks operator deploys; combined with the MUST-FIX #6 conventional-commit rule in the base prompt, changes here need a `feat!:` / `fix!:` marker and a matching env-var / chart update called out in the PR description.
+
+### Schema regeneration — version-comment invariant
+
+The base prompt already blocks schema changes without a `types_gen.go` regen. One extra concrete check on top of that: after regen, the version comment at the top of `adcp/types_gen.go` (line 2, `// AdCP schema version: X.Y.Z`) MUST match the contents of `adcp/schemas/VERSION`. A drift there means the regen ran against a stale bundle. Verify with `head -2 adcp/types_gen.go` and `cat adcp/schemas/VERSION`.
+
+### Metrics error-label discipline
+
+`targeting/prommetrics/**` covers the label conventions in general. On top of that: error-outcome labels on identity-agent and context-agent metrics quantize to the closed set `"timeout" | "canceled" | "error"` (see `targeting/identityagent/metrics.go` and `targeting/contextagent/metrics.go`). Never `err.Error()`, never a fresh label per error kind — the set is closed by design and expanding it is a cardinality change that ripples through Grafana dashboards.
+
+### Keep this file in sync
+
+Every rule above is a claim about how the repo actually behaves — file paths, invariants, escalation targets. When a diff changes any of that (a rule becomes stale, a new invariant lands, a boundary moves), the same diff must update `ARGUS.md`. Argus and any other reviewing agent should flag PRs whose behavior changes contradict something in this file without a corresponding `ARGUS.md` edit — an out-of-date `ARGUS.md` is worse than none because it teaches the reviewer the wrong priors.
+
+Applies equally to human contributors and coding agents. Whenever you add, remove, or change something covered here — fcap symmetry, router endpoints / env vars, schema pipeline, metrics discipline, escalation ownership, or when a new class of invariant becomes worth capturing — update this file in the same PR.
+
+Note: `ARGUS.md` is in the self-modification gate (`.github/workflows/ai-review.yml`), so any PR touching this file will pause Argus and require a human reviewer. That is intentional — this file's content is injected verbatim into every review prompt.
+
+## Escalation Reviewers
+
+- bokelley


### PR DESCRIPTION
## Summary

Adds a repo-root `ARGUS.md` that layers repo-specific priors on top of the base prompt at `.github/ai-review/expert-adcp-reviewer.md`. Deliberately scoped to invariants the base prompt does not already encode:

- **fcap seller_agent_url read/write symmetry** — PR #406 landed canonicalization on the reader side (via `canonicalizeSellerAgentURL` in `targeting/identityagent/service.go`). A new `fcap.Field{...}` construction that skips the helper fragments cap buckets by URL spelling and silently fails cap enforcement open.
- **Router public endpoint surface + env-var contract** — enumerates `/registry/snapshot`, `/tmp/context`, `/tmp/identity` and the `TMP_*` env-var prefix in `cmd/router/main.go`. The base prompt's MUST-FIX #6 covers the conventional-commit marker; ARGUS.md names the concrete surface it applies to.
- **Schema regen — one extra check** — after regen, the version comment at line 2 of `adcp/types_gen.go` must match `adcp/schemas/VERSION`. A drift means the regen ran against a stale bundle.
- **Metrics error-label discipline** — closed-set outcome labels (`"timeout" | "canceled" | "error"`) on identity-agent and context-agent metrics, per `targeting/identityagent/metrics.go` and `targeting/contextagent/metrics.go`. Grafana-relevant.
- **Explicit sync clause** — every rule is a claim about repo behavior, so a diff that invalidates one must update ARGUS.md in the same PR. Written to be obvious to both human contributors and coding agents.

Sections that would have duplicated the base prompt or `AGENTS.md` (general TMP-signing MUST-FIX, protocol-managed-skills read-only rule, pinhole overview, generic high-risk-paths list) are deliberately omitted. Draft caught by a Fable-5 audit pass that flagged five duplicative sections and two BLOCKING trivial-path globs — see the commit for the trim rationale.

## Workflow changes

1. **`Build Argus review prompt` step** now reads `ARGUS.md` if present and injects it into the prompt under a `# Repo-specific context (from ARGUS.md)` header before the pre-computed inputs. Missing file → no-op, existing behavior preserved.
2. **Self-modification gate regex** extended to include `^ARGUS\.md$`. Argus pauses on this PR (and any future PR that edits `ARGUS.md`), which is intentional — a review agent must not approve changes to its own priors. CODEOWNERS gates the merge.
3. **`--max-turns` raised from 60 to 70** to give the reviewer more room on the multi-hunk cross-file audits the current MUST-FIX list drives.

## Test plan

- [x] YAML change is structural bash-heredoc addition inside an existing string; verified by inspection
- [x] Self-mod gate will fire on this PR — Argus should post the "🛑 Argus paused" comment, not a review. That is the expected behavior and validates the gate change.
- [x] ARGUS.md content audited by a separate Fable-5 pass against the current tree: all cited paths and behaviors verified; duplicative content pruned

🤖 Generated with [Claude Code](https://claude.com/claude-code)