### PR TITLE
tmproto,router: reject control chars in seller_agent_url + #410 follow-ups

### DIFF
--- a/router/context_cache.go
+++ b/router/context_cache.go
@@ -275,9 +275,11 @@ func (c *ContextCache) Size() int {
 // contextCacheKey assembles the canonical cache key. NUL is used as
 // the separator so a component containing "|" or "/" cannot collide
 // with it. tmproto request validation rejects control bytes in
-// property_rid and placement_id, and every component ultimately
-// originates from a JSON string (which cannot contain a raw NUL under
-// the JSON grammar), so no component can carry NUL by construction.
+// property_rid, placement_id, and seller_agent_url (validateSafeID /
+// validateSellerAgentURL); provider_id is bounded by the spec
+// (`^[A-Za-z0-9_]+$`, max 64) and only ever populated from
+// ProviderSet.ID; country is either empty or an ISO-3166 alpha-2
+// pair. No component can carry NUL by construction.
 func contextCacheKey(propertyRID, placementID, providerID, sellerAgentURL, country string) string {
 	var b strings.Builder
 	b.Grow(len(propertyRID) + len(placementID) + len(providerID) + len(sellerAgentURL) + len(country) + 4)

--- a/router/router.go
+++ b/router/router.go
@@ -411,7 +411,14 @@ func (r *Router) fanOutContext(ctx context.Context, providers []ProviderConfig, 
 			//
 			// The cache check runs before the circuit-breaker gate: a
 			// warm response is still useful when the provider went
-			// down, and the TTL bounds staleness.
+			// down, and the TTL bounds staleness. Race note: if a
+			// provider's circuit trips after a targeting-config
+			// change but before it can emit a fresh response with
+			// cache_ttl=0 (the spec's disable-caching signal), the
+			// router keeps serving the pre-change offers until the
+			// entry ages out. Bounded by the entry's TTL — the
+			// operator trades a brief post-change stale window for
+			// availability during the outage.
 			cacheSeller := canonicalizeSellerForCache(cmReq.SellerAgentURL)
 			cacheCountry := contextCountry(cmReq.Geo)
 			if r.contextCache != nil {

--- a/tmproto/validate.go
+++ b/tmproto/validate.go
@@ -131,6 +131,30 @@ func validateSafeID(field, value string) error {
 	return nil
 }
 
+// MaxSellerAgentURLLength caps the seller_agent_url string. The value flows
+// into structured logs, cache keys, and the RFC 9421 @target-uri signing
+// input; a pathologically long URL bloats every one of those.
+const MaxSellerAgentURLLength = 2048
+
+// validateSellerAgentURL rejects a seller_agent_url that carries C0 control
+// bytes (0x00–0x1F) or DEL (0x7F). The value is copied into the router's
+// context cache key (which uses NUL as a separator), echoed in structured
+// logs, and folded into the RFC 9421 @target-uri signing input — rejecting
+// control bytes at the wire boundary keeps all three surfaces well-formed.
+// Callers still check non-emptiness themselves so the error message can
+// name the request shape ("required" vs "invalid").
+func validateSellerAgentURL(value string) error {
+	if len(value) > MaxSellerAgentURLLength {
+		return fmt.Errorf("seller_agent_url exceeds maximum length of %d", MaxSellerAgentURLLength)
+	}
+	for _, r := range value {
+		if r < 0x20 || r == 0x7F {
+			return errors.New("seller_agent_url contains invalid characters")
+		}
+	}
+	return nil
+}
+
 // SafeRequestIDForEcho returns requestID only when it satisfies the same
 // constraints as request_id validation. HTTP boundaries use it before echoing a
 // parsed request_id in an error response or structured log.
@@ -189,6 +213,9 @@ func ValidateContextRequest(req *ContextMatchRequest) error {
 	if req.SellerAgentURL == "" {
 		return errors.New("seller_agent_url is required")
 	}
+	if err := validateSellerAgentURL(req.SellerAgentURL); err != nil {
+		return err
+	}
 	if len(req.PackageIDs) > MaxPackagesPerRequest {
 		return fmt.Errorf("package_ids exceeds maximum of %d", MaxPackagesPerRequest)
 	}
@@ -240,6 +267,9 @@ func ValidateIdentityRequest(req *IdentityMatchRequest) error {
 	}
 	if req.SellerAgentURL == "" {
 		return errors.New("seller_agent_url is required")
+	}
+	if err := validateSellerAgentURL(req.SellerAgentURL); err != nil {
+		return err
 	}
 	if len(req.Identities) == 0 {
 		return errors.New("identities must not be empty")

--- a/tmproto/validate_test.go
+++ b/tmproto/validate_test.go
@@ -46,6 +46,26 @@ func TestValidateIdentityRequest(t *testing.T) {
 			wantErr: "seller_agent_url is required",
 		},
 		{
+			name:    "seller_agent_url with NUL rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\x00" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url with CR rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\r/agent" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url with DEL rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\x7f" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url exceeding max length rejected",
+			mutate:  func(r *IdentityMatchRequest) { r.SellerAgentURL = "https://" + strings.Repeat("a", MaxSellerAgentURLLength) },
+			wantErr: "seller_agent_url exceeds maximum length",
+		},
+		{
 			name:    "empty identities rejected",
 			mutate:  func(r *IdentityMatchRequest) { r.Identities = nil },
 			wantErr: "identities must not be empty",
@@ -324,6 +344,26 @@ func TestValidateContextRequest_LadderConstraints(t *testing.T) {
 				r.Geo = map[string]any{"metro": map[string]any{"value": "501"}}
 			},
 			wantErr: "geo.metro.system",
+		},
+		{
+			name:    "seller_agent_url with NUL rejected",
+			mutate:  func(r *ContextMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\x00" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url with LF rejected",
+			mutate:  func(r *ContextMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\n/agent" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url with DEL rejected",
+			mutate:  func(r *ContextMatchRequest) { r.SellerAgentURL = "https://seller.example.com/\x7f" },
+			wantErr: "seller_agent_url contains invalid characters",
+		},
+		{
+			name:    "seller_agent_url exceeding max length rejected",
+			mutate:  func(r *ContextMatchRequest) { r.SellerAgentURL = "https://" + strings.Repeat("a", MaxSellerAgentURLLength) },
+			wantErr: "seller_agent_url exceeds maximum length",
 		},
 	}
 


### PR DESCRIPTION
## Summary

Addresses the non-blocking follow-ups from the [#410 review](https://github.com/adcontextprotocol/adcp-go/pull/410#pullrequestreview-4764886191).

1. **Reject C0 control bytes and DEL in `seller_agent_url`** (nit #1 in the review). The value flows into three surfaces that all misbehave with raw control bytes: the router's context cache key (which uses NUL as a separator), structured logs, and the RFC 9421 `@target-uri` signing input. The prior `contextCacheKey` docstring claimed "no NUL by construction" but only `property_rid`/`placement_id` were being scrubbed — `seller_agent_url` had a non-empty check and nothing else. New `validateSellerAgentURL` in `tmproto` rejects C0/DEL and caps the URL at 2048 bytes; wired into both `ValidateContextRequest` and `ValidateIdentityRequest`.

2. **Update the `contextCacheKey` docstring** so the "no NUL by construction" claim matches what's now actually enforced (`validateSafeID` + `validateSellerAgentURL` + schema-bounded `provider_id`/`country`).

3. **Race note at the cache-check site** (follow-up #2): if a provider's circuit trips after a targeting-config change but before it can emit `cache_ttl=0`, the router keeps serving pre-change offers until the entry ages out. Bounded by TTL, acceptable — documented at the check site so a future reader isn't surprised.

Out of scope:
- Follow-up #1 (release-notes item about the `int` → `*int` source-level break for external Go importers) — belongs in image-publish release notes, not code.
- Follow-up #3 (JSON round-trip deep clone of `Signals` nested values) — reviewer flagged as safe today and already documented; no mutator exists.

## Test plan

- [x] `go test ./tmproto/... ./router/... -race -count=1` — pass
- [x] `go test ./... -race -count=1` in `cmd/router` — pass
- [x] `golangci-lint run --new-from-rev origin/main` — 0 issues on both modules
- [x] `go vet` clean on both modules
- [x] 4 new tmproto test cases per request type (NUL, CR/LF, DEL, max-length)