### PR TITLE
ci: exempt release-please branches by head-ref prefix

### DIFF
--- a/.github/workflows/claude-bot-path-guard.yml
+++ b/.github/workflows/claude-bot-path-guard.yml
@@ -25,7 +25,7 @@ jobs:
       (github.event.pull_request.user.type == 'Bot' ||
        endsWith(github.event.pull_request.user.login, '[bot]') ||
        github.event.pull_request.user.login == 'claude[bot]') &&
-      github.event.pull_request.user.login != 'release-please[bot]'
+      !startsWith(github.event.pull_request.head.ref, 'release-please--')
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary
Follow-up to #457. The prior exemption checked `user.login == 'release-please[bot]'`, but release-please runs inside a workflow using `GITHUB_TOKEN`, so its PRs are authored by `github-actions[bot]`. The guard's `if:` still evaluated true and kept blocking every release PR.

Key off the head-ref prefix `release-please--*` instead — that's the stable identifier release-please controls regardless of which token identity it commits under.

## Context
- Still-failing example after #457: https://github.com/adcontextprotocol/adcp-go/actions/runs/31586995548/job/94083009737 — actor is `github-actions[bot]`, so the `!= 'release-please[bot]'` guard passes and the job runs.
- Release-please branch naming: `release-please--branches--main--components--<name>` (stable across all releases).

## Test plan
- [ ] After merge, re-run the guard on PRs #453 and #454 — the check should be skipped.
- [ ] Verify a non-release-please bot PR touching a protected path still fails the guard.