### PR TITLE
cmd/context-agent: raise registry require to v0.1.0 to match transitive pin

### DIFF
--- a/cmd/context-agent/go.mod
+++ b/cmd/context-agent/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/registry v0.0.0
+	github.com/adcontextprotocol/adcp-go/registry v0.1.0
 	github.com/adcontextprotocol/adcp-go/registry/redisstore v0.0.0
 	github.com/redis/go-redis/v9 v9.19.0
 )


### PR DESCRIPTION
## Summary

Hotfix. Image builds on `main` currently fail with:

```
go: updates to go.mod needed; to update it:
    go mod tidy
```

inside the `cmd/context-agent` Docker build.

**Root cause:** an earlier PR raised `registry/redisstore`'s pin of `github.com/adcontextprotocol/adcp-go/registry` from `v0.0.0` (local `replace`) to the real tag `v0.1.0`. `cmd/context-agent` imports both `registry` and `registry/redisstore` (via local `replace` directives) and still declared its direct `require` of `registry` as `v0.0.0`. Go's MVS raises the effective `registry` version to `v0.1.0` at build time, then complains because the direct pin in `cmd/context-agent/go.mod` didn't reflect that.

**Fix:** bump the direct require of `registry` in `cmd/context-agent/go.mod` from `v0.0.0` to `v0.1.0`. Single line, no `go.sum` change (both dep paths still go through local `replace`, which absorbs proxy resolution).

Verified in isolation:
- `origin/main` reproduces the failure at `cmd/context-agent`.
- The fix commit builds cleanly there.
- `cmd/router` and `cmd/identity-agent` still build unaffected.
- `replace` directives are untouched.

## Test plan

- [ ] `cd cmd/context-agent && go build ./...` succeeds against a fresh checkout (no `go.work`).
- [ ] Next image build for `cmd/context-agent` on `main` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)