### PR TITLE
tmproto: pin real tmproto v0.1.0 across consumers

### DIFF
--- a/bench/context-perf/go.mod
+++ b/bench/context-perf/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0
 	github.com/redis/go-redis/v9 v9.19.0
 )
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/bench/context-perf/go.sum
+++ b/bench/context-perf/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/bench/identity-perf/go.mod
+++ b/bench/identity-perf/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/redis/go-redis/v9 v9.19.0
 )
 
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/bench/identity-perf/go.sum
+++ b/bench/identity-perf/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/cmd/context-agent/go.mod
+++ b/cmd/context-agent/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0 // indirect
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 // indirect
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -46,5 +46,3 @@ replace github.com/adcontextprotocol/adcp-go => ../../
 replace github.com/adcontextprotocol/adcp-go/registry => ../../registry
 
 replace github.com/adcontextprotocol/adcp-go/registry/redisstore => ../../registry/redisstore
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/cmd/context-agent/go.sum
+++ b/cmd/context-agent/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/cmd/identity-agent/go.mod
+++ b/cmd/identity-agent/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 )
 
 require (
@@ -42,5 +42,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/cmd/identity-agent/go.sum
+++ b/cmd/identity-agent/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/cmd/router/go.mod
+++ b/cmd/router/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
 	github.com/adcontextprotocol/adcp-go/registry v0.0.0-20260716182726-fdf3ef034a47
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -24,5 +24,3 @@ require (
 replace github.com/adcontextprotocol/adcp-go => ../../
 
 replace github.com/adcontextprotocol/adcp-go/registry => ../../registry
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/cmd/router/go.sum
+++ b/cmd/router/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/adcontextprotocol/adcp-go/e2e
 
 go 1.25.0
 
-require github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+require github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 
 require (
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 // indirect
@@ -21,5 +21,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../tmproto

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/prometheus/client_golang v1.23.2
@@ -79,5 +79,3 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	lukechampine.com/blake3 v1.4.1 // indirect
 )
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ./tmproto

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/reference/context-agent/go.mod
+++ b/reference/context-agent/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/tmproto v0.0.0
+	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
 
@@ -21,5 +21,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/tmproto => ../../tmproto

--- a/reference/context-agent/go.sum
+++ b/reference/context-agent/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
+github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0/go.mod h1:cWWYEAyTy6EAB/4nses21g3UNqzcxYEFRG8Hm7l1xiM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

Follow-up to the tmproto extraction. Now that `github.com/adcontextprotocol/adcp-go/tmproto` is published at `v0.1.0` and resolves through the module proxy, the transitional `v0.0.0 + local replace` pattern in every consumer is no longer needed.

For each of the 8 affected modules:
- `require github.com/adcontextprotocol/adcp-go/tmproto v0.0.0` → `v0.1.0` (preserving the `// indirect` marker on `cmd/context-agent` where it applies)
- Corresponding `replace github.com/adcontextprotocol/adcp-go/tmproto => <path>` directive dropped
- `go mod tidy` refreshes `go.sum` — exactly two new `h1:` lines (module + go.mod checksums for v0.1.0), no other churn

Mirrors the pattern used when `registry/redisstore` and `registry/glidestore` were pinned to real `registry v0.1.0` after that tag landed.

**Modules updated (8):** `.`, `cmd/context-agent`, `cmd/identity-agent`, `cmd/router`, `bench/context-perf`, `bench/identity-perf`, `e2e`, `reference/context-agent`. **Files touched (16):** `go.mod` + `go.sum` in each. No `.go` files modified.

Consumer builds now resolve `tmproto` via proxy checksums rather than a filesystem override — the shape downstream (non-repo) consumers see.

## Test plan

- [ ] `go build ./...` succeeds in every affected module without `go.work` present (proxy path exercised)
- [ ] Same builds pass with a fresh `go.work` copied from `go.work.example` (workspace path)
- [ ] `bash scripts/check-goworkexample.sh` still reports OK
- [ ] Consumer Docker builds (`cmd/context-agent`, `cmd/identity-agent`, `cmd/router`) succeed on `main` after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)