### PR TITLE
identityagent: drop duplicate audience StoreError + dead test scaffold

### DIFF
--- a/targeting/identity_engine.go
+++ b/targeting/identity_engine.go
@@ -120,7 +120,13 @@ func (e *IdentityEngine) resolveUserSegments(ctx context.Context, identities []U
 	}
 	results, err := e.audience.IsMemberBatch(ctx, lookups)
 	if err != nil {
-		e.metrics.StoreError(ctx, "load_user_audiences", err)
+		// runAudienceStage records store_errors_total{stage="audience"}
+		// on the caller side when it observes this error — no engine-layer
+		// StoreError call here, otherwise a single failed request double-
+		// counts against both `store="load_user_audiences"` and
+		// `stage="audience"` and a summed dashboard over-reports 2×. fcap
+		// single-counts via the same pattern (runFcapStage records on the
+		// caller side); keep audience symmetric.
 		return nil, err
 	}
 	matched := make(map[string]struct{})

--- a/targeting/identity_engine_test.go
+++ b/targeting/identity_engine_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/adcontextprotocol/adcp-go/targeting/audience"
 	"github.com/adcontextprotocol/adcp-go/tmproto"
@@ -97,6 +96,3 @@ func (e *erroringAudienceStore) HDelBatch(context.Context, []audience.HDelItem) 
 	return e.err
 }
 
-// _ = time is here so the import stays if a future test adds a
-// time-sensitive case. Keep as-is to avoid churn.
-var _ = time.Second


### PR DESCRIPTION
Two nits from https://github.com/adcontextprotocol/adcp-go/pull/415#pullrequestreview-4756652528 — non-blocking on that approval, filed as a follow-up.

- **Drop double-counted audience StoreError.** The engine-layer emission at `identity_engine.go` was recording `store_errors_total{store="load_user_audiences"}` on the same failed request that `runAudienceStage` also records at `store_errors_total{stage="audience"}`. Any dashboard summing across labels was over-reporting 2× for audience while fcap was single-counting via the same caller-side pattern. Now symmetric.
- **Remove dead `var _ = time.Second` scaffolding** and the unused `time` import from `identity_engine_test.go`. The placeholder-for-a-hypothetical-future-test was the churn, not what it was guarding against.

## Test plan
- [x] `go build ./...`, `go vet ./targeting/...`, `gofmt` clean.
- [x] `go test ./targeting/...` still green — the existing propagation tests exercise the caller-side StoreError path via runAudienceStage.