### PR TITLE
liveramp: treat 410 Gone as ErrNoMapping

### DIFF
--- a/targeting/internal/liveramp/sidecar.go
+++ b/targeting/internal/liveramp/sidecar.go
@@ -63,8 +63,17 @@ const (
 )
 
 // ErrNoMapping is the sentinel returned by MappedID when the sidecar
-// reachably responds but has no mapping for the supplied env. Distinguished
-// from transport errors so callers can treat "miss" as a routine outcome.
+// reachably responds but has no mapping for the supplied env. Two sidecar
+// responses map to this sentinel:
+//
+//   - 200 with an empty (or Scope3-key-absent) body: the env was accepted but
+//     no platform-mapped value is available.
+//   - 410 Gone: LiveRamp knows the env but treats it as permanently
+//     unresolvable (expired / revoked envelope). Semantically a miss, not a
+//     transport failure — envelopes rotate as part of normal cookie lifetime.
+//
+// Distinguished from transport errors so callers can treat "miss" as a
+// routine outcome.
 var ErrNoMapping = errors.New("liveramp: no mapping")
 
 // Config carries the connection parameters for a LiveRamp sidecar Client.
@@ -143,8 +152,9 @@ type mapping struct {
 // platform-mapped value (the value the sidecar publishes under the
 // scope3SeatID wire key).
 // Returns ErrNoMapping when the sidecar reachably responds but has no
-// mapping. Transport, decode, and non-OK status errors are returned as-is
-// so the caller can decide whether to alert.
+// mapping — either 200 with an empty/Scope3-key-absent body, or 410 Gone
+// for an expired/revoked envelope. Transport, decode, and other non-OK
+// status errors are returned as-is so the caller can decide whether to alert.
 //
 // env is sent unmodified as the ?env= query parameter; the caller is
 // responsible for URL-encoding constraints (the underlying net/url machinery
@@ -174,6 +184,13 @@ func (c *Client) MappedID(ctx context.Context, env string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusGone {
+		// LiveRamp knows the env but the envelope is permanently
+		// unresolvable (expired / revoked). Same downstream treatment as
+		// the 200-empty-body miss.
+		_, _ = io.CopyN(io.Discard, resp.Body, 4*1024)
+		return "", ErrNoMapping
+	}
 	if resp.StatusCode != http.StatusOK {
 		// Drain a bounded prefix so the connection can be reused. A misbehaving
 		// sidecar shouldn't be allowed to wedge connections by holding the

--- a/targeting/internal/liveramp/sidecar_test.go
+++ b/targeting/internal/liveramp/sidecar_test.go
@@ -96,6 +96,21 @@ func TestMappedID_Non200IsError(t *testing.T) {
 	assert.NotErrorIs(t, err, ErrNoMapping, "500 must not be conflated with miss")
 }
 
+func TestMappedID_GoneMeansNoMapping(t *testing.T) {
+	// 410 Gone is LiveRamp's signal for a permanently unresolvable envelope
+	// (expired / revoked). Semantically a miss — callers must be able to
+	// distinguish it from a transport error via errors.Is(err, ErrNoMapping).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "envelope expired", http.StatusGone)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(Config{URL: srv.URL, HTTPClient: srv.Client()})
+	require.NoError(t, err)
+	_, err = c.MappedID(t.Context(), "expired-env")
+	require.ErrorIs(t, err, ErrNoMapping)
+}
+
 func TestMappedID_MalformedJSONIsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("not json"))


### PR DESCRIPTION
## Why

LiveRamp's `idl-mapper` sidecar returns **HTTP 410 Gone** for envelopes it knows about but treats as permanently unresolvable (expired / revoked). This is a routine outcome — envelopes rotate as part of normal cookie lifetime.

Before this change, the client only recognized `200 + empty body` (and `200 + Scope3-key-absent body`) as a miss. A 410 fell through the generic non-OK branch and surfaced as `fmt.Errorf("liveramp: sidecar status 410")`. Callers that classify decode outcomes had no way to separate that from a real transport failure — the identity-agent's `decoder_error` counter (intended to page on transport / parse / status failures) was inflated by envelope-aging traffic, burying real signal.

## What Changed

`targeting/internal/liveramp/sidecar.go`:
- Added an explicit `resp.StatusCode == http.StatusGone` branch before the generic non-OK handler. Drains the response body the same bounded way, returns `ErrNoMapping`.
- Updated the `ErrNoMapping` and `MappedID` godoc to enumerate both cases that map to the sentinel (200-empty-body and 410 Gone).

`targeting/internal/liveramp/sidecar_test.go`:
- New `TestMappedID_GoneMeansNoMapping` pins the behavior — asserts `errors.Is(err, ErrNoMapping)` on a handler that responds with 410.

Every other non-OK status (400, 5xx, transport errors, timeouts, parse errors) continues to return a generic error, so the caller-side `decoder_error` counter still catches genuine failures.

Deliberately narrow: 404 and other statuses are outside this change.

## Test plan

- [x] `go test ./targeting/internal/liveramp/... ./targeting/tmpxdecoders/... ./targeting/identityagent/...` — all pass locally
- [x] `go vet ./targeting/...` — clean
- [x] `golangci-lint run ./targeting/internal/liveramp/...` — 0 issues
- [ ] Post-merge: identity-agent bump picks up the new client; `identity_agent_tmpx_identity_drops_total{reason="decoder_error", uid_type="rampid"}` rate drops as 410 traffic re-routes to `decoder_drop`.