### PR TITLE
bench/perf: address PR #413 review followups

### DIFF
--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -135,7 +135,11 @@ edit the relevant `scenarios/*.env`:
 - `AUDIENCE_PACKAGES` — how many packages carry an audience rule.
 - `AUDIENCES_PER_PACKAGE` — anyOf list length on each such package.
 - `PACKAGES_PER_REQ` — package_ids on each identity-match request.
-- `IDENTITIES_PER_REQ` — identity tokens per request (1..3, per TMP schema).
+- `IDENTITIES_PER_REQ` — identity tokens per request. **Gated to `1`
+  today** — only MAID-shaped tokens survive the identity-agent's
+  canonicalizer end-to-end with the seeder's current key format. See
+  the comment in `cmd/loadgen/main.go` around `identitiesPerReq`.
+  Multi-identity sweeps would silently read cold keys.
 
 ## Manual invocation
 

--- a/bench/perf/cmd/loadgen/main.go
+++ b/bench/perf/cmd/loadgen/main.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"sort"
 	"sync"
 	"syscall"
@@ -68,8 +69,24 @@ func main() {
 	label := flag.String("label", envStr("LABEL", ""), "label included in the report")
 	flag.Parse()
 
-	if *identitiesPerReq < 1 || *identitiesPerReq > 3 {
-		log.Fatalf("identities-per-req must be between 1 and 3 (got %d)", *identitiesPerReq)
+	if *identitiesPerReq != 1 {
+		// Multi-identity requests would silently mismeasure: the seeder
+		// keys every user off a single 32-hex-char token that only the
+		// MAID decoder (16-byte binary form → Canonical re-encodes to
+		// the same 32 hex chars) round-trips to the same identityhash
+		// as what the identity-agent computes at request time. ID5's
+		// decoder is a byte-for-byte pass-through, so the same 32-hex
+		// input becomes 32 raw bytes whose Canonical form is 64 hex
+		// chars — hash mismatch → cold miss on every request. UID2 has
+		// no registered decoder and gets dropped from the canonicalized
+		// slice entirely. Bench numbers under identities-per-req>1 do
+		// not reflect the read path they appear to be measuring.
+		//
+		// A future extension could generate per-uid-type user pools
+		// (MAID hex, ID5 32-byte binary encoded as itself, UID2 UUIDs)
+		// and teach the seeder to write under each canonical form. The
+		// harness stays at 1 identity/request until that lands.
+		log.Fatalf("identities-per-req=%d is not supported; only 1 is measurable today (see comment in loadgen/main.go)", *identitiesPerReq)
 	}
 
 	client := &http.Client{
@@ -209,7 +226,15 @@ loop:
 		select {
 		case tickets <- struct{}{}:
 		default:
+			// Workers can't keep up. Yield the goroutine so we don't
+			// pin a core spinning on the drop path at saturation —
+			// achieved_qps is still derived from completed samples,
+			// but a spinning pacer inflates SUT-observed latency
+			// when loadgen and SUT share cores. Gosched is enough:
+			// the next iteration re-evaluates the interval-based
+			// deadline and will time.Sleep if we're still behind.
 			dropped++
+			runtime.Gosched()
 		}
 	}
 	close(tickets)
@@ -290,32 +315,24 @@ func buildRequest(r *rand.Rand, p waveParams) identityMatchRequest {
 	return req
 }
 
-// uidTypeFor returns distinct uid_type strings so requests with >1 identity
-// don't trip the "duplicate (uid_type, user_token) pair" validator. Every
-// value here must appear in tmproto.validUIDTypes or the request 400s, and
-// its decoder must accept the userToken() format below.
+// uidTypeFor returns the uid_type string for the i-th identity in a
+// request. Only i=0 is exercised today (the loadgen gates
+// identities-per-req at 1). Kept in place with a single MAID entry so a
+// future multi-identity extension has an obvious hook.
 func uidTypeFor(i int) string {
-	switch i {
-	case 0:
-		return "maid"
-	case 1:
-		return "id5"
-	default:
-		return "uid2"
-	}
+	// MAID: 32 hex chars → decoder produces 16 bytes → Canonical()
+	// re-encodes to the same 32 hex chars → identityhash matches the
+	// seeder's Hash(userToken(u)).
+	return "maid"
 }
 
-// userToken returns a 32-char lowercase hex string deterministic in the user
-// index. That format decodes through MAID/ID5/UID2 to a 16- or 32-byte binary
-// token whose Canonical() form is the same 32-char hex — so the fcap/audience
-// key seeded ahead of time matches what the identity-agent computes at
-// request time, regardless of which uid_type carried the request.
+// userToken returns a 32-char lowercase hex string deterministic in the
+// user index. Paired with uid_type=maid — see the comment there for why
+// this format round-trips through the identity-agent's canonicalizer
+// unchanged. The seeder writes fcap/audience keys under
+// identityhash.Hash(userToken(u)); the agent computes the same hash
+// after canonicalization only for MAID-shaped tokens.
 func userToken(u int) string {
-	// 128 bits of "user index" packed into 16 bytes → 32 hex chars.
-	// MAID's decoder requires exactly 32 hex chars (16 bytes); ID5's
-	// pass-through decoder pins ID5 at 32 bytes so it needs a 32-char
-	// string too. This function is a lower bound: use MAID as the uid_type
-	// (16-byte decoder) for zero-drop.
 	return fmt.Sprintf("%032x", u)
 }
 

--- a/bench/perf/cmd/writer/main.go
+++ b/bench/perf/cmd/writer/main.go
@@ -27,6 +27,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -140,9 +141,11 @@ func runFcapWriter(ctx context.Context, r *router.Router, qps, concurrency, tota
 		select {
 		case tickets <- struct{}{}:
 		default:
-			// Consumer can't keep up; drop this tick — the write rate here
-			// is meant to be lower than reader saturation, so dropping is a
-			// signal the target rate is too aggressive.
+			// Consumer can't keep up; drop this tick and yield —
+			// spinning on the drop path at saturation pins a core
+			// and inflates SUT-observed latency if writer and SUT
+			// share cores.
+			runtime.Gosched()
 		}
 	})
 	close(tickets)
@@ -186,6 +189,7 @@ func runAudienceWriter(ctx context.Context, r *router.Router, qps, concurrency, 
 		select {
 		case tickets <- struct{}{}:
 		default:
+			runtime.Gosched()
 		}
 	})
 	close(tickets)

--- a/bench/perf/docker-compose.yml
+++ b/bench/perf/docker-compose.yml
@@ -13,10 +13,18 @@
 # default. Set HOST_METRICS_PORT to expose /metrics for external Prometheus
 # scraping (optional).
 services:
+  # audience-valkey / fcap-valkey are the baseline standalone Valkey
+  # backends — used by run.sh (identity-agent CPU sweep) and by
+  # run-scaling.sh's `standalone-1` and `shadow-*` topologies as shard 0.
+  # Cluster topologies use the fcap-cluster-* / audience-cluster-* services
+  # below and don't touch these — so both are profile-gated to avoid
+  # spinning up two idle Valkey pods on cluster runs. Enable with
+  # `--profile baseline` when using them.
   audience-valkey:
     image: valkey/valkey:8.0-alpine
     command: ["valkey-server", "--maxmemory-policy", "allkeys-lru", "--appendonly", "no", "--save", ""]
     restart: unless-stopped
+    profiles: [baseline, shadow]
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 2s
@@ -27,6 +35,7 @@ services:
     image: valkey/valkey:8.0-alpine
     command: ["valkey-server", "--maxmemory-policy", "allkeys-lru", "--appendonly", "no", "--save", ""]
     restart: unless-stopped
+    profiles: [baseline, shadow]
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 2s
@@ -77,11 +86,13 @@ services:
       dockerfile: cmd/identity-agent/Dockerfile
     image: adcp-identity-agent:latest
     restart: unless-stopped
+    # No depends_on for the Valkey backends: which ones actually exist
+    # depends on the runtime topology (baseline / shadow / cluster). Both
+    # runner scripts explicitly bring up the correct Valkey services
+    # before starting identity-agent, so ordering is enforced there. A
+    # static depends_on on audience-valkey / fcap-valkey would pull those
+    # baseline services in even under cluster topologies.
     depends_on:
-      audience-valkey:
-        condition: service_healthy
-      fcap-valkey:
-        condition: service_healthy
       configserver:
         condition: service_started
     # CPU/memory caps — set by run.sh via IDENTITY_CPUS / IDENTITY_MEMORY.

--- a/bench/perf/run-scaling.sh
+++ b/bench/perf/run-scaling.sh
@@ -41,7 +41,7 @@ export WRITE_QPS_FCAP WRITE_QPS_AUDIENCE PACKAGES_PER_WRITE AUDIENCES_PER_WRITE
 # Topology descriptors (space-separated): name|mode|nshards|profiles
 # `profiles` is a comma-separated list of compose profiles to activate.
 ALL_TOPOLOGIES=(
-  "standalone-1|standalone|1|"
+  "standalone-1|standalone|1|baseline"
   "shadow-2|shadow|2|shadow"
   "shadow-4|shadow|4|shadow"
   "cluster-3|cluster|3|cluster"
@@ -289,7 +289,7 @@ for topo_line in "${TOPOLOGIES[@]}"; do
   export AUDIENCE_VALKEY_SHARDS="$(audience_shard_json "$mode" "$nshards")"
 
   # Tear down anything from a previous topology so container IDs are clean.
-  docker compose --profile shadow --profile cluster --profile cluster-large down -v --remove-orphans >/dev/null 2>&1 || true
+  docker compose --profile baseline --profile shadow --profile cluster --profile cluster-large down -v --remove-orphans >/dev/null 2>&1 || true
 
   # Bring up shards + config.
   echo "  starting valkeys + configserver"
@@ -387,6 +387,17 @@ for topo_line in "${TOPOLOGIES[@]}"; do
     kill "$sampler_pid" 2>/dev/null || true
     wait "$sampler_pid" 2>/dev/null || true
     trap - EXIT INT TERM
+
+    # Safety net matching run.sh: a compose-driven recreate of identity-
+    # agent under our feet would silently invalidate the measurement (new
+    # cgroup limits, empty caches, stats sampler now pointing at the wrong
+    # container). Inline env passthrough on the loadgen invocation above
+    # should keep this from firing — but if it ever does, fail loud.
+    post_cid=$(docker compose ps -q identity-agent)
+    if [[ "$post_cid" != "$identity_cid" ]]; then
+      echo "!! identity-agent container changed during loadgen (was $identity_cid, now $post_cid)" >&2
+      exit 1
+    fi
 
     if [[ -f "$host_report" ]]; then
       # Peak identity-agent CPU + aggregate Valkey peaks (max over all shards of

--- a/bench/perf/run.sh
+++ b/bench/perf/run.sh
@@ -135,12 +135,16 @@ for scenario in "${SCENARIOS[@]}"; do
     echo "SCENARIO=$scenario CPUS=$cpus MEMORY=$memory"
     echo "==================================================================="
 
+    # `--profile baseline` activates the standalone audience-valkey /
+    # fcap-valkey services (profile-gated so cluster topologies via
+    # run-scaling.sh don't spin them up idle). Named-service startup
+    # would also work but this is explicit.
     IDENTITY_CPUS="$cpus" \
     IDENTITY_MEMORY="$memory" \
-      docker compose up -d audience-valkey fcap-valkey configserver
+      docker compose --profile baseline up -d audience-valkey fcap-valkey configserver
     IDENTITY_CPUS="$cpus" \
     IDENTITY_MEMORY="$memory" \
-      docker compose up -d --force-recreate identity-agent
+      docker compose --profile baseline up -d --force-recreate identity-agent
 
     # docker compose's `deploy.resources.limits` isn't reliably honored
     # outside swarm mode on Linux/cgroup-v2, so force the cgroup via


### PR DESCRIPTION
## Summary

Four followups from the [PR #413 review](https://github.com/adcontextprotocol/adcp-go/pull/413#pullrequestreview-4755694127), all non-blocking on that PR:

1. **Hard-gate `identities-per-req` at 1** with a clear fatal message explaining why. The flag previously accepted 1..3, but only MAID-shaped tokens round-trip through the identity-agent's canonicalizer with the seeder's current key format — ID5's pass-through decoder produces a 64-hex Canonical form (32-byte raw token → hex), so `Hash(64-char)` at the agent ≠ `Hash(32-char)` at the seeder → cold key miss. UID2 has no decoder and is dropped outright. Shipped scenarios all pin 1, so this is latent — but the surviving flag was a foot-gun for future scenario authors. Also fixes the factually-inverted comment on `userToken()` and calls out the constraint in the README.

2. **Port the container-recreate guard from `run.sh` into `run-scaling.sh`.** `run.sh` asserts `docker compose ps -q identity-agent` returns the same container id after the loadgen step; `run-scaling.sh` didn't. Inline env passthrough on the loadgen invocation should keep a compose-driven recreate from firing — but if it ever does, the sampler would be pointing at the wrong container and the CSV silently wrong. Fail loud instead.

3. **`runtime.Gosched()` on the pacer's ticket-drop path** in both loadgen and writer. At saturation with the ticket channel full, the deadline-based pacer previously spun the drop path with no yield → pinned a core → inflates SUT-observed latency when loadgen and SUT share cores. Yielding is cheap and the next iteration's deadline check will still `time.Sleep` if we're behind. `achieved_qps` (derived from completed samples) is unaffected.

4. **Profile-gate the baseline standalone Valkeys.** `audience-valkey` and `fcap-valkey` now carry `profiles: [baseline, shadow]`. Cluster topologies in `run-scaling.sh` (`cluster-3`, `cluster-6`) no longer pull those services in as idle depends-on side effects — the two `depends_on` entries on `identity-agent` that would have forced them in are removed, since both runners sequence Valkey→agent startup explicitly. `run.sh` and `run-scaling.sh`'s `standalone-1` topology pass `--profile baseline` to activate them.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean on all touched Go files.
- [x] `bash -n` clean on both runner scripts.
- [x] `docker compose --profile baseline config --services` includes `audience-valkey` + `fcap-valkey`; `docker compose --profile cluster config --services` does not (verified locally).
- [x] `docker compose config --services` (no profile) omits the baseline Valkeys — a bare `up` on the compose file no longer starts them.

## Not touched here

- The union-fallback follow-ups from PR #414 review land in a separate PR (identity-agent code, different subtree).