### PR TITLE
targeting: pin real targeting v0.1.0 across consumers

### DIFF
--- a/bench/context-perf/go.mod
+++ b/bench/context-perf/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/bench/context-perf
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0
 	github.com/redis/go-redis/v9 v9.22.0
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/bench/context-perf/go.sum
+++ b/bench/context-perf/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/bench/identity-perf/go.mod
+++ b/bench/identity-perf/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/bench/identity-perf
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/redis/go-redis/v9 v9.22.0
 )
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/bench/identity-perf/go.sum
+++ b/bench/identity-perf/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/cmd/context-agent/go.mod
+++ b/cmd/context-agent/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/adcontextprotocol/adcp-go/registry v0.1.0
 	github.com/adcontextprotocol/adcp-go/registry/redisstore v0.0.0
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/redis/go-redis/v9 v9.22.0
 )
 
@@ -43,5 +43,3 @@ require (
 replace github.com/adcontextprotocol/adcp-go/registry => ../../registry
 
 replace github.com/adcontextprotocol/adcp-go/registry/redisstore => ../../registry/redisstore
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/cmd/context-agent/go.sum
+++ b/cmd/context-agent/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/cmd/identity-agent/go.mod
+++ b/cmd/identity-agent/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 )
 
@@ -42,5 +42,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/cmd/identity-agent/go.sum
+++ b/cmd/identity-agent/go.sum
@@ -4,6 +4,8 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/cmd/router/go.mod
+++ b/cmd/router/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/adcontextprotocol/adcp-go v0.0.0
 	github.com/adcontextprotocol/adcp-go/registry v0.0.0-20260716182726-fdf3ef034a47
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -26,5 +26,3 @@ require (
 replace github.com/adcontextprotocol/adcp-go => ../../
 
 replace github.com/adcontextprotocol/adcp-go/registry => ../../registry
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/cmd/router/go.sum
+++ b/cmd/router/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/adcontextprotocol/adcp-go
 
 go 1.25.0
 
-replace github.com/adcontextprotocol/adcp-go/targeting => ./targeting
-
 require (
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=

--- a/reference/context-agent/go.mod
+++ b/reference/context-agent/go.mod
@@ -3,7 +3,7 @@ module github.com/adcontextprotocol/adcp-go/reference/context-agent
 go 1.25.0
 
 require (
-	github.com/adcontextprotocol/adcp-go/targeting v0.0.0
+	github.com/adcontextprotocol/adcp-go/targeting v0.1.0
 	github.com/adcontextprotocol/adcp-go/tmproto v0.1.0
 	github.com/stretchr/testify v1.11.1
 )
@@ -24,5 +24,3 @@ require (
 )
 
 replace github.com/adcontextprotocol/adcp-go => ../../
-
-replace github.com/adcontextprotocol/adcp-go/targeting => ../../targeting

--- a/reference/context-agent/go.sum
+++ b/reference/context-agent/go.sum
@@ -1,3 +1,5 @@
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0 h1:ely68qctnF/JbEPDUcM5wJ1duyMgLVkRbZYG/tKohLQ=
+github.com/adcontextprotocol/adcp-go/targeting v0.1.0/go.mod h1:5TgUaaEZG8w3spbfRPukv1xL1wgoTP8vJr5Q9hPKRBk=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0 h1:7yuDHgCINlWsOXIqdzv1JYl0nlL3GswzNHi9R4ddJxQ=
 github.com/adcontextprotocol/adcp-go/tmproto v0.1.0/go.mod h1:IB7hhgE9PT9bVGcJEtTo7Z5bBpYXXEoVkt8x375KaC8=
 github.com/adcontextprotocol/adcp-go/urlcanon v0.1.0 h1:zmLYfwIQBr3dPq+fDXtIgUr7LNHu56LZhaZp3uVCzFo=


### PR DESCRIPTION
## Summary

Follow-up to the targeting extraction. Now that `github.com/adcontextprotocol/adcp-go/targeting` is published at `v0.1.0` and resolves through the module proxy, the transitional `v0.0.0 + local replace` pattern in every consumer is no longer needed.

For each of the 7 affected modules:

- `require github.com/adcontextprotocol/adcp-go/targeting v0.0.0` → `v0.1.0`
- Corresponding `replace github.com/adcontextprotocol/adcp-go/targeting => <path>` directive dropped
- `go.sum` gains exactly two `h1:` lines (module + go.mod checksums for v0.1.0). No transitive drift.

Mirrors the pattern used when `registry`, `tmproto`, and `adcp/v3` landed their first tagged versions. Consumer builds now resolve `targeting` via proxy checksums rather than a filesystem override — the shape downstream (non-repo) consumers see.

**Modules updated (7):** `.`, `bench/context-perf`, `bench/identity-perf`, `cmd/context-agent`, `cmd/identity-agent`, `cmd/router`, `reference/context-agent`. **Files touched (14):** `go.mod` + `go.sum` in each. No `.go` files modified.

Other replaces in the same files (root's `adcp-go => ../../`, sub-module replaces for `registry`, `registry/redisstore`) stay untouched.

## Test plan

- [ ] `go build ./...` succeeds at root and each affected module without `go.work` (proxy path exercised)
- [ ] `cp go.work.example go.work && go build ./...` succeeds (workspace path)
- [ ] Consumer Docker builds (`cmd/context-agent`, `cmd/identity-agent`, `cmd/router`) succeed on `main` after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)