### PR TITLE
release: pin release-please scan baseline to current main SHA

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
+  "bootstrap-sha": "cd643a0fe5b9b088ed10b045a43fe22439191b7c",
   "packages": {
     "adcp": {
       "release-type": "go",


### PR DESCRIPTION
## Summary

Recent release-please runs opened release PRs (registry 0.2.0, urlcanon 0.2.0) whose changelogs pulled in every conventional commit touching those directories back to the beginning of the repo. That happens because release-please doesn't recognize maintainer-pushed tags as its own releases — without an explicit baseline it scans the whole history and treats every prior conventional commit as releasable.

Add a top-level `bootstrap-sha` in `release-please-config.json`. Per the release-please schema and source, this key sits at the top level (not per-package) and is gated per-package by `needsBootstrap = releasesFound < expectedReleases` — so it applies exactly to the packages release-please can't see native releases for (`urlcanon`, `registry`, `registry/redisstore`, `registry/glidestore`) and is a no-op for packages it can (like `adcp`, which release-please tracks natively through its own workflow).

**Chosen SHA:** current `origin/main` (`cd643a0fe5b9b088ed10b045a43fe22439191b7c`). Verified that no releasable-looking commits sit between the manual `urlcanon/v0.1.0` / `registry/v0.1.0` tag placements and this SHA that touch `urlcanon/`, `registry/` (top-level), `registry/redisstore/`, or `registry/glidestore/`. Future release-please runs will only consider commits after this SHA when computing bumps for those packages.

## Test plan

- [ ] `jq . release-please-config.json` succeeds
- [ ] Next release-please run against `main` does NOT reopen the spurious `registry 0.2.0` / `urlcanon 0.2.0` proposals
- [ ] A test conventional-commit against `registry/redisstore/` after this SHA triggers its first `registry/redisstore/v0.1.0` release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)