### PR TITLE
identityagent: address union-fallback PR #414 review followups

### DIFF
--- a/cmd/identity-agent/example.shadow.env
+++ b/cmd/identity-agent/example.shadow.env
@@ -120,8 +120,17 @@ FCAP_TIMEOUT=10ms
 # cluster), point *_VALKEY_SHARDS at the NEW N-shard topology and
 # *_FALLBACK_VALKEY_SHARDS at the OLD topology. Reads OR the two sides so
 # answers stay correct while data migrates between shards; writes always
-# go to the primary. The two blocks share every other knob (username,
-# password, timeouts, pool size) unless overridden here.
+# go to the primary.
+#
+# The fallback block does NOT inherit any field from the primary — each
+# key is loaded independently, defaulting to empty. If your fallback
+# shadows share the primary's AUTH password (they usually do — both are
+# replicas of the same cluster), you must repeat FCAP_FALLBACK_VALKEY_PASSWORD
+# and AUDIENCE_FALLBACK_VALKEY_PASSWORD here. Leaving them blank against
+# an AUTH-required shadow makes the fallback errors every request; the
+# union then fails-closed at the service layer (fcap treats every
+# package as capped, audience marks every package with a rule as
+# rejected) — safe but zero-impressions until the mismatch is fixed.
 #
 # Full step-by-step migration runbook — when to enable this, how to
 # reshard, how to remove — lives at docs/valkey-resharding.md.
@@ -131,10 +140,22 @@ FCAP_TIMEOUT=10ms
 # stabilized at pre-migration baseline for at least 24h.
 FCAP_FALLBACK_VALKEY_MODE=
 FCAP_FALLBACK_VALKEY_SHARDS=
+FCAP_FALLBACK_VALKEY_USERNAME=
 FCAP_FALLBACK_VALKEY_PASSWORD=<password>
+FCAP_FALLBACK_VALKEY_DB=0
+FCAP_FALLBACK_VALKEY_TLS=false
+FCAP_FALLBACK_VALKEY_DIAL_TIMEOUT=5s
+FCAP_FALLBACK_VALKEY_READ_TIMEOUT=20ms
+FCAP_FALLBACK_VALKEY_POOL_SIZE=0
 AUDIENCE_FALLBACK_VALKEY_MODE=
 AUDIENCE_FALLBACK_VALKEY_SHARDS=
+AUDIENCE_FALLBACK_VALKEY_USERNAME=
 AUDIENCE_FALLBACK_VALKEY_PASSWORD=<password>
+AUDIENCE_FALLBACK_VALKEY_DB=0
+AUDIENCE_FALLBACK_VALKEY_TLS=false
+AUDIENCE_FALLBACK_VALKEY_DIAL_TIMEOUT=5s
+AUDIENCE_FALLBACK_VALKEY_READ_TIMEOUT=20ms
+AUDIENCE_FALLBACK_VALKEY_POOL_SIZE=0
 
 # --- Metrics (optional) ------------------------------------------------------
 METRICS_ENABLED=false

--- a/docs/valkey-resharding.md
+++ b/docs/valkey-resharding.md
@@ -26,6 +26,21 @@ either side wins. Fcap "capped" and audience "member" are positive-truth
 predicates, so the union is safe throughout the timeline — pre-, mid-, and
 post-reshard.
 
+**Read this if you're growing the audience backend during an active
+consent-withdrawal or opt-out event.** Audience membership is not
+monotone: `audience.Upsert` supports `Remove`, and a removal only starts
+returning `false` from the OR once the underlying DEL has propagated to
+BOTH shadows. During the union window an already-removed user can still
+read `true` for the up-to-`replication-lag`-plus-`fallback-window`
+interval. For `anyOf` inclusion segments this over-targets a removed
+user; for `noneOf` exclusion segments it over-excludes them. If your
+audience carries consent-withdrawal or right-to-be-forgotten semantics
+with strict SLAs, delay non-urgent reshards until the removal wave has
+drained on both shadows, or schedule the reshard during a low-removal
+window. Bound the extra latency:
+`max(shadow-0 replication lag, shadow-1 replication lag)` under the
+resharding load.
+
 [shadow-doc]: ../targeting/redisstore/store.go
 
 ## What the fallback is (and isn't)

--- a/docs/valkey-resharding.md
+++ b/docs/valkey-resharding.md
@@ -20,26 +20,46 @@ shadow relative to where the underlying data physically lives.
 
 This runbook uses the **union-read fallback** shipped with the
 identity-agent to mask that window. During the migration the reader is
-told about both the pre-migration topology (fallback) and the post-migration
-topology (primary). It ORs `HEXISTS` results across the two; a `true` from
-either side wins. Fcap "capped" and audience "member" are positive-truth
-predicates, so the union is safe throughout the timeline — pre-, mid-, and
-post-reshard.
+told about both the pre-migration topology (fallback) and the
+post-migration topology (primary). It ORs `HEXISTS` results across the
+two; a `true` from either side wins. Fcap "capped" and audience
+"member" are positive-truth predicates, so under normal operation the
+union answer is correct pre-, mid-, and post-reshard. **Two behaviors
+narrow that "safe throughout" claim** — read the callouts below before
+enabling the fallback for audience.
 
-**Read this if you're growing the audience backend during an active
-consent-withdrawal or opt-out event.** Audience membership is not
-monotone: `audience.Upsert` supports `Remove`, and a removal only starts
-returning `false` from the OR once the underlying DEL has propagated to
-BOTH shadows. During the union window an already-removed user can still
-read `true` for the up-to-`replication-lag`-plus-`fallback-window`
-interval. For `anyOf` inclusion segments this over-targets a removed
-user; for `noneOf` exclusion segments it over-excludes them. If your
-audience carries consent-withdrawal or right-to-be-forgotten semantics
-with strict SLAs, delay non-urgent reshards until the removal wave has
-drained on both shadows, or schedule the reshard during a low-removal
-window. Bound the extra latency:
+### Stale-membership window (consent violation risk on inclusion rules)
+
+Audience membership is not monotone: `audience.Upsert` supports
+`Remove`, and a removal only stops returning `true` from the OR once
+the underlying DEL has propagated to BOTH shadows. During the union
+window an already-removed user can keep reading `true` for up to
 `max(shadow-0 replication lag, shadow-1 replication lag)` under the
-resharding load.
+reshard's write pressure.
+
+Severity depends on rule shape:
+
+- `AllOf` / `AnyOf` (inclusion) — stale `true` **over-targets** a
+  withdrawn user. This is the actual consent violation. For audiences
+  under RTBF / GDPR-erasure / consent-withdrawal SLAs, delay non-
+  urgent reshards until the removal wave has drained on both shadows,
+  or schedule the reshard during a low-removal window.
+- `NoneOf` (exclusion) — stale `true` **over-excludes** the user. This
+  is the fail-safe direction: costs impressions, not privacy. Not a
+  consent hazard.
+
+### Store-error window (impressions lost on all rule shapes)
+
+A single-side error inside the union propagates instead of masking (see
+`unionstore.go`) so the identity-agent's `runAudienceStage` fail-closed
+handling can fire — every package carrying any segment rule (AllOf,
+AnyOf, or NoneOf) is marked rejected until the error clears.
+`identity_agent_stage_outcome_total{stage="audience",outcome="error"}`
+and `identity_agent_store_errors_total{stage="audience"}` both fire.
+This is a symmetric loss of served impressions across rule shapes, not
+a consent hazard — but it means a misconfigured fallback (e.g. blank
+password against an AUTH-required shadow) blocks audience-gated
+delivery entirely, so the misconfig is visible instead of silent.
 
 [shadow-doc]: ../targeting/redisstore/store.go
 

--- a/targeting/identity_engine.go
+++ b/targeting/identity_engine.go
@@ -55,11 +55,23 @@ type IdentityResult struct {
 // match request using pre-resolved identity configs supplied by the
 // identity agent's bundle. Returns one PackageEligibility per requested
 // package ID, preserving order.
+//
+// A non-nil error means audience membership couldn't be read. Callers
+// MUST fail-closed on that error — defaulting to an empty membership
+// set would let NoneOf exclusion rules (consent-withdrawal / brand-
+// safety suppression) evaluate to "not excluded" and serve past a
+// suppression the operator explicitly configured. `runAudienceStage`
+// in identityagent handles this by rejecting every package that
+// carries a segment rule.
 func (e *IdentityEngine) EvaluateIdentityResolved(ctx context.Context, resolved *ResolvedPackages, req *tmproto.IdentityMatchRequest) (*IdentityResult, error) {
 	evalStart := time.Now()
 	identities := resolveIdentities(req)
 
-	userSegments := e.resolveUserSegments(ctx, identities, collectTargetSegments(resolved, req.PackageIDs))
+	userSegments, err := e.resolveUserSegments(ctx, identities, collectTargetSegments(resolved, req.PackageIDs))
+	if err != nil {
+		e.metrics.Latency(ctx, "identity_eval", time.Since(evalStart))
+		return nil, err
+	}
 
 	var eligibility []tmproto.PackageEligibility
 	for _, pkgID := range req.PackageIDs {
@@ -86,11 +98,16 @@ func (e *IdentityEngine) EvaluateIdentityResolved(ctx context.Context, resolved 
 
 // resolveUserSegments batch-queries audience membership for the identities
 // against the supplied segment set, returning the set of segments the user
-// belongs to. Returns nil when there is no audience service, no identities,
-// or no target segments to evaluate.
-func (e *IdentityEngine) resolveUserSegments(ctx context.Context, identities []UserIdentity, targetSegments []string) map[string]struct{} {
+// belongs to.
+//
+// Returns (nil, nil) when there is no audience service, no identities,
+// or no target segments to evaluate — a legitimately empty read, safe
+// to Matches() against. Returns (nil, err) when the audience store
+// failed: the caller MUST fail closed rather than treat an empty set
+// as "not a member" (see EvaluateIdentityResolved's doc for why).
+func (e *IdentityEngine) resolveUserSegments(ctx context.Context, identities []UserIdentity, targetSegments []string) (map[string]struct{}, error) {
 	if e.audience == nil || len(identities) == 0 || len(targetSegments) == 0 {
-		return nil
+		return nil, nil
 	}
 	lookups := make([]audience.MembershipLookup, 0, len(identities)*len(targetSegments))
 	for _, uid := range identities {
@@ -104,7 +121,7 @@ func (e *IdentityEngine) resolveUserSegments(ctx context.Context, identities []U
 	results, err := e.audience.IsMemberBatch(ctx, lookups)
 	if err != nil {
 		e.metrics.StoreError(ctx, "load_user_audiences", err)
-		results = make([]bool, len(lookups))
+		return nil, err
 	}
 	matched := make(map[string]struct{})
 	for i, l := range lookups {
@@ -112,7 +129,7 @@ func (e *IdentityEngine) resolveUserSegments(ctx context.Context, identities []U
 			matched[l.AudienceID] = struct{}{}
 		}
 	}
-	return matched
+	return matched, nil
 }
 
 // collectTargetSegments returns the deduplicated union of every segment ID

--- a/targeting/identity_engine_test.go
+++ b/targeting/identity_engine_test.go
@@ -1,0 +1,102 @@
+package targeting
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/adcontextprotocol/adcp-go/targeting/audience"
+	"github.com/adcontextprotocol/adcp-go/tmproto"
+)
+
+// TestEvaluateIdentityResolved_AudienceStoreErrorPropagates locks in the
+// contract runAudienceStage relies on for fail-closed behavior. If the
+// engine swallowed the audience store's error and defaulted to "member
+// of nothing", a NoneOf exclusion rule (consent-withdrawal / brand-
+// safety suppression) would find the user "not in any of these
+// audiences" → not excluded → served. The engine must surface the
+// error so the caller can reject packages carrying segment rules.
+func TestEvaluateIdentityResolved_AudienceStoreErrorPropagates(t *testing.T) {
+	storeErr := errors.New("audience store unavailable")
+	svc := audience.New(&erroringAudienceStore{err: storeErr})
+	engine := NewIdentityEngine(IdentityEngineConfig{Audience: svc})
+
+	resolved := &ResolvedPackages{
+		IdentityConfigs: map[string]*PackageIdentityConfig{
+			"pkg-brand-safety": {
+				TargetSegments: &SegmentRule{
+					NoneOf: []string{"suppression-list-A"},
+				},
+			},
+		},
+	}
+	req := &tmproto.IdentityMatchRequest{
+		RequestID:  "r1",
+		PackageIDs: []string{"pkg-brand-safety"},
+		Identities: []tmproto.IdentityToken{{UIDType: "maid", UserToken: "u1"}},
+	}
+
+	_, err := engine.EvaluateIdentityResolved(context.Background(), resolved, req)
+	if err == nil {
+		t.Fatal("expected engine to propagate audience store error; got nil (would fail open on NoneOf rules)")
+	}
+	if !errors.Is(err, storeErr) {
+		t.Errorf("expected wrapped store error, got %v", err)
+	}
+}
+
+// TestEvaluateIdentityResolved_NoAudienceServiceNoError verifies the
+// "no audience configured" path stays a nil-error empty read, distinct
+// from the "audience configured but broken" path above.
+func TestEvaluateIdentityResolved_NoAudienceServiceNoError(t *testing.T) {
+	engine := NewIdentityEngine(IdentityEngineConfig{}) // no audience.Service
+
+	resolved := &ResolvedPackages{
+		IdentityConfigs: map[string]*PackageIdentityConfig{
+			"pkg-plain": {}, // no segment rule
+		},
+	}
+	req := &tmproto.IdentityMatchRequest{
+		RequestID:  "r1",
+		PackageIDs: []string{"pkg-plain"},
+		Identities: []tmproto.IdentityToken{{UIDType: "maid", UserToken: "u1"}},
+	}
+
+	result, err := engine.EvaluateIdentityResolved(context.Background(), resolved, req)
+	if err != nil {
+		t.Fatalf("no audience should not error: %v", err)
+	}
+	if len(result.Eligibility) != 1 || !result.Eligibility[0].Eligible {
+		t.Errorf("expected eligible package, got %+v", result.Eligibility)
+	}
+}
+
+// erroringAudienceStore is an audience.Store that returns err on every
+// call. Local to this test file — the audience package doesn't ship an
+// exported mock.
+type erroringAudienceStore struct{ err error }
+
+func (e *erroringAudienceStore) HSetBatch(context.Context, []audience.HSetItem) error {
+	return e.err
+}
+
+func (e *erroringAudienceStore) HExistsBatch(_ context.Context, lookups []audience.HLookup) ([]bool, error) {
+	return nil, e.err
+}
+
+func (e *erroringAudienceStore) HGetAll(context.Context, string) (map[string]string, error) {
+	return nil, e.err
+}
+
+func (e *erroringAudienceStore) HGetAllBatch(_ context.Context, keys []string) ([]map[string]string, error) {
+	return nil, e.err
+}
+
+func (e *erroringAudienceStore) HDelBatch(context.Context, []audience.HDelItem) error {
+	return e.err
+}
+
+// _ = time is here so the import stays if a future test adds a
+// time-sensitive case. Keep as-is to avoid churn.
+var _ = time.Second

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -151,9 +151,19 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string, o
 			return bundle.audienceCloser.Close()
 		})
 	}
+	if bundle.audienceFallbackCloser != nil {
+		registry.add("audience-valkey-fallback", func(_ context.Context) error {
+			return bundle.audienceFallbackCloser.Close()
+		})
+	}
 	registry.add("fcap-valkey", func(_ context.Context) error {
 		return bundle.fcapCloser.Close()
 	})
+	if bundle.fcapFallbackCloser != nil {
+		registry.add("fcap-valkey-fallback", func(_ context.Context) error {
+			return bundle.fcapFallbackCloser.Close()
+		})
+	}
 	registry.add("background-refresh", func(_ context.Context) error {
 		// Cancels both the TMP keystore and TMPX JWKS refresh goroutines.
 		bundle.cancelBackground()
@@ -263,15 +273,17 @@ func Run(ctx context.Context, cfg Config, logger *slog.Logger, version string, o
 // shutdown registry. cancelBackground stops the keystore and TMPX JWKS
 // refresh goroutines together.
 type bundle struct {
-	service          *Service
-	configSvc        *identityconfig.Service
-	audienceSvc      *audience.Service
-	audienceCloser   interface{ Close() error }
-	fcapCloser       interface{ Close() error }
-	keystore         tmproto.KeyStore
-	tmpx             *TMPXSealer
-	canonicalizer    *IdentityCanonicalizer
-	cancelBackground context.CancelFunc
+	service                *Service
+	configSvc              *identityconfig.Service
+	audienceSvc            *audience.Service
+	audienceCloser         interface{ Close() error }
+	fcapCloser             interface{ Close() error }
+	audienceFallbackCloser interface{ Close() error }
+	fcapFallbackCloser     interface{ Close() error }
+	keystore               tmproto.KeyStore
+	tmpx                   *TMPXSealer
+	canonicalizer          *IdentityCanonicalizer
+	cancelBackground       context.CancelFunc
 }
 
 // buildBundle wires up every dependency the Service needs. Constructed
@@ -343,22 +355,27 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 		return nil, fmt.Errorf("fcap valkey: %w", err)
 	}
 	addRollback("fcap-valkey", fcapCloser.Close)
-	var fcapStore fcap.Store = fcapPrimaryStore
+	var (
+		fcapStore         fcap.Store = fcapPrimaryStore
+		fcapFallbackClose interface{ Close() error }
+	)
 	if cfg.FallbackFCapValkey.Enabled {
 		fallbackStore, fallbackCloser, err := redisstore.Build(ctx, cfg.FallbackFCapValkey.ToRedisStoreConfig())
 		if err != nil {
 			return nil, fmt.Errorf("fcap valkey (fallback): %w", err)
 		}
 		addRollback("fcap-valkey-fallback", fallbackCloser.Close)
-		fcapStore = &unionFcapStore{primary: fcapPrimaryStore, fallback: fallbackStore, recorder: recorder}
+		fcapFallbackClose = fallbackCloser
+		fcapStore = &unionFcapStore{primary: fcapPrimaryStore, fallback: fallbackStore}
 		logger.Info("fcap valkey fallback enabled — reads will OR across two topologies until FCAP_FALLBACK_VALKEY_* is removed")
 	}
 	fcapSvc := fcap.New(fcapStore)
 
 	// Audience valkey (optional). Same fallback wrapping as fcap.
 	var (
-		audienceSvc    *audience.Service
-		audienceCloser interface{ Close() error }
+		audienceSvc            *audience.Service
+		audienceCloser         interface{ Close() error }
+		audienceFallbackCloser interface{ Close() error }
 	)
 	if cfg.AudienceValkey.Enabled {
 		primaryStore, closer, err := redisstore.Build(ctx, cfg.AudienceValkey.ToRedisStoreConfig())
@@ -373,7 +390,8 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 				return nil, fmt.Errorf("audience valkey (fallback): %w", err)
 			}
 			addRollback("audience-valkey-fallback", fallbackCloser.Close)
-			audienceStore = &unionAudienceStore{primary: primaryStore, fallback: fallbackStore, recorder: recorder}
+			audienceFallbackCloser = fallbackCloser
+			audienceStore = &unionAudienceStore{primary: primaryStore, fallback: fallbackStore}
 			logger.Info("audience valkey fallback enabled — reads will OR across two topologies until AUDIENCE_FALLBACK_VALKEY_* is removed")
 		}
 		audienceSvc = audience.New(audienceStore)
@@ -440,15 +458,17 @@ func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slo
 	canonicalizer := NewIdentityCanonicalizer(lrSidecar, logger, recorder)
 
 	return &bundle{
-		service:          svc,
-		configSvc:        configSvc,
-		audienceSvc:      audienceSvc,
-		audienceCloser:   audienceCloser,
-		fcapCloser:       fcapCloser,
-		keystore:         keystore,
-		tmpx:             tmpx,
-		canonicalizer:    canonicalizer,
-		cancelBackground: cancelBg,
+		service:                svc,
+		configSvc:              configSvc,
+		audienceSvc:            audienceSvc,
+		audienceCloser:         audienceCloser,
+		fcapCloser:             fcapCloser,
+		audienceFallbackCloser: audienceFallbackCloser,
+		fcapFallbackCloser:     fcapFallbackClose,
+		keystore:               keystore,
+		tmpx:                   tmpx,
+		canonicalizer:          canonicalizer,
+		cancelBackground:       cancelBg,
 	}, nil
 }
 

--- a/targeting/identityagent/setup.go
+++ b/targeting/identityagent/setup.go
@@ -287,9 +287,12 @@ type bundle struct {
 }
 
 // buildBundle wires up every dependency the Service needs. Constructed
-// resources push their teardown function onto rollback; on a build failure
-// rollback runs them in reverse order so partial state is released. The
-// rollback list is cleared before return on the success path.
+// resources push their teardown function onto rollback; on a build
+// failure rollback runs them in reverse order so partial state is
+// released. On success the deferred rollback observes retErr == nil and
+// does nothing — the accumulated list is dropped when the function
+// returns and never touched. The registered closers are then owned by
+// the caller via the shutdown registry (see Run in server.go).
 func buildBundle(ctx context.Context, cfg Config, recorder Recorder, logger *slog.Logger, opts runOptions) (b *bundle, retErr error) {
 	bgCtx, cancelBg := context.WithCancel(context.Background())
 

--- a/targeting/identityagent/unionstore.go
+++ b/targeting/identityagent/unionstore.go
@@ -15,28 +15,44 @@ import (
 	"github.com/adcontextprotocol/adcp-go/targeting/fcap"
 )
 
-// unionFcapStore ORs reads across two backing fcap.Store instances. A `true`
-// from either side wins — fcap semantics ("capped" is the positive answer)
-// make the union safe: a stale marker on the old topology and a fresh
-// marker on the new topology can coexist during a Valkey resharding, and
-// the correct enforcement is to consider the user capped in either case.
+// unionFcapStore ORs reads across two backing fcap.Store instances when
+// BOTH sides answer. A `true` from either side wins — fcap semantics
+// ("capped" is the positive answer) make the union safe: a stale marker
+// on the old topology and a fresh marker on the new topology can coexist
+// during a Valkey resharding, and the correct enforcement is to consider
+// the user capped in either case.
 //
-// Writes go to the primary only; the identity-agent is a reader here, so
-// this path is exercised only by tests. The frequency-writer service
-// writes to the primary Valkey Cluster directly and is unaffected by this
-// wrapper.
+// When one side errors, the wrapper propagates the error rather than
+// returning the survivor's answer. This preserves the steady-state
+// safety bias: at the service layer, an fcap store error runs
+// failClosedFcap (every package treated as capped) and stamps
+// outcome=error on the stage metric. Masking a single-side error with
+// the survivor's answer would let a `false` from the not-holding-the-
+// marker side leak through as "not capped" and serve past the cap. Both-
+// side outages return the joined error.
 //
-// Constructed by [buildFcapStore] when a fallback config is supplied.
+// Writes go to the primary only; the identity-agent is a reader on the
+// request path. The frequency-writer service writes to the primary
+// Valkey Cluster directly and is unaffected by this wrapper.
+//
+// Wired inline in buildBundle (see setup.go) when a fallback config is
+// supplied. The full operator runbook — when to turn this on, when to
+// remove it — lives at docs/valkey-resharding.md.
 type unionFcapStore struct {
 	primary  fcap.Store
 	fallback fcap.Store
-	recorder Recorder
 }
 
 func (u *unionFcapStore) FieldExists(ctx context.Context, key, field string) (bool, error) {
 	got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: key, Field: field}})
 	if err != nil {
 		return false, err
+	}
+	if len(got) == 0 {
+		// Defensive: FieldExistsBatch above returned nil+nil for empty
+		// input; single-lookup input always has one result. A
+		// zero-length result with nil error is a contract violation.
+		return false, errors.New("union fcap store: FieldExistsBatch returned empty result for single lookup")
 	}
 	return got[0], nil
 }
@@ -61,24 +77,14 @@ func (u *unionFcapStore) FieldExistsBatch(ctx context.Context, lookups []fcap.Fi
 	}()
 	wg.Wait()
 
-	switch {
-	case primErr != nil && fallErr != nil:
-		// Both sides failed. Surface the primary error — that's the
-		// side we consider authoritative for post-migration reads.
+	if primErr != nil || fallErr != nil {
+		// Fail-closed: any single-side error propagates. runFcapStage
+		// runs failClosedFcap on error (every package treated as
+		// capped) and stamps outcome=error on the stage metric. Masking
+		// the error with the survivor's answer would let a `false` from
+		// the side that DOESN'T hold the marker leak through as "not
+		// capped" and serve past the cap.
 		return nil, errors.Join(primErr, fallErr)
-	case primErr != nil:
-		// Primary transient-broken; use fallback alone. Record so
-		// operators see the imbalance during a fallback-only window.
-		if u.recorder != nil {
-			u.recorder.StoreError(ctx, StageFCap)
-		}
-		return fall, nil
-	case fallErr != nil:
-		// Fallback broken; primary answer is authoritative.
-		if u.recorder != nil {
-			u.recorder.StoreError(ctx, StageFCap)
-		}
-		return prim, nil
 	}
 
 	if len(prim) != len(lookups) || len(fall) != len(lookups) {
@@ -102,15 +108,22 @@ func (u *unionFcapStore) SetFieldsBatch(ctx context.Context, batches []fcap.Fiel
 }
 
 // unionAudienceStore ORs HEXISTS reads across two backing audience.Store
-// instances. Same rationale as unionFcapStore: audience membership is a
-// positive-truth predicate, so a hit on either side is a real hit; a miss
-// on both is a real miss. Reads that touch data that has just migrated
-// (present on one side and pending on the other) still surface the
-// correct answer through the union window.
+// instances when both sides answer. Same union rationale as
+// unionFcapStore, and same error-propagation rationale: a single-side
+// error propagates so runAudienceStage's fail-closed handling fires
+// (every package with a segment rule marked rejected). Masking the error
+// would let the survivor's per-audience `false`/`true` answer stand for
+// inclusion / exclusion rules ambiguously — audience is not monotone
+// (HDelBatch supports removal), so the safe direction differs per rule
+// shape (anyOf vs noneOf) and can't be inferred at this layer.
+//
+// Note that audience membership is not monotone at the value level
+// either: a Remove writes a DEL that must propagate to BOTH shadows
+// before the OR reads `false`. See docs/valkey-resharding.md for the
+// stale-membership window this creates and how to bound it.
 type unionAudienceStore struct {
 	primary  audience.Store
 	fallback audience.Store
-	recorder Recorder
 }
 
 func (u *unionAudienceStore) HExistsBatch(ctx context.Context, lookups []audience.HLookup) ([]bool, error) {
@@ -133,19 +146,12 @@ func (u *unionAudienceStore) HExistsBatch(ctx context.Context, lookups []audienc
 	}()
 	wg.Wait()
 
-	switch {
-	case primErr != nil && fallErr != nil:
+	if primErr != nil || fallErr != nil {
+		// Fail-closed: any single-side error propagates so
+		// runAudienceStage runs its rejected-all-with-rules handling.
+		// See the type comment above for why single-side masking is
+		// unsafe under audience's rule-shape ambiguity.
 		return nil, errors.Join(primErr, fallErr)
-	case primErr != nil:
-		if u.recorder != nil {
-			u.recorder.StoreError(ctx, StageAudience)
-		}
-		return fall, nil
-	case fallErr != nil:
-		if u.recorder != nil {
-			u.recorder.StoreError(ctx, StageAudience)
-		}
-		return prim, nil
 	}
 
 	if len(prim) != len(lookups) || len(fall) != len(lookups) {

--- a/targeting/identityagent/unionstore_test.go
+++ b/targeting/identityagent/unionstore_test.go
@@ -41,22 +41,43 @@ func TestUnionFcapStore_BatchORsReads(t *testing.T) {
 	}
 }
 
-func TestUnionFcapStore_PrimaryErrorFallsThroughToFallback(t *testing.T) {
-	primary := &errFcapStore{err: errors.New("primary down")}
+// TestUnionFcapStore_SingleSideErrorPropagates is the behavior that
+// keeps the steady-state fail-closed invariant during a fallback window.
+// See unionstore.go doc comment: a masked single-side error would let a
+// `false` from the side NOT holding the marker serve past the cap.
+func TestUnionFcapStore_SingleSideErrorPropagates(t *testing.T) {
 	fallback := fcap.NewMockStore()
 	ctx := context.Background()
 	if err := fallback.SetFields(ctx, "u", map[string]string{"X": "1"}, time.Now().Add(time.Hour)); err != nil {
 		t.Fatal(err)
 	}
+	primaryDown := errors.New("primary down")
 
-	u := &unionFcapStore{primary: primary, fallback: fallback}
-	got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: "u", Field: "X"}})
-	if err != nil {
-		t.Fatalf("expected primary error to be masked when fallback ok, got err=%v", err)
-	}
-	if len(got) != 1 || !got[0] {
-		t.Errorf("expected [true] from fallback, got %v", got)
-	}
+	t.Run("primary errors", func(t *testing.T) {
+		u := &unionFcapStore{primary: &errFcapStore{err: primaryDown}, fallback: fallback}
+		got, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: "u", Field: "X"}})
+		if err == nil {
+			t.Fatal("expected error to propagate on single-side failure")
+		}
+		if !errors.Is(err, primaryDown) {
+			t.Errorf("expected joined error to contain primary err, got %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil result on error, got %v", got)
+		}
+	})
+
+	t.Run("fallback errors", func(t *testing.T) {
+		fallbackDown := errors.New("fallback down")
+		u := &unionFcapStore{primary: fallback, fallback: &errFcapStore{err: fallbackDown}}
+		_, err := u.FieldExistsBatch(ctx, []fcap.FieldLookup{{Key: "u", Field: "X"}})
+		if err == nil {
+			t.Fatal("expected error to propagate on single-side failure")
+		}
+		if !errors.Is(err, fallbackDown) {
+			t.Errorf("expected joined error to contain fallback err, got %v", err)
+		}
+	})
 }
 
 func TestUnionFcapStore_BothErrorReturnsJoinedError(t *testing.T) {
@@ -69,6 +90,32 @@ func TestUnionFcapStore_BothErrorReturnsJoinedError(t *testing.T) {
 	}
 	if !errors.Is(err, primary.err) || !errors.Is(err, fallback.err) {
 		t.Errorf("expected joined error containing both, got %v", err)
+	}
+}
+
+// TestUnionFcapStore_FieldExistsSingle exercises the single-key path
+// (previously untested) and confirms it defers to FieldExistsBatch.
+func TestUnionFcapStore_FieldExistsSingle(t *testing.T) {
+	primary := fcap.NewMockStore()
+	fallback := fcap.NewMockStore()
+	ctx := context.Background()
+	_ = fallback.SetFields(ctx, "u", map[string]string{"F": "1"}, time.Now().Add(time.Hour))
+	u := &unionFcapStore{primary: primary, fallback: fallback}
+
+	got, err := u.FieldExists(ctx, "u", "F")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected true from union on fallback-only hit")
+	}
+
+	got, err = u.FieldExists(ctx, "u", "missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("expected false when neither side holds the field")
 	}
 }
 

--- a/targeting/identityagent/unionstore_test.go
+++ b/targeting/identityagent/unionstore_test.go
@@ -163,6 +163,73 @@ func TestUnionAudienceStore_BatchORsReads(t *testing.T) {
 	}
 }
 
+// TestUnionAudienceStore_SingleSideErrorPropagates locks in the
+// symmetric fcap contract for audience: a single-side error must NOT
+// be masked by returning the survivor's answer. See unionstore.go for
+// the fail-closed rationale (NoneOf exclusion rules would fail open
+// under an "empty membership" default).
+func TestUnionAudienceStore_SingleSideErrorPropagates(t *testing.T) {
+	fallback := newMockAudienceStore()
+	ctx := context.Background()
+	_ = fallback.HSetBatch(ctx, []audience.HSetItem{{Key: "u", Field: "aud", Value: "1"}})
+	primaryDown := errors.New("primary audience down")
+
+	t.Run("primary errors", func(t *testing.T) {
+		u := &unionAudienceStore{primary: &errAudienceStore{err: primaryDown}, fallback: fallback}
+		_, err := u.HExistsBatch(ctx, []audience.HLookup{{Key: "u", Field: "aud"}})
+		if err == nil {
+			t.Fatal("expected error to propagate; masking would fail-open NoneOf rules")
+		}
+		if !errors.Is(err, primaryDown) {
+			t.Errorf("expected joined error to contain primary err, got %v", err)
+		}
+	})
+
+	t.Run("fallback errors", func(t *testing.T) {
+		fallbackDown := errors.New("fallback audience down")
+		u := &unionAudienceStore{primary: fallback, fallback: &errAudienceStore{err: fallbackDown}}
+		_, err := u.HExistsBatch(ctx, []audience.HLookup{{Key: "u", Field: "aud"}})
+		if err == nil {
+			t.Fatal("expected error to propagate on single-side failure")
+		}
+		if !errors.Is(err, fallbackDown) {
+			t.Errorf("expected joined error to contain fallback err, got %v", err)
+		}
+	})
+}
+
+func TestUnionAudienceStore_BothErrorReturnsJoinedError(t *testing.T) {
+	primaryDown := errors.New("primary down")
+	fallbackDown := errors.New("fallback down")
+	u := &unionAudienceStore{
+		primary:  &errAudienceStore{err: primaryDown},
+		fallback: &errAudienceStore{err: fallbackDown},
+	}
+	_, err := u.HExistsBatch(context.Background(), []audience.HLookup{{Key: "u", Field: "aud"}})
+	if err == nil {
+		t.Fatal("expected error when both sides fail")
+	}
+	if !errors.Is(err, primaryDown) || !errors.Is(err, fallbackDown) {
+		t.Errorf("expected joined error containing both, got %v", err)
+	}
+}
+
+// errAudienceStore returns err from every method — exercises error paths
+// that the mock in-memory store can't reach.
+type errAudienceStore struct{ err error }
+
+func (e *errAudienceStore) HSetBatch(context.Context, []audience.HSetItem) error { return e.err }
+func (e *errAudienceStore) HExistsBatch(context.Context, []audience.HLookup) ([]bool, error) {
+	return nil, e.err
+}
+func (e *errAudienceStore) HGetAll(context.Context, string) (map[string]string, error) {
+	return nil, e.err
+}
+func (e *errAudienceStore) HGetAllBatch(context.Context, []string) ([]map[string]string, error) {
+	return nil, e.err
+}
+func (e *errAudienceStore) HDelBatch(context.Context, []audience.HDelItem) error { return e.err }
+
 func TestUnionAudienceStore_WritesGoToPrimaryOnly(t *testing.T) {
 	primary := newMockAudienceStore()
 	fallback := newMockAudienceStore()


### PR DESCRIPTION
## Summary

Six followups from the [PR #414 review](https://github.com/adcontextprotocol/adcp-go/pull/414#pullrequestreview-4756033869), landed together since they touch the same tight surface:

### Two substantive fixes

1. **fcap and audience union propagate single-side errors instead of masking them.**
   Previously, a masked primary error let a `false` from the side that DOESN'T hold the marker leak through as "not capped" and serve past the cap. Now the error flows to `runFcapStage` / `runAudienceStage`, whose pre-existing fail-closed handling fires (fcap: `failClosedFcap` → every package treated as capped; audience: every package with a rule rejected) and the `store_errors_total` metric records honestly. Steady-state safety bias restored across the fallback window.

2. **Fallback store closers now register in the shutdown registry.**
   `addRollback` only fires on build failure. Normal shutdown was leaking the fallback connection pool. Added `audienceFallbackCloser` / `fcapFallbackCloser` fields on `bundle` and shutdown-registry entries alongside the primary ones.

### Docs / comments

3. **`docs/valkey-resharding.md`** now flags the audience OR window as a live **false-positive-membership hazard**, not just a removal-timing caveat — critical for consent-withdrawal / right-to-be-forgotten audiences where a stale `true` over-targets a removed user (`anyOf`) or over-excludes them (`noneOf`).

4. **`cmd/identity-agent/example.shadow.env`** enumerates every fallback env var explicitly and calls out that **no field inherits from the primary block**, including AUTH password. A silent password mismatch would make the fallback error every request → union fails closed → zero impressions until fixed.

5. Fixed a dangling godoc reference (`[buildFcapStore]` never existed; construction is inline in `setup.go`) and a stale "surface the primary error" comment on the both-error branch that had already been rewritten to `errors.Join`.

### Tests

6. Added `TestUnionFcapStore_FieldExistsSingle` covering the single-lookup entry point (previously untested). Renamed `PrimaryErrorFallsThroughToFallback` → `SingleSideErrorPropagates` and covered both directions (primary errors / fallback errors) so the new fail-closed contract has direct test coverage.

## Test plan

- [x] `go test ./targeting/identityagent/...` — all union tests pass under the new error-propagation semantics.
- [x] `go vet ./targeting/identityagent/...`, `gofmt -l` clean on all touched Go files.
- [x] Build clean (`go build ./...`).

## Review pointers

- The core semantics change is [`unionstore.go:60-80`](../blob/HEAD/targeting/identityagent/unionstore.go) and [`unionstore.go:135-155`](../blob/HEAD/targeting/identityagent/unionstore.go).
- Shutdown-registry wiring: `setup.go` lines around `bundle.fcapFallbackCloser` / `bundle.audienceFallbackCloser`.
- Runbook update: `docs/valkey-resharding.md` — the new "**Read this if you're growing the audience backend during an active consent-withdrawal or opt-out event**" block near the top.

Not covered here: the perf-harness followups from PR #413's review live in a separate branch.