### PR TITLE
registry: pin real registry v0.1.0 in redisstore/glidestore

### DIFF
--- a/registry/glidestore/go.mod
+++ b/registry/glidestore/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/registry/glidestore
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/registry v0.0.0
+	github.com/adcontextprotocol/adcp-go/registry v0.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/valkey-io/valkey-glide/go/v2 v2.3.1
@@ -61,5 +61,3 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/adcontextprotocol/adcp-go/registry => ../

--- a/registry/glidestore/go.sum
+++ b/registry/glidestore/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/registry v0.1.0 h1:N/rr232aNPf0/o9/QikrDEqWullj+MePdO5nmnqJk84=
+github.com/adcontextprotocol/adcp-go/registry v0.1.0/go.mod h1:uaO4VM4XzzJkJrISNtYqtU9RqsYXDa9lzZOz8GfNCLY=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/registry/redisstore/go.mod
+++ b/registry/redisstore/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/registry/redisstore
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/registry v0.0.0
+	github.com/adcontextprotocol/adcp-go/registry v0.1.0
 	github.com/redis/go-redis/v9 v9.19.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -61,5 +61,3 @@ require (
 	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/adcontextprotocol/adcp-go/registry => ../

--- a/registry/redisstore/go.sum
+++ b/registry/redisstore/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/registry v0.1.0 h1:N/rr232aNPf0/o9/QikrDEqWullj+MePdO5nmnqJk84=
+github.com/adcontextprotocol/adcp-go/registry v0.1.0/go.mod h1:uaO4VM4XzzJkJrISNtYqtU9RqsYXDa9lzZOz8GfNCLY=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=


### PR DESCRIPTION
## Summary

Now that `github.com/adcontextprotocol/adcp-go/registry` is published at `v0.1.0` and resolves through the module proxy, the `v0.0.0` + local-`replace` pattern is no longer needed in the dependent stores.

- `registry/redisstore/go.mod` — `require github.com/adcontextprotocol/adcp-go/registry v0.1.0`; drop `replace github.com/adcontextprotocol/adcp-go/registry => ../`.
- `registry/glidestore/go.mod` — same treatment.

Both `go.sum` files gain only the two expected `h1:` lines for the newly-resolved dependency. No transitive churn.

Downstream builds now see the real dependency graph the module proxy publishes, instead of relying on an in-tree `replace` that only works for contributors with the repo checked out locally.

## Test plan

- [ ] `cd registry/redisstore && GOFLAGS=-mod=mod go build ./...` succeeds against the proxy
- [ ] `cd registry/glidestore && GOFLAGS=-mod=mod go build ./...` succeeds against the proxy
- [ ] `go mod tidy` is clean in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)