### PR TITLE
release: manage tmproto, tmpclient, targeting; refresh scan baseline

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -3,5 +3,8 @@
   "urlcanon": "0.1.0",
   "registry": "0.1.0",
   "registry/redisstore": "0.0.0",
-  "registry/glidestore": "0.0.0"
+  "registry/glidestore": "0.0.0",
+  "tmproto": "0.1.0",
+  "tmpclient": "0.1.0",
+  "targeting": "0.1.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
-  "bootstrap-sha": "cd643a0fe5b9b088ed10b045a43fe22439191b7c",
+  "bootstrap-sha": "a657544f714b776b8042a5a04f634d805a429b53",
   "packages": {
     "adcp": {
       "release-type": "go",
@@ -34,6 +34,27 @@
     "registry/glidestore": {
       "release-type": "go",
       "component": "registry/glidestore",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "tmproto": {
+      "release-type": "go",
+      "component": "tmproto",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "tmpclient": {
+      "release-type": "go",
+      "component": "tmpclient",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "targeting": {
+      "release-type": "go",
+      "component": "targeting",
       "tag-separator": "/",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true


### PR DESCRIPTION
## Summary

Two changes:

**1. Add `tmproto`, `tmpclient`, `targeting` to release-please.** All three sub-modules are extracted and tagged at `v0.1.0`. Config entries follow the same shape as `urlcanon` / `registry`: `tag-separator: "/"`, `bump-minor-pre-major: true`, `include-component-in-tag: true`. Manifest entries pin each at `0.1.0` (matching the tags).

**2. Refresh top-level `bootstrap-sha` to current `origin/main` HEAD.** All three tags were maintainer-pushed, so release-please's `needsBootstrap` gate would fire for each. Without a refreshed baseline, release-please would scan from the previous SHA and treat the extraction commits themselves as releasable — the same failure mode that produced the earlier spurious `registry 0.2.0` / `urlcanon 0.2.0` PRs. Moving `bootstrap-sha` forward makes history through today "already released" for every bootstrapping package.

## Test plan

- [ ] `jq . release-please-config.json` and `jq . .release-please-manifest.json` succeed
- [ ] Next release-please run against `main` does NOT propose spurious 0.2.0 bumps for tmproto/tmpclient/targeting (their v0.1.0 changelogs already exist on the tags)
- [ ] A test conventional-commit against `targeting/` after this SHA triggers a proper `targeting v0.2.0` release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)