### PR TITLE
refactor(adcp)!: migrate in-tree consumers to adcp/v3

### DIFF
--- a/reference/seller-agent/cmd/seller-agent/main.go
+++ b/reference/seller-agent/cmd/seller-agent/main.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/adcontextprotocol/adcp-go/adcp"
+	"github.com/adcontextprotocol/adcp-go/adcp/v3"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/reference/seller-agent/cmd/seller-agent/main_test.go
+++ b/reference/seller-agent/cmd/seller-agent/main_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/adcontextprotocol/adcp-go/adcp"
+	"github.com/adcontextprotocol/adcp-go/adcp/v3"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/reference/seller-agent/go.mod
+++ b/reference/seller-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/reference/seller-agent
 go 1.26.2
 
 require (
-	github.com/adcontextprotocol/adcp-go/adcp v0.0.0
+	github.com/adcontextprotocol/adcp-go/adcp/v3 v3.0.0
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 )
 
@@ -16,4 +16,4 @@ require (
 	golang.org/x/sys v0.41.0 // indirect
 )
 
-replace github.com/adcontextprotocol/adcp-go/adcp => ../../adcp
+replace github.com/adcontextprotocol/adcp-go/adcp/v3 => ../../adcp/v3


### PR DESCRIPTION
## Summary

Every `.go` file in the repo now imports `github.com/adcontextprotocol/adcp-go/adcp/v3` (and its subpackages) instead of the frozen v2 path. Consumer `go.mod`s require the new module path with a local `replace` — matching the transitional shape used for `tmproto` and `tmpclient` — until `adcp/v3.0.0` is tagged post-merge and a small follow-up drops the replace to pin the real version.

**Scope turned out narrower than the plan anticipated.** Only `reference/seller-agent` imports `.../adcp` in-tree. `tmproto`, `tmpclient`, `targeting`, `router`, and every `cmd/*` are TMP-wire code that doesn't reach into the adcp module.

## What this PR does

Three files touched:

- `reference/seller-agent/cmd/seller-agent/main.go` — import `.../adcp` → `.../adcp/v3`
- `reference/seller-agent/cmd/seller-agent/main_test.go` — same rewrite
- `reference/seller-agent/go.mod` — swaps the `.../adcp v0.0.0 + replace` pattern for `.../adcp/v3 v3.0.0 + replace ../../adcp/v3`

Go's SIV rule rejects `require .../adcp/v3 v0.0.0` (the require's major must match the `/v3` suffix). The require uses `v3.0.0` — matching the tag the maintainer will push post-merge. The local `replace` makes it resolve locally in the meantime.

`go.sum` is not touched — the local `replace` absorbs proxy resolution.

## adcp/vN spec-alignment policy

The Go module's major will track the AdCP protocol spec's major going forward: `adcp/v3` speaks AdCP 3.x. When the upstream spec bumps to 4.0 (target early 2027 per the spec's own cadence commitment), we cut `adcp/v4/` — no Go-only major bumps during a spec major's lifecycle. This gets written down in the migration guide / README module map that lands in a subsequent PR.

## Test plan

- [ ] `cd reference/seller-agent && go build ./... && go test ./...` succeeds
- [ ] `cp go.work.example go.work && go build ./...` succeeds (workspace path)
- [ ] `bash scripts/check-goworkexample.sh` reports 19 modules, all declared
- [ ] `grep -rn '"github.com/adcontextprotocol/adcp-go/adcp"' --include='*.go' .` returns only files under `adcp/`
- [ ] Existing `github.com/adcontextprotocol/adcp-go/adcp@v2.1.1` continues to resolve for external consumers (no v2 changes)

## Downstream migration

External consumers of `github.com/adcontextprotocol/adcp-go/adcp` can either:
- Stay pinned at `github.com/adcontextprotocol/adcp-go/adcp@v2.1.1` — continues to work unchanged (the v2 module is frozen, not removed).
- Switch to `github.com/adcontextprotocol/adcp-go/adcp/v3` once `adcp/v3.0.0` is tagged.

The v2 module receives security patches during the standard support window per the AdCP spec's own commitment (≥12 months after successor major GA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)