### PR TITLE
identityagent: harden loadValkeyBlock against empty-SHARDS misconfigs

### DIFF
--- a/targeting/identityagent/canonicalizer_test.go
+++ b/targeting/identityagent/canonicalizer_test.go
@@ -46,8 +46,8 @@ func TestIdentityCanonicalizer_Decode_ProducesCanonicalBytes(t *testing.T) {
 	ids := []tmproto.IdentityToken{
 		{UIDType: tmproto.UIDTypeMAID, UserToken: validUserTokenFor(tmproto.UIDTypeMAID)},
 		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: validUserTokenFor(tmproto.UIDTypeHashedEmail)},
-		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"},          // no decoder
-		{UIDType: tmproto.UIDTypeOther, UserToken: "ignored"},          // no mapping
+		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"}, // no decoder
+		{UIDType: tmproto.UIDTypeOther, UserToken: "ignored"}, // no mapping
 	}
 	decoded := canon.Decode(t.Context(), ids)
 	require.Len(t, decoded, 4)
@@ -72,9 +72,9 @@ func TestIdentityCanonicalizer_Decode_RecordsDropsLikeSealer(t *testing.T) {
 		recorder: rec,
 	}
 	canon.Decode(t.Context(), []tmproto.IdentityToken{
-		{UIDType: tmproto.UIDTypeOther, UserToken: "x"},                 // unmapped
-		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"},           // no decoder
-		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: "deadbeef"},    // decoder_error (too short)
+		{UIDType: tmproto.UIDTypeOther, UserToken: "x"},              // unmapped
+		{UIDType: tmproto.UIDTypeUID2, UserToken: "any-uid2"},        // no decoder
+		{UIDType: tmproto.UIDTypeHashedEmail, UserToken: "deadbeef"}, // decoder_error (too short)
 	})
 	assert.Equal(t, 1, rec.dropCount(TmpxDropUnmapped, string(tmproto.UIDTypeOther)))
 	assert.Equal(t, 1, rec.dropCount(TmpxDropNoDecoder, string(tmproto.UIDTypeUID2)))

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -673,26 +673,33 @@ func (c Config) Validate() error {
 }
 
 // loadValkeyBlock reads {prefix}_VALKEY_* env vars into a ValkeyBlock. The
-// block is marked Enabled when the SHARDS variable is present and non-empty
-// — that single variable acts as the "configured" signal.
+// block is marked Enabled when SHARDS parses to a non-empty JSON object.
+// An unset SHARDS env var, an empty string, and a valid-JSON empty object
+// ("{}") all collapse to the same disabled block — a ConfigMap emitter
+// can't easily omit a key, so an unconfigured block often lands as "{}"
+// on the pod and len(shards)==0 is never a useful runtime configuration.
+//
+// If SHARDS is empty but a sibling {prefix}_VALKEY_MODE is set, that's
+// "intended but broken" — operator meant to wire this block but the
+// SHARDS render came out empty. Loud error instead of silent disable so
+// a mis-emitted config during a resharding window doesn't quietly turn
+// the fallback off (which would drop the union OR and reopen the exact
+// stale-membership window the fallback exists to close).
 func loadValkeyBlock(prefix string) (ValkeyBlock, []error) {
 	var errs []error
 	shardsRaw := os.Getenv(prefix + "_VALKEY_SHARDS")
-	if shardsRaw == "" {
-		return ValkeyBlock{}, nil
-	}
+	shardsEmpty := shardsRaw == ""
 
 	shards := map[string]string{}
-	if err := json.Unmarshal([]byte(shardsRaw), &shards); err != nil {
-		return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_SHARDS is not a JSON object: %w", prefix, err)}
+	if !shardsEmpty {
+		if err := json.Unmarshal([]byte(shardsRaw), &shards); err != nil {
+			return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_SHARDS is not a JSON object: %w", prefix, err)}
+		}
 	}
-	// Treat a valid-JSON empty object identically to an unset env var. A
-	// ConfigMap emitter can't easily omit a key, so an unconfigured
-	// fallback often lands as "{}" on the pod — which without this check
-	// falls through with Enabled=true and empty Shards, then fails
-	// Config.Validate. Since len(shards)==0 is never a useful runtime
-	// configuration anyway, collapse both spellings to "disabled".
 	if len(shards) == 0 {
+		if _, modeSet := os.LookupEnv(prefix + "_VALKEY_MODE"); modeSet {
+			return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_MODE is set but %s_VALKEY_SHARDS is empty or {}; either configure both or unset both", prefix, prefix)}
+		}
 		return ValkeyBlock{}, nil
 	}
 

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -686,6 +686,15 @@ func loadValkeyBlock(prefix string) (ValkeyBlock, []error) {
 	if err := json.Unmarshal([]byte(shardsRaw), &shards); err != nil {
 		return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_SHARDS is not a JSON object: %w", prefix, err)}
 	}
+	// Treat a valid-JSON empty object identically to an unset env var. A
+	// ConfigMap emitter can't easily omit a key, so an unconfigured
+	// fallback often lands as "{}" on the pod — which without this check
+	// falls through with Enabled=true and empty Shards, then fails
+	// Config.Validate. Since len(shards)==0 is never a useful runtime
+	// configuration anyway, collapse both spellings to "disabled".
+	if len(shards) == 0 {
+		return ValkeyBlock{}, nil
+	}
 
 	mode := lookupString(prefix+"_VALKEY_MODE", string(redisstore.ModeStandalone))
 	db, err := lookupInt(prefix+"_VALKEY_DB", 0)

--- a/targeting/identityagent/config.go
+++ b/targeting/identityagent/config.go
@@ -679,12 +679,15 @@ func (c Config) Validate() error {
 // can't easily omit a key, so an unconfigured block often lands as "{}"
 // on the pod and len(shards)==0 is never a useful runtime configuration.
 //
-// If SHARDS is empty but a sibling {prefix}_VALKEY_MODE is set, that's
-// "intended but broken" — operator meant to wire this block but the
-// SHARDS render came out empty. Loud error instead of silent disable so
-// a mis-emitted config during a resharding window doesn't quietly turn
-// the fallback off (which would drop the union OR and reopen the exact
-// stale-membership window the fallback exists to close).
+// For *_FALLBACK prefixes, an empty SHARDS combined with a non-empty
+// sibling {prefix}_VALKEY_MODE is "intended but broken" — the operator
+// meant to wire the fallback but the SHARDS render came out empty.
+// Loud error instead of silent disable so a mis-emitted config during
+// a resharding window doesn't quietly turn the fallback off (which
+// would drop the union OR and reopen the exact stale-membership window
+// the fallback exists to close). Primary prefixes are exempt: the
+// AUDIENCE primary is optional, and a deployment running with audience
+// intentionally disabled can still have the chart emit a default MODE.
 func loadValkeyBlock(prefix string) (ValkeyBlock, []error) {
 	var errs []error
 	shardsRaw := os.Getenv(prefix + "_VALKEY_SHARDS")
@@ -697,8 +700,10 @@ func loadValkeyBlock(prefix string) (ValkeyBlock, []error) {
 		}
 	}
 	if len(shards) == 0 {
-		if _, modeSet := os.LookupEnv(prefix + "_VALKEY_MODE"); modeSet {
-			return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_MODE is set but %s_VALKEY_SHARDS is empty or {}; either configure both or unset both", prefix, prefix)}
+		if strings.HasSuffix(prefix, "_FALLBACK") {
+			if mode, ok := os.LookupEnv(prefix + "_VALKEY_MODE"); ok && mode != "" {
+				return ValkeyBlock{}, []error{fmt.Errorf("%s_VALKEY_MODE is set but %s_VALKEY_SHARDS is empty or {}; either configure both or unset both", prefix, prefix)}
+			}
 		}
 		return ValkeyBlock{}, nil
 	}

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -1,12 +1,30 @@
 package identityagent
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// unsetenvT unsets an env var for the duration of the test, restoring the
+// prior value (or unset state) on cleanup. Companion to t.Setenv, which
+// can't express "unset". Needed for tests that assert behavior when a
+// specific env is absent while a parent t.Setenv has already set it.
+func unsetenvT(t *testing.T, key string) {
+	t.Helper()
+	prev, hadPrev := os.LookupEnv(key)
+	require.NoError(t, os.Unsetenv(key))
+	t.Cleanup(func() {
+		if hadPrev {
+			_ = os.Setenv(key, prev)
+			return
+		}
+		_ = os.Unsetenv(key)
+	})
+}
 
 func TestConfigValidate(t *testing.T) {
 	base := func() Config {
@@ -299,6 +317,28 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
 	})
 
+	// The silent-disable collapse above only applies when the ENTIRE block
+	// is unset. If a sibling MODE is set but SHARDS renders empty, the
+	// operator meant to wire the block but the config-map emit came out
+	// broken — a resharding-window mis-config that would drop the union
+	// OR and reopen the stale-membership window the fallback exists to
+	// close. Loud error, not silent disable.
+	t.Run(`MODE set with empty SHARDS is a validation error, not silent disable`, func(t *testing.T) {
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", "{}")
+		_, err := LoadConfigFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "AUDIENCE_FALLBACK_VALKEY_MODE is set but AUDIENCE_FALLBACK_VALKEY_SHARDS is empty")
+	})
+
+	t.Run(`MODE set with unset SHARDS is a validation error, not silent disable`, func(t *testing.T) {
+		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
+		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", "")
+		_, err := LoadConfigFromEnv()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "FCAP_FALLBACK_VALKEY_MODE is set but FCAP_FALLBACK_VALKEY_SHARDS is empty")
+	})
+
 	t.Run("fallback env sets both blocks with N-shard shape", func(t *testing.T) {
 		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)
@@ -314,10 +354,15 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 	})
 
 	t.Run("fallback without primary is a validation error", func(t *testing.T) {
-		// Wipe primaries via t.Setenv-with-empty (Setenv can't unset, but
-		// loadValkeyBlock treats empty SHARDS as disabled).
+		// Wipe primaries entirely — both SHARDS and MODE. loadValkeyBlock
+		// now rejects "MODE set with empty SHARDS" (intended-but-broken),
+		// so leaving the parent's MODE=shadow in place would short-circuit
+		// this test with the load-time error instead of exercising the
+		// Config.Validate cross-block check we're pinning here.
 		t.Setenv("FCAP_VALKEY_SHARDS", "")
 		t.Setenv("AUDIENCE_VALKEY_SHARDS", "")
+		unsetenvT(t, "FCAP_VALKEY_MODE")
+		unsetenvT(t, "AUDIENCE_VALKEY_MODE")
 		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)
 		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -284,6 +284,21 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
 	})
 
+	// A ConfigMap emitter that renders an unset map as jsonencode({}) →
+	// "{}" was blowing up identity-agent at startup with "shards must
+	// contain at least one entry" because loadValkeyBlock only gated on
+	// shardsRaw == "". len(shards)==0 must be treated identically to
+	// unset — a fallback with zero shards is never a valid runtime.
+	t.Run(`empty-map JSON "{}" is disabled, not a validation error`, func(t *testing.T) {
+		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", "{}")
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", "{}")
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		require.NoError(t, cfg.Validate())
+		assert.False(t, cfg.FallbackFCapValkey.Enabled)
+		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
+	})
+
 	t.Run("fallback env sets both blocks with N-shard shape", func(t *testing.T) {
 		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)

--- a/targeting/identityagent/config_test.go
+++ b/targeting/identityagent/config_test.go
@@ -1,30 +1,12 @@
 package identityagent
 
 import (
-	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// unsetenvT unsets an env var for the duration of the test, restoring the
-// prior value (or unset state) on cleanup. Companion to t.Setenv, which
-// can't express "unset". Needed for tests that assert behavior when a
-// specific env is absent while a parent t.Setenv has already set it.
-func unsetenvT(t *testing.T, key string) {
-	t.Helper()
-	prev, hadPrev := os.LookupEnv(key)
-	require.NoError(t, os.Unsetenv(key))
-	t.Cleanup(func() {
-		if hadPrev {
-			_ = os.Setenv(key, prev)
-			return
-		}
-		_ = os.Unsetenv(key)
-	})
-}
 
 func TestConfigValidate(t *testing.T) {
 	base := func() Config {
@@ -317,13 +299,13 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
 	})
 
-	// The silent-disable collapse above only applies when the ENTIRE block
-	// is unset. If a sibling MODE is set but SHARDS renders empty, the
-	// operator meant to wire the block but the config-map emit came out
-	// broken — a resharding-window mis-config that would drop the union
-	// OR and reopen the stale-membership window the fallback exists to
-	// close. Loud error, not silent disable.
-	t.Run(`MODE set with empty SHARDS is a validation error, not silent disable`, func(t *testing.T) {
+	// For *_FALLBACK prefixes, empty SHARDS with a non-empty sibling MODE
+	// is "intended but broken" — the operator meant to wire the fallback
+	// but the config-map emit came out broken. A resharding-window
+	// mis-config here would drop the union OR and reopen the stale-
+	// membership window the fallback exists to close. Loud error, not
+	// silent disable.
+	t.Run(`fallback MODE set with empty SHARDS is a validation error, not silent disable`, func(t *testing.T) {
 		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", "{}")
 		_, err := LoadConfigFromEnv()
@@ -331,12 +313,36 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 		assert.Contains(t, err.Error(), "AUDIENCE_FALLBACK_VALKEY_MODE is set but AUDIENCE_FALLBACK_VALKEY_SHARDS is empty")
 	})
 
-	t.Run(`MODE set with unset SHARDS is a validation error, not silent disable`, func(t *testing.T) {
+	t.Run(`fallback MODE set with unset SHARDS is a validation error, not silent disable`, func(t *testing.T) {
 		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", "")
 		_, err := LoadConfigFromEnv()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "FCAP_FALLBACK_VALKEY_MODE is set but FCAP_FALLBACK_VALKEY_SHARDS is empty")
+	})
+
+	// Regression pin: the MODE-intent check is scoped to *_FALLBACK
+	// prefixes. AUDIENCE primary is optional (Config.Validate only
+	// validates it when enabled), so a deployment intentionally running
+	// with audience disabled but where the chart still emits a default
+	// AUDIENCE_VALKEY_MODE must stay a silent-disable, not crash-loop.
+	t.Run(`AUDIENCE primary MODE set with empty SHARDS is disabled, not error`, func(t *testing.T) {
+		t.Setenv("AUDIENCE_VALKEY_MODE", "shadow")
+		t.Setenv("AUDIENCE_VALKEY_SHARDS", "")
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.False(t, cfg.AudienceValkey.Enabled)
+	})
+
+	// MODE explicitly rendered as an empty string is not an intent
+	// signal — lookupString on the enabled path treats it the same as
+	// unset (→ standalone default), so the disabled path must agree.
+	t.Run(`fallback MODE="" with empty SHARDS is disabled, not error`, func(t *testing.T) {
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "")
+		t.Setenv("AUDIENCE_FALLBACK_VALKEY_SHARDS", "{}")
+		cfg, err := LoadConfigFromEnv()
+		require.NoError(t, err)
+		assert.False(t, cfg.FallbackAudienceValkey.Enabled)
 	})
 
 	t.Run("fallback env sets both blocks with N-shard shape", func(t *testing.T) {
@@ -354,15 +360,12 @@ func TestLoadConfigFromEnv_FallbackBlocks(t *testing.T) {
 	})
 
 	t.Run("fallback without primary is a validation error", func(t *testing.T) {
-		// Wipe primaries entirely — both SHARDS and MODE. loadValkeyBlock
-		// now rejects "MODE set with empty SHARDS" (intended-but-broken),
-		// so leaving the parent's MODE=shadow in place would short-circuit
-		// this test with the load-time error instead of exercising the
-		// Config.Validate cross-block check we're pinning here.
+		// Wipe primaries via t.Setenv-with-empty (Setenv can't unset, but
+		// loadValkeyBlock treats empty SHARDS as disabled). Primary MODE
+		// is exempt from the load-time intent check, so leaving the
+		// parent's FCAP_VALKEY_MODE / AUDIENCE_VALKEY_MODE in place is fine.
 		t.Setenv("FCAP_VALKEY_SHARDS", "")
 		t.Setenv("AUDIENCE_VALKEY_SHARDS", "")
-		unsetenvT(t, "FCAP_VALKEY_MODE")
-		unsetenvT(t, "AUDIENCE_VALKEY_MODE")
 		t.Setenv("FCAP_FALLBACK_VALKEY_MODE", "shadow")
 		t.Setenv("FCAP_FALLBACK_VALKEY_SHARDS", `{"0":"fc-old:6379"}`)
 		t.Setenv("AUDIENCE_FALLBACK_VALKEY_MODE", "shadow")

--- a/targeting/identityagent/unionstore_test.go
+++ b/targeting/identityagent/unionstore_test.go
@@ -3,6 +3,7 @@ package identityagent
 import (
 	"context"
 	"errors"
+	"maps"
 	"testing"
 	"time"
 
@@ -298,9 +299,7 @@ func (m *mockAudienceStore) HExistsBatch(_ context.Context, lookups []audience.H
 func (m *mockAudienceStore) HGetAll(_ context.Context, key string) (map[string]string, error) {
 	src := m.data[key]
 	out := make(map[string]string, len(src))
-	for k, v := range src {
-		out[k] = v
-	}
+	maps.Copy(out, src)
 	return out, nil
 }
 


### PR DESCRIPTION
## Fix
\`loadValkeyBlock\`'s enabled-signal was \`shardsRaw == ""\` — empty envvar → "no fallback wired". A ConfigMap-driven deployment can't easily omit a key though, so an unconfigured fallback frequently landed as \`AUDIENCE_FALLBACK_VALKEY_SHARDS="{}"\` on the pod. \`"{}"\` is not empty, so the code proceeded with \`Enabled=true, Shards={}\`, then \`Config.Validate\` rejected:

\`\`\`
invalid configuration: AUDIENCE_FALLBACK_VALKEY:
  redisstore: shards must contain at least one entry
\`\`\`

Crash-looped every staging identity-match pod after a Terraform PR started emitting \`jsonencode({})\` for the fallback key across all consumers.

## Change
Collapse both spellings to "disabled" — \`len(shards) == 0\` is never a useful runtime configuration (redisstore.Config.Validate already refuses it), so treating it as unset in loadValkeyBlock is safe and saves future operators from the same trap.

Emitters can and should still emit \`""\` for the unset case (the Terraform hotfix does — scope3data/terraform#2691); this change just makes the reader robust to the more common shape a ConfigMap can produce.

## Test coverage
Adds an \`"empty-map JSON is disabled"\` subtest under \`TestLoadConfigFromEnv_FallbackBlocks\` pinning the new behavior next to the existing "no fallback env" case.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test ./targeting/identityagent/ -run TestLoadConfigFromEnv_FallbackBlocks -v\` — new subtest passes; existing three still pass.
- [x] \`gofmt\` / \`go vet\` clean.