### PR TITLE
release: add adcp/v3 and drop legacy adcp v2 from release-please management

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,5 +6,6 @@
   "registry/glidestore": "0.0.0",
   "tmproto": "0.1.0",
   "tmpclient": "0.1.0",
-  "targeting": "0.1.0"
+  "targeting": "0.1.0",
+  "adcp/v3": "3.0.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
-  "adcp": "2.1.1",
   "urlcanon": "0.1.0",
   "registry": "0.1.0",
   "registry/redisstore": "0.0.0",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,9 @@
       "package-name": "adcp",
       "changelog-path": "CHANGELOG.md",
       "bump-minor-pre-major": true,
-      "include-component-in-tag": true
+      "include-component-in-tag": true,
+      "release-as": "2.1.1",
+      "skip-github-release": true
     },
     "urlcanon": {
       "release-type": "go",
@@ -55,6 +57,15 @@
     "targeting": {
       "release-type": "go",
       "component": "targeting",
+      "tag-separator": "/",
+      "bump-minor-pre-major": true,
+      "include-component-in-tag": true
+    },
+    "adcp/v3": {
+      "release-type": "go",
+      "package-name": "adcp/v3",
+      "component": "adcp",
+      "changelog-path": "CHANGELOG.md",
       "tag-separator": "/",
       "bump-minor-pre-major": true,
       "include-component-in-tag": true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,15 +3,6 @@
   "separate-pull-requests": true,
   "bootstrap-sha": "a657544f714b776b8042a5a04f634d805a429b53",
   "packages": {
-    "adcp": {
-      "release-type": "go",
-      "package-name": "adcp",
-      "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "include-component-in-tag": true,
-      "release-as": "2.1.1",
-      "skip-github-release": true
-    },
     "urlcanon": {
       "release-type": "go",
       "component": "urlcanon",


### PR DESCRIPTION
## Summary

Wire `adcp/v3` into release-please. Its config entry composes tags as `adcp/vX.Y.Z` (matching the existing `adcp/v3.0.0` tag shape) via `component: "adcp"` + `tag-separator: "/"` + `include-v-in-tag: true` — the only source-verified combination that produces this format.

**Original approach abandoned.** The first commit added a "frozen" `adcp` v2 entry with `release-as` + `skip-github-release`. Reviewer flagged a real hazard: source inspection (`base.js:88-90, 167-170, 316-318, 326-328, 354-359`; `manifest.js:344-386, 547-577`) confirmed that:

- `skip-github-release` only gates post-merge GitHub Release creation — NOT candidate PR generation.
- `release-as` forces a version but doesn't short-circuit PR generation either.
- Both `adcp` (component defaults from package-name to `"adcp"`) and `adcp/v3` (explicit `component: "adcp"`) would derive the SAME release-PR branch: `release-please--branches--main--components--adcp`.
- The existing `chore(adcp)!:` commit under `adcp/schemas/*` would have triggered a phantom v2.1.1 PR on the next release-please run. Any future `adcp/v3/` commit would then race with it on the same branch.

**Fix in the second commit:** drop the legacy `adcp` entry from `release-please-config.json` AND from `.release-please-manifest.json`. `adcp/v3` becomes the sole adcp-family package in release-please state. No shared component, no phantom PR, no branch race.

Historical `adcp-v*` tags stay resolvable via the module proxy. If a critical v2 patch is ever needed, it's hand-cut from a maintenance branch off `adcp-v2.1.1` — same posture as any manually-managed frozen major.

## Test plan

- [ ] `jq .` on both files succeeds
- [ ] Next release-please run against `main` proposes bumps ONLY for `adcp/v3` under the `adcp/**` paths — no phantom v2.1.1 PR
- [ ] A test conventional-commit against `adcp/v3/` produces an `adcp/v3.0.1` release PR (or `v3.1.0` for a `feat:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)