### PR TITLE
ci: publish the router image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,59 @@
+# Docker build-context exclusions.
+#
+# Every image here builds with the repo root as its context — cmd/*/Dockerfile
+# through the image workflows, bench/*/Dockerfile through the perf compose
+# files (context: ../..). This list applies to all of them, so it names only
+# paths no image build reads. No package uses go:embed today, so excluding
+# non-Go files cannot change what gets compiled in — a future embed of a path
+# excluded here would fail its image build, so revisit this list alongside one.
+#
+# BuildKit transfers only the paths a COPY pattern reaches, so the entries that
+# earn their keep are the ones sitting inside a copied directory. The inert
+# trees below still matter when the context is uploaded wholesale — a plain
+# `docker build` with BuildKit disabled.
+
+# Host-architecture binaries left by a local `go build`. All are gitignored, but
+# .gitignore has no bearing on the build context. The three service binaries sit
+# inside copied directories, so without these entries they ride along into the
+# build stage and invalidate its COPY layer on every rebuild — ~70 MB of it. The
+# other three are reachable only when the context uploads wholesale.
+cmd/context-agent/context-agent
+cmd/identity-agent/identity-agent
+cmd/router/router
+internal/generate/generate
+reference/context-agent/context-agent
+reference/seller-agent/seller-agent
+**/*.test
+
+# Documentation and operator examples that sit beside copied source. Excluded
+# so editing them does not bust a build stage's cache. Narrower than *.env on
+# purpose: bench/*/perf.env and bench/*/scenarios/*.env are real inputs.
+**/*.md
+**/example*.env
+
+# Git metadata and CI definitions. Nothing injects a git-derived version at
+# build time — the Dockerfiles pass only -trimpath and -ldflags="-s -w".
+.git
+.gitignore
+.dockerignore
+.github
+
+# Go workspace files. No Dockerfile copies these; the per-module `replace`
+# directives are what resolve dependencies in-image.
+go.work
+go.work.example
+go.work.sum
+
+# Trees no image build reads. reference/ is deliberately absent: those are Go
+# modules a future Dockerfile could plausibly build, unlike the rest here.
+adcp
+docs
+e2e
+skills
+
+# Editor, tooling, and agent scratch directories.
+.agents
+.claude
+.context
+.idea
+.vscode

--- a/.github/workflows/context-agent-image.yml
+++ b/.github/workflows/context-agent-image.yml
@@ -26,6 +26,8 @@ on:
     branches: [main]
     paths:
       - cmd/context-agent/**
+      # Resolved through a local `replace`, so edits here change the image.
+      - registry/**
       - targeting/**
       - tmproto/**
       - go.mod

--- a/.github/workflows/router-image.yml
+++ b/.github/workflows/router-image.yml
@@ -1,12 +1,12 @@
-name: identity-agent image
+name: router image
 
-# Builds the cmd/identity-agent OCI image for linux/amd64 and linux/arm64,
-# pushes to ghcr.io/<owner>/<repo>/identity-agent, and signs each pushed
+# Builds the cmd/router OCI image for linux/amd64 and linux/arm64,
+# pushes to ghcr.io/<owner>/<repo>/router, and signs each pushed
 # digest with cosign keyless (OIDC against Sigstore).
 #
 # Triggers:
 #   - push to main           → tags: edge, main-<short_sha>
-#   - push of identity-agent-v* tag → tags: <semver>, <major>.<minor>, <major>, latest
+#   - push of router-v* tag  → tags: <semver>, <major>.<minor>, <major>, latest
 #   - pull_request           → build only, no push (verifies Dockerfile stays green)
 #   - workflow_dispatch      → manual rebuild
 #
@@ -16,27 +16,31 @@ name: identity-agent image
 #
 # First-push note: GHCR creates the package as private. After the first
 # successful push, a repo admin must flip visibility to public via
-# GitHub → Packages → identity-agent → Package settings → Change visibility.
+# GitHub → Packages → router → Package settings → Change visibility.
 
 on:
   push:
     branches: [main]
-    tags: ['identity-agent-v*']
+    tags: ['router-v*']
   pull_request:
     branches: [main]
     paths:
-      - cmd/identity-agent/**
-      # A root-module package the agent imports, so edits here change the image.
-      - verify/worldid/**
-      - targeting/**
-      - tmproto/**
+      # The build inputs: cmd/router's own module, the two modules it resolves
+      # through a local `replace` (the root module, whose only package here is
+      # router/, and registry/), and the root go.mod/go.sum that pin the
+      # versions of everything else. targeting/, tmproto/ and urlcanon/ are
+      # deliberately absent — no `replace` points at them, so the image builds
+      # those from the module proxy and editing them cannot change it.
+      - cmd/router/**
+      - router/**
+      - registry/**
       - go.mod
       - go.sum
-      - .github/workflows/identity-agent-image.yml
+      - .github/workflows/router-image.yml
   workflow_dispatch:
 
 concurrency:
-  group: identity-agent-image-${{ github.ref }}
+  group: router-image-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -45,7 +49,7 @@ permissions:
   id-token: write
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}/identity-agent
+  IMAGE: ghcr.io/${{ github.repository }}/router
 
 jobs:
   build:
@@ -78,13 +82,13 @@ jobs:
           tags: |
             type=raw,value=edge,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
             type=sha,prefix=main-,format=short,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-            type=match,pattern=identity-agent-v(.*),group=1
-            type=match,pattern=identity-agent-v(\d+\.\d+),group=1
-            type=match,pattern=identity-agent-v(\d+),group=1
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/identity-agent-v') }}
+            type=match,pattern=router-v(.*),group=1
+            type=match,pattern=router-v(\d+\.\d+),group=1
+            type=match,pattern=router-v(\d+),group=1
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/router-v') }}
           labels: |
-            org.opencontainers.image.title=identity-agent
-            org.opencontainers.image.description=Production TMP identity-match service
+            org.opencontainers.image.title=router
+            org.opencontainers.image.description=Production TMP router
             org.opencontainers.image.vendor=Ad Context Protocol
 
       - name: Build & push
@@ -92,13 +96,13 @@ jobs:
         uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6
         with:
           context: .
-          file: cmd/identity-agent/Dockerfile
+          file: cmd/router/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=identity-agent
-          cache-to: type=gha,mode=max,scope=identity-agent
+          cache-from: type=gha,scope=router
+          cache-to: type=gha,mode=max,scope=router
           provenance: mode=max
           sbom: true
 
@@ -113,8 +117,8 @@ jobs:
         # Signs every pushed tag against the build's content digest, so all
         # tags that resolve to the same image share a single transparency-log
         # entry per digest. Verify with:
-        #   cosign verify ghcr.io/<owner>/<repo>/identity-agent:<tag> \
-        #     --certificate-identity-regexp='https://github.com/<owner>/<repo>/.github/workflows/identity-agent-image\.yml@.*' \
+        #   cosign verify ghcr.io/<owner>/<repo>/router:<tag> \
+        #     --certificate-identity-regexp='https://github.com/<owner>/<repo>/.github/workflows/router-image\.yml@.*' \
         #     --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
         if: github.event_name != 'pull_request'
         env:

--- a/cmd/router/Dockerfile
+++ b/cmd/router/Dockerfile
@@ -4,6 +4,7 @@ COPY go.mod go.sum* ./
 COPY tmproto/ tmproto/
 COPY targeting/ targeting/
 COPY urlcanon/ urlcanon/
+COPY registry/ registry/
 COPY router/ router/
 COPY cmd/router/ cmd/router/
 WORKDIR /src/cmd/router
@@ -11,4 +12,5 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /router .
 
 FROM gcr.io/distroless/static-debian13:nonroot
 COPY --from=build /router /router
+EXPOSE 8080
 ENTRYPOINT ["/router"]

--- a/cmd/router/example.env
+++ b/cmd/router/example.env
@@ -1,0 +1,107 @@
+# router — example environment.
+#
+# Use this file as the basis for `docker run --env-file=example.env ...`
+# Replace every <…> placeholder with a real value.
+#
+# Providers are not configurable through the environment. The router reads its
+# provider list from the file at TMP_ROUTER_CONFIG. Drop the file and — as long
+# as the signing settings below are satisfied — the router still starts and
+# serves /healthz, but every fan-out resolves zero providers.
+#
+# Settings resolve as: env var > config file > default. The two flags the
+# binary exposes, -config and -addr, outrank the environment for those two
+# values only.
+#
+# TMP_ROUTER_CONFIG, TMP_ROUTER_TLS_* and TMP_ROUTER_SIGNING_KEY_PATH resolve
+# *inside* the container, so each needs a bind mount —
+# `docker run --env-file=example.env -v ...`. The image runs as distroless
+# nonroot (uid 65532); a key or certificate the mount leaves unreadable to that
+# uid fails startup.
+#
+# Logging is not configurable: the router logs JSON to stdout at info level.
+
+# --- Config file -------------------------------------------------------------
+# JSON or YAML (.yaml/.yml parse as YAML, any other extension as JSON). Carries
+# `providers[]` plus the health, health_check, discovery and shutdown sections,
+# none of which have an env equivalent.
+#
+# Two behaviors to know before you point this at a file:
+#
+#   1. Loading a file replaces the built-in defaults wholesale — any field the
+#      file omits takes its zero value, not the default documented here. Three
+#      of those zero values are harmful, and only these three lack a code-side
+#      fallback, so set them explicitly in every config file:
+#        addr                     — empty binds :80 (:443 under TLS). Plain
+#                                   `docker run` permits that; under
+#                                   Kubernetes the nonroot uid cannot.
+#                                   Setting TMP_ROUTER_ADDR also covers it.
+#        shutdown.drain_seconds   — 0 makes the drain context expire before it
+#                                   is used, so in-flight requests are cut off
+#                                   instead of draining.
+#        health.failure_threshold — 0 (with cooldown_seconds 0) reopens the
+#        health.cooldown_seconds    circuit the instant it trips, so a dead
+#                                   provider is never dropped from fan-out.
+#   2. A provider whose endpoint or config fails validation is skipped and the
+#      router boots without it. Grep the startup log for "skipping" before
+#      assuming a provider is live.
+TMP_ROUTER_CONFIG=<path/to/router-config.json>
+
+# --- Listeners ---------------------------------------------------------------
+TMP_ROUTER_ADDR=:8080
+# Moves the operator endpoints (/metrics, /providers) onto a second listener.
+# /healthz stays on TMP_ROUTER_ADDR either way — that is the address load
+# balancers probe. Must differ from TMP_ROUTER_ADDR; startup rejects the two
+# being equal. Left unset, both share the public listener and /providers
+# discloses provider endpoints and audience keys to anyone who can reach the
+# request port. Bind it to :9090 and restrict at the network layer, or to
+# 127.0.0.1:9090 to reach it only from inside the pod's network namespace.
+# The Dockerfile does not EXPOSE this port — publish it explicitly if you
+# scrape it from outside the container.
+TMP_ROUTER_ADMIN_ADDR=:9090
+
+# --- TLS (optional) ----------------------------------------------------------
+# Set both to serve HTTPS, neither to serve cleartext HTTP (typical when TLS
+# terminates at an upstream ingress). Setting only one is rejected at startup.
+# HTTPS is served on TMP_ROUTER_ADDR — enabling TLS does not move the listener
+# to a different port.
+TMP_ROUTER_TLS_CERT=
+TMP_ROUTER_TLS_KEY=
+
+# --- Outbound request signing ------------------------------------------------
+# The router signs the fan-outs it sends to providers. Fail-closed: startup
+# aborts unless both KID and KEY_PATH are set, or signing is explicitly
+# disabled below.
+TMP_ROUTER_SIGNING_KID=<key-id>
+# PEM PKCS#8 Ed25519 private key.
+TMP_ROUTER_SIGNING_KEY_PATH=<path/to/router-signing-key.pem>
+# Comma-separated property_rid values this router is authorized to sign for.
+# Each one gets a registry record carrying the router's public key so
+# downstream providers can resolve the kid.
+TMP_ROUTER_SIGNING_PROPERTY_RIDS=<property-rid-uuid-1>,<property-rid-uuid-2>
+# Dev only — spec-conformant providers reject unsigned fan-outs.
+TMP_ROUTER_SIGNING_DISABLED=false
+
+# --- Registry feed (optional) ------------------------------------------------
+# With FEED_URL set the router syncs the AdCP registry feed and serves real
+# property metadata from /registry/snapshot. Left empty it seeds only the RIDs
+# in TMP_ROUTER_SIGNING_PROPERTY_RIDS, and only when signing is enabled —
+# no feed plus disabled signing leaves /registry/snapshot empty. The index is
+# in memory only: the router is stateless by design, so a restart re-bootstraps
+# from the feed.
+TMP_ROUTER_REGISTRY_FEED_URL=<https://registry.agenticadvertising.org>
+TMP_ROUTER_REGISTRY_FEED_TOKEN=<bearer-token>
+TMP_ROUTER_REGISTRY_POLL_INTERVAL_SEC=30
+# Events per page during the initial catch-up drain.
+TMP_ROUTER_REGISTRY_BOOTSTRAP_LIMIT=10000
+# Events per page during steady-state polling.
+TMP_ROUTER_REGISTRY_FEED_LIMIT=1000
+
+# --- Context Match response cache --------------------------------------------
+# Disabling the cache makes the router fan out on every request. Useful for A/B
+# comparisons and when caching terminates at an upstream layer.
+TMP_ROUTER_CACHE_DISABLED=false
+# Fallback TTL applied to entries whose provider response omits cache_ttl.
+TMP_ROUTER_CACHE_DEFAULT_TTL_SEC=300
+# Cap on live entries, so a caller varying placement/seller/country cannot grow
+# the cache without bound. Expired-then-oldest are evicted on overflow.
+TMP_ROUTER_CACHE_MAX_ENTRIES=10000

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -1,3 +1,8 @@
+// Command router runs a production TMP router.
+// Providers, health, discovery and shutdown settings come from the JSON/YAML
+// config file. The listen addresses, TLS, signing, registry-feed and cache
+// settings can also come from the environment; see the adjacent example.env
+// file for that surface.
 package main
 
 import (
@@ -28,12 +33,15 @@ func main() {
 	addr := flag.String("addr", "", "Listen address (overrides config)")
 	flag.Parse()
 
-	// Load config: flags > env vars > JSON config > defaults.
-	cfg := loadConfig(*configFile, *addr)
-
-	// Set up structured logging
+	// Set up structured logging before the first thing that can fail, so
+	// config-load errors and per-provider skip warnings land on the same
+	// JSON stream as the rest of the router's output rather than on stderr
+	// through slog's default text handler.
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
+
+	// Load config: flags > env vars > JSON config > defaults.
+	cfg := loadConfig(*configFile, *addr)
 
 	// Initialize components
 	registry := router.NewRegistry("", "")


### PR DESCRIPTION
The context and identity agents publish images to GHCR; the router does not. This adds the missing workflow, following the agents' pattern.

## The Dockerfile never built

`cmd/router/Dockerfile` existed but nothing ever exercised it, and it was broken: `cmd/router/go.mod` resolves the `registry` module through a local `replace`, and the image never copied that directory.

```
registry_bridge.go:10:2: github.com/adcontextprotocol/adcp-go/registry@v0.0.0-...:
  replacement directory ../../registry does not exist
```

Fixed by copying it. Also added `EXPOSE 8080` to match the agents — `DefaultServerConfig` binds `:8080`.

## What's here

- **`.github/workflows/router-image.yml`** — a faithful analogue of the two agent workflows. Multi-arch (amd64/arm64), pushes `edge` + `main-<sha>` on main and `<semver>`/`<major>.<minor>`/`<major>`/`latest` on `router-v*` tags, cosign keyless signing per pushed tag, provenance + SBOM. Pinned action SHAs, permissions, concurrency and the signing loop are identical to the siblings.
- **`.dockerignore`** — all five images build with the repo root as context (three services via the workflows, two perf harnesses via their compose files), so one root file covers them. The router's context drops from 11.2 MB to 527 kB; the bulk is the gitignored host-arch binaries, which sat inside a copied directory and invalidated its `COPY` layer on every local rebuild.
- **`cmd/router/example.env`** — the router is the first published image needing mounted files (config, signing key, TLS pair), and its provider list has no env equivalent, so a bare `docker run` fails closed with no pointer to what it wanted.
- **`cmd/router/main.go`** — the JSON log handler was installed *after* the config load, so config errors and per-provider skip warnings went to stderr as plain text while everything else was JSON on stdout. Those warnings are the only signal that a provider was dropped from the fan-out.

Two path filters on the agent workflows were missing a real build input: `registry/**` for context-agent (reached through a `replace`) and `verify/worldid/**` for identity-agent (a root-module package it imports). A PR touching either got no image build, so the failure surfaced only after merge.

## Verification

- All five images build. The router image starts and serves `/healthz` on `:8080`; `docker run --env-file cmd/router/example.env` parses and every var reaches the binary.
- Startup config errors now arrive as JSON on stdout with stderr empty.
- `actionlint` clean on all three workflows. `gofmt`/`go build`/`go vet`/`go test` clean on `cmd/router`. The 3 `golangci-lint` gosec G706 findings in `main.go` are pre-existing — same count with this change stashed.
- Every default in `example.env` and every documented config-file footgun was checked against code, and the harmful zero values reproduced against a running container: an omitted `addr` binds `:80`, an omitted `shutdown` section makes the drain context expire before use, and an omitted `health` section reopens the provider circuit the instant it trips. Those three are the only config fields with no code-side fallback.

## For reviewers

Three things I deliberately did not change:

1. **The images build `targeting`/`tmproto`/`urlcanon` from the module proxy, not from this repo.** No `replace` points at them from either the root module or the `cmd/*` modules, so `ghcr.io/…/router:edge` off main ships `targeting v0.1.0` regardless of what's on main. The `COPY` lines for them in all three Dockerfiles are inert. This is pre-existing for both agent images; the new router filter therefore omits those paths and says why inline. If you'd rather the images track repo source, that's local `replace` directives across all three modules — happy to do it here or separately.
2. **No version stamping.** Builds pass only `-trimpath -ldflags="-s -w"`, so an image published as `router-v1.2.3` reports `{"version":"dev"}`. Pre-existing for all three; fixing it is a `--build-arg` plus `-X main.version` in each.
3. **An RC tag would clobber the floating tags.** `router-v1.2.3-rc.1` publishes `1.2`, `1` and `latest`. Inherited verbatim from both siblings, so this workflow stays consistent with them rather than diverging alone.

Also still missing, and the remaining gap in the adoption story: the provider config file has **no documented format or example anywhere in the repo**, so `example.env` points at a file an operator has to reverse-engineer from `router.ProviderConfig`.

**After the first push, a repo admin must flip the `router` package to public** — GHCR creates it private, same as the agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
