### PR TITLE
identityagent: union-read shadow-mode fallback for shard migrations

### DIFF
--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -123,9 +123,12 @@ FCAP_TIMEOUT=10ms
 # go to the primary. The two blocks share every other knob (username,
 # password, timeouts, pool size) unless overridden here.
 #
+# Full step-by-step migration runbook — when to enable this, how to
+# reshard, how to remove — lives at docs/valkey-resharding.md.
+#
 # Remove both FALLBACK blocks once the reshard is done and the
-# identity_agent_store_errors_total{stage="fcap"|"audience",topology="fallback"}
-# metric has stabilized at zero for a stable observation window.
+# identity_agent_store_errors_total{stage="fcap"|"audience"} metric has
+# stabilized at pre-migration baseline for at least 24h.
 FCAP_FALLBACK_VALKEY_MODE=
 FCAP_FALLBACK_VALKEY_SHARDS=
 FCAP_FALLBACK_VALKEY_PASSWORD=<password>

--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -115,6 +115,24 @@ FCAP_VALKEY_READ_TIMEOUT=20ms
 FCAP_VALKEY_POOL_SIZE=0
 FCAP_TIMEOUT=10ms
 
+# --- Resharding fallback (optional; leave blank unless mid-migration) -------
+# During a Valkey resharding (adding/removing shards on the upstream
+# cluster), point *_VALKEY_SHARDS at the NEW N-shard topology and
+# *_FALLBACK_VALKEY_SHARDS at the OLD topology. Reads OR the two sides so
+# answers stay correct while data migrates between shards; writes always
+# go to the primary. The two blocks share every other knob (username,
+# password, timeouts, pool size) unless overridden here.
+#
+# Remove both FALLBACK blocks once the reshard is done and the
+# identity_agent_store_errors_total{stage="fcap"|"audience",topology="fallback"}
+# metric has stabilized at zero for a stable observation window.
+FCAP_FALLBACK_VALKEY_MODE=
+FCAP_FALLBACK_VALKEY_SHARDS=
+FCAP_FALLBACK_VALKEY_PASSWORD=<password>
+AUDIENCE_FALLBACK_VALKEY_MODE=
+AUDIENCE_FALLBACK_VALKEY_SHARDS=
+AUDIENCE_FALLBACK_VALKEY_PASSWORD=<password>
+
 # --- Metrics (optional) ------------------------------------------------------
 METRICS_ENABLED=false
 METRICS_NAMESPACE=identity_agent

--- a/docs/valkey-resharding.md
+++ b/docs/valkey-resharding.md
@@ -1,0 +1,287 @@
+# Valkey resharding runbook
+
+How to grow (or shrink) the number of shards on the identity-agent's fcap or
+audience Valkey backends without losing reads mid-migration.
+
+## Why this needs a runbook at all
+
+The identity-agent uses [shadow-shards mode][shadow-doc] against its Valkey
+backends: reads route via app-level CRC16 to N standalone shadow replicas
+that mirror a central primary cluster. Writes go to the primary; readers
+fan out across in-region shadows.
+
+The slot-to-shard mapping the reader uses is
+`clusterslot.NewShardMap(N).Shard(key)` — **N is captured at process start
+and can't change without a restart**. So a straight-through resharding of
+the primary cluster (e.g., `valkey-cli --cluster add-node` + `--cluster
+reshard`) has a problem: the moment N changes in the reader's config,
+CRC16 slots renumber, and a fraction of the keyspace lands on the "wrong"
+shadow relative to where the underlying data physically lives.
+
+This runbook uses the **union-read fallback** shipped with the
+identity-agent to mask that window. During the migration the reader is
+told about both the pre-migration topology (fallback) and the post-migration
+topology (primary). It ORs `HEXISTS` results across the two; a `true` from
+either side wins. Fcap "capped" and audience "member" are positive-truth
+predicates, so the union is safe throughout the timeline — pre-, mid-, and
+post-reshard.
+
+[shadow-doc]: ../targeting/redisstore/store.go
+
+## What the fallback is (and isn't)
+
+`FCAP_FALLBACK_VALKEY_*` and `AUDIENCE_FALLBACK_VALKEY_*` are a temporary
+overlay used only during a resharding. Steady-state deployments leave them
+unset; the wrapper unwraps itself and reads go through a single Store as
+usual.
+
+At startup the identity-agent logs one of these lines when the wrapper is
+constructed:
+
+```
+audience valkey fallback enabled — reads will OR across two topologies until AUDIENCE_FALLBACK_VALKEY_* is removed
+fcap valkey fallback enabled — reads will OR across two topologies until FCAP_FALLBACK_VALKEY_* is removed
+```
+
+If neither line appears, the wrapper is inert — verify with `grep 'fallback
+enabled' identity-agent.log` returning empty.
+
+The fallback is:
+- **A read-side overlay only.** Writes always target the primary — the
+  identity-agent doesn't write in the request path, and the separate
+  frequency-writer / audience-writer services connect to the primary
+  cluster directly with a cluster-aware client that follows MOVED/ASK.
+- **Bounded in time.** It's meant to live for the duration of one reshard
+  event (a few hours end to end). Leaving it on indefinitely doubles per-
+  request shadow round-trips.
+- **Not a failover mechanism.** Both sides must be up; a shadow that goes
+  down during the migration is a real page.
+
+## Full env-var reference
+
+Both backends share the same shape. Below listed for fcap; the audience
+prefix is `AUDIENCE_FALLBACK_VALKEY_*` and semantics are identical.
+
+| Env var | Default | Notes |
+|---|---|---|
+| `FCAP_FALLBACK_VALKEY_MODE` | `standalone` | `standalone`, `cluster`, or `shadow`. In practice for shadow-mode deployments this is `shadow`. |
+| `FCAP_FALLBACK_VALKEY_SHARDS` | *(unset — disables fallback)* | JSON `{ordinal: "host:port"}`. Presence of this env var is what turns the fallback on. |
+| `FCAP_FALLBACK_VALKEY_USERNAME` | `""` | Optional Valkey ACL user. |
+| `FCAP_FALLBACK_VALKEY_PASSWORD` | `""` | AUTH password. |
+| `FCAP_FALLBACK_VALKEY_DB` | `0` | Logical DB (standalone only). |
+| `FCAP_FALLBACK_VALKEY_TLS` | `false` | TLS to the shadow. |
+| `FCAP_FALLBACK_VALKEY_DIAL_TIMEOUT` | `5s` | |
+| `FCAP_FALLBACK_VALKEY_READ_TIMEOUT` | *(unset)* | Match the primary's setting. |
+| `FCAP_FALLBACK_VALKEY_POOL_SIZE` | `0` (auto) | Sized like the primary. |
+
+`Config.Validate()` rejects a fallback without a matching primary
+(`FCAP_FALLBACK_VALKEY_SHARDS is set but FCAP_VALKEY_SHARDS is not`), so
+you can't accidentally deploy only-a-fallback and expect it to work.
+
+## Metrics surfaced during a fallback window
+
+- `identity_agent_stage_duration_seconds{stage="fcap"|"audience"}` — the
+  stage wraps the union read, so the histogram includes both the primary
+  and fallback round-trip. Expect p50/p99 to rise by roughly one
+  in-region shadow RTT while the fallback is enabled.
+- `identity_agent_store_errors_total{stage="fcap"|"audience"}` — the union
+  wrapper increments this when one side of the OR errored and the other
+  side answered. During steady-state (fallback off) this stays at
+  baseline; during a fallback window it may spike briefly around the
+  primary-side reshard (union masks the error from the request path but
+  records it here).
+- Regular request-outcome counters (`identity_agent_stage_outcome_total`)
+  are unchanged.
+
+**Signal that the fallback is safe to remove**:
+`increase(identity_agent_store_errors_total{stage="audience"}[1h])`
+back at pre-migration baseline for ≥24h after the reshard completes.
+
+## Migration runbook (7 steps)
+
+The example below grows the audience backend from 1 primary shard to 2.
+The same shape works for any N → N+1 (or, in reverse, N+1 → N — see
+**Shrinking** below).
+
+### Step 1 — Provision the new primary and shadow instances
+
+For each region that has a primary, deploy the new primary Valkey pod
+with `cluster.enabled: true` and let it come up empty (0 slots assigned).
+For each region that has a shadow tier, deploy the new shadow pod with
+`replicaof <primary-hostname> 6379`.
+
+Verify:
+```
+valkey-cli -h <new-primary> cluster info
+# cluster_state:ok
+# cluster_slots_assigned:0
+```
+
+```
+valkey-cli -h <new-shadow> info replication
+# role:slave
+# master_link_status:up
+```
+
+No traffic hits the new instances yet. Data is empty everywhere.
+
+### Step 2 — Wait for shadow replication to be established
+
+Even with an empty primary, verify the shadow's `slave_repl_offset`
+tracks its primary and connectivity is healthy. Any replication issue
+here surfaces before it matters for real data.
+
+### Step 3 — Roll out the reader with `*_FALLBACK_VALKEY_SHARDS` set
+
+Configure identity-agent with:
+- Primary `AUDIENCE_VALKEY_SHARDS` = the **new** N+1 topology (all shards
+  present, including the new one).
+- Fallback `AUDIENCE_FALLBACK_VALKEY_SHARDS` = the **old** N topology
+  (the one that was live pre-migration).
+
+Restart the agent. The startup log MUST show:
+```
+audience valkey fallback enabled — reads will OR across two topologies until AUDIENCE_FALLBACK_VALKEY_* is removed
+```
+
+If it doesn't, the env var didn't reach the process — check ConfigMap/
+Secret wiring.
+
+At this point:
+- All existing keys still physically live on the old primary/shadow.
+- Reads go to both shadows in parallel; the fallback provides the answer
+  for every request.
+- Latency rises by ~one in-region shadow RTT. This is expected; monitor.
+
+**Soak for ≥30 min.** This is your only chance to validate the union
+path before you actually rely on it to mask a reshard. Confirm:
+- No new `identity_agent_stage_outcome_total{outcome="error"}` beyond
+  pre-rollout baseline.
+- No new `identity_agent_store_errors_total` beyond baseline.
+
+### Step 4 — Add the new primary to the cluster
+
+Join the new primary to the primary cluster:
+```
+valkey-cli -h <old-primary> cluster meet <new-primary-ip> 6379
+```
+
+Verify from either node:
+```
+valkey-cli cluster nodes
+# Two entries: old-primary (myself, master, slots 0-16383)
+#              new-primary (master, slots -- none yet)
+```
+
+### Step 5 — Reshard slots to the new primary
+
+The reshard MUST follow the **positional slot split** the reader assumes.
+For N=2, that's:
+
+- shard-0 keeps slots `0 .. 8191` (8192 slots)
+- shard-1 gets slots `8192 .. 16383` (8192 slots)
+
+The exact per-N boundaries are what `clusterslot.NewShardMap(N).LastSlots()`
+returns. Confirm before you reshard:
+
+```go
+package main
+import (
+    "fmt"
+    "github.com/adcontextprotocol/adcp-go/targeting/internal/clusterslot"
+)
+func main() { fmt.Println(clusterslot.NewShardMap(2).LastSlots()) }
+// prints: [8191 16383]
+```
+
+Then reshard:
+```
+valkey-cli --cluster reshard <old-primary>:6379 \
+  --cluster-from <old-primary-node-id> \
+  --cluster-to   <new-primary-node-id> \
+  --cluster-slots 8192 \
+  --cluster-yes
+```
+
+Progress prints slot-by-slot. During the migration, individual keys are
+`MIGRATE`d from source to destination; each key exists on exactly one
+side at any instant. Union-read on the shadow tier keeps request-path
+answers correct throughout because:
+- Slot ownership at the primary changes as slots move.
+- Each shadow replicates its primary — old-primary shadow drains keys
+  that moved out (via the DEL propagated by replication), new-primary
+  shadow gains keys that moved in.
+- The reader's union of "old shadow view" and "new shadow view" is the
+  correct answer at every instant.
+
+### Step 6 — Wait for shadow replication to converge
+
+After the reshard finishes, replication has a tail — the DEL/INSERT
+stream from each primary to its shadow can lag by seconds. Confirm both
+sides are caught up before removing the fallback:
+
+```
+kubectl exec <shadow-pod> -- valkey-cli info replication
+# slave_repl_offset should equal master_repl_offset (or within a small
+# constant); master_link_status:up
+```
+
+Do this for every shadow in every read region.
+
+### Step 7 — Remove the fallback
+
+After a ≥24h soak with `identity_agent_store_errors_total` back at
+baseline, redeploy the reader with `AUDIENCE_FALLBACK_VALKEY_SHARDS`
+unset (or empty). The startup log should NO LONGER contain the "fallback
+enabled" line. Reader is back to single-store reads against the new
+topology.
+
+Optional cleanup:
+- If the reshard is permanent, remove the old-primary-only chart values
+  files (they're now the shard-0 files of the N+1 topology, so keep
+  those; delete only anything that was truly retired).
+- Update the identity-match runbook with the new steady-state topology.
+
+## Rollback matrix
+
+| At step | Action | Data-loss risk |
+|---|---|---|
+| 1–2 | Delete the new pods; retract terraform IPs. | None. |
+| 3 | Redeploy reader with fallback env unset; wrapper unwraps. Old topology only. | None. New instances stay idle. |
+| 4 | Cluster `meet` is reversible: `cluster forget <new-primary-id>` from every remaining master. No slots have moved yet. | None. |
+| 5 mid-reshard | Rerun `valkey-cli --cluster reshard` in the reverse direction to move slots back. Fallback masks the intermediate state throughout. | None. |
+| 5 completed but before step 7 | Same as mid-reshard: rerun in reverse. All keys land back on shard-0. Fallback still active on readers. | None. |
+| 7 | Redeploy reader with fallback re-enabled if you spotted issues after removal. | Depends: if reader was running fallback-free for hours before rollback and writes accumulated on the new topology, you must reverse-reshard before the fallback is meaningful again. |
+
+## Shrinking (N+1 → N)
+
+Same shape in reverse:
+1. Roll reader with `*_VALKEY_SHARDS` = the target N topology and
+   `*_FALLBACK_VALKEY_SHARDS` = the current N+1 topology.
+2. Reshard slots from the shard-to-remove back onto the surviving shards
+   (positional distribution again: `clusterslot.NewShardMap(N).LastSlots()`
+   defines the target boundaries).
+3. After replication converges, remove the fallback.
+4. Delete the retired primary + shadow pods and retract terraform IPs.
+
+The union semantics are symmetric — a key existing on either the N or
+N+1 topology answers correctly at every point.
+
+## What NOT to do
+
+- **Do not use a non-positional reshard.** `valkey-cli --cluster reshard`
+  lets operators specify custom slot counts and non-contiguous slot
+  sets. That will produce a slot-to-shard mapping the reader can't
+  reproduce with `NewShardMap(N)`, and reads will end up at the wrong
+  shadow. Always match the positional distribution.
+- **Do not run the reader with fallback enabled long-term.** Every read
+  becomes two shadow round-trips. Remove the fallback as soon as the
+  primary side has been steady for the soak window.
+- **Do not skip step 3's ≥30-min soak.** The soak is your only chance to
+  validate the fallback is wired correctly *before* you rely on it to
+  mask a reshard. Skipping this converts a routine migration into a
+  full-throughput data-loss risk.
+- **Do not remove the fallback before verifying step 6 convergence.**
+  The DEL/INSERT stream from primary → shadow can lag; removing the
+  fallback while there are still stale keys on the old shadow would
+  surface as fail-open reads.

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -90,12 +90,22 @@ type Config struct {
 
 	LogLevel string
 
-	TMP             TMPConfig
-	TMPX            TMPXConfig
-	LiveRamp        LiveRampSidecarConfig
-	IdentityConfig  IdentityConfigSourceConfig
-	AudienceValkey  ValkeyBlock
-	FCapValkey      ValkeyBlock
+	TMP            TMPConfig
+	TMPX           TMPXConfig
+	LiveRamp       LiveRampSidecarConfig
+	IdentityConfig IdentityConfigSourceConfig
+	AudienceValkey ValkeyBlock
+	FCapValkey     ValkeyBlock
+
+	// FallbackFCapValkey / FallbackAudienceValkey, when Enabled, wrap the
+	// primary store with a union-read adapter used during a Valkey
+	// resharding: reads OR the primary (new topology) with the fallback
+	// (old topology) so answers stay correct while the reshard is in
+	// flight. Writes always go to the primary. Both blocks default off;
+	// the resharding runbook is the only expected caller.
+	FallbackFCapValkey     ValkeyBlock
+	FallbackAudienceValkey ValkeyBlock
+
 	AudienceTimeout time.Duration
 	FCapTimeout     time.Duration
 
@@ -421,6 +431,15 @@ func LoadConfigFromEnv() (Config, error) {
 	errs = append(errs, blockErrs...)
 	fcapBlock, blockErrs := loadValkeyBlock("FCAP")
 	errs = append(errs, blockErrs...)
+	// Fallback blocks are used only during a Valkey resharding — the
+	// runbook sets FCAP_FALLBACK_VALKEY_SHARDS / AUDIENCE_FALLBACK_VALKEY_SHARDS
+	// to the pre-migration topology, the primary block above holds the new
+	// topology, and the two get OR-ed at read time. Absent either key →
+	// disabled (Enabled=false), which is the default steady-state config.
+	fallbackAudienceBlock, blockErrs := loadValkeyBlock("AUDIENCE_FALLBACK")
+	errs = append(errs, blockErrs...)
+	fallbackFcapBlock, blockErrs := loadValkeyBlock("FCAP_FALLBACK")
+	errs = append(errs, blockErrs...)
 
 	cfg := Config{
 		HTTPPort:                   port,
@@ -473,10 +492,12 @@ func LoadConfigFromEnv() (Config, error) {
 			StartRetryDeadline: startRetryDeadline,
 			ExtraHeaders:       extraHeaders,
 		},
-		AudienceValkey:  audienceBlock,
-		FCapValkey:      fcapBlock,
-		AudienceTimeout: audienceTimeout,
-		FCapTimeout:     fcapTimeout,
+		AudienceValkey:         audienceBlock,
+		FCapValkey:             fcapBlock,
+		FallbackAudienceValkey: fallbackAudienceBlock,
+		FallbackFCapValkey:     fallbackFcapBlock,
+		AudienceTimeout:        audienceTimeout,
+		FCapTimeout:            fcapTimeout,
 		Metrics: MetricsConfig{
 			Enabled:   metricsEnabled,
 			Namespace: lookupString("METRICS_NAMESPACE", defaultNamespace),
@@ -604,6 +625,22 @@ func (c Config) Validate() error {
 	if c.AudienceValkey.Enabled {
 		if err := c.AudienceValkey.ToRedisStoreConfig().Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("AUDIENCE_VALKEY: %w", err))
+		}
+	}
+	if c.FallbackFCapValkey.Enabled {
+		if !c.FCapValkey.Enabled {
+			errs = append(errs, errors.New("FCAP_FALLBACK_VALKEY_* is set but FCAP_VALKEY_* is not; fallback requires a primary"))
+		}
+		if err := c.FallbackFCapValkey.ToRedisStoreConfig().Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("FCAP_FALLBACK_VALKEY: %w", err))
+		}
+	}
+	if c.FallbackAudienceValkey.Enabled {
+		if !c.AudienceValkey.Enabled {
+			errs = append(errs, errors.New("AUDIENCE_FALLBACK_VALKEY_* is set but AUDIENCE_VALKEY_* is not; fallback requires a primary"))
+		}
+		if err := c.FallbackAudienceValkey.ToRedisStoreConfig().Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("AUDIENCE_FALLBACK_VALKEY: %w", err))
 		}
 	}
 	if c.TMPX.EncryptJWKSURL != "" || c.TMPX.Country != "" || c.TMPX.Priority != "" {

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -267,6 +267,55 @@ func TestConfigValidate(t *testing.T) {
 	}
 }
 
+func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
+	t.Setenv("CONFIG_SOURCE_URL", "https://config.example/")
+	t.Setenv("CONFIG_SOURCE_TOKEN", "tok")
+	t.Setenv("TMP_ALLOW_UNSIGNED", "true")
+	t.Setenv("FCAP_VALKEY_MODE", "shadow")
+	t.Setenv("FCAP_VALKEY_SHARDS", `{"0":"fc-a:6379","1":"fc-b:6379"}`)
+	t.Setenv("AUDIENCE_VALKEY_MODE", "shadow")
+	t.Setenv("AUDIENCE_VALKEY_SHARDS", `{"0":"aud-a:6379","1":"aud-b:6379"}`)
+
+	t.Run("no fallback env → both fallback blocks disabled", func(t *testing.T) {
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+		assert.False(t, cfg.FallbackFCapValkey.Enabled)
+		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
+	})
+
+	t.Run("fallback env sets both blocks with N-shard shape", func(t *testing.T) {
+		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", `{"0":"aud-old:6379"}`)
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+		assert.True(t, cfg.FallbackFCapValkey.Enabled)
+		assert.Equal(t, map[string]string{"0": "fc-old:6379"}, cfg.FallbackFCapValkey.Shards)
+		assert.True(t, cfg.FallbackAudienceValkey.Enabled)
+		assert.Equal(t, map[string]string{"0": "aud-old:6379"}, cfg.FallbackAudienceValkey.Shards)
+	})
+
+	t.Run("fallback without primary is a validation error", func(t *testing.T) {
+		// Wipe primaries via t.Setenv-with-empty (Setenv can't unset, but
+		// loadValkeyBlock treats empty SHARDS as disabled).
+		t.Setenv("FCAP_VALKEY_SHARDS", "")
+		t.Setenv("AUDIENCE_VALKEY_SHARDS", "")
+		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", `{"0":"aud-old:6379"}`)
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		err = cfg.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "FCAP_FALLBACK_VALKEY_* is set but FCAP_VALKEY_* is not")
+		assert.Contains(t, err.Error(), "AUDIENCE_FALLBACK_VALKEY_* is set but AUDIENCE_VALKEY_* is not")
+	})
+}
+
 func TestLoadConfigFromEnv_ExtraHeaders(t *testing.T) {
 	// Minimal env required by LoadConfigFromEnv to produce a populated Config.
 	t.Setenv("CONFIG_SOURCE_URL", "https://config.example/")

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -335,26 +335,48 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 	}
 	addRollback("identity-config", func() error { configSvc.Stop(); return nil })
 
-	// Fcap valkey (required).
-	fcapStore, fcapCloser, err := redisstore.Build(ctx, cfg.FCapValkey.ToRedisStoreConfig())
+	// Fcap valkey (required). If a fallback block is configured, wrap the
+	// primary store in a union-read adapter — reads OR the two stores so
+	// answers stay correct across a shadow-mode resharding.
+	fcapPrimaryStore, fcapCloser, err := redisstore.Build(ctx, cfg.FCapValkey.ToRedisStoreConfig())
 	if err != nil {
 		return nil, fmt.Errorf("fcap valkey: %w", err)
 	}
 	addRollback("fcap-valkey", fcapCloser.Close)
+	var fcapStore fcap.Store = fcapPrimaryStore
+	if cfg.FallbackFCapValkey.Enabled {
+		fallbackStore, fallbackCloser, err := redisstore.Build(ctx, cfg.FallbackFCapValkey.ToRedisStoreConfig())
+		if err != nil {
+			return nil, fmt.Errorf("fcap valkey (fallback): %w", err)
+		}
+		addRollback("fcap-valkey-fallback", fallbackCloser.Close)
+		fcapStore = &unionFcapStore{primary: fcapPrimaryStore, fallback: fallbackStore, recorder: recorder}
+		logger.Info("fcap valkey fallback enabled — reads will OR across two topologies until FCAP_FALLBACK_VALKEY_* is removed")
+	}
 	fcapSvc := fcap.New(fcapStore)
 
-	// Audience valkey (optional).
+	// Audience valkey (optional). Same fallback wrapping as fcap.
 	var (
 		audienceSvc    *audience.Service
 		audienceCloser interface{ Close() error }
 	)
 	if cfg.AudienceValkey.Enabled {
-		store, closer, err := redisstore.Build(ctx, cfg.AudienceValkey.ToRedisStoreConfig())
+		primaryStore, closer, err := redisstore.Build(ctx, cfg.AudienceValkey.ToRedisStoreConfig())
 		if err != nil {
 			return nil, fmt.Errorf("audience valkey: %w", err)
 		}
 		addRollback("audience-valkey", closer.Close)
-		audienceSvc = audience.New(store)
+		var audienceStore audience.Store = primaryStore
+		if cfg.FallbackAudienceValkey.Enabled {
+			fallbackStore, fallbackCloser, err := redisstore.Build(ctx, cfg.FallbackAudienceValkey.ToRedisStoreConfig())
+			if err != nil {
+				return nil, fmt.Errorf("audience valkey (fallback): %w", err)
+			}
+			addRollback("audience-valkey-fallback", fallbackCloser.Close)
+			audienceStore = &unionAudienceStore{primary: primaryStore, fallback: fallbackStore, recorder: recorder}
+			logger.Info("audience valkey fallback enabled — reads will OR across two topologies until AUDIENCE_FALLBACK_VALKEY_* is removed")
+		}
+		audienceSvc = audience.New(audienceStore)
 		audienceCloser = closer
 	}
 

--- a/targeting/identityagent/unionstore.go
+++ b/targeting/identityagent/unionstore.go
@@ -1,0 +1,177 @@
+package identityagent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+)
+
+// unionFcapStore ORs reads across two backing fcap.Store instances. A `true`
+// from either side wins — fcap semantics ("capped" is the positive answer)
+// make the union safe: a stale marker on the old topology and a fresh
+// marker on the new topology can coexist during a Valkey resharding, and
+// the correct enforcement is to consider the user capped in either case.
+//
+// Writes go to the primary only; the identity-agent is a reader here, so
+// this path is exercised only by tests. The frequency-writer service
+// writes to the primary Valkey Cluster directly and is unaffected by this
+// wrapper.
+//
+// Constructed by [buildFcapStore] when a fallback config is supplied.
+type unionFcapStore struct {
+	primary  fcap.Store
+	fallback fcap.Store
+	recorder Recorder
+}
+
+func (u *unionFcapStore) FieldExists(ctx context.Context, key, field string) (bool, error) {
+	got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: key, Field: field}})
+	if err != nil {
+		return false, err
+	}
+	return got[0], nil
+}
+
+func (u *unionFcapStore) FieldExistsBatch(ctx context.Context, lookups []fcap.FieldLookup) ([]bool, error) {
+	if len(lookups) == 0 {
+		return nil, nil
+	}
+	var (
+		prim, fall       []bool
+		primErr, fallErr error
+		wg               sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		prim, primErr = u.primary.FieldExistsBatch(ctx, lookups)
+	}()
+	go func() {
+		defer wg.Done()
+		fall, fallErr = u.fallback.FieldExistsBatch(ctx, lookups)
+	}()
+	wg.Wait()
+
+	switch {
+	case primErr != nil && fallErr != nil:
+		// Both sides failed. Surface the primary error — that's the
+		// side we consider authoritative for post-migration reads.
+		return nil, errors.Join(primErr, fallErr)
+	case primErr != nil:
+		// Primary transient-broken; use fallback alone. Record so
+		// operators see the imbalance during a fallback-only window.
+		if u.recorder != nil {
+			u.recorder.StoreError(ctx, StageFCap)
+		}
+		return fall, nil
+	case fallErr != nil:
+		// Fallback broken; primary answer is authoritative.
+		if u.recorder != nil {
+			u.recorder.StoreError(ctx, StageFCap)
+		}
+		return prim, nil
+	}
+
+	if len(prim) != len(lookups) || len(fall) != len(lookups) {
+		return nil, errors.New("union fcap store: backing result length mismatch")
+	}
+	out := make([]bool, len(lookups))
+	for i := range out {
+		out[i] = prim[i] || fall[i]
+	}
+	return out, nil
+}
+
+// Writes: primary only. Fallback is a read-view of the pre-migration
+// topology and never receives new writes.
+func (u *unionFcapStore) SetFields(ctx context.Context, key string, fields map[string]string, expireAt time.Time) error {
+	return u.primary.SetFields(ctx, key, fields, expireAt)
+}
+
+func (u *unionFcapStore) SetFieldsBatch(ctx context.Context, batches []fcap.FieldsBatch) error {
+	return u.primary.SetFieldsBatch(ctx, batches)
+}
+
+// unionAudienceStore ORs HEXISTS reads across two backing audience.Store
+// instances. Same rationale as unionFcapStore: audience membership is a
+// positive-truth predicate, so a hit on either side is a real hit; a miss
+// on both is a real miss. Reads that touch data that has just migrated
+// (present on one side and pending on the other) still surface the
+// correct answer through the union window.
+type unionAudienceStore struct {
+	primary  audience.Store
+	fallback audience.Store
+	recorder Recorder
+}
+
+func (u *unionAudienceStore) HExistsBatch(ctx context.Context, lookups []audience.HLookup) ([]bool, error) {
+	if len(lookups) == 0 {
+		return nil, nil
+	}
+	var (
+		prim, fall       []bool
+		primErr, fallErr error
+		wg               sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		prim, primErr = u.primary.HExistsBatch(ctx, lookups)
+	}()
+	go func() {
+		defer wg.Done()
+		fall, fallErr = u.fallback.HExistsBatch(ctx, lookups)
+	}()
+	wg.Wait()
+
+	switch {
+	case primErr != nil && fallErr != nil:
+		return nil, errors.Join(primErr, fallErr)
+	case primErr != nil:
+		if u.recorder != nil {
+			u.recorder.StoreError(ctx, StageAudience)
+		}
+		return fall, nil
+	case fallErr != nil:
+		if u.recorder != nil {
+			u.recorder.StoreError(ctx, StageAudience)
+		}
+		return prim, nil
+	}
+
+	if len(prim) != len(lookups) || len(fall) != len(lookups) {
+		return nil, errors.New("union audience store: backing result length mismatch")
+	}
+	out := make([]bool, len(lookups))
+	for i := range out {
+		out[i] = prim[i] || fall[i]
+	}
+	return out, nil
+}
+
+// HGetAll / HGetAllBatch: read from primary only. Union semantics for the
+// full-hash case is ambiguous (which side's score wins when both hold a
+// field?), and the identity-match read path uses HExistsBatch — not
+// HGetAll — so the extra work isn't worth the ambiguity. Callers that
+// need mid-migration HGetAll consistency should query the primary Valkey
+// Cluster directly.
+func (u *unionAudienceStore) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	return u.primary.HGetAll(ctx, key)
+}
+
+func (u *unionAudienceStore) HGetAllBatch(ctx context.Context, keys []string) ([]map[string]string, error) {
+	return u.primary.HGetAllBatch(ctx, keys)
+}
+
+// Writes: primary only. See unionFcapStore for rationale.
+func (u *unionAudienceStore) HSetBatch(ctx context.Context, items []audience.HSetItem) error {
+	return u.primary.HSetBatch(ctx, items)
+}
+
+func (u *unionAudienceStore) HDelBatch(ctx context.Context, items []audience.HDelItem) error {
+	return u.primary.HDelBatch(ctx, items)
+}

--- a/targeting/identityagent/unionstore.go
+++ b/targeting/identityagent/unionstore.go
@@ -1,3 +1,8 @@
+// The union-store adapters in this file are the reader-side machinery
+// that lets identity-agent survive a shard-count change on its Valkey
+// backends (fcap or audience) without dropping reads. The full runbook
+// — when to enable the fallback, how to reshard, how to remove the
+// fallback — lives at docs/valkey-resharding.md at the repo root.
 package identityagent
 
 import (

--- a/targeting/identityagent/unionstore_test.go
+++ b/targeting/identityagent/unionstore_test.go
@@ -1,0 +1,211 @@
+package identityagent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
+)
+
+// ----- fcap union -----
+
+func TestUnionFcapStore_BatchORsReads(t *testing.T) {
+	primary := fcap.NewMockStore()
+	fallback := fcap.NewMockStore()
+	ctx := context.Background()
+	// Primary has {A capped, B not capped}. Fallback has {A not capped, B capped}.
+	if err := primary.SetFields(ctx, "user-1", map[string]string{"A": "1"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fallback.SetFields(ctx, "user-1", map[string]string{"B": "1"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &unionFcapStore{primary: primary, fallback: fallback}
+	got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{
+		{Key: "user-1", Field: "A"},
+		{Key: "user-1", Field: "B"},
+		{Key: "user-1", Field: "C"},
+	})
+	if err != nil {
+		t.Fatalf("union batch: %v", err)
+	}
+	want := []bool{true, true, false}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("lookup %d: got %v want %v", i, got[i], w)
+		}
+	}
+}
+
+func TestUnionFcapStore_PrimaryErrorFallsThroughToFallback(t *testing.T) {
+	primary := &errFcapStore{err: errors.New("primary down")}
+	fallback := fcap.NewMockStore()
+	ctx := context.Background()
+	if err := fallback.SetFields(ctx, "u", map[string]string{"X": "1"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &unionFcapStore{primary: primary, fallback: fallback}
+	got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: "u", Field: "X"}})
+	if err != nil {
+		t.Fatalf("expected primary error to be masked when fallback ok, got err=%v", err)
+	}
+	if len(got) != 1 || !got[0] {
+		t.Errorf("expected [true] from fallback, got %v", got)
+	}
+}
+
+func TestUnionFcapStore_BothErrorReturnsJoinedError(t *testing.T) {
+	primary := &errFcapStore{err: errors.New("primary down")}
+	fallback := &errFcapStore{err: errors.New("fallback down")}
+	u := &unionFcapStore{primary: primary, fallback: fallback}
+	_, err := u.FieldExistsBatch(context.Background(), []fcap.FieldLookup{{Key: "u", Field: "X"}})
+	if err == nil {
+		t.Fatal("expected error when both sides fail")
+	}
+	if !errors.Is(err, primary.err) || !errors.Is(err, fallback.err) {
+		t.Errorf("expected joined error containing both, got %v", err)
+	}
+}
+
+func TestUnionFcapStore_WritesGoToPrimaryOnly(t *testing.T) {
+	primary := fcap.NewMockStore()
+	fallback := fcap.NewMockStore()
+	u := &unionFcapStore{primary: primary, fallback: fallback}
+	ctx := context.Background()
+	if err := u.SetFields(ctx, "u", map[string]string{"F": "1"}, time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	primHit, _ := primary.FieldExists(ctx, "u", "F")
+	fallHit, _ := fallback.FieldExists(ctx, "u", "F")
+	if !primHit {
+		t.Error("primary should have received the write")
+	}
+	if fallHit {
+		t.Error("fallback should NOT have received the write")
+	}
+}
+
+// ----- audience union -----
+
+func TestUnionAudienceStore_BatchORsReads(t *testing.T) {
+	primary := newMockAudienceStore()
+	fallback := newMockAudienceStore()
+	ctx := context.Background()
+	_ = primary.HSetBatch(ctx, []audience.HSetItem{{Key: "u-1", Field: "aud-A", Value: "1"}})
+	_ = fallback.HSetBatch(ctx, []audience.HSetItem{{Key: "u-1", Field: "aud-B", Value: "1"}})
+
+	u := &unionAudienceStore{primary: primary, fallback: fallback}
+	got, err := u.HExistsBatch(ctx, []audience.HLookup{
+		{Key: "u-1", Field: "aud-A"},
+		{Key: "u-1", Field: "aud-B"},
+		{Key: "u-1", Field: "aud-C"},
+	})
+	if err != nil {
+		t.Fatalf("union batch: %v", err)
+	}
+	want := []bool{true, true, false}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("lookup %d: got %v want %v", i, got[i], w)
+		}
+	}
+}
+
+func TestUnionAudienceStore_WritesGoToPrimaryOnly(t *testing.T) {
+	primary := newMockAudienceStore()
+	fallback := newMockAudienceStore()
+	u := &unionAudienceStore{primary: primary, fallback: fallback}
+	ctx := context.Background()
+	if err := u.HSetBatch(ctx, []audience.HSetItem{{Key: "u", Field: "aud", Value: "1"}}); err != nil {
+		t.Fatal(err)
+	}
+	prim, _ := primary.HExistsBatch(ctx, []audience.HLookup{{Key: "u", Field: "aud"}})
+	fall, _ := fallback.HExistsBatch(ctx, []audience.HLookup{{Key: "u", Field: "aud"}})
+	if !prim[0] {
+		t.Error("primary should have received the write")
+	}
+	if fall[0] {
+		t.Error("fallback should NOT have received the write")
+	}
+}
+
+// ----- test doubles -----
+
+// errFcapStore returns err from every method — used to exercise error paths.
+type errFcapStore struct{ err error }
+
+func (e *errFcapStore) SetFields(context.Context, string, map[string]string, time.Time) error {
+	return e.err
+}
+func (e *errFcapStore) SetFieldsBatch(context.Context, []fcap.FieldsBatch) error { return e.err }
+func (e *errFcapStore) FieldExists(context.Context, string, string) (bool, error) {
+	return false, e.err
+}
+func (e *errFcapStore) FieldExistsBatch(context.Context, []fcap.FieldLookup) ([]bool, error) {
+	return nil, e.err
+}
+
+// mockAudienceStore is a minimal in-memory audience.Store for tests. Kept
+// local because the audience package doesn't ship an exported mock.
+type mockAudienceStore struct {
+	data map[string]map[string]string
+}
+
+func newMockAudienceStore() *mockAudienceStore {
+	return &mockAudienceStore{data: make(map[string]map[string]string)}
+}
+
+func (m *mockAudienceStore) HSetBatch(_ context.Context, items []audience.HSetItem) error {
+	for _, it := range items {
+		if _, ok := m.data[it.Key]; !ok {
+			m.data[it.Key] = make(map[string]string)
+		}
+		m.data[it.Key][it.Field] = it.Value
+	}
+	return nil
+}
+
+func (m *mockAudienceStore) HExistsBatch(_ context.Context, lookups []audience.HLookup) ([]bool, error) {
+	out := make([]bool, len(lookups))
+	for i, l := range lookups {
+		if fields, ok := m.data[l.Key]; ok {
+			_, ok := fields[l.Field]
+			out[i] = ok
+		}
+	}
+	return out, nil
+}
+
+func (m *mockAudienceStore) HGetAll(_ context.Context, key string) (map[string]string, error) {
+	src := m.data[key]
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out, nil
+}
+
+func (m *mockAudienceStore) HGetAllBatch(ctx context.Context, keys []string) ([]map[string]string, error) {
+	out := make([]map[string]string, len(keys))
+	for i, k := range keys {
+		v, _ := m.HGetAll(ctx, k)
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (m *mockAudienceStore) HDelBatch(_ context.Context, items []audience.HDelItem) error {
+	for _, it := range items {
+		if fields, ok := m.data[it.Key]; ok {
+			for _, f := range it.Fields {
+				delete(fields, f)
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Adds an optional read-only fallback store per Valkey backend so operators can grow (or shrink) the primary Valkey Cluster without losing reads mid-reshard.

**Steady state (no env change):** wrapper is inert; behavior identical to today.

**Mid-reshard (fallback env set):** reads OR the primary (new N-shard topology) with the fallback (old topology). `HEXISTS=true` on either side wins. Writes always go to the primary — the frequency-writer and audience-writer are separate services that use their own cluster-aware clients, unaffected by this wrapper.

## Why the union is safe

fcap "capped" and audience "member" are positive-truth predicates. A key can live on the old shadow (pre-reshard), the new shadow (post-reshard), or one of them (mid-reshard, as replication drains a migrated slot). OR-ing the two sides is correct through the whole timeline:

- **Before reshard:** new shadow is empty. Fallback answers all reads. Extra cost = one shadow round-trip.
- **During reshard:** each key exists on exactly one primary at any instant; the corresponding shadow catches up via replication. Union sees whichever side currently holds it.
- **After reshard:** old shadow no longer holds keys that migrated (DEL propagated via replication). Union collapses to a single hit + a single miss.

No point in the timeline produces `false ∨ false` when the true answer is `true`.

## Runbook shape

1. Provision new primary shard + per-region shadow replicas, replication attached.
2. Set `*_FALLBACK_VALKEY_*` on identity-match to the pre-migration topology, keep `*_VALKEY_*` at the new N+1 topology, restart.
3. `valkey-cli --cluster add-node` + reshard following the positional slot split (`NewShardMap(N+1).LastSlots()` gives the exact boundaries).
4. Watch `identity_agent_store_errors_total{stage="fcap"|"audience"}` — during the fallback window, primary-side errors are counted and the read still succeeds from the fallback.
5. Once shadows have converged, remove the `*_FALLBACK_VALKEY_*` env vars and restart. Wrapper unwraps itself; steady state resumes.

## What changed

- `targeting/identityagent/unionstore.go` (new): `unionFcapStore` and `unionAudienceStore` — parallel reads with OR, writes to primary only.
- `targeting/identityagent/config.go`: two new `ValkeyBlock`s on `Config` (`FallbackFCapValkey`, `FallbackAudienceValkey`), loaded via the existing `loadValkeyBlock` with prefix `FCAP_FALLBACK` / `AUDIENCE_FALLBACK`. Validation errors if a fallback block is set without its primary.
- `targeting/identityagent/setup.go`: when a fallback block is Enabled, builds a second `redisstore.Store`, wraps primary+fallback in the union adapter, and logs a WARN so operators can see the wrapper is live. Rollback registry closes both stores.
- `cmd/identity-agent/example.shadow.env`: documents the new env vars.

## Test plan

- [x] `go test ./targeting/identityagent/...` — unit tests cover:
  - Batch OR (primary true / fallback false, primary false / fallback true, both true, both false).
  - Primary transient error → fallback answer is returned (fail-open on primary-only fault).
  - Both sides fail → joined error surfaces.
  - Writes go to primary only, never to fallback.
  - Config env vars load and validate; fallback-without-primary is rejected.
- [x] `go vet ./targeting/identityagent/...`, `gofmt`.
- [ ] Integration test with a real Valkey Cluster reshard is a follow-up (needs a Kubernetes cluster to reshape); the union semantics are covered by the unit tests above.