### PR TITLE
release: manage urlcanon and registry sub-modules independently

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,7 @@
 {
-  "adcp": "2.1.1"
+  "adcp": "2.1.1",
+  "urlcanon": "0.1.0",
+  "registry": "0.1.0",
+  "registry/redisstore": "0.0.0",
+  "registry/glidestore": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,39 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
   "packages": {
     "adcp": {
       "release-type": "go",
       "package-name": "adcp",
       "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "urlcanon": {
+      "release-type": "go",
+      "component": "urlcanon",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "registry": {
+      "release-type": "go",
+      "component": "registry",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "registry/redisstore": {
+      "release-type": "go",
+      "component": "registry/redisstore",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "registry/glidestore": {
+      "release-type": "go",
+      "component": "registry/glidestore",
+      "tag-separator": "/",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true
     }


### PR DESCRIPTION
## Summary

Expands `release-please-config.json` (and `.release-please-manifest.json`) to manage the four extracted/tagged sub-modules alongside the existing `adcp` package:

- `urlcanon` — pinned at current tagged version `0.1.0`.
- `registry` — pinned at current tagged version `0.1.0`.
- `registry/redisstore` — tracked from `0.0.0`; not yet tagged.
- `registry/glidestore` — tracked from `0.0.0`; not yet tagged.

Also enables `separate-pull-requests: true` so each module's release lands as its own PR rather than one bundled cross-module PR.

All new entries use `tag-separator: "/"` so tags come out in canonical Go nested-module form (`<component>/v<X.Y.Z>`). The existing `adcp` entry is untouched — its `adcp-v*` tag scheme stays as-is for the frozen v2 line.

For the two untagged stores, the first releasable commit against either directory will cause release-please to cut a real `v0.1.0` release with a matching tag through the normal flow.

## Test plan

- [ ] `jq . release-please-config.json` and `jq . .release-please-manifest.json` succeed
- [ ] Next release-please run against `main` produces at most one release PR per module (no bundling)
- [ ] A test conventional-commit against `urlcanon/` triggers a `urlcanon`-only release PR
- [ ] A test conventional-commit against `registry/redisstore/` triggers a `registry/redisstore` release PR cutting `v0.1.0` (bump-minor-pre-major)

🤖 Generated with [Claude Code](https://claude.com/claude-code)