### PR TITLE
ci: exempt release-please[bot] from the bot path guard

### DIFF
--- a/.github/workflows/claude-bot-path-guard.yml
+++ b/.github/workflows/claude-bot-path-guard.yml
@@ -22,9 +22,10 @@ jobs:
     # Only fire on bot-authored PRs. Human contributors should hit
     # CODEOWNERS review, not this guard.
     if: >-
-      github.event.pull_request.user.type == 'Bot' ||
-      endsWith(github.event.pull_request.user.login, '[bot]') ||
-      github.event.pull_request.user.login == 'claude[bot]'
+      (github.event.pull_request.user.type == 'Bot' ||
+       endsWith(github.event.pull_request.user.login, '[bot]') ||
+       github.event.pull_request.user.login == 'claude[bot]') &&
+      github.event.pull_request.user.login != 'release-please[bot]'
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
- `Claude Bot Path Guard` fires on any bot-authored PR that touches TEE / workflow / agent / dep / release-please paths. Because its `if:` matches every bot, release-please PRs (which by design update `.release-please-manifest.json` and package `CHANGELOG.md`) get blocked, jamming every release.
- Add a single exemption for `release-please[bot]` so its PRs skip the guard. Claude and other unknown bots remain covered, and human contributors still hit CODEOWNERS as before.

## Context
- Example blocked release PR: https://github.com/adcontextprotocol/adcp-go/pull/454
- Blocking job: https://github.com/adcontextprotocol/adcp-go/actions/runs/31585406085/job/94079098706?pr=454

## Test plan
- [ ] Re-run the guard job on PR #454 (or a fresh release-please PR) after this merges — the guard should be skipped and the PR unblocked.
- [ ] Verify a non-release-please bot PR touching a protected path still fails the guard.