### PR TITLE
docs(valkey-resharding): correct expected cluster_state on new empty shard

### DIFF
--- a/docs/valkey-resharding.md
+++ b/docs/valkey-resharding.md
@@ -148,8 +148,13 @@ For each region that has a shadow tier, deploy the new shadow pod with
 Verify:
 ```
 valkey-cli -h <new-primary> cluster info
-# cluster_state:ok
-# cluster_slots_assigned:0
+# cluster_state:fail             ← expected pre-join: a solo cluster-mode
+#                                  node covers 0 of 16384 slots, so
+#                                  Valkey reports `fail` until step 4's
+#                                  add-node lets gossip surface the
+#                                  existing shard's slot coverage.
+# cluster_slots_assigned:0       ← the load-bearing invariant. `state`
+#                                  flips to `ok` at step 4, not here.
 ```
 
 ```


### PR DESCRIPTION
## Summary
Step 1's post-provision verify block in \`docs/valkey-resharding.md\` claimed \`cluster_state:ok\` alongside \`cluster_slots_assigned:0\`. That combination is impossible on a solo cluster-mode Valkey — \`CLUSTER INFO\` reports \`state:fail\` whenever the union of known masters doesn't cover all 16384 slots, and a fresh node covers zero. \`state\` transitions to \`ok\` at step 4's \`valkey-cli --cluster add-node\` once gossip surfaces the existing shard's slot coverage.

## How I noticed
Deployed rta-audience-1 today across 3 primary regions and got \`cluster_state:fail, cluster_slots_assigned:0\` from all three — exactly what Valkey emits pre-join, but the runbook told the operator to expect \`ok\`. Small enough to catch, but confusing without context.

## Change
One markdown block. Preserves the 0-slots invariant as load-bearing; annotates \`state:fail\` as expected and points at step 4 for the transition.

## Test plan
- [x] Rendered the diff — reads correctly with the inline arrow annotations.
- [x] No other \`cluster_state\` mentions in the runbook needed the same treatment (grepped).