### PR TITLE
reference/seller-agent: pin real adcp/v3 v3.0.0 through the module proxy

### DIFF
--- a/reference/seller-agent/go.mod
+++ b/reference/seller-agent/go.mod
@@ -15,5 +15,3 @@ require (
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )
-
-replace github.com/adcontextprotocol/adcp-go/adcp/v3 => ../../adcp/v3

--- a/reference/seller-agent/go.sum
+++ b/reference/seller-agent/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/adcp/v3 v3.0.0 h1:uNF/mgr6prXsPKKBcFKCh4vu8RmFoaHEV2BHBuQ9nmI=
+github.com/adcontextprotocol/adcp-go/adcp/v3 v3.0.0/go.mod h1:KV2eR/I8At1vXfMt1BEmxjhLaduPtk+CRr8ruYaq8Nk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=


### PR DESCRIPTION
## Summary

Follow-up to the adcp/v3 consumer migration. Now that `github.com/adcontextprotocol/adcp-go/adcp/v3` is published at `v3.0.0` and resolves through the module proxy, the transitional local `replace` in `reference/seller-agent/go.mod` is no longer needed.

- Drop `replace github.com/adcontextprotocol/adcp-go/adcp/v3 => ../../adcp/v3`.
- Existing `require github.com/adcontextprotocol/adcp-go/adcp/v3 v3.0.0` stays as-is.
- `go.sum` gains the two expected `h1:` lines (module + go.mod checksums for v3.0.0). No other churn.

Mirrors the pattern used when `registry v0.1.0` and `tmproto v0.1.0` landed. `reference/seller-agent` now resolves adcp/v3 through the proxy exactly the way downstream (non-repo) consumers see it.

## Test plan

- [ ] `cd reference/seller-agent && go build ./... && go test ./...` succeeds against the proxy (no `go.work`, no local replace)
- [ ] `cp go.work.example go.work && go build ./...` succeeds (workspace path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)